### PR TITLE
feat(core): make HTTP timeout configurable via GGMCP_HTTP_TIMEOUT

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -85,8 +85,10 @@ DEFAULT_PAGINATION_MAX_BYTES = 20_000
 # Prevents runaway loops regardless of byte limit effectiveness
 MAX_PAGINATION_PAGES = 10
 
-# Default HTTP timeout in seconds (to handle slow pagination)
-DEFAULT_HTTP_TIMEOUT = 20
+# Default HTTP timeout in seconds (to handle slow pagination).
+# Override with GGMCP_HTTP_TIMEOUT env var for environments with higher latency
+# (e.g. E2E tests where the MCP server calls back to Django through a proxy).
+DEFAULT_HTTP_TIMEOUT = int(os.environ.get("GGMCP_HTTP_TIMEOUT", "20"))
 
 
 class PaginatedResult(TypedDict):


### PR DESCRIPTION
## Summary
- Add `GGMCP_HTTP_TIMEOUT` env var to configure the httpx timeout in `gg_api_core` client
- Default remains 20s (no behavior change)
- Needed for E2E test environments where the MCP server calls back to Django through a reverse proxy chain, causing the default 20s to be insufficient

## Test plan
- [ ] Verify default behavior unchanged (no env var set → 20s timeout)
- [ ] Verify `GGMCP_HTTP_TIMEOUT=60` increases the timeout

Refs: APPAI-576