### PR TITLE
fix(tools): pass has_more flag in list_users single-page response

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/tools/list_users.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_users.py
@@ -14,13 +14,17 @@ class ListUsersParams(BaseModel):
     """Parameters for listing workspace members/users."""
 
     cursor: str | None = Field(default=None, description="Pagination cursor for fetching next page of results")
-    per_page: int = Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)")
+    per_page: int = Field(
+        default=20,
+        description="Number of results per page (default: 20, min: 1, max: 100)",
+    )
     role: str | None = Field(
         default=None,
         description="Filter members based on their role (owner, manager, member, restricted). Deprecated - use access_level instead",
     )
     access_level: str | None = Field(
-        default=None, description="Filter members based on their access level (owner, manager, member, restricted)"
+        default=None,
+        description="Filter members based on their access level (owner, manager, member, restricted)",
     )
     active: bool | None = Field(default=None, description="Filter members based on their active status")
     search: str | None = Field(default=None, description="Search members based on their name or email")
@@ -40,7 +44,10 @@ class ListUsersResult(BaseModel):
     members: list[dict[str, Any]] = Field(description="List of workspace member objects")
     total_count: int = Field(description="Total number of members returned")
     next_cursor: str | None = Field(default=None, description="Pagination cursor for next page (if applicable)")
-    has_more: bool = Field(default=False, description="True if more results exist (use next_cursor to fetch)")
+    has_more: bool = Field(
+        default=False,
+        description="True if more results exist (use next_cursor to fetch)",
+    )
 
 
 async def list_users(params: ListUsersParams) -> ListUsersResult:
@@ -98,5 +105,10 @@ async def list_users(params: ListUsersParams) -> ListUsersResult:
     else:
         # Single page request
         result = await client.list_members(params=query_params)
-        logger.debug(f"Found {len(result['data'])} members")
-        return ListUsersResult(members=result["data"], total_count=len(result["data"]), next_cursor=result["cursor"])
+        logger.debug(f"Found {len(result['data'])} members (has_more={result['has_more']})")
+        return ListUsersResult(
+            members=result["data"],
+            total_count=len(result["data"]),
+            next_cursor=result["cursor"],
+            has_more=result["has_more"],
+        )


### PR DESCRIPTION
## Summary
- Fix `list_users` MCP tool to pass `has_more` flag when fetching a single page
- The client already computes `has_more` based on cursor presence in response headers, but the tool was not forwarding it to the result
- This allows the model to know when there are more results available beyond the current page

## Test plan
- [x] Existing VCR tests pass (`tests/tools/vcr/test_list_users.py`)

Issue: APPAI-393

<img width="862" height="327" alt="image" src="https://github.com/user-attachments/assets/2970922f-5982-4a60-b1a4-ff2819f60fa0" />
