### PR TITLE
Attach stack traces to sentry events

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -354,7 +354,7 @@ class GitGuardianClient:
                     self._token_info = oauth_client.get_token_info()
                     logger.info("OAuth authentication successful")
             except Exception as e:
-                logger.error(f"OAuth authentication failed: {e}")
+                logger.exception(f"OAuth authentication failed: {e}")
                 raise
 
     async def _clear_invalid_oauth_token(self):
@@ -501,8 +501,8 @@ class GitGuardianClient:
 
                     return data
                 except json.JSONDecodeError as e:
-                    logger.error(f"Failed to parse JSON response: {str(e)}")
-                    logger.error(f"Raw response content: {response.content!r}")
+                    logger.exception(f"Failed to parse JSON response: {str(e)}")
+                    logger.debug(f"Raw response content: {response.content!r}")
                     raise
 
             except httpx.HTTPStatusError as e:
@@ -530,17 +530,17 @@ class GitGuardianClient:
                         # If we can't parse the error response, continue with normal error handling
                         pass
 
-                logger.error(f"HTTP error occurred: {e.response.status_code} - {e.response.reason_phrase}")
-                logger.error(f"Error response content: {e.response.text}")
-                logger.error(f"Failed URL: {url}")
+                logger.exception(f"HTTP error occurred: {e.response.status_code} - {e.response.reason_phrase}")
+                logger.debug(f"Error response content: {e.response.text}")
+                logger.debug(f"Failed URL: {url}")
                 raise
             except httpx.RequestError as e:
-                logger.error(f"Request error occurred: {str(e)}")
-                logger.error(f"Failed URL: {url}")
+                logger.exception(f"Request error occurred: {str(e)}")
+                logger.debug(f"Failed URL: {url}")
                 raise
             except Exception as e:
                 logger.exception(f"Unexpected error during API request: {str(e)}")
-                logger.error(f"Failed URL: {url}")
+                logger.debug(f"Failed URL: {url}")
                 raise
 
             # If we got here with no exceptions, break out of the retry loop (should have returned above)
@@ -1712,7 +1712,7 @@ class GitGuardianClient:
                 return None
 
         except Exception as e:
-            logger.error(f"Error getting source by name: {str(e)}")
+            logger.exception(f"Error getting source by name: {str(e)}")
             return None
 
     async def create_code_fix_request(self, locations: list[dict[str, Any]]) -> dict[str, Any]:

--- a/packages/gg_api_core/src/gg_api_core/mcp_server.py
+++ b/packages/gg_api_core/src/gg_api_core/mcp_server.py
@@ -169,7 +169,7 @@ class AbstractGitGuardianFastMCP(FastMCP, ABC):
             logger.debug("API token revoked")
             return result
         except Exception as e:
-            logger.error(f"Error revoking current API token: {str(e)}")
+            logger.exception(f"Error revoking current API token: {str(e)}")
             raise
 
     def tool(self, *args, required_scopes: list[str] | None = None, **kwargs):
@@ -294,7 +294,7 @@ def register_common_tools(mcp_instance: AbstractGitGuardianFastMCP):
             }
 
         except Exception as e:
-            logger.error(f"Error during token revocation: {str(e)}")
+            logger.exception(f"Error during token revocation: {str(e)}")
             return {"success": False, "error": f"Failed to revoke token: {str(e)}"}
 
     logger.debug("Registered common MCP tools")

--- a/packages/gg_api_core/src/gg_api_core/oauth.py
+++ b/packages/gg_api_core/src/gg_api_core/oauth.py
@@ -571,7 +571,7 @@ class GitGuardianOAuthClient:
                 else:
                     logger.debug(f"Browser window opened successfully for '{self.token_name}'")
             except Exception as e:
-                logger.error(f"Error opening browser: {e}")
+                logger.exception(f"Error opening browser: {e}")
                 print("\n\n-------------------------------------------------------------")
                 print("Please open the following URL in your browser to authenticate:")
                 print(f"\n{authorization_url}\n")
@@ -748,7 +748,7 @@ class GitGuardianOAuthClient:
                 raise Exception("Failed to obtain access token during OAuth flow")
 
         except Exception as e:
-            logger.error(f"OAuth authentication failed: {e}")
+            logger.exception(f"OAuth authentication failed: {e}")
             raise
 
     async def _fetch_token_info(self) -> APITokenInfo | None:

--- a/packages/gg_api_core/src/gg_api_core/sentry_integration.py
+++ b/packages/gg_api_core/src/gg_api_core/sentry_integration.py
@@ -80,7 +80,7 @@ def init_sentry() -> bool:
         return True
 
     except Exception as e:
-        logger.error(f"Failed to initialize Sentry: {str(e)}")
+        logger.exception(f"Failed to initialize Sentry: {str(e)}")
         return False
 
 

