### PR TITLE
feat(tools): Use the with_sources=False query param on public API

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -1290,6 +1290,7 @@ class GitGuardianClient:
         severity: list[str] | None = None,
         validity: list[str] | None = None,
         status: list[str] | None = None,
+        with_sources: bool | None = None,
     ) -> dict[str, Any] | list[dict[str, Any]]:
         """List secret occurrences with optional filtering and cursor-based pagination.
 
@@ -1309,6 +1310,7 @@ class GitGuardianClient:
             severity: Filter by severity (list of severity names)
             validity: Filter by validity (list of validity names)
             status: Filter by status (list of status names)
+            with_sources: Whether to include source details in the response
 
         Returns:
             List of occurrences matching the criteria or an empty dict/list if no results
@@ -1345,6 +1347,8 @@ class GitGuardianClient:
             params["validity"] = ",".join(validity)
         if status:
             params["status"] = ",".join(status)
+        if with_sources is not None:
+            params["with_sources"] = str(with_sources).lower()
 
         # If get_all is True, use paginate_all to get all results
         if get_all:

--- a/packages/gg_api_core/src/gg_api_core/tools/list_repo_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_repo_incidents.py
@@ -74,7 +74,7 @@ async def list_repo_incidents(params: ListRepoIncidentsParams) -> dict[str, Any]
         # If source_id is provided, use it directly; otherwise use repository_name lookup
         if params.source_id:
             # Prepare parameters for the API call
-            api_params = {}
+            api_params = {"with_sources": "false"}
             if params.from_date:
                 api_params["from_date"] = params.from_date
             if params.to_date:

--- a/packages/gg_api_core/src/gg_api_core/tools/list_repo_occurrences.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_repo_occurrences.py
@@ -98,6 +98,7 @@ async def list_repo_occurrences(params: ListRepoOccurrencesParams) -> dict[str, 
                 status=params.status,
                 severity=params.severity,
                 validity=params.validity,
+                with_sources=False,
             )
         else:
             # Use source_name (legacy path)
@@ -117,6 +118,7 @@ async def list_repo_occurrences(params: ListRepoOccurrencesParams) -> dict[str, 
                 status=params.status,
                 severity=params.severity,
                 validity=params.validity,
+                with_sources=False,
             )
 
         # Handle the response format

--- a/tests/tools/test_list_repo_incidents.py
+++ b/tests/tools/test_list_repo_incidents.py
@@ -96,8 +96,14 @@ class TestListRepoIncidents:
             )
         )
 
-        # Verify client was called with correct parameters
+        # Verify client was called with correct parameters including with_sources=false
         mock_gitguardian_client.list_source_incidents.assert_called_once()
+        call_args = mock_gitguardian_client.list_source_incidents.call_args
+        # Check positional arg (source_id)
+        assert call_args[0][0] == "source_123"
+        # Check keyword args include with_sources
+        assert "with_sources" in call_args[1]
+        assert call_args[1]["with_sources"] == "false"
 
         # Verify response
         assert "source_id" in result

--- a/tests/tools/test_list_repo_occurrences.py
+++ b/tests/tools/test_list_repo_occurrences.py
@@ -14,7 +14,7 @@ class TestListRepoOccurrences:
         """
         GIVEN: A repository name
         WHEN: Listing occurrences for the repository
-        THEN: The API returns occurrences with exact match locations
+        THEN: The API returns occurrences with exact match locations and with_sources=False
         """
         # Mock the client response
         mock_response = {
@@ -57,11 +57,12 @@ class TestListRepoOccurrences:
             )
         )
 
-        # Verify client was called
+        # Verify client was called with with_sources=False
         mock_gitguardian_client.list_occurrences.assert_called_once()
         call_kwargs = mock_gitguardian_client.list_occurrences.call_args.kwargs
         assert call_kwargs["source_name"] == "GitGuardian/test-repo"
         assert call_kwargs["source_type"] == "github"
+        assert call_kwargs["with_sources"] is False
 
         # Verify response
         assert result["repository"] == "GitGuardian/test-repo"
@@ -73,7 +74,7 @@ class TestListRepoOccurrences:
         """
         GIVEN: A GitGuardian source ID
         WHEN: Listing occurrences for the source
-        THEN: The API returns occurrences for that source
+        THEN: The API returns occurrences for that source with with_sources=False
         """
         # Mock the client response
         mock_response = {
@@ -94,10 +95,11 @@ class TestListRepoOccurrences:
             ListRepoOccurrencesParams(source_id="source_123")
         )
 
-        # Verify client was called with source_id
+        # Verify client was called with source_id and with_sources=False
         mock_gitguardian_client.list_occurrences.assert_called_once()
         call_kwargs = mock_gitguardian_client.list_occurrences.call_args.kwargs
         assert call_kwargs["source_id"] == "source_123"
+        assert call_kwargs["with_sources"] is False
 
         # Verify response
         assert result["occurrences_count"] == 1


### PR DESCRIPTION
Works well : 

<img width="839" height="276" alt="image" src="https://github.com/user-attachments/assets/1695f210-ee2b-42cc-a02b-520c39c592b5" />
