### PR TITLE
feat(api): add list incident members and teams MCP tools

### DIFF
--- a/packages/developer_mcp_server/src/developer_mcp_server/register_tools.py
+++ b/packages/developer_mcp_server/src/developer_mcp_server/register_tools.py
@@ -6,6 +6,8 @@ from gg_api_core.tools.get_incident import get_incident
 from gg_api_core.tools.get_member import get_member
 from gg_api_core.tools.list_detectors import list_detectors
 from gg_api_core.tools.list_honeytokens import list_honeytokens
+from gg_api_core.tools.list_incident_members import list_incident_members
+from gg_api_core.tools.list_incident_teams import list_incident_teams
 from gg_api_core.tools.list_incidents import list_incidents
 from gg_api_core.tools.list_repo_occurrences import list_repo_occurrences
 from gg_api_core.tools.list_sources import list_sources
@@ -144,4 +146,16 @@ def register_developer_tools(mcp: AbstractGitGuardianFastMCP):
         get_member,
         description="Retrieve a specific member by their ID with information including name, email, role, access level, and activity status.",
         required_scopes=["members:read"],
+    )
+
+    mcp.tool(
+        list_incident_members,
+        description="List members with access to a secret incident. Filter by access level, search by name/email, and filter on direct or indirect accesses.",
+        required_scopes=["incidents:read"],
+    )
+
+    mcp.tool(
+        list_incident_teams,
+        description="List teams with access to a secret incident. Search by team name/description and filter on direct or indirect accesses.",
+        required_scopes=["incidents:read"],
     )

--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -1497,17 +1497,53 @@ class GitGuardianClient:
         logger.info(f"Revoking access to incident {incident_id} from member {member_id}")
         return await self._request_post(f"/incidents/secrets/{incident_id}/revoke_access", json=payload)
 
-    async def list_incident_members(self, incident_id: str) -> dict[str, Any]:
+    async def list_incident_members(
+        self,
+        incident_id: int,
+        params: dict[str, Any] | None = None,
+        get_all: bool = False,
+    ) -> ListResponse:
         """List members having access to a secret incident.
 
         Args:
             incident_id: ID of the secret incident
+            params: Optional query parameters for filtering and pagination
+            get_all: If True, fetch all pages using paginate_all
 
         Returns:
-            List of members with access to the incident
+            ListResponse with data, cursor, and has_more fields
         """
         logger.info(f"Listing members with access to incident {incident_id}")
