### PR TITLE
Remove repository_name param as it is unreliable

### DIFF
--- a/packages/developer_mcp_server/src/developer_mcp_server/register_tools.py
+++ b/packages/developer_mcp_server/src/developer_mcp_server/register_tools.py
@@ -51,9 +51,9 @@ All tools operate within your IDE environment to provide immediate feedback and 
 def register_developer_tools(mcp: AbstractGitGuardianFastMCP):
     mcp.tool(
         remediate_secret_incidents,
-        description="Find and fix secrets in the current repository using exact match locations (file paths, line numbers, character indices). "
-        "This tool leverages the occurrences API to provide precise remediation instructions without needing to search for secrets in files. "
-        "By default, this only shows incidents assigned to the current user. Pass mine=False to get all incidents related to this repo.",
+        description="List secrets in a given source (identified by source_id) and return exact match locations (file paths, line numbers, character indices). "
+        "along with precise remediation instructions. This tool leverages the occurrences API."
+        "By default, this only shows incidents assigned to the current user. Pass mine=False to get all incidents related to this source.",
         required_scopes=["incidents:read", "sources:read"],
     )
 
@@ -73,7 +73,7 @@ def register_developer_tools(mcp: AbstractGitGuardianFastMCP):
     mcp.tool(
         list_incidents,
         description="List secret incidents with advanced filtering options. "
-        "Filter by repository (via repository_name or source_ids), detector type, severity, status, and more. "
+        "Filter by repository (via source_ids), detector type, severity, status, and more. "
         "With mine=True, this tool only shows incidents assigned to the current user.",
         required_scopes=["incidents:read", "sources:read"],
     )