--- a/packages/gg_api_core/src/gg_api_core/tools/assign_incident.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/assign_incident.py
@@ -116,7 +116,7 @@ async def assign_incident(params: AssignIncidentParams) -> AssignIncidentResult:
         except ToolError:
             raise
         except Exception as e:
-            logger.error(f"Failed to look up member by email: {str(e)}")
+            logger.exception(f"Failed to look up member by email: {str(e)}")
             raise ToolError(f"Failed to look up member by email: {str(e)}")
 
     elif params.mine:
@@ -153,5 +153,5 @@ async def assign_incident(params: AssignIncidentParams) -> AssignIncidentResult:
             return AssignIncidentResult(incident_id=params.incident_id, assignee_id=assignee_id, success=True)
 
     except Exception as e:
-        logger.error(f"Error assigning incident {params.incident_id}: {str(e)}")
+        logger.exception(f"Error assigning incident {params.incident_id}: {str(e)}")
         raise ToolError(str(e))

--- a/packages/gg_api_core/src/gg_api_core/tools/create_code_fix_request.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/create_code_fix_request.py
@@ -107,7 +107,7 @@ async def create_code_fix_request(params: CreateCodeFixRequestParams) -> CreateC
 
     except Exception as e:
         error_message = str(e)
-        logger.error(f"Error creating code fix request: {error_message}")
+        logger.exception(f"Error creating code fix request: {error_message}")
 
         # Provide more context based on common error scenarios
         if "not enabled" in error_message.lower():

--- a/packages/gg_api_core/src/gg_api_core/tools/find_current_source_id.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/find_current_source_id.py
@@ -229,5 +229,5 @@ async def find_current_source_id(repository_path: str = ".") -> FindCurrentSourc
             )
 
     except Exception as e:
-        logger.error(f"Error finding source_id: {str(e)}")
+        logger.exception(f"Error finding source_id: {str(e)}")
         return FindCurrentSourceIdError(error=f"Failed to find source_id: {str(e)}")

--- a/packages/gg_api_core/src/gg_api_core/tools/generate_honey_token.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/generate_honey_token.py
@@ -125,5 +125,5 @@ async def generate_honeytoken(params: GenerateHoneytokenParams) -> GenerateHoney
 
         return GenerateHoneytokenResult(**creation_result)
     except Exception as e:
-        logger.error(f"Error generating honeytoken: {str(e)}")
+        logger.exception(f"Error generating honeytoken: {str(e)}")
         raise ToolError(f"Failed to generate honeytoken: {str(e)}")

--- a/packages/gg_api_core/src/gg_api_core/tools/list_honeytokens.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_honeytokens.py
@@ -101,5 +101,5 @@ async def list_honeytokens(params: ListHoneytokensParams) -> ListHoneytokensResu
             has_more=response.get("has_more", False),
         )
     except Exception as e:
-        logger.error(f"Error listing honeytokens: {str(e)}")
+        logger.exception(f"Error listing honeytokens: {str(e)}")
         raise ToolError(str(e))

--- a/packages/gg_api_core/src/gg_api_core/tools/list_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_incidents.py
@@ -275,5 +275,5 @@ async def list_incidents(params: ListIncidentsParams) -> ListIncidentsResult | L
         )
 
     except Exception as e:
-        logger.error(f"Error listing repository incidents: {str(e)}")
+        logger.exception(f"Error listing repository incidents: {str(e)}")
         return ListIncidentsError(error=f"Failed to list repository incidents: {str(e)}")

--- a/packages/gg_api_core/src/gg_api_core/tools/list_repo_occurrences.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_repo_occurrences.py
@@ -263,5 +263,5 @@ async def list_repo_occurrences(
         )
 
     except Exception as e:
-        logger.error(f"Error listing repository occurrences: {str(e)}")
+        logger.exception(f"Error listing repository occurrences: {str(e)}")
         return ListRepoOccurrencesError(error=f"Failed to list repository occurrences: {str(e)}")

