### PR TITLE
Don't hide errors related to api-tokens

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -1073,22 +1073,18 @@ class GitGuardianClient:
         """
         logger.info("Getting current API token information")
 
-        try:
-            # If we already have token info, return it
-            if self._token_info is not None:
-                # Convert Pydantic model to dict if needed
-                if hasattr(self._token_info, "model_dump"):
-                    return dict(self._token_info.model_dump())
-                elif isinstance(self._token_info, dict):
-                    return self._token_info
-                else:
-                    return await self._request_get("/api_tokens/self")
+        # If we already have token info, return it
+        if self._token_info is not None:
+            # Convert Pydantic model to dict if needed
+            if hasattr(self._token_info, "model_dump"):
+                return dict(self._token_info.model_dump())
+            elif isinstance(self._token_info, dict):
+                return self._token_info
+            else:
+                return await self._request_get("/api_tokens/self")
 
-            # Otherwise fetch from the API
-            return await self._request_get("/api_tokens/self")
-        except Exception as e:
-            logger.error(f"Failed to get current token info: {str(e)}")
-            raise
+        # Otherwise fetch from the API
+        return await self._request_get("/api_tokens/self")
 
     async def list_api_tokens(self) -> dict[str, Any]:
         """List all API tokens for the account.

--- a/packages/gg_api_core/src/gg_api_core/mcp_server.py
+++ b/packages/gg_api_core/src/gg_api_core/mcp_server.py
@@ -8,7 +8,7 @@ from enum import Enum
 from typing import Any
 
 from fastmcp import FastMCP
-from fastmcp.exceptions import FastMCPError, ValidationError
+from fastmcp.exceptions import ValidationError
 from fastmcp.server.dependencies import get_http_headers
 from fastmcp.server.middleware import Middleware
 from fastmcp.tools import Tool
