### PR TITLE
Don't silently bump major versions of dependencies.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --all-groups
+        run: uv sync --frozen --all-groups
 
       - name: Run ruff check
         run: uv run ruff check .
@@ -51,7 +51,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --all-groups
+        run: uv sync --frozen --all-groups
 
       - name: Run mypy
         run: uv run mypy packages/
@@ -74,7 +74,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --all-groups
+        run: uv sync --frozen --all-groups
 
       - name: Run unit tests
         env:
@@ -99,7 +99,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --all-groups
+        run: uv sync --frozen --all-groups
 
       - name: Run VCR tests
         env:

--- a/packages/developer_mcp_server/pyproject.toml
+++ b/packages/developer_mcp_server/pyproject.toml
@@ -24,11 +24,11 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = {text = "MIT"}
 dependencies = [
-    "fastmcp>=2.0.0,<3.0.0",
-    "httpx>=0.24.0",
-    "pydantic>=2.0.0",
+    "fastmcp~=2.13",
+    "httpx~=0.28",
+    "pydantic~=2.12",
     "gg-api-core",
-    "uvicorn>=0.27.0"
+    "uvicorn~=0.34"
 ]
 
 [project.optional-dependencies]

--- a/packages/gg_api_core/pyproject.toml
+++ b/packages/gg_api_core/pyproject.toml
@@ -24,16 +24,16 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = {text = "MIT"}
 dependencies = [
-    "httpx>=0.28.1",
-    "fastmcp>=2.0.0,<3.0.0",
-    "python-dotenv>=1.0.0",
-    "pydantic-settings>=2.0.0",
-    "jinja2>=3.1.0",
+    "httpx~=0.28",
+    "fastmcp~=2.13",
+    "python-dotenv~=1.1",
+    "pydantic-settings~=2.9",
+    "jinja2~=3.1",
 ]
 
 [project.optional-dependencies]
 sentry = [
-    "sentry-sdk>=2.0.0",
+    "sentry-sdk~=2.43",
 ]
 
 [build-system]

--- a/packages/secops_mcp_server/pyproject.toml
+++ b/packages/secops_mcp_server/pyproject.toml
@@ -25,12 +25,12 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = {text = "MIT"}
 dependencies = [
-    "fastmcp>=2.0.0,<3.0.0",
-    "httpx>=0.24.0",
-    "pydantic>=2.0.0",
+    "fastmcp~=2.13",
+    "httpx~=0.28",
+    "pydantic~=2.12",
     "gg-api-core",
-    "uvicorn>=0.27.0",
-    "gunicorn>=23.0.0"
+    "uvicorn~=0.34",
+    "gunicorn~=23.0"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ requires-python = ">=3.10"
 dependencies = [
     "developer-mcp-server",
     "secops-mcp-server",
-    "mcp>=1.23.0",  # CVE-2025-66416 / GHSA-9h52-p55h-vw2f: DNS rebinding vulnerability
+    "mcp~=1.24",  # CVE-2025-66416 / GHSA-9h52-p55h-vw2f: DNS rebinding vulnerability
 ]
 
 [project.urls]
@@ -44,14 +44,14 @@ Homepage = "https://github.com/GitGuardian/ggmcp"
 
 [dependency-groups]
 dev = [
-    "mypy>=1.0.0",
-    "pytest>=8.0.0",
-    "pytest-asyncio>=0.24.0",
-    "pytest-cov>=4.1.0",
-    "pytest-mock>=3.12.0",
-    "ruff>=0.8.0",
-    "vcrpy>=6.0.0",
-    "pyyaml>=6.0.0",
+    "mypy~=1.18",
+    "pytest~=8.4",
+    "pytest-asyncio~=1.2",
+    "pytest-cov~=7.0",
+    "pytest-mock~=3.15",
+    "ruff~=0.14",
+    "vcrpy~=8.0",
+    "pyyaml~=6.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -441,12 +441,12 @@ sentry = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=2.0.0" },
+    { name = "fastmcp", specifier = "~=2.13" },
     { name = "gg-api-core", editable = "packages/gg_api_core" },
     { name = "gg-api-core", extras = ["sentry"], marker = "extra == 'sentry'", editable = "packages/gg_api_core" },
-    { name = "httpx", specifier = ">=0.24.0" },
-    { name = "pydantic", specifier = ">=2.0.0" },
-    { name = "uvicorn", specifier = ">=0.27.0" },
+    { name = "httpx", specifier = "~=0.28" },
+    { name = "pydantic", specifier = "~=2.12" },
+    { name = "uvicorn", specifier = "~=0.34" },
 ]
 
 [[package]]