--- a/packages/secops_mcp_server/src/secops_mcp_server/server.py
+++ b/packages/secops_mcp_server/src/secops_mcp_server/server.py
@@ -240,7 +240,7 @@ mcp.tool(
 
 mcp.tool(
     list_incidents,
-    description="List secret incidents with advanced filtering options including detector type, secret category, source criticality, and public exposure. Uses page-based pagination. Status values: TRIGGERED, ASSIGNED, RESOLVED, IGNORED.",
+    description="List secret incidents with advanced filtering options including detector type, secret category, source criticality, and public exposure. Filter by repository using source_ids. Uses page-based pagination. Status values: TRIGGERED, ASSIGNED, RESOLVED, IGNORED.",
     required_scopes=["incidents:read"],
 )
 

--- a/tests/cassettes/tools/vcr/test_list_repo_occurrences_with_mine_true.yaml
+++ b/tests/cassettes/tools/vcr/test_list_repo_occurrences_with_mine_true.yaml
@@ -80,7 +80,7 @@ interactions:
       User-Agent:
       - GitGuardian-MCP-Server/1.0
     method: GET
-    uri: https://api.gitguardian.com/v1/occurrences/secrets?source_type=github&exclude_tags=TEST_FILE%2CFALSE_POSITIVE%2CCHECK_RUN_SKIP_FALSE_POSITIVE%2CCHECK_RUN_SKIP_LOW_RISK%2CCHECK_RUN_SKIP_TEST_CRED&per_page=10&severity=critical%2Chigh%2Cmedium%2Cunknown&validity=valid%2Cfailed_to_check%2Cno_checker%2Cunknown&status=TRIGGERED%2CASSIGNED%2CRESOLVED&with_sources=false&member_assignee_id=480870
+    uri: https://api.gitguardian.com/v1/occurrences/secrets?exclude_tags=TEST_FILE%2CFALSE_POSITIVE%2CCHECK_RUN_SKIP_FALSE_POSITIVE%2CCHECK_RUN_SKIP_LOW_RISK%2CCHECK_RUN_SKIP_TEST_CRED&per_page=10&severity=critical%2Chigh%2Cmedium%2Cunknown&validity=valid%2Cfailed_to_check%2Cno_checker%2Cunknown&status=TRIGGERED%2CASSIGNED%2CRESOLVED&with_sources=false&member_assignee_id=480870
   response:
     body:
       string: '[{"id": 78199, "incident_id": 21461, "date": "2020-10-29T10:19:39.723768Z",
@@ -170,7 +170,7 @@ interactions:
       date:
       - Thu, 05 Feb 2026 08:03:32 GMT
       link:
-      - <https://api.gitguardian.com/v1/occurrences/secrets?cursor=cD03ODIxOA%3D%3D&exclude_tags=TEST_FILE%2CFALSE_POSITIVE%2CCHECK_RUN_SKIP_FALSE_POSITIVE%2CCHECK_RUN_SKIP_LOW_RISK%2CCHECK_RUN_SKIP_TEST_CRED&member_assignee_id=480870&per_page=10&severity=critical%2Chigh%2Cmedium%2Cunknown&source_type=github&status=TRIGGERED%2CASSIGNED%2CRESOLVED&validity=valid%2Cfailed_to_check%2Cno_checker%2Cunknown&with_sources=false>;
+      - <https://api.gitguardian.com/v1/occurrences/secrets?cursor=cD03ODIxOA%3D%3D&exclude_tags=TEST_FILE%2CFALSE_POSITIVE%2CCHECK_RUN_SKIP_FALSE_POSITIVE%2CCHECK_RUN_SKIP_LOW_RISK%2CCHECK_RUN_SKIP_TEST_CRED&member_assignee_id=480870&per_page=10&severity=critical%2Chigh%2Cmedium%2Cunknown&status=TRIGGERED%2CASSIGNED%2CRESOLVED&validity=valid%2Cfailed_to_check%2Cno_checker%2Cunknown&with_sources=false>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -387,20 +387,8 @@ def mock_gitguardian_client(request):
         # Also patch GitGuardianClient constructor to prevent any direct instantiation
         stack.enter_context(patch("gg_api_core.utils.GitGuardianClient", return_value=mock_client))
 
-        # Patch find_current_source_id to avoid real GitHub calls
-        from gg_api_core.tools.find_current_source_id import FindCurrentSourceIdResult
-
-        mock_find_source_result = FindCurrentSourceIdResult(
-            repository_name="GitGuardian/test-repo",
-            source_id="source_123",
-            message="Found source",
-        )
-        stack.enter_context(
-            patch(
-                "gg_api_core.tools.list_incidents.find_current_source_id",
-                new_callable=lambda: AsyncMock(return_value=mock_find_source_result),
-            )
-        )
+        # Note: find_current_source_id is no longer called by list_incidents
+        # (repository_name param was removed), so no patching needed here
 
         # Reset the singleton to None before each test to ensure clean state
         import gg_api_core.utils

--- a/tests/tools/test_remediate_secret_incidents.py
+++ b/tests/tools/test_remediate_secret_incidents.py
@@ -1,7 +1,10 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from gg_api_core.tools.list_repo_occurrences import ListRepoOccurrencesError, ListRepoOccurrencesResult
+from gg_api_core.tools.list_repo_occurrences import (
+    ListRepoOccurrencesError,
+    ListRepoOccurrencesResult,
+)
 from gg_api_core.tools.remediate_secret_incidents import (
     ListRepoOccurrencesParamsForRemediate,
     RemediateSecretIncidentsParams,
@@ -13,16 +16,6 @@ from gg_api_core.tools.remediate_secret_incidents import (
 class TestRemediateSecretIncidentsParams:
     """Tests for RemediateSecretIncidentsParams validation."""
 
-    def test_params_with_repository_name(self):
-        """
-        GIVEN: RemediateSecretIncidentsParams with repository_name provided
-        WHEN: Creating the params
-        THEN: Validation should pass
-        """
-        params = RemediateSecretIncidentsParams(repository_name="GitGuardian/test-repo")
-        assert params.repository_name == "GitGuardian/test-repo"
-        assert params.source_id is None
-
     def test_params_with_source_id(self):
         """
         GIVEN: RemediateSecretIncidentsParams with source_id provided
@@ -31,26 +24,14 @@ class TestRemediateSecretIncidentsParams:
         """
         params = RemediateSecretIncidentsParams(source_id="source_123")
         assert params.source_id == "source_123"
-        assert params.repository_name is None
 
-    def test_params_with_both_repository_name_and_source_id(self):
+    def test_params_with_no_source_id(self):
         """
-        GIVEN: RemediateSecretIncidentsParams with both repository_name and source_id provided
-        WHEN: Creating the params
-        THEN: Validation should pass
-        """
-        params = RemediateSecretIncidentsParams(repository_name="GitGuardian/test-repo", source_id="source_123")
-        assert params.repository_name == "GitGuardian/test-repo"
-        assert params.source_id == "source_123"
-
-    def test_params_with_neither_repository_name_nor_source_id(self):
-        """
-        GIVEN: RemediateSecretIncidentsParams with neither repository_name nor source_id provided
+        GIVEN: RemediateSecretIncidentsParams with no source_id provided
         WHEN: Creating the params
         THEN: Validation should pass and return all occurrences
         """
         params = RemediateSecretIncidentsParams()
-        assert params.repository_name is None
         assert params.source_id is None
         assert params.list_repo_occurrences_params is not None
 
@@ -61,13 +42,11 @@ class TestRemediateSecretIncidentsParams:
         THEN: Nested params should be properly set
         """
         params = RemediateSecretIncidentsParams(
-            repository_name="GitGuardian/test-repo",
-            list_repo_occurrences_params=ListRepoOccurrencesParamsForRemediate(
-                repository_name="GitGuardian/test-repo", per_page=20
-            ),
+            source_id="source_123",
+            list_repo_occurrences_params=ListRepoOccurrencesParamsForRemediate(source_id="source_123", per_page=20),
         )
         assert params.list_repo_occurrences_params.per_page == 20
-        assert params.list_repo_occurrences_params.repository_name == "GitGuardian/test-repo"
+        assert params.list_repo_occurrences_params.source_id == "source_123"
 
 
 class TestRemediateSecretIncidents:
@@ -118,9 +97,7 @@ class TestRemediateSecretIncidents:
             AsyncMock(return_value=mock_occurrences),
         ):
             # Call the function
-            result = await remediate_secret_incidents(
-                RemediateSecretIncidentsParams(repository_name="GitGuardian/test-repo")
-            )
+            result = await remediate_secret_incidents(RemediateSecretIncidentsParams(source_id="source_123"))
 
             # Verify response structure
             assert result.remediation_instructions is not None
@@ -155,9 +132,7 @@ class TestRemediateSecretIncidents:
             AsyncMock(return_value=mock_occurrences),
         ):
             # Call the function
-            result = await remediate_secret_incidents(
-                RemediateSecretIncidentsParams(repository_name="GitGuardian/test-repo")
-            )
+            result = await remediate_secret_incidents(RemediateSecretIncidentsParams(source_id="source_123"))
 
             # Verify response
             assert result.remediation_instructions is not None
@@ -182,9 +157,7 @@ class TestRemediateSecretIncidents:
             AsyncMock(return_value=mock_occurrences),
         ):
             # Call the function
-            result = await remediate_secret_incidents(
-                RemediateSecretIncidentsParams(repository_name="GitGuardian/test-repo")
-            )
+            result = await remediate_secret_incidents(RemediateSecretIncidentsParams(source_id="source_123"))
 
             # Verify error response
             assert hasattr(result, "error")
@@ -234,7 +207,7 @@ class TestRemediateSecretIncidents:
         ):
             # Call the function with mine=False
             result = await remediate_secret_incidents(
-                RemediateSecretIncidentsParams(repository_name="GitGuardian/test-repo", mine=False)
+                RemediateSecretIncidentsParams(source_id="source_123", mine=False)
             )
 
             # Verify all occurrences are included (not filtered by assignee)
@@ -287,7 +260,7 @@ class TestRemediateSecretIncidents:
             # Call the function with git_commands=False
             result = await remediate_secret_incidents(
                 RemediateSecretIncidentsParams(
-                    repository_name="GitGuardian/test-repo",
+                    source_id="source_123",
                     git_commands=False,
                     mine=False,
                 )
@@ -343,7 +316,7 @@ class TestRemediateSecretIncidents:
             # Call the function with create_env_example=False
             result = await remediate_secret_incidents(
                 RemediateSecretIncidentsParams(
-                    repository_name="GitGuardian/test-repo",
+                    source_id="source_123",
                     create_env_example=False,
                     mine=False,
                 )
@@ -417,7 +390,7 @@ class TestRemediateSecretIncidents:
         ):
             # Call the function
             result = await remediate_secret_incidents(
-                RemediateSecretIncidentsParams(repository_name="GitGuardian/test-repo", mine=False)
+                RemediateSecretIncidentsParams(source_id="source_123", mine=False)
             )
 
             # Verify response
@@ -442,7 +415,6 @@ class TestRemediateSecretIncidentsResultSerialization:
         """
         # Create a nested ListRepoOccurrencesResult
         nested_result = ListRepoOccurrencesResult(
-            repository="GitGuardian/test-repo",
             occurrences_count=2,
             occurrences=[
                 {"id": "occ_1", "filepath": "config.py"},
@@ -472,7 +444,6 @@ class TestRemediateSecretIncidentsResultSerialization:
         # Verify the nested result is fully serialized
         nested_serialized = serialized["sub_tools_results"]["list_repo_occurrences"]
         assert nested_serialized != {}
-        assert nested_serialized["repository"] == "GitGuardian/test-repo"
         assert nested_serialized["occurrences_count"] == 2
         assert len(nested_serialized["occurrences"]) == 2
         assert nested_serialized["occurrences"][0]["id"] == "occ_1"
@@ -490,7 +461,6 @@ class TestRemediateSecretIncidentsResultSerialization:
         import json
 
         nested_result = ListRepoOccurrencesResult(
-            repository="GitGuardian/test-repo",
             occurrences_count=1,
             occurrences=[{"id": "occ_1", "filepath": "secret.py"}],
         )
@@ -508,6 +478,5 @@ class TestRemediateSecretIncidentsResultSerialization:
 
         # Verify nested data is present in JSON
         nested_json = parsed["sub_tools_results"]["list_repo_occurrences"]
-        assert nested_json["repository"] == "GitGuardian/test-repo"
         assert nested_json["occurrences_count"] == 1
         assert nested_json["occurrences"][0]["id"] == "occ_1"


### PR DESCRIPTION
Remove repository_name param as it is unreliable. source_id is better and works well in conjuction with list_sources

Issue: APPAI-407