@@ -215,28 +215,21 @@ class AbstractGitGuardianFastMCP(FastMCP, ABC):
         Returns:
             set: The fetched scopes, or empty set on error
         """
-        try:
-            client_to_use = self.get_client()
+        client_to_use = self.get_client()
 
-            # Fetch the complete token info
-            logger.debug("Attempting to fetch token scopes from GitGuardian API")
-            token_info = await client_to_use.get_current_token_info()
+        # Fetch the complete token info
+        logger.debug("Attempting to fetch token scopes from GitGuardian API")
+        token_info = await client_to_use.get_current_token_info()
 
-            # Extract scopes
-            scopes = token_info.get("scopes", [])
-            logger.debug(f"Retrieved token scopes: {scopes}")
+        # Extract scopes
+        scopes = token_info.get("scopes", [])
+        logger.debug(f"Retrieved token scopes: {scopes}")
 
-            return set(scopes)
-
-        except Exception as e:
-            raise FastMCPError("Error fetching token scopes from /api_tokens/self endpoint") from e
+        return set(scopes)
 
     async def _fetch_token_info_from_api(self) -> dict[str, Any]:
-        try:
-            client = self.get_client()
-            return await client.get_current_token_info()
-        except Exception as e:
-            raise FastMCPError("Error fetching token info from /api_tokens/self endpoint") from e
+        client = self.get_client()
+        return await client.get_current_token_info()
 
     async def get_scopes(self) -> set[str]:
         cached_scopes: set[str] | None = getattr(self, "_token_scopes", None)

--- a/packages/gg_api_core/src/gg_api_core/tools/assign_incident.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/assign_incident.py
@@ -121,18 +121,12 @@ async def assign_incident(params: AssignIncidentParams) -> AssignIncidentResult:
 
     elif params.mine:
         # Get current user's ID from token info
-        try:
-            token_info = await client.get_current_token_info()
-            if token_info and "member_id" in token_info:
-                assignee_id = token_info["member_id"]
-                logger.debug(f"Using current user ID for assignment: {assignee_id}")
-            else:
-                raise ToolError("Could not determine current user ID from token info")
-        except ToolError:
-            raise
-        except Exception as e:
-            logger.error(f"Failed to get current user info: {str(e)}")
-            raise ToolError(f"Failed to get current user info: {str(e)}")
+        token_info = await client.get_current_token_info()
+        if token_info and "member_id" in token_info:
+            assignee_id = token_info["member_id"]
+            logger.debug(f"Using current user ID for assignment: {assignee_id}")
+        else:
+            raise ToolError("Could not determine current user ID from token info")
 
     # Final validation
     if not assignee_id:

--- a/packages/gg_api_core/src/gg_api_core/tools/list_honeytokens.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_honeytokens.py
@@ -63,18 +63,15 @@ async def list_honeytokens(params: ListHoneytokensParams) -> ListHoneytokensResu
     # the current user's info first and set creator_id accordingly
     creator_id = params.creator_id
     if params.mine:
-        try:
-            # Get current token info to identify the user
-            token_info = await client.get_current_token_info()
-            logger.debug(f"Token info: {token_info}")
-            if token_info and "member_id" in token_info:
-                # If we have member_id, use it as creator_id
-                creator_id = token_info["member_id"]
-                logger.debug(f"Setting creator_id to current user: {creator_id}")
-            else:
-                logger.warning("Could not determine current user ID for 'mine' filter")
-        except Exception as e:
-            logger.warning(f"Failed to get current user info for 'mine' filter: {str(e)}")
+        # Get current token info to identify the user
+        token_info = await client.get_current_token_info()
+        logger.debug(f"Token info: {token_info}")
+        if token_info and "member_id" in token_info:
+            # If we have member_id, use it as creator_id
+            creator_id = token_info["member_id"]
+            logger.debug(f"Setting creator_id to current user: {creator_id}")
+        else:
+            logger.warning("Could not determine current user ID for 'mine' filter")
 
     try:
         response = await client.list_honeytokens(

--- a/tests/tools/test_list_honey_tokens.py
+++ b/tests/tools/test_list_honey_tokens.py
@@ -440,7 +440,7 @@ class TestListHoneytokens:
         """
         GIVEN: get_current_token_info raises an exception
         WHEN: Listing honeytokens with mine=True
-        THEN: The function continues without user filtering
+        THEN: The exception propagates to the caller
         """
         # Mock get_current_token_info to raise exception
         mock_gitguardian_client.get_current_token_info = AsyncMock(side_effect=Exception("Token info failed"))
@@ -449,23 +449,21 @@ class TestListHoneytokens:
         mock_response = {"data": [], "cursor": None, "has_more": False}
         mock_gitguardian_client.list_honeytokens = AsyncMock(return_value=mock_response)
 
-        # Call the function with mine=True (should not fail, just log warning)
-        result = await list_honeytokens(
-            ListHoneytokensParams(
-                status=None,
-                search=None,
-                ordering=None,
-                show_token=False,
-                creator_id=None,
-                creator_api_token_id=None,
-                per_page=20,
-                get_all=False,
-                mine=True,
+        # Call the function with mine=True - should raise the exception
+        with pytest.raises(Exception, match="Token info failed"):
+            await list_honeytokens(
+                ListHoneytokensParams(
+                    status=None,
+                    search=None,
+                    ordering=None,
+                    show_token=False,
+                    creator_id=None,
+                    creator_api_token_id=None,
+                    per_page=20,
+                    get_all=False,
+                    mine=True,
+                )
             )
-        )
-
-        # Verify function completes without error
-        assert result.honeytokens == []
 
     @pytest.mark.asyncio
     async def test_list_honeytokens_cursor_pagination(self, mock_gitguardian_client):


### PR DESCRIPTION
To be able to investigate this bug : https://linear.app/gitguardian/issue/APPAI-172/mcperror-error-fetching-token-scopes-from-api-tokensself-endpoint

Don't hide errors related to api-tokens