@@ -554,12 +554,12 @@ sentry = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=2.0.0" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "jinja2", specifier = ">=3.1.0" },
-    { name = "pydantic-settings", specifier = ">=2.0.0" },
-    { name = "python-dotenv", specifier = ">=1.0.0" },
-    { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = ">=2.0.0" },
+    { name = "fastmcp", specifier = "~=2.13" },
+    { name = "httpx", specifier = "~=0.28" },
+    { name = "jinja2", specifier = "~=3.1" },
+    { name = "pydantic-settings", specifier = "~=2.9" },
+    { name = "python-dotenv", specifier = "~=1.1" },
+    { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = "~=2.43" },
 ]
 
 [[package]]
@@ -587,20 +587,20 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "developer-mcp-server", editable = "packages/developer_mcp_server" },
-    { name = "mcp", specifier = ">=1.23.0" },
+    { name = "mcp", specifier = "~=1.24" },
     { name = "secops-mcp-server", editable = "packages/secops_mcp_server" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=1.0.0" },
-    { name = "pytest", specifier = ">=8.0.0" },
-    { name = "pytest-asyncio", specifier = ">=0.24.0" },
-    { name = "pytest-cov", specifier = ">=4.1.0" },
-    { name = "pytest-mock", specifier = ">=3.12.0" },
-    { name = "pyyaml", specifier = ">=6.0.0" },
-    { name = "ruff", specifier = ">=0.8.0" },
-    { name = "vcrpy", specifier = ">=6.0.0" },
+    { name = "mypy", specifier = "~=1.18" },
+    { name = "pytest", specifier = "~=8.4" },
+    { name = "pytest-asyncio", specifier = "~=1.2" },
+    { name = "pytest-cov", specifier = "~=7.0" },
+    { name = "pytest-mock", specifier = "~=3.15" },
+    { name = "pyyaml", specifier = "~=6.0" },
+    { name = "ruff", specifier = "~=0.14" },
+    { name = "vcrpy", specifier = "~=8.0" },
 ]
 
 [[package]]
@@ -1613,13 +1613,13 @@ sentry = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=2.0.0" },
+    { name = "fastmcp", specifier = "~=2.13" },
     { name = "gg-api-core", editable = "packages/gg_api_core" },
     { name = "gg-api-core", extras = ["sentry"], marker = "extra == 'sentry'", editable = "packages/gg_api_core" },
-    { name = "gunicorn", specifier = ">=23.0.0" },
-    { name = "httpx", specifier = ">=0.24.0" },
-    { name = "pydantic", specifier = ">=2.0.0" },
-    { name = "uvicorn", specifier = ">=0.27.0" },
+    { name = "gunicorn", specifier = "~=23.0" },
+    { name = "httpx", specifier = "~=0.28" },
+    { name = "pydantic", specifier = "~=2.12" },
+    { name = "uvicorn", specifier = "~=0.34" },
 ]
 
 [[package]]


### PR DESCRIPTION
Don't silently bump major versions of dependencies.

I "pinned to compatible versions" all dependencies to their current value in uv.lock. (means : not pinned, but prevented from bumping major versions)