-        return await self._request_get(f"/incidents/secrets/{incident_id}/members")
+        endpoint = f"/incidents/secrets/{incident_id}/members"
+
+        if get_all:
+            return await self.paginate_all(endpoint, params)
+
+        return await self._request_list(endpoint, params=params)
+
+    async def list_incident_teams(
+        self,
+        incident_id: int,
+        params: dict[str, Any] | None = None,
+        get_all: bool = False,
+    ) -> ListResponse:
+        """List teams having access to a secret incident.
+
+        Args:
+            incident_id: ID of the secret incident
+            params: Optional query parameters for filtering and pagination
+            get_all: If True, fetch all pages using paginate_all
+
+        Returns:
+            ListResponse with data, cursor, and has_more fields
+        """
+        logger.info(f"Listing teams with access to incident {incident_id}")
+        endpoint = f"/incidents/secrets/{incident_id}/teams"
+
+        if get_all:
+            return await self.paginate_all(endpoint, params)
+
+        return await self._request_list(endpoint, params=params)
 
     async def get_incident_impacted_perimeter(self, incident_id: str) -> dict[str, Any]:
         """Retrieve the impacted perimeter of a secret incident.

--- a/packages/gg_api_core/src/gg_api_core/tools/list_incident_members.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_incident_members.py
@@ -1,0 +1,107 @@
+import json
+import logging
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from gg_api_core.client import DEFAULT_PAGINATION_MAX_BYTES
+from gg_api_core.utils import get_client
+
+logger = logging.getLogger(__name__)
+
+
+class ListIncidentMembersParams(BaseModel):
+    """Parameters for listing members with access to a secret incident."""
+
+    incident_id: int = Field(description="The ID of the secret incident to retrieve members for")
+    cursor: str | None = Field(default=None, description="Pagination cursor for fetching next page of results")
+    per_page: int = Field(
+        default=20,
+        description="Number of results per page (default: 20, min: 1, max: 100)",
+    )
+    access_level: str | None = Field(
+        default=None,
+        description="Filter members based on their access level (owner, manager, member, restricted)",
+    )
+    search: str | None = Field(default=None, description="Search members based on their name or email")
+    ordering: str | None = Field(
+        default=None,
+        description="Sort results by field (created_at, -created_at, last_login, -last_login). Use '-' prefix for descending order",
+    )
+    direct_access: bool | None = Field(
+        default=None,
+        description="Filter on direct or indirect accesses",
+    )
+    get_all: bool = Field(
+        default=False,
+        description=f"If True, fetch all pages (capped at ~{DEFAULT_PAGINATION_MAX_BYTES / 1000}KB; check 'has_more' and use cursor to continue)",
+    )
+
+
+class ListIncidentMembersResult(BaseModel):
+    """Result from listing members with access to a secret incident."""
+
+    members: list[dict[str, Any]] = Field(description="List of member objects with access to the incident")
+    total_count: int = Field(description="Total number of members returned")
+    next_cursor: str | None = Field(default=None, description="Pagination cursor for next page (if applicable)")
+    has_more: bool = Field(
+        default=False,
+        description="True if more results exist (use next_cursor to fetch)",
+    )
+
+
+async def list_incident_members(params: ListIncidentMembersParams) -> ListIncidentMembersResult:
+    """
+    List members with access to a secret incident.
+
+    Returns information about members who have access to a specific secret incident,
+    including their ID, name, email, role, access level, active status, creation date,
+    and last login.
+
+    Args:
+        params: ListIncidentMembersParams model containing incident ID and filtering/pagination options
+
+    Returns:
+        ListIncidentMembersResult: Pydantic model containing:
+            - members: List of member objects with access information
+            - total_count: Total number of members returned
+            - next_cursor: Pagination cursor for next page (if applicable)
+            - has_more: Whether more results are available
+
+    Raises:
+        ToolError: If the listing operation fails
+    """
+    client = await get_client()
+    logger.debug(f"Listing members with access to incident {params.incident_id}")
+
+    # Build query parameters
+    query_params: dict[str, Any] = {}
+
+    if params.cursor:
+        query_params["cursor"] = params.cursor
+    if params.per_page:
+        query_params["per_page"] = params.per_page
+    if params.access_level:
+        query_params["access_level"] = params.access_level
+    if params.search:
+        query_params["search"] = params.search
+    if params.ordering:
+        query_params["ordering"] = params.ordering
+    if params.direct_access is not None:
+        query_params["direct_access"] = "true" if params.direct_access else "false"
+
+    logger.debug(f"Query parameters: {json.dumps(query_params)}")
+
+    result = await client.list_incident_members(
+        incident_id=params.incident_id,
+        params=query_params,
+        get_all=params.get_all,
+    )
+
+    logger.debug(f"Found {len(result['data'])} members (has_more={result['has_more']})")
+    return ListIncidentMembersResult(
+        members=result["data"],
+        total_count=len(result["data"]),
+        next_cursor=result["cursor"],
+        has_more=result["has_more"],
+    )

--- a/packages/gg_api_core/src/gg_api_core/tools/list_incident_teams.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_incident_teams.py
@@ -1,0 +1,94 @@
+import json
+import logging
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from gg_api_core.client import DEFAULT_PAGINATION_MAX_BYTES
+from gg_api_core.utils import get_client
+
+logger = logging.getLogger(__name__)
+
+
+class ListIncidentTeamsParams(BaseModel):
+    """Parameters for listing teams with access to a secret incident."""
+
+    incident_id: int = Field(description="The ID of the secret incident to retrieve teams for")
+    cursor: str | None = Field(default=None, description="Pagination cursor for fetching next page of results")
+    per_page: int = Field(
+        default=20,
+        description="Number of results per page (default: 20, min: 1, max: 100)",
+    )
+    search: str | None = Field(default=None, description="Search teams based on their name and/or description")
+    direct_access: bool | None = Field(
+        default=None,
+        description="Filter on direct or indirect accesses",
+    )
+    get_all: bool = Field(
+        default=False,
+        description=f"If True, fetch all pages (capped at ~{DEFAULT_PAGINATION_MAX_BYTES / 1000}KB; check 'has_more' and use cursor to continue)",
+    )
+
+
+class ListIncidentTeamsResult(BaseModel):
+    """Result from listing teams with access to a secret incident."""
+
+    teams: list[dict[str, Any]] = Field(description="List of team objects with access to the incident")
+    total_count: int = Field(description="Total number of teams returned")
+    next_cursor: str | None = Field(default=None, description="Pagination cursor for next page (if applicable)")
+    has_more: bool = Field(
+        default=False,
+        description="True if more results exist (use next_cursor to fetch)",
+    )
+
+
+async def list_incident_teams(params: ListIncidentTeamsParams) -> ListIncidentTeamsResult:
+    """
+    List teams with access to a secret incident.
+
+    Returns information about teams who have access to a specific secret incident,
+    including their ID, name, description, global status, GitGuardian URL, and external provider ID.
+
+    Args:
+        params: ListIncidentTeamsParams model containing incident ID and filtering/pagination options
+
+    Returns:
+        ListIncidentTeamsResult: Pydantic model containing:
+            - teams: List of team objects with access information
+            - total_count: Total number of teams returned
+            - next_cursor: Pagination cursor for next page (if applicable)
+            - has_more: Whether more results are available
+
+    Raises:
+        ToolError: If the listing operation fails
+    """
+    client = await get_client()
+    logger.debug(f"Listing teams with access to incident {params.incident_id}")
+
+    # Build query parameters
+    query_params: dict[str, Any] = {}
+
+    if params.cursor:
+        query_params["cursor"] = params.cursor
+    if params.per_page:
+        query_params["per_page"] = params.per_page
+    if params.search:
+        query_params["search"] = params.search
+    if params.direct_access is not None:
+        query_params["direct_access"] = "true" if params.direct_access else "false"
+
+    logger.debug(f"Query parameters: {json.dumps(query_params)}")
+
+    result = await client.list_incident_teams(
+        incident_id=params.incident_id,
+        params=query_params,
+        get_all=params.get_all,
+    )
+
+    logger.debug(f"Found {len(result['data'])} teams (has_more={result['has_more']})")
+    return ListIncidentTeamsResult(
+        teams=result["data"],
+        total_count=len(result["data"]),
+        next_cursor=result["cursor"],
+        has_more=result["has_more"],
+    )

--- a/tests/cassettes/tools/vcr/test_list_incident_members_basic.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incident_members_basic.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/1.0
+    method: GET
+    uri: https://api.gitguardian.com/v1/incidents/secrets/21460/members?per_page=5
+  response:
+    body:
+      string: '[{"id": 10, "member_id": 10, "role": "manager", "name": "Bruce Wayne",
+        "email": "bruce-wayne-gg@protonmail.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 13, "member_id": 13, "role": "manager", "name": "Aymeric
+        Sicard", "email": "aymeric.sicard@gitguardian.com", "incident_id": 21460,
+        "incident_permission": "full_access"}, {"id": 2508, "member_id": 2508, "role":
+        "manager", "name": "Guillaume Charpiat", "email": "guillaume.charpiat@gitguardian.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 37699,
+        "member_id": 37699, "role": "manager", "name": "Alexis Larnaud", "email":
+        "alexis.larnaud@gitguardian.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 63809, "member_id": 63809, "role": "manager", "name":
+        "Orian Roturier", "email": "orian.roturier@gitguardian.com", "incident_id":
+        21460, "incident_permission": "full_access"}]'
+    headers:
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      content-length:
+      - '836'
+      content-security-policy:
+      - frame-ancestors 'none'
+      content-type:
+      - application/json
+      cross-origin-opener-policy:
+      - same-origin
+      date:
+      - Wed, 04 Mar 2026 11:39:06 GMT
+      link:
+      - <https://api.gitguardian.com/v1/incidents/secrets/21460/members?cursor=cD02MzgwOQ%3D%3D&per_page=5>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      server:
+      - istio-envoy
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.404.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '47'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.157.1
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/tools/vcr/test_list_incident_members_with_access_level.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incident_members_with_access_level.yaml
@@ -1,0 +1,87 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/1.0
+    method: GET
+    uri: https://api.gitguardian.com/v1/incidents/secrets/21460/members?per_page=10&access_level=owner
+  response:
+    body:
+      string: '[{"id": 10, "member_id": 10, "role": "manager", "name": "Bruce Wayne",
+        "email": "bruce-wayne-gg@protonmail.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 13, "member_id": 13, "role": "manager", "name": "Aymeric
+        Sicard", "email": "aymeric.sicard@gitguardian.com", "incident_id": 21460,
+        "incident_permission": "full_access"}, {"id": 2508, "member_id": 2508, "role":
+        "manager", "name": "Guillaume Charpiat", "email": "guillaume.charpiat@gitguardian.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 37699,
+        "member_id": 37699, "role": "manager", "name": "Alexis Larnaud", "email":
+        "alexis.larnaud@gitguardian.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 63809, "member_id": 63809, "role": "manager", "name":
+        "Orian Roturier", "email": "orian.roturier@gitguardian.com", "incident_id":
+        21460, "incident_permission": "full_access"}, {"id": 69474, "member_id": 69474,
+        "role": "member", "name": "Eric", "email": "elacaille0@gmail.com", "incident_id":
+        21460, "incident_permission": "can_edit"}, {"id": 104544, "member_id": 104544,
+        "role": "manager", "name": "Pierre Lalanne", "email": "pierre.lalanne@gitguardian.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 104916,
+        "member_id": 104916, "role": "manager", "name": "wassim hana", "email": "wassim.hana@gitguardian.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 113168,
+        "member_id": 113168, "role": "owner", "name": "Henri Hubert", "email": "henri.hubert@gitguardian.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 136170,
+        "member_id": 136170, "role": "manager", "name": "Eric Fourrier", "email":
+        "eric.fourrier@gitguardian.com", "incident_id": 21460, "incident_permission":
+        "full_access"}]'
+    headers:
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      content-length:
+      - '1651'
+      content-security-policy:
+      - frame-ancestors 'none'
+      content-type:
+      - application/json
+      cross-origin-opener-policy:
+      - same-origin
+      date:
+      - Wed, 04 Mar 2026 11:39:07 GMT
+      link:
+      - <https://api.gitguardian.com/v1/incidents/secrets/21460/members?access_level=owner&cursor=cD0xMzYxNzA%3D&per_page=10>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      server:
+      - istio-envoy
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.404.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '36'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '10'
+      x-secrets-engine-version:
+      - 2.157.1
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/tools/vcr/test_list_incident_members_with_direct_access.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incident_members_with_direct_access.yaml
@@ -1,0 +1,87 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/1.0
+    method: GET
+    uri: https://api.gitguardian.com/v1/incidents/secrets/21460/members?per_page=10&direct_access=true
+  response:
+    body:
+      string: '[{"id": 10, "member_id": 10, "role": "manager", "name": "Bruce Wayne",
+        "email": "bruce-wayne-gg@protonmail.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 13, "member_id": 13, "role": "manager", "name": "Aymeric
+        Sicard", "email": "aymeric.sicard@gitguardian.com", "incident_id": 21460,
+        "incident_permission": "full_access"}, {"id": 2508, "member_id": 2508, "role":
+        "manager", "name": "Guillaume Charpiat", "email": "guillaume.charpiat@gitguardian.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 37699,
+        "member_id": 37699, "role": "manager", "name": "Alexis Larnaud", "email":
+        "alexis.larnaud@gitguardian.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 63809, "member_id": 63809, "role": "manager", "name":
+        "Orian Roturier", "email": "orian.roturier@gitguardian.com", "incident_id":
+        21460, "incident_permission": "full_access"}, {"id": 69474, "member_id": 69474,
+        "role": "member", "name": "Eric", "email": "elacaille0@gmail.com", "incident_id":
+        21460, "incident_permission": "can_edit"}, {"id": 104544, "member_id": 104544,
+        "role": "manager", "name": "Pierre Lalanne", "email": "pierre.lalanne@gitguardian.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 104916,
+        "member_id": 104916, "role": "manager", "name": "wassim hana", "email": "wassim.hana@gitguardian.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 113168,
+        "member_id": 113168, "role": "owner", "name": "Henri Hubert", "email": "henri.hubert@gitguardian.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 136170,
+        "member_id": 136170, "role": "manager", "name": "Eric Fourrier", "email":
+        "eric.fourrier@gitguardian.com", "incident_id": 21460, "incident_permission":
+        "full_access"}]'
+    headers:
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      content-length:
+      - '1651'
+      content-security-policy:
+      - frame-ancestors 'none'
+      content-type:
+      - application/json
+      cross-origin-opener-policy:
+      - same-origin
+      date:
+      - Wed, 04 Mar 2026 11:39:09 GMT
+      link:
+      - <https://api.gitguardian.com/v1/incidents/secrets/21460/members?cursor=cD0xMzYxNzA%3D&direct_access=true&per_page=10>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      server:
+      - istio-envoy
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.404.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '32'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '10'
+      x-secrets-engine-version:
+      - 2.157.1
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/tools/vcr/test_list_incident_members_with_ordering.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incident_members_with_ordering.yaml
@@ -1,0 +1,87 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/1.0
+    method: GET
+    uri: https://api.gitguardian.com/v1/incidents/secrets/21460/members?per_page=10&ordering=-created_at
+  response:
+    body:
+      string: '[{"id": 10, "member_id": 10, "role": "manager", "name": "Bruce Wayne",
+        "email": "bruce-wayne-gg@protonmail.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 13, "member_id": 13, "role": "manager", "name": "Aymeric
+        Sicard", "email": "aymeric.sicard@gitguardian.com", "incident_id": 21460,
+        "incident_permission": "full_access"}, {"id": 2508, "member_id": 2508, "role":
+        "manager", "name": "Guillaume Charpiat", "email": "guillaume.charpiat@gitguardian.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 37699,
+        "member_id": 37699, "role": "manager", "name": "Alexis Larnaud", "email":
+        "alexis.larnaud@gitguardian.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 63809, "member_id": 63809, "role": "manager", "name":
+        "Orian Roturier", "email": "orian.roturier@gitguardian.com", "incident_id":
+        21460, "incident_permission": "full_access"}, {"id": 69474, "member_id": 69474,
+        "role": "member", "name": "Eric", "email": "elacaille0@gmail.com", "incident_id":
+        21460, "incident_permission": "can_edit"}, {"id": 104544, "member_id": 104544,
+        "role": "manager", "name": "Pierre Lalanne", "email": "pierre.lalanne@gitguardian.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 104916,
+        "member_id": 104916, "role": "manager", "name": "wassim hana", "email": "wassim.hana@gitguardian.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 113168,
+        "member_id": 113168, "role": "owner", "name": "Henri Hubert", "email": "henri.hubert@gitguardian.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 136170,
+        "member_id": 136170, "role": "manager", "name": "Eric Fourrier", "email":
+        "eric.fourrier@gitguardian.com", "incident_id": 21460, "incident_permission":
+        "full_access"}]'
+    headers:
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      content-length:
+      - '1651'
+      content-security-policy:
+      - frame-ancestors 'none'
+      content-type:
+      - application/json
+      cross-origin-opener-policy:
+      - same-origin
+      date:
+      - Wed, 04 Mar 2026 11:39:08 GMT
+      link:
+      - <https://api.gitguardian.com/v1/incidents/secrets/21460/members?cursor=cD0xMzYxNzA%3D&ordering=-created_at&per_page=10>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      server:
+      - istio-envoy
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.404.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '36'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '10'
+      x-secrets-engine-version:
+      - 2.157.1
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/tools/vcr/test_list_incident_members_with_search.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incident_members_with_search.yaml
@@ -1,0 +1,87 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/1.0
+    method: GET
+    uri: https://api.gitguardian.com/v1/incidents/secrets/21460/members?per_page=10&search=gitguardian
+  response:
+    body:
+      string: '[{"id": 13, "member_id": 13, "role": "manager", "name": "Aymeric Sicard",
+        "email": "aymeric.sicard@gitguardian.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 2508, "member_id": 2508, "role": "manager", "name":
+        "Guillaume Charpiat", "email": "guillaume.charpiat@gitguardian.com", "incident_id":
+        21460, "incident_permission": "full_access"}, {"id": 37699, "member_id": 37699,
+        "role": "manager", "name": "Alexis Larnaud", "email": "alexis.larnaud@gitguardian.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 63809,
+        "member_id": 63809, "role": "manager", "name": "Orian Roturier", "email":
+        "orian.roturier@gitguardian.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 104544, "member_id": 104544, "role": "manager", "name":
+        "Pierre Lalanne", "email": "pierre.lalanne@gitguardian.com", "incident_id":
+        21460, "incident_permission": "full_access"}, {"id": 104916, "member_id":
+        104916, "role": "manager", "name": "wassim hana", "email": "wassim.hana@gitguardian.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 113168,
+        "member_id": 113168, "role": "owner", "name": "Henri Hubert", "email": "henri.hubert@gitguardian.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 136170,
+        "member_id": 136170, "role": "manager", "name": "Eric Fourrier", "email":
+        "eric.fourrier@gitguardian.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 160089, "member_id": 160089, "role": "manager", "name":
+        "Aur\u00e9lien G\u00e2teau", "email": "aurelien.gateau@gitguardian.com", "incident_id":
+        21460, "incident_permission": "full_access"}, {"id": 166199, "member_id":
+        166199, "role": "manager", "name": "Stanislas Cr\u00e9pin", "email": "stanislas.crepin@gitguardian.com",
+        "incident_id": 21460, "incident_permission": "full_access"}]'
+    headers:
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      content-length:
+      - '1698'
+      content-security-policy:
+      - frame-ancestors 'none'
+      content-type:
+      - application/json
+      cross-origin-opener-policy:
+      - same-origin
+      date:
+      - Wed, 04 Mar 2026 11:39:07 GMT
+      link:
+      - <https://api.gitguardian.com/v1/incidents/secrets/21460/members?cursor=cD0xNjYxOTk%3D&per_page=10&search=gitguardian>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      server:
+      - istio-envoy
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.404.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '37'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '10'
+      x-secrets-engine-version:
+      - 2.157.1
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/tools/vcr/test_list_incident_teams_basic.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incident_teams_basic.yaml
@@ -1,0 +1,67 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/1.0
+    method: GET
+    uri: https://api.gitguardian.com/v1/incidents/secrets/21460/teams?per_page=5
+  response:
+    body:
+      string: '[{"team_id": 304856, "incident_id": 21460, "incident_permission": "full_access"},
+        {"team_id": 305252, "incident_id": 21460, "incident_permission": "full_access"},
+        {"team_id": 306598, "incident_id": 21460, "incident_permission": "full_access"},
+        {"team_id": 337146, "incident_id": 21460, "incident_permission": "full_access"}]'
+    headers:
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      content-length:
+      - '301'
+      content-security-policy:
+      - frame-ancestors 'none'
+      content-type:
+      - application/json
+      cross-origin-opener-policy:
+      - same-origin
+      date:
+      - Wed, 04 Mar 2026 11:39:09 GMT
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      server:
+      - istio-envoy
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.404.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '97'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.157.1
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/tools/vcr/test_list_incident_teams_with_direct_access.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incident_teams_with_direct_access.yaml
@@ -1,0 +1,67 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/1.0
+    method: GET
+    uri: https://api.gitguardian.com/v1/incidents/secrets/21460/teams?per_page=10&direct_access=true
+  response:
+    body:
+      string: '[{"team_id": 304856, "incident_id": 21460, "incident_permission": "full_access"},
+        {"team_id": 305252, "incident_id": 21460, "incident_permission": "full_access"},
+        {"team_id": 306598, "incident_id": 21460, "incident_permission": "full_access"},
+        {"team_id": 337146, "incident_id": 21460, "incident_permission": "full_access"}]'
+    headers:
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      content-length:
+      - '301'
+      content-security-policy:
+      - frame-ancestors 'none'
+      content-type:
+      - application/json
+      cross-origin-opener-policy:
+      - same-origin
+      date:
+      - Wed, 04 Mar 2026 11:39:11 GMT
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      server:
+      - istio-envoy
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.404.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '38'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '10'
+      x-secrets-engine-version:
+      - 2.157.1
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/tools/vcr/test_list_incident_teams_with_search.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incident_teams_with_search.yaml
@@ -1,0 +1,67 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/1.0
+    method: GET
+    uri: https://api.gitguardian.com/v1/incidents/secrets/21460/teams?per_page=10&search=feature
+  response:
+    body:
+      string: '[{"team_id": 304856, "incident_id": 21460, "incident_permission": "full_access"},
+        {"team_id": 305252, "incident_id": 21460, "incident_permission": "full_access"},
+        {"team_id": 306598, "incident_id": 21460, "incident_permission": "full_access"},
+        {"team_id": 337146, "incident_id": 21460, "incident_permission": "full_access"}]'
+    headers:
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      content-length:
+      - '301'
+      content-security-policy:
+      - frame-ancestors 'none'
+      content-type:
+      - application/json
+      cross-origin-opener-policy:
+      - same-origin
+      date:
+      - Wed, 04 Mar 2026 11:39:10 GMT
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      server:
+      - istio-envoy
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.404.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '37'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '10'
+      x-secrets-engine-version:
+      - 2.157.1
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -374,6 +374,8 @@ def mock_gitguardian_client(request):
         "gg_api_core.tools.remediate_secret_incidents",
         "gg_api_core.tools.read_custom_tags",
         "gg_api_core.tools.list_users",
+        "gg_api_core.tools.list_incident_members",
+        "gg_api_core.tools.list_incident_teams",
         "gg_api_core.tools.list_detectors",
         "gg_api_core.tools.list_sources",
         "gg_api_core.tools.get_incident",

--- a/tests/tools/test_list_incident_members.py
+++ b/tests/tools/test_list_incident_members.py
@@ -26,14 +26,10 @@ class TestListIncidentMembers:
         mock_client.list_incident_members.return_value = {
             "data": [
                 {
-                    "id": 3252,
-                    "name": "John Smith",
+                    "id": 10,
                     "email": "john.smith@example.org",
-                    "role": "owner",
-                    "access_level": "owner",
-                    "active": True,
-                    "created_at": "2023-06-28T16:40:26.897Z",
-                    "last_login": "2023-06-28T16:40:26.897Z",
+                    "incident_id": 42,
+                    "incident_permission": "full_access",
                 }
             ],
             "cursor": None,
@@ -49,7 +45,7 @@ class TestListIncidentMembers:
 
             assert isinstance(result, ListIncidentMembersResult)
             assert result.total_count == 1
-            assert result.members[0]["name"] == "John Smith"
+            assert result.members[0]["email"] == "john.smith@example.org"
             assert result.has_more is False
             assert result.next_cursor is None
 

--- a/tests/tools/test_list_incident_members.py
+++ b/tests/tools/test_list_incident_members.py
@@ -1,0 +1,186 @@
+"""
+Tests for list_incident_members tool.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from gg_api_core.tools.list_incident_members import (
+    ListIncidentMembersParams,
+    ListIncidentMembersResult,
+    list_incident_members,
+)
+
+
+class TestListIncidentMembers:
+    """Tests for the list_incident_members tool."""
+
+    @pytest.mark.asyncio
+    async def test_list_incident_members_basic(self):
+        """
+        GIVEN a valid incident ID
+        WHEN calling list_incident_members with minimal parameters
+        THEN returns a list of members with access to the incident
+        """
+        mock_client = AsyncMock()
+        mock_client.list_incident_members.return_value = {
+            "data": [
+                {
+                    "id": 3252,
+                    "name": "John Smith",
+                    "email": "john.smith@example.org",
+                    "role": "owner",
+                    "access_level": "owner",
+                    "active": True,
+                    "created_at": "2023-06-28T16:40:26.897Z",
+                    "last_login": "2023-06-28T16:40:26.897Z",
+                }
+            ],
+            "cursor": None,
+            "has_more": False,
+        }
+
+        with patch(
+            "gg_api_core.tools.list_incident_members.get_client",
+            return_value=mock_client,
+        ):
+            params = ListIncidentMembersParams(incident_id=42)
+            result = await list_incident_members(params)
+
+            assert isinstance(result, ListIncidentMembersResult)
+            assert result.total_count == 1
+            assert result.members[0]["name"] == "John Smith"
+            assert result.has_more is False
+            assert result.next_cursor is None
+
+            mock_client.list_incident_members.assert_called_once_with(
+                incident_id=42,
+                params={"per_page": 20},
+                get_all=False,
+            )
+
+    @pytest.mark.asyncio
+    async def test_list_incident_members_with_filters(self):
+        """
+        GIVEN a valid incident ID and filter parameters
+        WHEN calling list_incident_members with access_level and search filters
+        THEN passes the correct query parameters to the client
+        """
+        mock_client = AsyncMock()
+        mock_client.list_incident_members.return_value = {
+            "data": [],
+            "cursor": None,
+            "has_more": False,
+        }
+
+        with patch(
+            "gg_api_core.tools.list_incident_members.get_client",
+            return_value=mock_client,
+        ):
+            params = ListIncidentMembersParams(
+                incident_id=42,
+                access_level="manager",
+                search="john",
+                ordering="-created_at",
+                direct_access=True,
+                per_page=50,
+            )
+            result = await list_incident_members(params)
+
+            assert isinstance(result, ListIncidentMembersResult)
+            assert result.total_count == 0
+
+            mock_client.list_incident_members.assert_called_once_with(
+                incident_id=42,
+                params={
+                    "per_page": 50,
+                    "access_level": "manager",
+                    "search": "john",
+                    "ordering": "-created_at",
+                    "direct_access": "true",
+                },
+                get_all=False,
+            )
+
+    @pytest.mark.asyncio
+    async def test_list_incident_members_with_pagination(self):
+        """
+        GIVEN a valid incident ID and pagination cursor
+        WHEN calling list_incident_members with a cursor
+        THEN returns results with pagination info
+        """
+        mock_client = AsyncMock()
+        mock_client.list_incident_members.return_value = {
+            "data": [{"id": 1, "name": "Member 1"}],
+            "cursor": "next_page_cursor",
+            "has_more": True,
+        }
+
+        with patch(
+            "gg_api_core.tools.list_incident_members.get_client",
+            return_value=mock_client,
+        ):
+            params = ListIncidentMembersParams(
+                incident_id=42,
+                cursor="some_cursor",
+            )
+            result = await list_incident_members(params)
+
+            assert result.has_more is True
+            assert result.next_cursor == "next_page_cursor"
+
+    @pytest.mark.asyncio
+    async def test_list_incident_members_get_all(self):
+        """
+        GIVEN a valid incident ID with get_all=True
+        WHEN calling list_incident_members
+        THEN passes get_all=True to the client
+        """
+        mock_client = AsyncMock()
+        mock_client.list_incident_members.return_value = {
+            "data": [{"id": 1}, {"id": 2}],
+            "cursor": None,
+            "has_more": False,
+        }
+
+        with patch(
+            "gg_api_core.tools.list_incident_members.get_client",
+            return_value=mock_client,
+        ):
+            params = ListIncidentMembersParams(incident_id=42, get_all=True)
+            result = await list_incident_members(params)
+
+            assert result.total_count == 2
+            mock_client.list_incident_members.assert_called_once_with(
+                incident_id=42,
+                params={"per_page": 20},
+                get_all=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_list_incident_members_direct_access_false(self):
+        """
+        GIVEN a valid incident ID with direct_access=False
+        WHEN calling list_incident_members
+        THEN passes direct_access=false as string to the client
+        """
+        mock_client = AsyncMock()
+        mock_client.list_incident_members.return_value = {
+            "data": [],
+            "cursor": None,
+            "has_more": False,
+        }
+
+        with patch(
+            "gg_api_core.tools.list_incident_members.get_client",
+            return_value=mock_client,
+        ):
+            params = ListIncidentMembersParams(incident_id=42, direct_access=False)
+            result = await list_incident_members(params)
+
+            assert isinstance(result, ListIncidentMembersResult)
+            mock_client.list_incident_members.assert_called_once_with(
+                incident_id=42,
+                params={"per_page": 20, "direct_access": "false"},
+                get_all=False,
+            )

--- a/tests/tools/test_list_incident_teams.py
+++ b/tests/tools/test_list_incident_teams.py
@@ -1,0 +1,180 @@
+"""
+Tests for list_incident_teams tool.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from gg_api_core.tools.list_incident_teams import (
+    ListIncidentTeamsParams,
+    ListIncidentTeamsResult,
+    list_incident_teams,
+)
+
+
+class TestListIncidentTeams:
+    """Tests for the list_incident_teams tool."""
+
+    @pytest.mark.asyncio
+    async def test_list_incident_teams_basic(self):
+        """
+        GIVEN a valid incident ID
+        WHEN calling list_incident_teams with minimal parameters
+        THEN returns a list of teams with access to the incident
+        """
+        mock_client = AsyncMock()
+        mock_client.list_incident_teams.return_value = {
+            "data": [
+                {
+                    "id": 3252,
+                    "name": "feature team A",
+                    "description": "Description of my team",
+                    "is_global": False,
+                    "gitguardian_url": "https://dashboard.gitguardian.com/workspace/1/settings/user/teams/1",
+                    "external_provider_id": "123-456-7890",
+                }
+            ],
+            "cursor": None,
+            "has_more": False,
+        }
+
+        with patch(
+            "gg_api_core.tools.list_incident_teams.get_client",
+            return_value=mock_client,
+        ):
+            params = ListIncidentTeamsParams(incident_id=42)
+            result = await list_incident_teams(params)
+
+            assert isinstance(result, ListIncidentTeamsResult)
+            assert result.total_count == 1
+            assert result.teams[0]["name"] == "feature team A"
+            assert result.has_more is False
+            assert result.next_cursor is None
+
+            mock_client.list_incident_teams.assert_called_once_with(
+                incident_id=42,
+                params={"per_page": 20},
+                get_all=False,
+            )
+
+    @pytest.mark.asyncio
+    async def test_list_incident_teams_with_filters(self):
+        """
+        GIVEN a valid incident ID and filter parameters
+        WHEN calling list_incident_teams with search and direct_access filters
+        THEN passes the correct query parameters to the client
+        """
+        mock_client = AsyncMock()
+        mock_client.list_incident_teams.return_value = {
+            "data": [],
+            "cursor": None,
+            "has_more": False,
+        }
+
+        with patch(
+            "gg_api_core.tools.list_incident_teams.get_client",
+            return_value=mock_client,
+        ):
+            params = ListIncidentTeamsParams(
+                incident_id=42,
+                search="feature",
+                direct_access=True,
+                per_page=50,
+            )
+            result = await list_incident_teams(params)
+
+            assert isinstance(result, ListIncidentTeamsResult)
+            assert result.total_count == 0
+
+            mock_client.list_incident_teams.assert_called_once_with(
+                incident_id=42,
+                params={
+                    "per_page": 50,
+                    "search": "feature",
+                    "direct_access": "true",
+                },
+                get_all=False,
+            )
+
+    @pytest.mark.asyncio
+    async def test_list_incident_teams_with_pagination(self):
+        """
+        GIVEN a valid incident ID and pagination cursor
+        WHEN calling list_incident_teams with a cursor
+        THEN returns results with pagination info
+        """
+        mock_client = AsyncMock()
+        mock_client.list_incident_teams.return_value = {
+            "data": [{"id": 1, "name": "Team 1"}],
+            "cursor": "next_page_cursor",
+            "has_more": True,
+        }
+
+        with patch(
+            "gg_api_core.tools.list_incident_teams.get_client",
+            return_value=mock_client,
+        ):
+            params = ListIncidentTeamsParams(
+                incident_id=42,
+                cursor="some_cursor",
+            )
+            result = await list_incident_teams(params)
+
+            assert result.has_more is True
+            assert result.next_cursor == "next_page_cursor"
+
+    @pytest.mark.asyncio
+    async def test_list_incident_teams_get_all(self):
+        """
+        GIVEN a valid incident ID with get_all=True
+        WHEN calling list_incident_teams
+        THEN passes get_all=True to the client
+        """
+        mock_client = AsyncMock()
+        mock_client.list_incident_teams.return_value = {
+            "data": [{"id": 1}, {"id": 2}],
+            "cursor": None,
+            "has_more": False,
+        }
+
+        with patch(
+            "gg_api_core.tools.list_incident_teams.get_client",
+            return_value=mock_client,
+        ):
+            params = ListIncidentTeamsParams(incident_id=42, get_all=True)
+            result = await list_incident_teams(params)
+
+            assert result.total_count == 2
+            mock_client.list_incident_teams.assert_called_once_with(
+                incident_id=42,
+                params={"per_page": 20},
+                get_all=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_list_incident_teams_direct_access_false(self):
+        """
+        GIVEN a valid incident ID with direct_access=False
+        WHEN calling list_incident_teams
+        THEN passes direct_access=false as string to the client
+        """
+        mock_client = AsyncMock()
+        mock_client.list_incident_teams.return_value = {
+            "data": [],
+            "cursor": None,
+            "has_more": False,
+        }
+
+        with patch(
+            "gg_api_core.tools.list_incident_teams.get_client",
+            return_value=mock_client,
+        ):
+            params = ListIncidentTeamsParams(incident_id=42, direct_access=False)
+            result = await list_incident_teams(params)
+
+            assert isinstance(result, ListIncidentTeamsResult)
+            mock_client.list_incident_teams.assert_called_once_with(
+                incident_id=42,
+                params={"per_page": 20, "direct_access": "false"},
+                get_all=False,
+            )

--- a/tests/tools/test_list_incident_teams.py
+++ b/tests/tools/test_list_incident_teams.py
@@ -26,12 +26,9 @@ class TestListIncidentTeams:
         mock_client.list_incident_teams.return_value = {
             "data": [
                 {
-                    "id": 3252,
-                    "name": "feature team A",
-                    "description": "Description of my team",
-                    "is_global": False,
-                    "gitguardian_url": "https://dashboard.gitguardian.com/workspace/1/settings/user/teams/1",
-                    "external_provider_id": "123-456-7890",
+                    "team_id": 304856,
+                    "incident_id": 42,
+                    "incident_permission": "full_access",
                 }
             ],
             "cursor": None,
@@ -47,7 +44,7 @@ class TestListIncidentTeams:
 
             assert isinstance(result, ListIncidentTeamsResult)
             assert result.total_count == 1
-            assert result.teams[0]["name"] == "feature team A"
+            assert result.teams[0]["team_id"] == 304856
             assert result.has_more is False
             assert result.next_cursor is None
 

--- a/tests/tools/vcr/test_list_incident_members.py
+++ b/tests/tools/vcr/test_list_incident_members.py
@@ -1,0 +1,174 @@
+"""
+VCR tests for list_incident_members tool.
+
+These tests use recorded HTTP interactions to verify tool behavior
+without requiring a live API connection.
+
+Note: These tests require VCR cassettes to be recorded. Run with a valid
+GITGUARDIAN_API_KEY to record cassettes:
+    make test-vcr-with-env
+"""
+
+from unittest.mock import patch
+
+import pytest
+from gg_api_core.tools.list_incident_members import (
+    ListIncidentMembersParams,
+    ListIncidentMembersResult,
+    list_incident_members,
+)
+
+
+class TestListIncidentMembersVCR:
+    """VCR tests for the list_incident_members tool.
+
+    These tests cover various parameter combinations for the list_incident_members tool.
+    The tool uses the /incidents/secrets/{incident_id}/members endpoint to retrieve
+    members with access to a secret incident.
+    """
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_incident_members_basic(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key with incidents:read scope
+        WHEN calling list_incident_members with minimal parameters
+        THEN returns a list of members with access to the incident
+
+        Note: This test requires a cassette to be recorded with `make test-vcr-with-env`
+        """
+        with use_cassette("test_list_incident_members_basic"):
+            with patch(
+                "gg_api_core.tools.list_incident_members.get_client",
+                return_value=real_client,
+            ):
+                params = ListIncidentMembersParams(
+                    incident_id=21460,
+                    per_page=5,
+                )
+
+                result = await list_incident_members(params)
+
+                assert result is not None
+                assert isinstance(result, ListIncidentMembersResult)
+                assert result.members is not None
+                assert isinstance(result.members, list)
+                assert result.total_count >= 0
+                # Verify member structure
+                if result.members:
+                    member = result.members[0]
+                    assert "id" in member
+                    assert "email" in member
+                    assert "incident_id" in member
+                    assert "incident_permission" in member
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_incident_members_with_search(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key with incidents:read scope
+        WHEN calling list_incident_members with a search filter
+        THEN returns members matching the search term
+
+        Note: This test requires a cassette to be recorded with `make test-vcr-with-env`
+        """
+        with use_cassette("test_list_incident_members_with_search"):
+            with patch(
+                "gg_api_core.tools.list_incident_members.get_client",
+                return_value=real_client,
+            ):
+                params = ListIncidentMembersParams(
+                    incident_id=21460,
+                    search="gitguardian",
+                    per_page=10,
+                )
+
+                result = await list_incident_members(params)
+
+                assert result is not None
+                assert isinstance(result, ListIncidentMembersResult)
+                assert result.members is not None
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_incident_members_with_access_level(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key with incidents:read scope
+        WHEN calling list_incident_members filtered by access_level
+        THEN returns only members with that access level
+
+        Note: This test requires a cassette to be recorded with `make test-vcr-with-env`
+        """
+        with use_cassette("test_list_incident_members_with_access_level"):
+            with patch(
+                "gg_api_core.tools.list_incident_members.get_client",
+                return_value=real_client,
+            ):
+                params = ListIncidentMembersParams(
+                    incident_id=21460,
+                    access_level="owner",
+                    per_page=10,
+                )
+
+                result = await list_incident_members(params)
+
+                assert result is not None
+                assert isinstance(result, ListIncidentMembersResult)
+                assert result.members is not None
+                # Verify all returned members have incident permission info
+                for member in result.members:
+                    assert "incident_permission" in member
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_incident_members_with_ordering(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key with incidents:read scope
+        WHEN calling list_incident_members with ordering by created_at descending
+        THEN returns members sorted by creation date (newest first)
+
+        Note: This test requires a cassette to be recorded with `make test-vcr-with-env`
+        """
+        with use_cassette("test_list_incident_members_with_ordering"):
+            with patch(
+                "gg_api_core.tools.list_incident_members.get_client",
+                return_value=real_client,
+            ):
+                params = ListIncidentMembersParams(
+                    incident_id=21460,
+                    ordering="-created_at",
+                    per_page=10,
+                )
+
+                result = await list_incident_members(params)
+
+                assert result is not None
+                assert isinstance(result, ListIncidentMembersResult)
+                assert result.members is not None
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_incident_members_with_direct_access(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key with incidents:read scope
+        WHEN calling list_incident_members filtered by direct access
+        THEN returns only members with direct access to the incident
+
+        Note: This test requires a cassette to be recorded with `make test-vcr-with-env`
+        """
+        with use_cassette("test_list_incident_members_with_direct_access"):
+            with patch(
+                "gg_api_core.tools.list_incident_members.get_client",
+                return_value=real_client,
+            ):
+                params = ListIncidentMembersParams(
+                    incident_id=21460,
+                    direct_access=True,
+                    per_page=10,
+                )
+
+                result = await list_incident_members(params)
+
+                assert result is not None
+                assert isinstance(result, ListIncidentMembersResult)
+                assert result.members is not None

--- a/tests/tools/vcr/test_list_incident_teams.py
+++ b/tests/tools/vcr/test_list_incident_teams.py
@@ -1,0 +1,116 @@
+"""
+VCR tests for list_incident_teams tool.
+
+These tests use recorded HTTP interactions to verify tool behavior
+without requiring a live API connection.
+
+Note: These tests require VCR cassettes to be recorded. Run with a valid
+GITGUARDIAN_API_KEY to record cassettes:
+    make test-vcr-with-env
+"""
+
+from unittest.mock import patch
+
+import pytest
+from gg_api_core.tools.list_incident_teams import (
+    ListIncidentTeamsParams,
+    ListIncidentTeamsResult,
+    list_incident_teams,
+)
+
+
+class TestListIncidentTeamsVCR:
+    """VCR tests for the list_incident_teams tool.
+
+    These tests cover various parameter combinations for the list_incident_teams tool.
+    The tool uses the /incidents/secrets/{incident_id}/teams endpoint to retrieve
+    teams with access to a secret incident.
+    """
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_incident_teams_basic(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key with incidents:read scope
+        WHEN calling list_incident_teams with minimal parameters
+        THEN returns a list of teams with access to the incident
+
+        Note: This test requires a cassette to be recorded with `make test-vcr-with-env`
+        """
+        with use_cassette("test_list_incident_teams_basic"):
+            with patch(
+                "gg_api_core.tools.list_incident_teams.get_client",
+                return_value=real_client,
+            ):
+                params = ListIncidentTeamsParams(
+                    incident_id=21460,
+                    per_page=5,
+                )
+
+                result = await list_incident_teams(params)
+
+                assert result is not None
+                assert isinstance(result, ListIncidentTeamsResult)
+                assert result.teams is not None
+                assert isinstance(result.teams, list)
+                assert result.total_count >= 0
+                # Verify team structure
+                if result.teams:
+                    team = result.teams[0]
+                    assert "team_id" in team
+                    assert "incident_id" in team
+                    assert "incident_permission" in team
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_incident_teams_with_search(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key with incidents:read scope
+        WHEN calling list_incident_teams with a search filter
+        THEN returns teams matching the search term
+
+        Note: This test requires a cassette to be recorded with `make test-vcr-with-env`
+        """
+        with use_cassette("test_list_incident_teams_with_search"):
+            with patch(
+                "gg_api_core.tools.list_incident_teams.get_client",
+                return_value=real_client,
+            ):
+                params = ListIncidentTeamsParams(
+                    incident_id=21460,
+                    search="feature",
+                    per_page=10,
+                )
+
+                result = await list_incident_teams(params)
+
+                assert result is not None
+                assert isinstance(result, ListIncidentTeamsResult)
+                assert result.teams is not None
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_incident_teams_with_direct_access(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key with incidents:read scope
+        WHEN calling list_incident_teams filtered by direct access
+        THEN returns only teams with direct access to the incident
+
+        Note: This test requires a cassette to be recorded with `make test-vcr-with-env`
+        """
+        with use_cassette("test_list_incident_teams_with_direct_access"):
+            with patch(
+                "gg_api_core.tools.list_incident_teams.get_client",
+                return_value=real_client,
+            ):
+                params = ListIncidentTeamsParams(
+                    incident_id=21460,
+                    direct_access=True,
+                    per_page=10,
+                )
+
+                result = await list_incident_teams(params)
+
+                assert result is not None
+                assert isinstance(result, ListIncidentTeamsResult)
+                assert result.teams is not None


### PR DESCRIPTION
## Summary
- Add two new MCP tools: `list_incident_members` and `list_incident_teams` to list members/teams with access to a secret incident
- Add client methods with pagination support (`_request_list` + `paginate_all`)
- Register tools in developer and secops servers with `incidents:read` scope

## Test plan
- [x] Unit tests for both tools (10 tests covering basic, filters, pagination, get_all, direct_access)
- [x] VCR tests for both tools (8 tests with recorded cassettes)
- [x] Run `make test-vcr-with-env` to re-record cassettes if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)