### PR TITLE
Handle pagination and optimize token usage

### DIFF
--- a/packages/developer_mcp_server/src/developer_mcp_server/server.py
+++ b/packages/developer_mcp_server/src/developer_mcp_server/server.py
@@ -67,8 +67,9 @@ mcp = GitGuardianFastMCP(
 
     1. **Finding Existing Secret Incidents**:
        - Detect secrets already identified as GitGuardian incidents in your repository
-       - Use `list_repo_incidents` to view all secret incidents in a repository
+       - Use `list_repo_incidents` to view secret incidents in a repository (defaults to first page)
        - Filter incidents by various criteria including those assigned to you
+       - Pass get_all=True when you need comprehensive results
 
     2. **Proactive Secret Scanning**:
        - Use `scan_secrets` to detect secrets in code before they're committed
@@ -77,6 +78,7 @@ mcp = GitGuardianFastMCP(
 
     3. **Complete Secret Remediation**:
        - Use `remediate_secret_incidents` for guided secret removal
+       - By default fetches the first page of results for token efficiency; pass get_all=True for comprehensive results
        - Get best practice recommendations for different types of secrets
        - Replace hardcoded secrets with environment variables
        - Create .env.example files with placeholders for detected secrets
@@ -97,7 +99,8 @@ logger.info("Created Developer GitGuardianFastMCP instance")
 mcp.add_tool(remediate_secret_incidents,
     description="Find and fix secrets in the current repository using exact match locations (file paths, line numbers, character indices). "
     "This tool leverages the occurrences API to provide precise remediation instructions without needing to search for secrets in files. "
-    "By default, this only shows incidents assigned to the current user. Pass mine=False to get all incidents related to this repo.",
+    "By default, only shows incidents assigned to the current user and fetches the first page of results for token efficiency. "
+    "Pass mine=False to get all incidents. Pass get_all=True for comprehensive results when explicitly requested.",
     required_scopes=["incidents:read", "sources:read"],
 )
 
@@ -114,9 +117,9 @@ mcp.add_tool(scan_secrets,
 )
 
 mcp.add_tool(list_repo_incidents,
-    description="List secret incidents or occurrences related to a specific repository, and assigned to the current user."
-    "By default, this tool only shows incidents assigned to the current user. "
-    "Only pass mine=False to get all incidents related to this repo if the user explicitly asks for all incidents even the ones not assigned to him.",
+    description="List secret incidents or occurrences related to a specific repository. "
+    "By default, only shows incidents assigned to the current user and fetches the first page of results for token efficiency. "
+    "Pass mine=False to get all incidents (even ones not assigned to you). Pass get_all=True for comprehensive results when explicitly requested.",
     required_scopes=["incidents:read", "sources:read"],
 )
 
@@ -125,6 +128,7 @@ mcp.add_tool(
     list_repo_occurrences,
     description="List secret occurrences for a specific repository with exact match locations. "
     "Returns detailed occurrence data including file paths, line numbers, and character indices where secrets were detected. "
+    "By default fetches the first page of results for token efficiency; pass get_all=True for comprehensive results. "
     "Use this tool when you need to locate and remediate secrets in the codebase with precise file locations.",
     required_scopes=["incidents:read"],
 )

--- a/packages/gg_api_core/src/gg_api_core/tools/remediate_secret_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/remediate_secret_incidents.py
@@ -20,7 +20,7 @@ async def remediate_secret_incidents(
     create_env_example: bool = Field(
         default=True, description="Whether to create a .env.example file with placeholders for detected secrets"
     ),
-    get_all: bool = Field(default=True, description="Whether to get all incidents or just the first page"),
+    get_all: bool = Field(default=False, description="Whether to get all incidents or just the first page. Set to True for comprehensive results."),
     mine: bool = Field(
         default=True,
         description="If True, fetch only incidents assigned to the current user. Set to False to get all incidents.",
@@ -29,9 +29,11 @@ async def remediate_secret_incidents(
     """
     Find and remediate secret incidents in the current repository using EXACT match locations.
 
-    By default, this tool only shows incidents assigned to the current user. Pass mine=False to get all incidents related to this repo.
+    By default, this tool:
+    - Only shows incidents assigned to the current user (pass mine=False for all incidents)
+    - Fetches only the first page of results (pass get_all=True for comprehensive results)
 
-    This tool now uses the occurrences API to get precise file locations, line numbers, and character indices,
+    This tool uses the occurrences API to get precise file locations, line numbers, and character indices,
     eliminating the need to search for secrets in files. The workflow is:
 
     1. Fetch secret occurrences with exact match locations (file path, line_start, line_end, index_start, index_end)
@@ -55,7 +57,7 @@ async def remediate_secret_incidents(
         repository_name: The full repository name (e.g., 'GitGuardian/gg-mcp')
         include_git_commands: Whether to include git commands to fix incidents in git history
         create_env_example: Whether to create a .env.example file with placeholders for detected secrets
-        get_all: Whether to get all occurrences or just the first page
+        get_all: Whether to get all occurrences or just the first page. Defaults to False for token efficiency.
         mine: If True, fetch only occurrences for incidents assigned to the current user. Set to False to get all.
 
     Returns:


### PR DESCRIPTION
# 1

The paginate_all method was only checking for "results" key in API responses, but some GitGuardian API endpoints return data using a "data" key instead. This caused get_all=True to fail by returning empty lists.

Added support for both response formats:
- {"results": [...]} (existing)
- {"data": [...]} (newly added)

This fixes MCP tool calls with get_all=True parameter for endpoints like list_repo_incidents, list_repo_occurrences, and remediate_secret_incidents.