### PR TITLE
fix(list_repo_occurrences): Allow it to work for in-app-agent.

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/tools/list_repo_occurrences.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_repo_occurrences.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field
 
 from gg_api_core.client import IncidentSeverity, IncidentStatus, IncidentValidity, TagNames
 from gg_api_core.utils import get_client
@@ -75,13 +75,6 @@ class ListRepoOccurrencesBaseParams(BaseModel):
     per_page: int = Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)")
     cursor: str | None = Field(default=None, description="Pagination cursor for fetching next page of results")
     get_all: bool = Field(default=False, description="If True, fetch all results using cursor-based pagination")
-
-    @model_validator(mode="after")
-    def validate_source_or_repository(self) -> "ListRepoOccurrencesBaseParams":
-        """Validate that either source_id or repository_name is provided."""
-        if not self.source_id and not self.repository_name:
-            raise ValueError("Either 'source_id' or 'repository_name' must be provided")
-        return self
 
 
 class ListRepoOccurrencesParams(ListRepoOccurrencesFilters, ListRepoOccurrencesBaseParams):
@@ -186,7 +179,7 @@ async def list_repo_occurrences(
 
     Args:
         params: ListRepoOccurrencesParams model containing all filtering options.
-               Either repository_name or source_id must be provided (validated by model).
+               Optionally filter by repository_name or source_id.
 
     Returns:
         ListRepoOccurrencesResult: Pydantic model containing:

--- a/tests/tools/test_remediate_secret_incidents.py
+++ b/tests/tools/test_remediate_secret_incidents.py
@@ -7,7 +7,6 @@ from gg_api_core.tools.remediate_secret_incidents import (
     RemediateSecretIncidentsParams,
     remediate_secret_incidents,
 )
-from pydantic import ValidationError
 
 
 class TestRemediateSecretIncidentsParams:
@@ -47,15 +46,12 @@ class TestRemediateSecretIncidentsParams:
         """
         GIVEN: RemediateSecretIncidentsParams with neither repository_name nor source_id provided
         WHEN: Creating the params
-        THEN: Validation should fail with ValueError since list_repo_occurrences_params requires one
+        THEN: Validation should pass and return all occurrences
         """
-        with pytest.raises(ValidationError) as exc_info:
-            RemediateSecretIncidentsParams()
-
-        # Verify the error message comes from the nested ListRepoOccurrencesParamsForRemediate
-        errors = exc_info.value.errors()
-        assert len(errors) == 1
-        assert "Either 'source_id' or 'repository_name' must be provided" in str(errors[0])
+        params = RemediateSecretIncidentsParams()
+        assert params.repository_name is None
+        assert params.source_id is None
+        assert params.list_repo_occurrences_params is not None
 
     def test_params_with_nested_list_repo_occurrences_params(self):
         """


### PR DESCRIPTION
In the agent, we can't use git to see the name of the current repository, so if the user request does not mention a source, we should not filter by source.

https://linear.app/gitguardian/issue/APPAI-155/1-validation-error-for-calllist-repo-occurrences-params-value-error