--- a/packages/gg_api_core/src/gg_api_core/tools/manage_incident.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/manage_incident.py
@@ -73,7 +73,7 @@ async def manage_private_incident(params: ManageIncidentParams) -> dict[str, Any
     except ToolError:
         raise
     except Exception as e:
-        logger.error(f"Error managing incident: {str(e)}")
+        logger.exception(f"Error managing incident: {str(e)}")
         raise ToolError(f"Error: {str(e)}")
 
 
@@ -102,5 +102,5 @@ async def update_incident_status(params: UpdateIncidentStatusParams) -> dict[str
         logger.debug(f"Updated incident {params.incident_id} status to {params.status}")
         return result
     except Exception as e:
-        logger.error(f"Error updating incident status: {str(e)}")
+        logger.exception(f"Error updating incident status: {str(e)}")
         raise ToolError(f"Error: {str(e)}")

--- a/packages/gg_api_core/src/gg_api_core/tools/read_custom_tags.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/read_custom_tags.py
@@ -47,5 +47,5 @@ async def read_custom_tags(params: ReadCustomTagsParams):
         else:
             raise ValueError(f"Invalid action: {params.action}. Must be one of ['list_tags', 'get_tag']")
     except Exception as e:
-        logger.error(f"Error reading custom tags: {str(e)}")
+        logger.exception(f"Error reading custom tags: {str(e)}")
         raise ToolError(f"Error: {str(e)}")

--- a/packages/gg_api_core/src/gg_api_core/tools/remediate_secret_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/remediate_secret_incidents.py
@@ -151,7 +151,7 @@ async def remediate_secret_incidents(
         )
 
     except Exception as e:
-        logger.error(f"Error remediating incidents: {str(e)}")
+        logger.exception(f"Error remediating incidents: {str(e)}")
         return RemediateSecretIncidentsError(error=f"Failed to remediate incidents: {str(e)}")
 
 

--- a/packages/gg_api_core/src/gg_api_core/tools/revoke_secret.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/revoke_secret.py
@@ -65,5 +65,5 @@ async def revoke_secret(params: RevokeSecretParams) -> RevokeSecretResult:
             raise ToolError(f"Unexpected response format: {type(result).__name__}")
 
     except Exception as e:
-        logger.error(f"Error revoking secret {params.secret_id}: {str(e)}")
+        logger.exception(f"Error revoking secret {params.secret_id}: {str(e)}")
         raise ToolError(str(e))

--- a/packages/gg_api_core/src/gg_api_core/tools/scan_secret.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/scan_secret.py
@@ -95,5 +95,5 @@ async def scan_secrets(params: ScanSecretsParams) -> ScanSecretsResult:
             # Fallback: wrap in scan_results
             return ScanSecretsResult(scan_results=[result])
     except Exception as e:
-        logger.error(f"Error scanning for secrets: {str(e)}")
+        logger.exception(f"Error scanning for secrets: {str(e)}")
         raise

--- a/packages/gg_api_core/src/gg_api_core/tools/write_custom_tags.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/write_custom_tags.py
@@ -73,7 +73,7 @@ async def write_custom_tags(params: WriteCustomTagsParams):
         else:
             raise ValueError(f"Invalid action: {params.action}. Must be one of ['create_tag', 'delete_tag']")
     except Exception as e:
-        logger.error(f"Error writing custom tags: {str(e)}")
+        logger.exception(f"Error writing custom tags: {str(e)}")
         raise ToolError(f"Error: {str(e)}")
 
 
@@ -135,5 +135,5 @@ async def update_or_create_incident_custom_tags(params: UpdateOrCreateIncidentCu
         logger.debug(f"Updated custom tags for incident {params.incident_id}")
         return result
     except Exception as e:
-        logger.error(f"Error updating custom tags: {str(e)}")
+        logger.exception(f"Error updating custom tags: {str(e)}")
         raise ToolError(f"Error: {str(e)}")

--- a/packages/gg_api_core/src/gg_api_core/utils.py
+++ b/packages/gg_api_core/src/gg_api_core/utils.py
@@ -58,7 +58,7 @@ def get_client(personal_access_token: str | None = None) -> GitGuardianClient:
             personal_access_token = get_personal_access_token_from_request()
             logger.debug("Successfully extracted token from HTTP request headers")
         except ValidationError as e:
-            logger.error(f"Failed to extract token from HTTP headers: {e}")
+            logger.exception(f"Failed to extract token from HTTP headers: {e}")
             raise
 
     # If a PAT is provided (explicitly or from headers), create per-request client (no caching)
@@ -85,7 +85,7 @@ def get_personal_access_token_from_request():
         headers = get_http_headers()
         logger.debug(f"Retrieved HTTP headers: {list(headers.keys()) if headers else 'None'}")
     except Exception as e:
-        logger.error(f"Failed to get HTTP headers: {e}")
+        logger.exception(f"Failed to get HTTP headers: {e}")
         raise ValidationError(f"Failed to retrieve HTTP headers: {e}")
 
     if not headers:

--- a/packages/secops_mcp_server/src/secops_mcp_server/server.py
+++ b/packages/secops_mcp_server/src/secops_mcp_server/server.py
@@ -153,7 +153,7 @@ async def get_current_token_info() -> dict[str, Any]:
         logger.debug(f"Retrieved token info for token ID: {result.get('id')}")
         return result
     except Exception as e:
-        logger.error(f"Error getting token info: {str(e)}")
+        logger.exception(f"Error getting token info: {str(e)}")
         raise ToolError(f"Error: {str(e)}")
 
 


### PR DESCRIPTION
Attach stack traces to sentry events

https://linear.app/gitguardian/issue/APPAI-95/mcp-replace-loggererror-by-loggerexception-if-supported-even-without