### PR TITLE
fix(remediation): Fix wrong serialization

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/tools/remediate_secret_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/remediate_secret_incidents.py
@@ -78,7 +78,7 @@ class RemediateSecretIncidentsResult(BaseModel):
         default=0, description="Number of occurrences suggested for remediation"
     )
 
-    sub_tools_results: dict[str, BaseModel] = Field(default_factory=dict, description="Results from sub tools")
+    sub_tools_results: dict[str, Any] = Field(default_factory=dict, description="Results from sub tools")
 
 
 class RemediateSecretIncidentsError(BaseModel):


### PR DESCRIPTION
Issue: APPAI-308

Fix wrong serialization

  1. Fix (remediate_secret_incidents.py):
    - Changed sub_tools_results: dict[str, BaseModel] to dict[str, Any]
  2. Tests (test_remediate_secret_incidents.py):
    - Added RemediateSecretIncidentsResult to imports
    - Added new test class TestRemediateSecretIncidentsResultSerialization with two tests:
        - test_sub_tools_results_serialization - verifies model_dump() serializes nested results
      - test_sub_tools_results_json_serialization - verifies model_dump_json() produces correct
  JSON