### PR TITLE
feat(mcp): Fix 301 redirect

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -432,7 +432,7 @@ class GitGuardianClient:
 
         while retry_count <= max_retries:
             try:
-                async with httpx.AsyncClient() as client:
+                async with httpx.AsyncClient(follow_redirects=True) as client:
                     logger.debug(f"Sending {method} request to {url}")
                     response = await client.request(method, url, headers=headers, **kwargs)
 
@@ -652,7 +652,7 @@ class GitGuardianClient:
         }
         headers.update(kwargs.pop("headers", {}))
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(follow_redirects=True) as client:
             response = await client.get(url, headers=headers, **kwargs)
             response.raise_for_status()
 

--- a/packages/gg_api_core/src/gg_api_core/oauth.py
+++ b/packages/gg_api_core/src/gg_api_core/oauth.py
@@ -690,7 +690,7 @@ class GitGuardianOAuthClient:
                 "User-Agent": f"MCP-Server/{self.token_name}",  # Include in user agent
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(follow_redirects=True) as client:
                 response = await client.post(token_url, data=token_params, headers=headers)
 
                 if response.status_code == 200:
@@ -763,7 +763,7 @@ class GitGuardianOAuthClient:
         try:
             import httpx  # Import here to avoid circular imports
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(follow_redirects=True) as client:
                 # Use the correct API endpoint with the full path
                 response = await client.get(
                     f"{self.api_url}/api_tokens/self",


### PR DESCRIPTION
Issue:APPAI-154

https://linear.app/gitguardian/issue/APPAI-154/toolerror-error-calling-tool-create-code-fix-request-failed-to-create

  Root Cause

  The httpx.AsyncClient() by default has follow_redirects=False. When the GitGuardian API at https://api.staging.gitguardian.tech/v1/code-fix-requests returns a 301 redirect (to add a trailing slash), httpx raises an error instead of following it.

  Fix

  Added follow_redirects=True to all httpx.AsyncClient() instantiations:

  | File      | Line | Method                              |
  |-----------|------|-------------------------------------|
  | client.py | 435  | _request() - general request method |
  | client.py | 655  | _request_list() - list endpoints    |
  | oauth.py  | 693  | OAuth token exchange                |
  | oauth.py  | 766  | Token info fetch                    |

  All 42 tests pass. The MCP server will now properly follow HTTP redirects from the API.