### PR TITLE
feat(mcp): add list_public_incidents and list_public_occurrences tools

### DIFF
--- a/packages/developer_mcp_server/src/developer_mcp_server/register_tools.py
+++ b/packages/developer_mcp_server/src/developer_mcp_server/register_tools.py
@@ -20,6 +20,23 @@ DEVELOPER_INSTRUCTIONS = """
 
 This server provides GitGuardian's secret detection and remediation capabilities through MCP for developers working within IDE environments like Cursor, Windsurf, or Zed.
 
+## Two incident categories — pick the right tool
+
+GitGuardian surfaces two distinct, non-overlapping categories of secret incidents:
+
+- **Internal incidents** — detected in sources the workspace has explicitly integrated:
+  private/org Git repos, Slack, Jira, Confluence, container registries, SharePoint, etc.
+  Identified by a `source_id`. Default category for most customer workflows.
+  Tools: `list_incidents`, `count_incidents`, `get_incident`, `list_repo_occurrences`,
+  `remediate_secret_incidents`, `list_sources`, `find_current_source_id`.
+- **Public incidents** — detected by GitGuardian Public Monitoring on the worldwide public
+  perimeter: public GitHub repos/gists, Docker Hub, etc. Not linked to a workspace source.
+  Tools: `list_public_incidents`, `list_public_occurrences`.
+
+Incident IDs are **not** interchangeable between the two categories. If the user's intent is
+about leaks "on public GitHub / outside the org / on Docker Hub / found by Public Monitoring",
+use the `list_public_*` tools. Otherwise default to the internal tools.
+
 ## Secret Management Capabilities
 
 This server focuses on helping developers manage secrets in their repositories through:
@@ -54,7 +71,7 @@ All tools operate within your IDE environment to provide immediate feedback and 
 def register_developer_tools(mcp: AbstractGitGuardianFastMCP):
     mcp.tool(
         remediate_secret_incidents,
-        description="List secrets in a given source (identified by source_id) and return exact match locations (file paths, line numbers, character indices). "
+        description="(Internal sources only) List secrets in a given source (identified by source_id) and return exact match locations (file paths, line numbers, character indices). "
         "along with precise remediation instructions. This tool leverages the occurrences API."
         "By default, this only shows incidents assigned to the current user. Pass mine=False to get all incidents related to this source.",
         required_scopes=["incidents:read", "sources:read"],
@@ -75,16 +92,19 @@ def register_developer_tools(mcp: AbstractGitGuardianFastMCP):
 
     mcp.tool(
         list_incidents,
-        description="List secret incidents with advanced filtering options including detector type, secret category, source criticality, and public exposure. "
-        "Filter by repository (via source_ids), detector type, severity, status (TRIGGERED, ASSIGNED, RESOLVED, IGNORED), secret category, source criticality, public exposure, and more. "
-        "With mine=True, this tool only shows incidents assigned to the current user. "
-        "Uses page-based pagination.",
+        description="(Internal sources only — for public GitHub/gists/Docker Hub use list_public_incidents) "
+        "List secret incidents detected in sources the workspace has integrated (private/org Git repos, Slack, Jira, "
+        "container registries, etc.) with advanced filtering including detector type, secret category, source criticality, "
+        "and public exposure. Filter by repository (via source_ids), detector type, severity, status "
+        "(TRIGGERED, ASSIGNED, RESOLVED, IGNORED), secret category, source criticality, public exposure, and more. "
+        "With mine=True, this tool only shows incidents assigned to the current user. Uses page-based pagination.",
         required_scopes=["incidents:read"],
     )
 
     mcp.tool(
         count_incidents,
-        description="Count secret incidents matching the given filters without fetching the full list. "
+        description="(Internal sources only — for public GitHub/gists/Docker Hub there is no equivalent count tool) "
+        "Count internal secret incidents matching the given filters without fetching the full list. "
         "Accepts the same filters as list_incidents (status, severity, detector type, source, tags, etc.) "
         "but returns only the total count. Useful for getting an overview of incident volume or checking filter results before paginating.",
         required_scopes=["incidents:read"],
@@ -92,7 +112,8 @@ def register_developer_tools(mcp: AbstractGitGuardianFastMCP):
 
     mcp.tool(
         list_repo_occurrences,
-        description="List secret occurrences for a specific repository with exact match locations. "
+        description="(Internal sources only — for public GitHub/gists/Docker Hub use list_public_occurrences) "
+        "List secret occurrences for a specific internal repository with exact match locations. "
         "Returns detailed occurrence data including file paths, line numbers, and character indices where secrets were detected. "
         "Use this tool when you need to locate and remediate secrets in the codebase with precise file locations.",
         required_scopes=["incidents:read"],
@@ -100,25 +121,29 @@ def register_developer_tools(mcp: AbstractGitGuardianFastMCP):
 
     mcp.tool(
         list_public_incidents,
-        description="List public secret incidents detected by GitGuardian Public Monitoring on public sources "
-        "(e.g. public GitHub repositories), as opposed to incidents from internal sources monitored by the workspace. "
-        "Use this when investigating secrets leaked outside the organization perimeter. Uses cursor-based pagination.",
+        description="(Public Monitoring only — for internal sources use list_incidents) "
+        "List public secret incidents detected by GitGuardian Public Monitoring on the worldwide public perimeter "
+        "(public GitHub repositories, public GitHub gists, Docker Hub, etc.). Use this when investigating secrets "
+        "leaked outside the organization perimeter. Incident IDs here are NOT interchangeable with internal incident IDs. "
+        "Uses cursor-based pagination.",
         required_scopes=["incidents:read"],
     )
 
     mcp.tool(
         list_public_occurrences,
-        description="List occurrences of a specific public secret incident detected by GitGuardian Public Monitoring on"
-        " public sources, including filepath, commit sha, source repository, "
-        "actor, and attachment reasons. Use this after list_public_incidents to drill into a specific public incident.",
+        description="(Public Monitoring only — for internal sources use list_repo_occurrences) "
+        "List occurrences of a specific public secret incident detected by GitGuardian Public Monitoring on "
+        "public sources, including filepath, commit sha, source repository, actor, and attachment reasons. "
+        "Use this after list_public_incidents to drill into a specific public incident.",
         required_scopes=["incidents:read"],
     )
 
     mcp.tool(
         find_current_source_id,
-        description="Find the GitGuardian source_id for the current repository. "
-        "This tool automatically detects the current git repository and searches for its source_id in GitGuardian. "
-        "Useful when you need to reference the repository in other API calls.",
+        description="(Internal sources only) Find the GitGuardian source_id for the current repository in the workspace's "
+        "internal perimeter. This tool automatically detects the current git repository and searches for its source_id "
+        "among the sources the workspace monitors. Useful when you need to reference the repository in other internal-incident "
+        "API calls. Does not apply to public GitHub / Public Monitoring.",
         required_scopes=["sources:read"],
     )
 
@@ -148,13 +173,17 @@ def register_developer_tools(mcp: AbstractGitGuardianFastMCP):
 
     mcp.tool(
         list_sources,
-        description="List sources (repositories, integrations) known by GitGuardian. Filter by type, health, visibility, criticality, and scan status.",
+        description="(Internal perimeter only) List sources (repositories, integrations) the workspace monitors — "
+        "private/org Git repos, Slack, Jira, container registries, etc. Filter by type, health, visibility, criticality, "
+        "and scan status. The worldwide public perimeter scanned by Public Monitoring is not represented here.",
         required_scopes=["sources:read"],
     )
 
     mcp.tool(
         get_incident,
-        description="Retrieve a specific secret incident by its ID with detailed information including occurrences, detector info, assignee details, and custom tags.",
+        description="(Internal sources only — for public GitHub/gists/Docker Hub incidents there is no equivalent retrieval tool yet) "
+        "Retrieve a specific internal secret incident by its ID with detailed information including occurrences, "
+        "detector info, assignee details, and custom tags.",
         required_scopes=["incidents:read"],
     )
 

--- a/packages/developer_mcp_server/src/developer_mcp_server/register_tools.py
+++ b/packages/developer_mcp_server/src/developer_mcp_server/register_tools.py
@@ -4,6 +4,7 @@ from gg_api_core.tools.find_current_source_id import find_current_source_id
 from gg_api_core.tools.generate_honey_token import generate_honeytoken
 from gg_api_core.tools.get_incident import get_incident
 from gg_api_core.tools.get_member import get_member
+from gg_api_core.tools.get_public_incident import get_public_incident
 from gg_api_core.tools.list_detectors import list_detectors
 from gg_api_core.tools.list_honeytokens import list_honeytokens
 from gg_api_core.tools.list_incidents import list_incidents
@@ -31,7 +32,7 @@ GitGuardian surfaces two distinct, non-overlapping categories of secret incident
   `remediate_secret_incidents`, `list_sources`, `find_current_source_id`.
 - **Public incidents** — detected by GitGuardian Public Monitoring on the worldwide public
   perimeter: public GitHub repos/gists, Docker Hub, etc. Not linked to a workspace source.
-  Tools: `list_public_incidents`, `list_public_occurrences`.
+  Tools: `list_public_incidents`, `get_public_incident`, `list_public_occurrences`.
 
 Incident IDs are **not** interchangeable between the two categories. If the user's intent is
 about leaks "on public GitHub / outside the org / on Docker Hub / found by Public Monitoring",
@@ -130,6 +131,15 @@ def register_developer_tools(mcp: AbstractGitGuardianFastMCP):
     )
 
     mcp.tool(
+        get_public_incident,
+        description="(Public Monitoring only — for internal sources use get_incident) "
+        "Retrieve a single public secret incident by id, with detector, status, severity, "
+        "validity, risk_score, tags, timestamps, assignee, and share_url. Incident IDs here "
+        "are NOT interchangeable with internal incident IDs.",
+        required_scopes=["incidents:read"],
+    )
+
+    mcp.tool(
         list_public_occurrences,
         description="(Public Monitoring only — for internal sources use list_repo_occurrences) "
         "List occurrences of a specific public secret incident detected by GitGuardian Public Monitoring on "
@@ -181,7 +191,7 @@ def register_developer_tools(mcp: AbstractGitGuardianFastMCP):
 
     mcp.tool(
         get_incident,
-        description="(Internal sources only — for public GitHub/gists/Docker Hub incidents there is no equivalent retrieval tool yet) "
+        description="(Internal sources only - for public GitHub/gists/Docker Hub incidents use get_public_incident)"
         "Retrieve a specific internal secret incident by its ID with detailed information including occurrences, "
         "detector info, assignee details, and custom tags.",
         required_scopes=["incidents:read"],

--- a/packages/developer_mcp_server/src/developer_mcp_server/register_tools.py
+++ b/packages/developer_mcp_server/src/developer_mcp_server/register_tools.py
@@ -7,6 +7,8 @@ from gg_api_core.tools.get_member import get_member
 from gg_api_core.tools.list_detectors import list_detectors
 from gg_api_core.tools.list_honeytokens import list_honeytokens
 from gg_api_core.tools.list_incidents import list_incidents
+from gg_api_core.tools.list_public_incidents import list_public_incidents
+from gg_api_core.tools.list_public_occurrences import list_public_occurrences
 from gg_api_core.tools.list_repo_occurrences import list_repo_occurrences
 from gg_api_core.tools.list_sources import list_sources
 from gg_api_core.tools.list_users import list_users
@@ -93,6 +95,22 @@ def register_developer_tools(mcp: AbstractGitGuardianFastMCP):
         description="List secret occurrences for a specific repository with exact match locations. "
         "Returns detailed occurrence data including file paths, line numbers, and character indices where secrets were detected. "
         "Use this tool when you need to locate and remediate secrets in the codebase with precise file locations.",
+        required_scopes=["incidents:read"],
+    )
+
+    mcp.tool(
+        list_public_incidents,
+        description="List public secret incidents detected by GitGuardian Public Monitoring on public sources "
+        "(e.g. public GitHub repositories), as opposed to incidents from internal sources monitored by the workspace. "
+        "Use this when investigating secrets leaked outside the organization perimeter. Uses cursor-based pagination.",
+        required_scopes=["incidents:read"],
+    )
+
+    mcp.tool(
+        list_public_occurrences,
+        description="List occurrences of a specific public secret incident detected by GitGuardian Public Monitoring on"
+        " public sources, including filepath, commit sha, source repository, "
+        "actor, and attachment reasons. Use this after list_public_incidents to drill into a specific public incident.",
         required_scopes=["incidents:read"],
     )
 

--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import re
+from collections.abc import Sequence
 from enum import Enum
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any, Dict, Optional, TypedDict, cast
@@ -92,9 +93,9 @@ DEFAULT_HTTP_TIMEOUT = 20
 def _serialize_enum_filter(value: Any) -> str:
     """Serialize a single enum/string or a list of them into a comma-separated API query value."""
     if isinstance(value, list):
-        return ",".join(v.value if isinstance(v, Enum) else str(v) for v in value)
+        return ",".join(str(v.value) if isinstance(v, Enum) else str(v) for v in value)
     if isinstance(value, Enum):
-        return value.value
+        return str(value.value)
     return str(value)
 
 
@@ -1698,9 +1699,9 @@ class GitGuardianClient:
         triggered_at_after: str | None = None,
         assignee_email: str | None = None,
         assignee_id: int | None = None,
-        status: IncidentStatus | str | list[IncidentStatus | str] | None = None,
-        severity: IncidentSeverity | str | list[IncidentSeverity | str] | None = None,
-        validity: IncidentValidity | str | list[IncidentValidity | str] | None = None,
+        status: IncidentStatus | str | Sequence[IncidentStatus | str] | None = None,
+        severity: IncidentSeverity | str | Sequence[IncidentSeverity | str] | None = None,
+        validity: IncidentValidity | str | Sequence[IncidentValidity | str] | None = None,
         tags: str | None = None,
         custom_tags: str | None = None,
         custom_tag_key: str | None = None,
@@ -1818,6 +1819,20 @@ class GitGuardianClient:
             return await self.paginate_all(endpoint, params)
 
         return await self._request_list(endpoint, params=params)
+
+    async def get_public_incident(self, incident_id: int) -> dict[str, Any]:
+        """Retrieve a single public secret incident by id.
+
+        Wraps GET /v1/public-incidents/secrets/{incident_id}.
+
+        Args:
+            incident_id: The id of the public incident to retrieve.
+
+        Returns:
+            Detailed public incident data.
+        """
+        logger.info(f"Getting public incident {incident_id}")
+        return await self._request_get(f"/public-incidents/secrets/{incident_id}")
 
     async def list_public_occurrences(
         self,

--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -89,6 +89,15 @@ MAX_PAGINATION_PAGES = 10
 DEFAULT_HTTP_TIMEOUT = 20
 
 
+def _serialize_enum_filter(value: Any) -> str:
+    """Serialize a single enum/string or a list of them into a comma-separated API query value."""
+    if isinstance(value, list):
+        return ",".join(v.value if isinstance(v, Enum) else str(v) for v in value)
+    if isinstance(value, Enum):
+        return value.value
+    return str(value)
+
+
 class PaginatedResult(TypedDict):
     """Result from paginate_all with size limit protection."""
 
@@ -1678,6 +1687,222 @@ class GitGuardianClient:
         # Otherwise, get a single page
         logger.info(f"Getting occurrences with params: {params}")
         return await self._request_list("occurrences/secrets", params=params)
+
+    async def list_public_incidents(
+        self,
+        cursor: str | None = None,
+        per_page: int = 20,
+        date_before: str | None = None,
+        date_after: str | None = None,
+        triggered_at_before: str | None = None,
+        triggered_at_after: str | None = None,
+        assignee_email: str | None = None,
+        assignee_id: int | None = None,
+        status: IncidentStatus | str | list[IncidentStatus | str] | None = None,
+        severity: IncidentSeverity | str | list[IncidentSeverity | str] | None = None,
+        validity: IncidentValidity | str | list[IncidentValidity | str] | None = None,
+        tags: str | None = None,
+        custom_tags: str | None = None,
+        custom_tag_key: str | None = None,
+        custom_tag_value: str | None = None,
+        ordering: str | None = None,
+        detector_group_name: str | None = None,
+        ignorer_id: int | None = None,
+        ignorer_api_token_id: str | None = None,
+        resolver_id: int | None = None,
+        resolver_api_token_id: str | None = None,
+        feedback: bool | None = None,
+        declarative_secret_status: str | None = None,
+        risk_score_min: int | None = None,
+        risk_score_max: int | None = None,
+        get_all: bool = False,
+    ) -> ListResponse:
+        """List public secret incidents (from public sources like public GitHub).
+
+        Wraps GET /v1/public-incidents/secrets.
+
+        Args:
+            cursor: Pagination cursor.
+            per_page: Number of results per page (1-100, default 20).
+            date_before: Entries found before this date (ISO datetime).
+            date_after: Entries found after this date (ISO datetime).
+            triggered_at_before: Incidents triggered before this date (ISO datetime).
+            triggered_at_after: Incidents triggered after this date (ISO datetime).
+            assignee_email: Incidents assigned to this email.
+            assignee_id: Incidents assigned to this user id.
+            status: Filter by status (IGNORED, TRIGGERED, ASSIGNED, RESOLVED).
+                Accepts a single value or a list (sent as comma-separated; the API
+                accepts multi-value filters here, like the sibling /incidents/secrets endpoint).
+            severity: Filter by severity (critical, high, medium, low, info, unknown).
+                Accepts a single value or a list (comma-separated).
+            validity: Filter by validity (valid, invalid, failed_to_check, no_checker, unknown).
+                Accepts a single value or a list (comma-separated).
+            tags: Filter by tags (comma-separated tag names, or "NONE" for incidents without tags).
+            custom_tags: Filter by custom tag UUIDs (comma-separated).
+            custom_tag_key: Filter by custom tag key.
+            custom_tag_value: Filter by custom tag value.
+            ordering: Sort field (date, -date, resolved_at, -resolved_at, ignored_at, -ignored_at,
+                risk_score, -risk_score).
+            detector_group_name: Filter by detector group name.
+            ignorer_id: Incidents ignored by this user id.
+            ignorer_api_token_id: Incidents ignored by this API token id.
+            resolver_id: Incidents resolved by this user id.
+            resolver_api_token_id: Incidents resolved by this API token id.
+            feedback: Filter by presence of feedback.
+            declarative_secret_status: Filter by declarative secret status (revoked, active,
+                test_credential, false_positive, low_risk).
+            risk_score_min: Minimum risk score (0-100).
+            risk_score_max: Maximum risk score (0-100).
+            get_all: If True, fetch all results using cursor-based pagination.
+
+        Returns:
+            ListResponse with public incident data, cursor, and has_more flag.
+        """
+        logger.info("Listing public secret incidents")
+
+        params: dict[str, Any] = {}
+        if cursor:
+            params["cursor"] = cursor
+        if per_page:
+            params["per_page"] = str(per_page)
+        if date_before:
+            params["date_before"] = date_before
+        if date_after:
+            params["date_after"] = date_after
+        if triggered_at_before:
+            params["triggered_at_before"] = triggered_at_before
+        if triggered_at_after:
+            params["triggered_at_after"] = triggered_at_after
+        if assignee_email:
+            params["assignee_email"] = assignee_email
+        if assignee_id is not None:
+            params["assignee_id"] = str(assignee_id)
+        if status:
+            params["status"] = _serialize_enum_filter(status)
+        if severity:
+            params["severity"] = _serialize_enum_filter(severity)
+        if validity:
+            params["validity"] = _serialize_enum_filter(validity)
+        if tags:
+            params["tags"] = tags
+        if custom_tags:
+            params["custom_tags"] = custom_tags
+        if custom_tag_key:
+            params["custom_tag_key"] = custom_tag_key
+        if custom_tag_value:
+            params["custom_tag_value"] = custom_tag_value
+        if ordering:
+            params["ordering"] = ordering
+        if detector_group_name:
+            params["detector_group_name"] = detector_group_name
+        if ignorer_id is not None:
+            params["ignorer_id"] = str(ignorer_id)
+        if ignorer_api_token_id:
+            params["ignorer_api_token_id"] = ignorer_api_token_id
+        if resolver_id is not None:
+            params["resolver_id"] = str(resolver_id)
+        if resolver_api_token_id:
+            params["resolver_api_token_id"] = resolver_api_token_id
+        if feedback is not None:
+            params["feedback"] = str(feedback).lower()
+        if declarative_secret_status:
+            params["declarative_secret_status"] = declarative_secret_status
+        if risk_score_min is not None:
+            params["risk_score_min"] = str(risk_score_min)
+        if risk_score_max is not None:
+            params["risk_score_max"] = str(risk_score_max)
+
+        endpoint = "/public-incidents/secrets"
+
+        if get_all:
+            return await self.paginate_all(endpoint, params)
+
+        return await self._request_list(endpoint, params=params)
+
+    async def list_public_occurrences(
+        self,
+        incident_id: int,
+        cursor: str | None = None,
+        per_page: int = 20,
+        date_before: str | None = None,
+        date_after: str | None = None,
+        source_id: int | None = None,
+        presence: str | None = None,
+        sha: str | None = None,
+        filepath: str | None = None,
+        attachment_reason: str | None = None,
+        severity: str | None = None,
+        status: str | None = None,
+        validity: str | None = None,
+        tags: str | None = None,
+        ordering: str | None = None,
+        get_all: bool = False,
+    ) -> ListResponse:
+        """List occurrences of a public secret incident.
+
+        Wraps GET /v1/public-incidents/secrets/{incident_id}/occurrences.
+
+        Args:
+            incident_id: The id of the public incident to list occurrences for.
+            cursor: Pagination cursor.
+            per_page: Number of results per page (1-100, default 20).
+            date_before: Entries found before this date (ISO datetime).
+            date_after: Entries found after this date (ISO datetime).
+            source_id: Filter by source ID.
+            presence: Filter by presence status (present, removed).
+            sha: Filter by commit sha (>=3 characters).
+            filepath: Filter by filepath (>=3 characters).
+            attachment_reason: Filter by attachment reason
+                (by_dev_from_perimeter, on_github_org_in_perimeter, from_secret_grasper).
+                Multiple values can be comma-separated.
+            severity: Filter by incident severity (comma-separated allowed).
+            status: Filter by incident status (comma-separated allowed).
+            validity: Filter by secret validity (comma-separated allowed).
+            tags: Filter by tags (comma-separated, or "NONE" for occurrences without tags).
+            ordering: Sort field (id, -id, date, -date).
+            get_all: If True, fetch all results using cursor-based pagination.
+
+        Returns:
+            ListResponse with occurrence data, cursor, and has_more flag.
+        """
+        logger.info(f"Listing public occurrences for incident {incident_id}")
+
+        params: dict[str, Any] = {}
+        if cursor:
+            params["cursor"] = cursor
+        if per_page:
+            params["per_page"] = str(per_page)
+        if date_before:
+            params["date_before"] = date_before
+        if date_after:
+            params["date_after"] = date_after
+        if source_id is not None:
+            params["source_id"] = str(source_id)
+        if presence:
+            params["presence"] = presence
+        if sha:
+            params["sha"] = sha
+        if filepath:
+            params["filepath"] = filepath
+        if attachment_reason:
+            params["attachment_reason"] = attachment_reason
+        if severity:
+            params["severity"] = severity
+        if status:
+            params["status"] = status
+        if validity:
+            params["validity"] = validity
+        if tags:
+            params["tags"] = tags
+        if ordering:
+            params["ordering"] = ordering
+
+        endpoint = f"/public-incidents/secrets/{incident_id}/occurrences"
+
+        if get_all:
+            return await self.paginate_all(endpoint, params)
+
+        return await self._request_list(endpoint, params=params)
 
     async def list_source_incidents(self, source_id: str, **kwargs) -> dict[str, Any]:
         """List secret incidents of a source.

--- a/packages/gg_api_core/src/gg_api_core/tools/get_public_incident.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/get_public_incident.py
@@ -1,0 +1,53 @@
+import logging
+from typing import Any
+
+from fastmcp.exceptions import ToolError
+from pydantic import BaseModel, Field
+
+from gg_api_core.utils import get_client
+
+logger = logging.getLogger(__name__)
+
+
+class GetPublicIncidentParams(BaseModel):
+    """Parameters for retrieving a public secret incident."""
+
+    incident_id: int = Field(description="The id of the public secret incident to retrieve")
+
+
+class GetPublicIncidentResult(BaseModel):
+    """Result from retrieving a public secret incident."""
+
+    incident: dict[str, Any] = Field(description="Detailed public incident data")
+
+
+async def get_public_incident(params: GetPublicIncidentParams) -> GetPublicIncidentResult:
+    """Retrieve a single public secret incident detected by GitGuardian Public Monitoring.
+
+    Public incidents live on public sources (public GitHub repos/gists, Docker Hub, etc.) and
+    have their own id namespace — incident ids are NOT interchangeable with internal incident
+    ids. Use this tool instead of `get_incident` when drilling into a leak surfaced by
+    `list_public_incidents`.
+
+    Wraps GET /v1/public-incidents/secrets/{incident_id}.
+
+    Args:
+        params: GetPublicIncidentParams model containing the incident_id.
+
+    Returns:
+        GetPublicIncidentResult: Pydantic model containing:
+            - incident: Detailed public incident data (detector, status, severity, validity,
+              risk_score, tags, custom_tags, timestamps, assignee, share_url, etc.)
+
+    Raises:
+        ToolError: If the retrieval operation fails (e.g. unknown id, API error).
+    """
+    client = await get_client()
+    logger.debug(f"Retrieving public incident {params.incident_id}")
+
+    try:
+        response = await client.get_public_incident(incident_id=params.incident_id)
+        return GetPublicIncidentResult(incident=response)
+    except Exception as e:
+        logger.exception(f"Error retrieving public incident {params.incident_id}: {str(e)}")
+        raise ToolError(str(e))

--- a/packages/gg_api_core/src/gg_api_core/tools/list_public_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_public_incidents.py
@@ -1,0 +1,335 @@
+import logging
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+from gg_api_core.client import (
+    DEFAULT_PAGINATION_MAX_BYTES,
+    IncidentSeverity,
+    IncidentStatus,
+    IncidentValidity,
+)
+from gg_api_core.utils import get_client
+
+logger = logging.getLogger(__name__)
+
+
+# Default filters mirror list_incidents to keep the two tools behaviorally consistent:
+# hide IGNORED statuses, LOW/INFO severities, and INVALID validity out of the box.
+DEFAULT_STATUSES: list[IncidentStatus] = [
+    IncidentStatus.TRIGGERED,
+    IncidentStatus.ASSIGNED,
+    IncidentStatus.RESOLVED,
+]
+DEFAULT_SEVERITIES: list[IncidentSeverity] = [
+    IncidentSeverity.CRITICAL,
+    IncidentSeverity.HIGH,
+    IncidentSeverity.MEDIUM,
+    IncidentSeverity.UNKNOWN,
+]
+# /public-incidents/secrets validity enum uses 'unknown' (not 'not_checked' like /incidents-for-mcp).
+DEFAULT_VALIDITIES: list[IncidentValidity] = [
+    IncidentValidity.VALID,
+    IncidentValidity.FAILED_TO_CHECK,
+    IncidentValidity.NO_CHECKER,
+    IncidentValidity.UNKNOWN,
+]
+
+
+class ListPublicIncidentsParams(BaseModel):
+    """Parameters for listing public secret incidents.
+
+    Public incidents are incidents detected by GitGuardian on public sources
+    (e.g. public GitHub repositories), as opposed to internal sources monitored
+    by the workspace.
+    """
+
+    # Pagination
+    per_page: int = Field(
+        default=20,
+        ge=1,
+        le=100,
+        description="Number of results per page (default: 20, max: 100)",
+    )
+    cursor: str | None = Field(
+        default=None,
+        description="Pagination cursor for fetching the next page of results",
+    )
+    get_all: bool = Field(
+        default=False,
+        description=(
+            f"If True, fetch all pages (capped at ~{DEFAULT_PAGINATION_MAX_BYTES / 1000}KB; "
+            "check 'has_more' and use cursor to continue)"
+        ),
+    )
+
+    # Date filters
+    date_before: str | None = Field(
+        default=None,
+        description="Entries found before this date (ISO datetime, e.g. 2025-01-31T00:00:00Z)",
+    )
+    date_after: str | None = Field(
+        default=None,
+        description="Entries found after this date (ISO datetime)",
+    )
+    triggered_at_before: str | None = Field(
+        default=None,
+        description="Incidents triggered before this date (ISO datetime)",
+    )
+    triggered_at_after: str | None = Field(
+        default=None,
+        description="Incidents triggered after this date (ISO datetime)",
+    )
+
+    # Assignment filters
+    assignee_email: str | None = Field(
+        default=None,
+        description="Filter by assignee email",
+    )
+    assignee_id: int | None = Field(
+        default=None,
+        description="Filter by assignee user id",
+    )
+
+    # Status / severity / validity
+    status: list[IncidentStatus] | None = Field(
+        default=DEFAULT_STATUSES,
+        description=(
+            "Filter by incident status. Values: TRIGGERED, ASSIGNED, RESOLVED, IGNORED. "
+            "Accepts a single value or a list. Default excludes IGNORED."
+        ),
+    )
+    severity: list[IncidentSeverity] | None = Field(
+        default=DEFAULT_SEVERITIES,
+        description=(
+            "Filter by severity. Values: critical, high, medium, low, info, unknown. "
+            "Accepts a single value or a list. Default excludes LOW and INFO."
+        ),
+    )
+    validity: list[IncidentValidity] | None = Field(
+        default=DEFAULT_VALIDITIES,
+        description=(
+            "Filter by validity. Values: valid, invalid, failed_to_check, no_checker, unknown. "
+            "Accepts a single value or a list. Default excludes INVALID."
+        ),
+    )
+
+    # Tags
+    tags: str | None = Field(
+        default=None,
+        description=(
+            "Filter by tags. Comma-separated list of tag names (e.g. "
+            "'FROM_HISTORICAL_SCAN,INTERNALLY_LEAKED'). Use 'NONE' to filter incidents with no tags."
+        ),
+    )
+    custom_tags: str | None = Field(
+        default=None,
+        description="Comma-separated list of custom tag UUIDs to filter by",
+    )
+    custom_tag_key: str | None = Field(
+        default=None,
+        description="Filter incidents that have a custom tag with this key",
+    )
+    custom_tag_value: str | None = Field(
+        default=None,
+        description="Filter incidents that have a custom tag with this value",
+    )
+
+    # Ordering
+    ordering: str | None = Field(
+        default="-date",
+        description=(
+            "Sort field with optional '-' prefix for descending. Options: date, -date, "
+            "resolved_at, -resolved_at, ignored_at, -ignored_at, risk_score, -risk_score"
+        ),
+    )
+
+    # Detector / actor filters
+    detector_group_name: str | None = Field(
+        default=None,
+        description="Filter by detector group name (e.g. 'slackbot_token')",
+    )
+    ignorer_id: int | None = Field(
+        default=None,
+        description="Filter incidents ignored by this user id",
+    )
+    ignorer_api_token_id: str | None = Field(
+        default=None,
+        description="Filter incidents ignored by this API token id",
+    )
+    resolver_id: int | None = Field(
+        default=None,
+        description="Filter incidents resolved by this user id",
+    )
+    resolver_api_token_id: str | None = Field(
+        default=None,
+        description="Filter incidents resolved by this API token id",
+    )
+
+    # Boolean / declarative filters
+    feedback: bool | None = Field(
+        default=None,
+        description="Filter to incidents with (True) or without (False) feedback",
+    )
+    declarative_secret_status: str | None = Field(
+        default=None,
+        description=(
+            "Filter by declarative secret status (revoked, active, test_credential, false_positive, low_risk)"
+        ),
+    )
+
+    # Risk score
+    risk_score_min: int | None = Field(
+        default=None,
+        ge=0,
+        le=100,
+        description="Filter incidents with risk score >= this value (0-100)",
+    )
+    risk_score_max: int | None = Field(
+        default=None,
+        ge=0,
+        le=100,
+        description="Filter incidents with risk score <= this value (0-100)",
+    )
+
+    # Coerce a single enum/string into a list so LLM callers can pass either shape.
+    @field_validator("status", "severity", "validity", mode="before")
+    @classmethod
+    def coerce_to_list(cls, v: Any) -> list[Any] | None:
+        if v is None:
+            return None
+        if isinstance(v, list):
+            return v
+        return [v]
+
+
+class ListPublicIncidentsResult(BaseModel):
+    """Result from listing public secret incidents."""
+
+    incidents_count: int = Field(description="Number of incidents returned")
+    incidents: list[dict[str, Any]] = Field(default_factory=list, description="List of public incident objects")
+    cursor: str | None = Field(default=None, description="Pagination cursor for next page")
+    has_more: bool = Field(default=False, description="True if more results exist (use cursor to fetch)")
+    applied_filters: dict[str, Any] = Field(default_factory=dict, description="Filters that were applied to the query")
+
+
+class ListPublicIncidentsError(BaseModel):
+    """Error result from listing public secret incidents."""
+
+    error: str = Field(description="Error message")
+
+
+def _build_filter_info(params: ListPublicIncidentsParams) -> dict[str, Any]:
+    filters: dict[str, Any] = {}
+    if params.date_before:
+        filters["date_before"] = params.date_before
+    if params.date_after:
+        filters["date_after"] = params.date_after
+    if params.triggered_at_before:
+        filters["triggered_at_before"] = params.triggered_at_before
+    if params.triggered_at_after:
+        filters["triggered_at_after"] = params.triggered_at_after
+    if params.assignee_email:
+        filters["assignee_email"] = params.assignee_email
+    if params.assignee_id is not None:
+        filters["assignee_id"] = params.assignee_id
+    if params.status:
+        filters["status"] = [s.value if hasattr(s, "value") else s for s in params.status]
+    if params.severity:
+        filters["severity"] = [s.value if hasattr(s, "value") else s for s in params.severity]
+    if params.validity:
+        filters["validity"] = [v.value if hasattr(v, "value") else v for v in params.validity]
+    if params.tags:
+        filters["tags"] = params.tags
+    if params.custom_tags:
+        filters["custom_tags"] = params.custom_tags
+    if params.custom_tag_key:
+        filters["custom_tag_key"] = params.custom_tag_key
+    if params.custom_tag_value:
+        filters["custom_tag_value"] = params.custom_tag_value
+    if params.detector_group_name:
+        filters["detector_group_name"] = params.detector_group_name
+    if params.ignorer_id is not None:
+        filters["ignorer_id"] = params.ignorer_id
+    if params.ignorer_api_token_id:
+        filters["ignorer_api_token_id"] = params.ignorer_api_token_id
+    if params.resolver_id is not None:
+        filters["resolver_id"] = params.resolver_id
+    if params.resolver_api_token_id:
+        filters["resolver_api_token_id"] = params.resolver_api_token_id
+    if params.feedback is not None:
+        filters["feedback"] = params.feedback
+    if params.declarative_secret_status:
+        filters["declarative_secret_status"] = params.declarative_secret_status
+    if params.risk_score_min is not None:
+        filters["risk_score_min"] = params.risk_score_min
+    if params.risk_score_max is not None:
+        filters["risk_score_max"] = params.risk_score_max
+    return filters
+
+
+async def list_public_incidents(
+    params: ListPublicIncidentsParams,
+) -> ListPublicIncidentsResult | ListPublicIncidentsError:
+    """List public secret incidents detected by GitGuardian on public sources (e.g. public GitHub).
+
+    Public incidents differ from internal incidents: they correspond to secrets leaked outside the
+    organization perimeter and surfaced via GitGuardian Public Monitoring (Explore). Use this tool
+    instead of `list_incidents` when investigating leaks on public sources.
+
+    Wraps GET /v1/public-incidents/secrets and uses cursor-based pagination.
+
+    Args:
+        params: ListPublicIncidentsParams model containing all filtering options.
+
+    Returns:
+        ListPublicIncidentsResult with the public incidents page, or
+        ListPublicIncidentsError on failure.
+    """
+    client = await get_client()
+
+    try:
+        result = await client.list_public_incidents(
+            cursor=params.cursor,
+            per_page=params.per_page,
+            date_before=params.date_before,
+            date_after=params.date_after,
+            triggered_at_before=params.triggered_at_before,
+            triggered_at_after=params.triggered_at_after,
+            assignee_email=params.assignee_email,
+            assignee_id=params.assignee_id,
+            status=params.status,
+            severity=params.severity,
+            validity=params.validity,
+            tags=params.tags,
+            custom_tags=params.custom_tags,
+            custom_tag_key=params.custom_tag_key,
+            custom_tag_value=params.custom_tag_value,
+            ordering=params.ordering,
+            detector_group_name=params.detector_group_name,
+            ignorer_id=params.ignorer_id,
+            ignorer_api_token_id=params.ignorer_api_token_id,
+            resolver_id=params.resolver_id,
+            resolver_api_token_id=params.resolver_api_token_id,
+            feedback=params.feedback,
+            declarative_secret_status=params.declarative_secret_status,
+            risk_score_min=params.risk_score_min,
+            risk_score_max=params.risk_score_max,
+            get_all=params.get_all,
+        )
+
+        incidents_data = result["data"]
+        next_cursor = result["cursor"]
+        has_more = result.get("has_more", False)
+
+        return ListPublicIncidentsResult(
+            incidents_count=len(incidents_data),
+            incidents=incidents_data,
+            cursor=next_cursor,
+            has_more=has_more,
+            applied_filters=_build_filter_info(params),
+        )
+
+    except Exception as e:
+        logger.exception(f"Error listing public incidents: {str(e)}")
+        return ListPublicIncidentsError(error=f"Failed to list public incidents: {str(e)}")

--- a/packages/gg_api_core/src/gg_api_core/tools/list_public_occurrences.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_public_occurrences.py
@@ -1,0 +1,211 @@
+import logging
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from gg_api_core.client import DEFAULT_PAGINATION_MAX_BYTES
+from gg_api_core.utils import get_client
+
+logger = logging.getLogger(__name__)
+
+
+class ListPublicOccurrencesParams(BaseModel):
+    """Parameters for listing occurrences of a public secret incident."""
+
+    incident_id: int = Field(
+        description="The id of the public secret incident to list occurrences for",
+    )
+
+    # Pagination
+    per_page: int = Field(
+        default=20,
+        ge=1,
+        le=100,
+        description="Number of results per page (default: 20, max: 100)",
+    )
+    cursor: str | None = Field(
+        default=None,
+        description="Pagination cursor for fetching the next page of results",
+    )
+    get_all: bool = Field(
+        default=False,
+        description=(
+            f"If True, fetch all pages (capped at ~{DEFAULT_PAGINATION_MAX_BYTES / 1000}KB; "
+            "check 'has_more' and use cursor to continue)"
+        ),
+    )
+
+    # Date filters
+    date_before: str | None = Field(
+        default=None,
+        description="Entries found before this date (ISO datetime, e.g. 2025-01-31T00:00:00Z)",
+    )
+    date_after: str | None = Field(
+        default=None,
+        description="Entries found after this date (ISO datetime)",
+    )
+
+    # Source / location filters
+    source_id: int | None = Field(
+        default=None,
+        description="Filter occurrences belonging to this source ID",
+    )
+    presence: str | None = Field(
+        default=None,
+        description="Filter by presence status (present, removed)",
+    )
+    sha: str | None = Field(
+        default=None,
+        min_length=3,
+        description="Filter by commit sha (>=3 characters)",
+    )
+    filepath: str | None = Field(
+        default=None,
+        min_length=3,
+        description="Filter by filepath (>=3 characters)",
+    )
+    attachment_reason: str | None = Field(
+        default=None,
+        description=(
+            "Filter by attachment reason. Comma-separated values allowed. "
+            "Options: by_dev_from_perimeter, on_github_org_in_perimeter, from_secret_grasper"
+        ),
+    )
+
+    # Related-incident filters
+    severity: str | None = Field(
+        default=None,
+        description=(
+            "Filter occurrences by the severity of their related incident. "
+            "Comma-separated values allowed (e.g. 'critical,high'). "
+            "Options: critical, high, medium, low, info, unknown"
+        ),
+    )
+    status: str | None = Field(
+        default=None,
+        description=(
+            "Filter occurrences by the status of their related incident. "
+            "Comma-separated values allowed (e.g. 'TRIGGERED,ASSIGNED'). "
+            "Options: IGNORED, TRIGGERED, ASSIGNED, RESOLVED"
+        ),
+    )
+    validity: str | None = Field(
+        default=None,
+        description=(
+            "Filter occurrences by the validity of their related secret. "
+            "Comma-separated values allowed. "
+            "Options: valid, invalid, failed_to_check, no_checker, unknown"
+        ),
+    )
+    tags: str | None = Field(
+        default=None,
+        description=(
+            "Filter by tags. Comma-separated list of tag names. Use 'NONE' to filter occurrences with no tags."
+        ),
+    )
+
+    # Ordering
+    ordering: str | None = Field(
+        default="-date",
+        description="Sort field with optional '-' prefix for descending. Options: id, -id, date, -date",
+    )
+
+
+class ListPublicOccurrencesResult(BaseModel):
+    """Result from listing public secret occurrences."""
+
+    occurrences_count: int = Field(description="Number of occurrences returned")
+    occurrences: list[dict[str, Any]] = Field(default_factory=list, description="List of public occurrence objects")
+    cursor: str | None = Field(default=None, description="Pagination cursor for next page")
+    has_more: bool = Field(default=False, description="True if more results exist (use cursor to fetch)")
+    applied_filters: dict[str, Any] = Field(default_factory=dict, description="Filters that were applied to the query")
+
+
+class ListPublicOccurrencesError(BaseModel):
+    """Error result from listing public secret occurrences."""
+
+    error: str = Field(description="Error message")
+
+
+def _build_filter_info(params: ListPublicOccurrencesParams) -> dict[str, Any]:
+    filters: dict[str, Any] = {"incident_id": params.incident_id}
+    if params.date_before:
+        filters["date_before"] = params.date_before
+    if params.date_after:
+        filters["date_after"] = params.date_after
+    if params.source_id is not None:
+        filters["source_id"] = params.source_id
+    if params.presence:
+        filters["presence"] = params.presence
+    if params.sha:
+        filters["sha"] = params.sha
+    if params.filepath:
+        filters["filepath"] = params.filepath
+    if params.attachment_reason:
+        filters["attachment_reason"] = params.attachment_reason
+    if params.severity:
+        filters["severity"] = params.severity
+    if params.status:
+        filters["status"] = params.status
+    if params.validity:
+        filters["validity"] = params.validity
+    if params.tags:
+        filters["tags"] = params.tags
+    return filters
+
+
+async def list_public_occurrences(
+    params: ListPublicOccurrencesParams,
+) -> ListPublicOccurrencesResult | ListPublicOccurrencesError:
+    """List occurrences of a public secret incident detected by GitGuardian Public Monitoring.
+
+    Returns occurrence-level details for a single public incident, including filepath,
+    commit sha, source repository, actor, and attachment reasons. Use this after
+    `list_public_incidents` to drill into a specific public incident.
+
+    Wraps GET /v1/public-incidents/secrets/{incident_id}/occurrences and uses cursor-based pagination.
+
+    Args:
+        params: ListPublicOccurrencesParams model containing the incident_id and all filters.
+
+    Returns:
+        ListPublicOccurrencesResult with the occurrences page, or
+        ListPublicOccurrencesError on failure.
+    """
+    client = await get_client()
+
+    try:
+        result = await client.list_public_occurrences(
+            incident_id=params.incident_id,
+            cursor=params.cursor,
+            per_page=params.per_page,
+            date_before=params.date_before,
+            date_after=params.date_after,
+            source_id=params.source_id,
+            presence=params.presence,
+            sha=params.sha,
+            filepath=params.filepath,
+            attachment_reason=params.attachment_reason,
+            severity=params.severity,
+            status=params.status,
+            validity=params.validity,
+            tags=params.tags,
+            ordering=params.ordering,
+            get_all=params.get_all,
+        )
+
+        occurrences_data = result["data"]
+        next_cursor = result["cursor"]
+        has_more = result.get("has_more", False)
+
+        return ListPublicOccurrencesResult(
+            occurrences_count=len(occurrences_data),
+            occurrences=occurrences_data,
+            cursor=next_cursor,
+            has_more=has_more,
+            applied_filters=_build_filter_info(params),
+        )
+
+    except Exception as e:
+        logger.exception(f"Error listing public occurrences: {str(e)}")
+        return ListPublicOccurrencesError(error=f"Failed to list public occurrences: {str(e)}")

--- a/packages/secops_mcp_server/src/secops_mcp_server/server.py
+++ b/packages/secops_mcp_server/src/secops_mcp_server/server.py
@@ -134,7 +134,7 @@ GitGuardian surfaces two distinct, non-overlapping categories of secret incident
   `update_or_create_incident_custom_tags`, `create_code_fix_request`.
 - **Public incidents** — detected by GitGuardian Public Monitoring on the worldwide public
   perimeter: public GitHub repos/gists, Docker Hub, etc. Not linked to a workspace source.
-  Read tools: `list_public_incidents`, `list_public_occurrences`.
+  Read tools: `list_public_incidents`, `get_public_incident`, `list_public_occurrences`.
   (Write actions on public incidents are not yet wrapped by this server.)
 
 Incident IDs are **not** interchangeable between the two categories. If the user's intent is

--- a/packages/secops_mcp_server/src/secops_mcp_server/server.py
+++ b/packages/secops_mcp_server/src/secops_mcp_server/server.py
@@ -121,6 +121,27 @@ Each tool requires specific API token scopes to function correctly.
 If you receive an error when calling a tool, it may be because your API token does not have the required scopes.
 Check the required scopes for each tool below and don't use another tool instead of the one that requires the missing scope.
 
+## Two incident categories — pick the right tool
+
+GitGuardian surfaces two distinct, non-overlapping categories of secret incidents:
+
+- **Internal incidents** — detected in sources the workspace has explicitly integrated:
+  private/org Git repos, Slack, Jira, Confluence, container registries, SharePoint, etc.
+  Identified by a `source_id`. Default category for most customer workflows.
+  Read tools: `list_incidents`, `count_incidents`, `get_incident`, `list_repo_occurrences`,
+  `remediate_secret_incidents`, `list_sources`, `find_current_source_id`.
+  Write tools: `manage_private_incident`, `update_incident_status`, `assign_incident`,
+  `update_or_create_incident_custom_tags`, `create_code_fix_request`.
+- **Public incidents** — detected by GitGuardian Public Monitoring on the worldwide public
+  perimeter: public GitHub repos/gists, Docker Hub, etc. Not linked to a workspace source.
+  Read tools: `list_public_incidents`, `list_public_occurrences`.
+  (Write actions on public incidents are not yet wrapped by this server.)
+
+Incident IDs are **not** interchangeable between the two categories. If the user's intent is
+about leaks "on public GitHub / outside the org / on Docker Hub / found by Public Monitoring",
+use the `list_public_*` tools. Otherwise default to the internal tools. Invoking an internal
+write tool with a public incident ID (or vice versa) will silently 404.
+
 Available capabilities:
 
 1. Honeytoken Management:
@@ -129,12 +150,12 @@ Available capabilities:
    - Get detailed information about tokens
 
 2. Incident Management:
-   - List and filter incidents by various criteria
-   - Manage incidents (assign, resolve, ignore)
-   - Update incident status and add custom tags
+   - List and filter incidents by various criteria (internal and public)
+   - Manage internal incidents (assign, resolve, ignore)
+   - Update internal incident status and add custom tags
 
 3. Repository Analysis:
-   - List incidents by repository
+   - List incidents by repository (internal)
    - Get detailed information about repository security status
 
 IMPORTANT:
@@ -183,13 +204,15 @@ async def get_current_token_info() -> dict[str, Any]:
 
 mcp.tool(
     update_or_create_incident_custom_tags,
-    description="Update or create custom tags for a secret incident",
+    description="(Internal sources only) Update or create custom tags for an internal secret incident. "
+    "Does not work on public-monitoring incident IDs.",
     required_scopes=["incidents:write", "custom_tags:write"],
 )
 
 mcp.tool(
     update_incident_status,
-    description="Update a secret incident with status",
+    description="(Internal sources only) Update an internal secret incident with status. "
+    "Does not work on public-monitoring incident IDs.",
     required_scopes=["incidents:write"],
 )
 
@@ -207,25 +230,30 @@ mcp.tool(
 
 mcp.tool(
     manage_private_incident,
-    description="Manage a secret incident (assign, unassign, resolve, ignore, reopen)",
+    description="(Internal sources only) Manage an internal secret incident (assign, unassign, resolve, ignore, reopen). "
+    "Does not work on public-monitoring incident IDs.",
     required_scopes=["incidents:write"],
 )
 
 mcp.tool(
     revoke_secret,
-    description="Revoke a secret by its ID through the GitGuardian API",
+    description="Revoke a secret by its ID through the GitGuardian API. Operates on a secret_id regardless of whether "
+    "the incident surfaced on an internal source or via Public Monitoring.",
     required_scopes=["write:secret"],
 )
 
 mcp.tool(
     assign_incident,
-    description="Assign a secret incident to a specific member or to the current user",
+    description="(Internal sources only) Assign an internal secret incident to a specific member or to the current user. "
+    "Does not work on public-monitoring incident IDs.",
     required_scopes=["incidents:write"],
 )
 
 mcp.tool(
     create_code_fix_request,
-    description="Create code fix requests for multiple secret incidents with their locations. This will generate pull requests to automatically remediate the detected secrets.",
+    description="(Internal sources only) Create code fix requests for multiple internal secret incidents with their "
+    "locations. This will generate pull requests to automatically remediate detected secrets in the repositories the "
+    "workspace monitors. Does not apply to public-monitoring incidents.",
     required_scopes=["incidents:write"],
 )
 

--- a/tests/cassettes/client/vcr/test_get_public_incident_returns_same_id.yaml
+++ b/tests/cassettes/client/vcr/test_get_public_incident_returns_same_id.yaml
@@ -1,0 +1,171 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=1
+  response:
+    body:
+      string: '[{"id": 1, "detector": {"name": "stripe", "display_name": "Stripe Keys",
+        "nature": "specific", "family": "token", "category": "payment_system", "detector_group_name":
+        "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
+        "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
+        "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
+        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
+        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
+        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
+        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "Stripe Keys"}]'
+    headers:
+      CF-RAY:
+      - 9efb894d0c5c9f0a-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:59:30 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1195'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0x&per_page=1>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '79'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '1'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/1
+  response:
+    body:
+      string: '{"id": 1, "detector": {"name": "stripe", "display_name": "Stripe Keys",
+        "nature": "specific", "family": "token", "category": "payment_system", "detector_group_name":
+        "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
+        "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
+        "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
+        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
+        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
+        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
+        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "Stripe Keys"}'
+    headers:
+      CF-RAY:
+      - 9efb894f3cf7d15d-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:59:30 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1193'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '81'
+      x-frame-options:
+      - DENY
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_incidents_basic.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_basic.yaml
@@ -1,0 +1,149 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=5
+  response:
+    body:
+      string: '[{"id": 1, "detector": {"name": "stripe", "display_name": "Stripe Keys",
+        "nature": "specific", "family": "token", "category": "payment_system", "detector_group_name":
+        "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
+        "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
+        "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
+        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
+        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
+        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
+        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "Stripe Keys"}, {"id": 2, "detector":
+        {"name": "slackbototken", "display_name": "Slack Bot Token", "nature": "specific",
+        "family": "token", "category": "messaging_system", "detector_group_name":
+        "slackbot_token", "detector_group_display_name": "Slack Bot Token"}, "date":
+        "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash": "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4",
+        "hmsl_hash": "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592836, "secret_hash": "UkaGM2d1NaALSIkUqCBkEgY+xnpQYM3vPZeWQp9v/O680MxYd9tR0/CjGaYu0TLp",
+        "hmsl_hash": "2cc5873afae5ee7747e26e2d73f7b8abe0ac63e7971442ceb50be7c4bf5c77c9",
+        "occurrences_count": 13, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/3", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 4, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
+        "hmsl_hash": "8d750888a3f74d018e742b42dfb51c60907b26c49fdad4ebdabe1350eedfe0fb",
+        "occurrences_count": 10, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/4", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 5, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-05-24T12:18:15Z", "secret_id": 14592838,
+        "secret_hash": "Z5EChCcGXgX/eXhBjNhs4sGINbMdnzWjcD4m3l7naZmf7qCBOMgPzYhV28m6OGG4",
+        "hmsl_hash": "dc66b2a9c718f0d32581426943c736bfed9bcfd865c77712ca43d96faf97f731",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}]'
+    headers:
+      CF-RAY:
+      - 9ef486f099e2d09b-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:33 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '5855'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD01&per_page=5>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '112'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_incidents_get_all.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_get_all.yaml
@@ -1,0 +1,586 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=5
+  response:
+    body:
+      string: '[{"id": 1, "detector": {"name": "stripe", "display_name": "Stripe Keys",
+        "nature": "specific", "family": "token", "category": "payment_system", "detector_group_name":
+        "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
+        "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
+        "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
+        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
+        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
+        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
+        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "Stripe Keys"}, {"id": 2, "detector":
+        {"name": "slackbototken", "display_name": "Slack Bot Token", "nature": "specific",
+        "family": "token", "category": "messaging_system", "detector_group_name":
+        "slackbot_token", "detector_group_display_name": "Slack Bot Token"}, "date":
+        "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash": "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4",
+        "hmsl_hash": "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592836, "secret_hash": "UkaGM2d1NaALSIkUqCBkEgY+xnpQYM3vPZeWQp9v/O680MxYd9tR0/CjGaYu0TLp",
+        "hmsl_hash": "2cc5873afae5ee7747e26e2d73f7b8abe0ac63e7971442ceb50be7c4bf5c77c9",
+        "occurrences_count": 13, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/3", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 4, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
+        "hmsl_hash": "8d750888a3f74d018e742b42dfb51c60907b26c49fdad4ebdabe1350eedfe0fb",
+        "occurrences_count": 10, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/4", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 5, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-05-24T12:18:15Z", "secret_id": 14592838,
+        "secret_hash": "Z5EChCcGXgX/eXhBjNhs4sGINbMdnzWjcD4m3l7naZmf7qCBOMgPzYhV28m6OGG4",
+        "hmsl_hash": "dc66b2a9c718f0d32581426943c736bfed9bcfd865c77712ca43d96faf97f731",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}]'
+    headers:
+      CF-RAY:
+      - 9ef487188cf60f1e-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:39 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '5855'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD01&per_page=5>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '77'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=5&cursor=cD01
+  response:
+    body:
+      string: '[{"id": 8, "detector": {"name": "sendgrid", "display_name": "SendGrid
+        Key", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "sendgrid_key", "detector_group_display_name": "SendGrid
+        Key"}, "date": "2019-02-11T12:36:02Z", "secret_id": 14592841, "secret_hash":
+        "56VyXyYsEkRVqTiCem+I1NhoZNp0IQKqlPItH+mlIkMmFjfwOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "31198eeb074a1722b082a6ea94edc8a133b115d7201acb47361741b236966830", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.746711Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/8",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 9, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-10-17T13:35:42Z", "secret_id": 14592842,
+        "secret_hash": "iPhCz0hiEKKcYiKnWwMgF+iE0K4tHJTBECUI1m+w7wJpZCyyOMgPzYhV28m6OGG4",
+        "hmsl_hash": "35764f7687c768b9e42ce14f6b7f4eece8d1cd71d4c63c8fd614b23a8e8c1c7d",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.747147Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/9", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 10, "detector": {"name": "generic_password", "display_name":
+        "Generic Password", "nature": "generic", "family": "other", "category": "other",
+        "detector_group_name": "generic_password", "detector_group_display_name":
+        "Generic Password"}, "date": "2022-06-20T16:04:33Z", "secret_id": 14592843,
+        "secret_hash": "1rC83I0fTz8CLTr6Tz7usCc9nbtqZqUU2qXEU2V6CGzNxOl3fma8ieOEhD7igl+v",
+        "hmsl_hash": "9f54d16410ea8fae5f1389bcfa2d48539da4491cf4998d5d8cbcb9b4b946255f",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.749479Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        51, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/10", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Generic Password"}, {"id": 17, "detector": {"name": "sendgrid", "display_name":
+        "SendGrid Key", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "sendgrid_key", "detector_group_display_name": "SendGrid
+        Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592850, "secret_hash":
+        "IRfE2CM4LTU9zkWZl7wtWYTnBxQiaOHtAcZ3uhDrcvPg22qYOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "046f4d07330d592e729e6a072661070a3686a0616bf1e72209789656ca471b17", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/17",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 18, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592851, "secret_hash":
+        "Uuk6ATzxus6ReU1GDCXUwr7vwE8ViniGIZwfovTm021h+oKmOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "99185204219cfb8df5e777a66f95fd7df357fed56ab23836bbaf6ea2514f961a", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/18",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}]'
+    headers:
+      CF-RAY:
+      - 9ef4871afe6ad886-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:40 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '5638'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0xOA%3D%3D&per_page=5>;
+        rel="next", <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cj0xJnA9OA%3D%3D&per_page=5>;
+        rel="prev"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '63'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=5&cursor=cD0xOA%3D%3D
+  response:
+    body:
+      string: '[{"id": 19, "detector": {"name": "sendgrid", "display_name": "SendGrid
+        Key", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "sendgrid_key", "detector_group_display_name": "SendGrid
+        Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592852, "secret_hash":
+        "GPMde0PsT+7OW6y5RryDp/j+pXQkud3HsGpajUFu0Tzqx9pZOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "694403f25caf188319a9b5df5776a6795ac760ad443807047f0771e3119ccd56", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/19",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 20, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592853, "secret_hash":
+        "bBXl1L03BPejq0HJOOIJN/egKAz5enmLatAafFYLw00oSifLOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "cf9bc1eaab8460fbeaaf779e9756c8a586a8f366debb06d2e937e4d85365ad9e", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/20",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 21, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2023-05-16T12:28:32Z", "secret_id": 14592854, "secret_hash":
+        "Xy7y/46z9WKji2j3qEcqzGFPKjkOeenb1PfQsvoEj05SynaIL4Qc71cZRqNcojMG", "hmsl_hash":
+        "dbbfaacc45fe15df6fc8445e5c8a9af230c5ec380ba8944a440009d4b58e8b68", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.757884Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/21",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 23, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2022-07-19T09:52:09Z", "secret_id": 7970364, "secret_hash":
+        "CBz9BMCUQDF3+MCOXcTqfTSvrVZTp8XQF+z38O1amQpnfh2zOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "049d5bbb613a172b0eb21c73a827ae34a30233dbfc9e9b75377a4743082bd447", "occurrences_count":
+        527, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.760032Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 0, "severity_rule_id":
+        10872, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/23",
+        "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "SendGrid Key"}, {"id": 24, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2022-07-19T09:52:09Z", "secret_id": 7970365, "secret_hash": "DQ6dPu9BXyq1FZTNVzfsEpxI24qF82fR4BvL62o1Q7AVIqBId9tR0/CjGaYu0TLp",
+        "hmsl_hash": "19c5c04da7b3d2372f1ab65fa2f311aff6ee3a0bfe37d4608797d5546814c335",
+        "occurrences_count": 190, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.760032Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "high", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        14, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/24", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}]'
+    headers:
+      CF-RAY:
+      - 9ef4871d0ea06ef7-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:40 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '5810'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0yNA%3D%3D&per_page=5>;
+        rel="next", <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cj0xJnA9MTk%3D&per_page=5>;
+        rel="prev"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '77'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=5&cursor=cD0yNA%3D%3D
+  response:
+    body:
+      string: '[{"id": 25, "detector": {"name": "stripe", "display_name": "Stripe
+        Keys", "nature": "specific", "family": "token", "category": "payment_system",
+        "detector_group_name": "stripe_keys", "detector_group_display_name": "Stripe
+        Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592856, "secret_hash":
+        "6tsYM/861fChIu3lkD9zTIE4r+Ye4PBnYxO1wHC4R2WAM9tMiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "3321c774dd4bff3b29cbae9b5ccfc64033ca13a397039769ea185509a247b8b2", "occurrences_count":
+        6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/25",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 26, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592857, "secret_hash":
+        "MitOZYWU/47TOCVlJ8xs0iLON2e7+dG8ZogVwnscopqJ56XGiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "ca5b862ee181bfd49edd91e65ee018b8109e624b6679d0a780eed0591bc03f14", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/26",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 27, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592858, "secret_hash":
+        "bhbBm4t+But3lH43U3ossWK1Xe5Xh8AC0io3FirV6kuFeJYwiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "47286022d32f48fe490e4c2fb25e73cdba391b974662e10aac440bbd32154890", "occurrences_count":
+        6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/27",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 28, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592859, "secret_hash":
+        "ZnxXuxqfCDl+HlqBWZKEO7H2L1fXnhwHImxR1f28xgkJuUB1iIVhmFkAG+mbE/6F", "hmsl_hash":
+        "84e555e48b1ed023a553264e9724fe9fa0b5421f8209d5a986f8985c58915ead", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/28",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 29, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592860, "secret_hash":
+        "qeoBkkmxoCbogO0cHEb8YDWNgokqR0foCqyClIti/qc9PkCHiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "f82922f64e2a32d86e7c939c405d9949701e6479ac42d22e4d6549ebec6bce3b", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/29",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}]'
+    headers:
+      CF-RAY:
+      - 9ef4871f39ded124-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:40 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '5566'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0yOQ%3D%3D&per_page=5>;
+        rel="next", <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cj0xJnA9MjU%3D&per_page=5>;
+        rel="prev"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '108'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_incidents_multi_value_severity.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_multi_value_severity.yaml
@@ -1,0 +1,372 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=20&severity=critical%2Chigh
+  response:
+    body:
+      string: '[{"id": 23, "detector": {"name": "sendgrid", "display_name": "SendGrid
+        Key", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "sendgrid_key", "detector_group_display_name": "SendGrid
+        Key"}, "date": "2022-07-19T09:52:09Z", "secret_id": 7970364, "secret_hash":
+        "CBz9BMCUQDF3+MCOXcTqfTSvrVZTp8XQF+z38O1amQpnfh2zOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "049d5bbb613a172b0eb21c73a827ae34a30233dbfc9e9b75377a4743082bd447", "occurrences_count":
+        527, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.760032Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 0, "severity_rule_id":
+        10872, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/23",
+        "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "SendGrid Key"}, {"id": 24, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2022-07-19T09:52:09Z", "secret_id": 7970365, "secret_hash": "DQ6dPu9BXyq1FZTNVzfsEpxI24qF82fR4BvL62o1Q7AVIqBId9tR0/CjGaYu0TLp",
+        "hmsl_hash": "19c5c04da7b3d2372f1ab65fa2f311aff6ee3a0bfe37d4608797d5546814c335",
+        "occurrences_count": 190, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.760032Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "high", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        14, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/24", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 52, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2024-12-17T10:19:33Z", "secret_id": 14592883, "secret_hash":
+        "jfpGRuRzwwkh+0rO1sdbA98K4zuSMBfQHlBIXMm5dQVFAmmDL4Qc71cZRqNcojMG", "hmsl_hash":
+        "e50cad6b8e0ca71b4e13b0091d440308990047320f621fadabfb37916010e8ad", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.777462Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/52",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 57, "detector": {"name": "gitguardian_test_token_checked",
+        "display_name": "GitGuardian Test Token Checked", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token_checked",
+        "detector_group_display_name": "GitGuardian Test Token Checked"}, "date":
+        "2021-12-10T10:36:08Z", "secret_id": 7970357, "secret_hash": "cfDzN5RpdE7fN0bd474gxh8fBT9kKunY+sHOlD+OeXGzGAkSCxpDOKaZihAFaYMH",
+        "hmsl_hash": "49b26d210036e493d068e32207ab35c98242c41d82db746b1342ef497560195e",
+        "occurrences_count": 187, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.015423Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 27, "severity_rule_id":
+        10866, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/57",
+        "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Test Token Checked"}, {"id": 59, "detector": {"name": "mysql_assignment",
+        "display_name": "MySQL Credentials", "nature": "specific", "family": "identifiers",
+        "category": "data_storage", "detector_group_name": "mysql_credentials", "detector_group_display_name":
+        "MySQL Credentials"}, "date": "2021-12-10T10:36:08Z", "secret_id": 7970366,
+        "secret_hash": "Gu1fKeBEFfI+t8NmzRmnYiaCXTNCM0k35NQ2cV/8G4nstGRImIOAGaePxkIreo8A",
+        "hmsl_hash": "24b34d3f5c513364d23c9f153915d1e651b1aca4cb93e44d51155eb54cf24a6f",
+        "occurrences_count": 70, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.015423Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "failed_to_check", "severity": "critical", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 45, "severity_rule_id": 10868, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/59", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "MySQL Credentials"}, {"id": 64, "detector": {"name": "generic_high_entropy_secret",
+        "display_name": "Generic High Entropy Secret", "nature": "generic", "family":
+        "other", "category": "other", "detector_group_name": "generic_high_entropy_secret",
+        "detector_group_display_name": "Generic High Entropy Secret"}, "date": "2024-06-05T08:52:39Z",
+        "secret_id": 14589069, "secret_hash": "Acx1sg7Sj4xnn7Z+BTdKp60Xz4GrCmR1Rab2IuaDHCsmnEjMp+KkPCNpyNbtXqJM",
+        "hmsl_hash": "95ff63fdc1a4a0b1fdcbee9b8f628b140d2d6c7da1d2050f5f822263401d3bfb",
+        "occurrences_count": 40, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.153475Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "high", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        0, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/64", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "IS_COMPANY_CONTEXT",
+        "TEST_FILE", "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Meta Facebook Credentials"}, {"id": 120, "detector":
+        {"name": "aws_iam", "display_name": "AWS IAM Keys", "nature": "specific",
+        "family": "credentials", "category": "cloud_provider", "detector_group_name":
+        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2022-09-21T07:47:10Z",
+        "secret_id": 14592936, "secret_hash": "HCWrG3nEt9czkeRivsO5t2mdGFXFrkwOSPchO87xypH14P2ML4Qc71cZRqNcojMG",
+        "hmsl_hash": "44126737df445f6b9468541f77e5c5bdac71b057644a7fe1c8c219940948acc4",
+        "occurrences_count": 1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:03.840266Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        "2026-01-26T14:38:12.774362Z", "resolver_id": 492181, "resolver_api_token_id":
+        null, "secret_revoked": true, "validity": "invalid", "severity": "critical",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 97, "severity_rule_id": 7263, "is_vaulted": false, "declarative_secret_status":
+        "revoked", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/120", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "AWS IAM Keys"}, {"id": 122, "detector": {"name": "generic_password", "display_name":
+        "Generic Password", "nature": "generic", "family": "other", "category": "other",
+        "detector_group_name": "generic_password", "detector_group_display_name":
+        "Generic Password"}, "date": "2023-01-12T15:18:48Z", "secret_id": 14592938,
+        "secret_hash": "grMUjNXkz+3KpugZrfscb34PsMn332maZU8rfwg5ExJgckP0fma8ieOEhD7igl+v",
+        "hmsl_hash": "885b7f778a33b34faa2299bced3d148ba2b58c663822c4080a05c48b51030827",
+        "occurrences_count": 219, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.906038Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "high", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        9, "severity_rule_id": 10877, "is_vaulted": true, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/122", "tags":
+        ["FROM_HISTORICAL_SCAN", "SENSITIVE_FILE", "INTERNALLY_LEAKED"], "custom_tags":
+        [], "destination_tickets": [], "incident_name": "PostgreSQL Identifiers"},
+        {"id": 123, "detector": {"name": "aws_iam", "display_name": "AWS IAM Keys",
+        "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2024-10-08T08:06:58Z", "secret_id": 14592939, "secret_hash":
+        "Ic0b2F+nC6t10UFsL2q4RoCOnxbICIPG8le5eLah1r7yCUW4L4Qc71cZRqNcojMG", "hmsl_hash":
+        "79daedb7dbd145002662f320d5b3497fe9f99eee48534675db9f85425e87c90f", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.922766Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/123",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 133, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2023-06-20T17:37:11Z", "secret_id": 14592949, "secret_hash":
+        "xREUeCg4rijhFTi2xfwsH3UKQ1nmE772jLaXnIwSSQX13b29L4Qc71cZRqNcojMG", "hmsl_hash":
+        "cf6f1f93b8a8c05eaec32d63ea56648a7f72805a9cbb9250ba543bcf32e25685", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.018836Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/133",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 160, "detector": {"name": "username_password",
+        "display_name": "Username Password", "nature": "generic", "family": "other",
+        "category": "other", "detector_group_name": "username_password", "detector_group_display_name":
+        "Username Password"}, "date": "2024-09-24T07:18:21Z", "secret_id": 14592975,
+        "secret_hash": "h7BYoSnMoSkemlgx3+vR3VMfD/+iB+KFkbtkwB7pvx4U5NJmP4G6lsSULyTx/pbN",
+        "hmsl_hash": "b8b5b99f1062d935ce673413a2492db38be49c41def15ce0f99a16640a58be14",
+        "occurrences_count": 8, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.258176Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "high", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        24, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/160", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE"],
+        "custom_tags": [], "destination_tickets": [], "incident_name": "Username Password"},
+        {"id": 223, "detector": {"name": "aws_iam", "display_name": "AWS IAM Keys",
+        "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2023-05-29T14:33:46Z", "secret_id": 14593033, "secret_hash":
+        "e//G4mtKFRjgDuoLBUbQZ/7EuqnpuP0bKzBqfd4NHisupFCKL4Qc71cZRqNcojMG", "hmsl_hash":
+        "0e6a563b189eabfecf1f34fee7b4253e70a07a53a36b6a92d28880042e105278", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.995414Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/223",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 227, "detector": {"name": "generic_high_entropy_secret",
+        "display_name": "Generic High Entropy Secret", "nature": "generic", "family":
+        "other", "category": "other", "detector_group_name": "generic_high_entropy_secret",
+        "detector_group_display_name": "Generic High Entropy Secret"}, "date": "2024-06-11T14:23:52Z",
+        "secret_id": 14589070, "secret_hash": "fjZ3jyx2auRab756YeJR8bzqlM2E3wrNg+2Mwj/Esf3MFc8Bp+KkPCNpyNbtXqJM",
+        "hmsl_hash": "534acd03d083a37e0f4a0b567111580cd5a643cc1ac70d24d16c6bce2657e601",
+        "occurrences_count": 18, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:05.087393Z",
+        "ignored_at": "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "high", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 0, "severity_rule_id": 10284, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/227", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FALSE_POSITIVE", "FROM_HISTORICAL_SCAN",
+        "IS_COMPANY_CONTEXT", "TEST_FILE", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "SendGrid Token"}, {"id": 245,
+        "detector": {"name": "aws_iam", "display_name": "AWS IAM Keys", "nature":
+        "specific", "family": "credentials", "category": "cloud_provider", "detector_group_name":
+        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2024-10-07T18:33:17Z",
+        "secret_id": 14593053, "secret_hash": "awCkSxVkZeR50syOZDuRTVJ77h9KpVq35/CzNZrq/pFoUknHL4Qc71cZRqNcojMG",
+        "hmsl_hash": "e17f96e6fd24e5fc2e609b4b5be916c383e4c10635e1a20ef34c0b92d8601f0c",
+        "occurrences_count": 3, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:05.371572Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/245",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 252, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2024-03-29T10:08:11Z", "secret_id": 14593061, "secret_hash":
+        "iDJDcn/Xvkd/k8+cgExZqE4fBiZfjJl5+WwtZC8s/zK6krQOL4Qc71cZRqNcojMG", "hmsl_hash":
+        "f0e9ab20a0c07a1724ac31b4671e587142d22d70dbe801febd309daf99762fd1", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:05.510762Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/252",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 258, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2024-10-07T18:42:20Z", "secret_id": 14593067, "secret_hash":
+        "dQiA0RFZBamkGhKtz+piOYa3rSUTooYJtXkhJSetmaj/1eesL4Qc71cZRqNcojMG", "hmsl_hash":
+        "08af43e11859516bdb0a7011f07960406e2fec40e4f5ee4e6223600ae69e149c", "occurrences_count":
+        2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:05.491648Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/258",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 381, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2023-06-01T07:54:57Z", "secret_id": 14593180, "secret_hash":
+        "uPVhj1ko9dBcKlnlHJw0oZrmswd8Prh8dbmHBvsWxiE/CpfwL4Qc71cZRqNcojMG", "hmsl_hash":
+        "e00dd5cecb527b29dc4bde752c43dbb59292ccc46398e77acf8161662b6c6e34", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:07.834378Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/381",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 441, "detector": {"name": "basic_auth_string",
+        "display_name": "Basic Auth String", "nature": "generic", "family": "other",
+        "category": "other", "detector_group_name": "basic_auth_string", "detector_group_display_name":
+        "Basic Auth String"}, "date": "2023-10-19T08:23:06Z", "secret_id": 9807847,
+        "secret_hash": "tRZTJ6rwJPJ/ktyL9OJEDtvFragplJoTKHMCtjPNXScVF3fbM5xa/7jbjmrFMxI3",
+        "hmsl_hash": "9a1132be80f80347a22819bb2a09557c6735866d69da5742c8cef147c8cb6e9b",
+        "occurrences_count": 41, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:09.174497Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "high", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        20, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/441", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Credentials"}, {"id": 465, "detector": {"name": "aws_iam", "display_name":
+        "AWS IAM Keys", "nature": "specific", "family": "credentials", "category":
+        "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2023-12-20T20:45:21Z", "secret_id": 12925726, "secret_hash":
+        "0BZO3LCbEw/8g25VzfNA2n4mCERAGEq/D0UQipLWykyGIUvgL4Qc71cZRqNcojMG", "hmsl_hash":
+        "cb93a7a7db62917a451cc826eb1c623c5b7ed4401f9752e2f202ed0404d6bd51", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:09.866755Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/465",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "AWS IAM Keys"}, {"id": 472, "detector":
+        {"name": "aws_iam", "display_name": "AWS IAM Keys", "nature": "specific",
+        "family": "credentials", "category": "cloud_provider", "detector_group_name":
+        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2023-05-23T15:50:18Z",
+        "secret_id": 14593270, "secret_hash": "TdYBYx7DS/AH/h2x00Ad8Y+r9LiVN784Od0SXxQbdaC+CdcQL4Qc71cZRqNcojMG",
+        "hmsl_hash": "fcf8989c038d6c2cca1d419da8f9c5aa51cfee577bd6c2c1b85acc70e848faa0",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:10.051731Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/472",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}]'
+    headers:
+      CF-RAY:
+      - 9efb60b2daa42298-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:31:47 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '23510'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD00NzI%3D&per_page=20&severity=critical%2Chigh>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '221'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '20'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_incidents_multi_value_status.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_multi_value_status.yaml
@@ -1,0 +1,364 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=20&status=TRIGGERED%2CASSIGNED
+  response:
+    body:
+      string: '[{"id": 2, "detector": {"name": "slackbototken", "display_name": "Slack
+        Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash":
+        "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4", "hmsl_hash":
+        "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3", "occurrences_count":
+        2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/2",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592836, "secret_hash": "UkaGM2d1NaALSIkUqCBkEgY+xnpQYM3vPZeWQp9v/O680MxYd9tR0/CjGaYu0TLp",
+        "hmsl_hash": "2cc5873afae5ee7747e26e2d73f7b8abe0ac63e7971442ceb50be7c4bf5c77c9",
+        "occurrences_count": 13, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/3", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 4, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
+        "hmsl_hash": "8d750888a3f74d018e742b42dfb51c60907b26c49fdad4ebdabe1350eedfe0fb",
+        "occurrences_count": 10, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/4", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 5, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-05-24T12:18:15Z", "secret_id": 14592838,
+        "secret_hash": "Z5EChCcGXgX/eXhBjNhs4sGINbMdnzWjcD4m3l7naZmf7qCBOMgPzYhV28m6OGG4",
+        "hmsl_hash": "dc66b2a9c718f0d32581426943c736bfed9bcfd865c77712ca43d96faf97f731",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 8, "detector": {"name": "sendgrid", "display_name":
+        "SendGrid Key", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "sendgrid_key", "detector_group_display_name": "SendGrid
+        Key"}, "date": "2019-02-11T12:36:02Z", "secret_id": 14592841, "secret_hash":
+        "56VyXyYsEkRVqTiCem+I1NhoZNp0IQKqlPItH+mlIkMmFjfwOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "31198eeb074a1722b082a6ea94edc8a133b115d7201acb47361741b236966830", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.746711Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/8",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 9, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-10-17T13:35:42Z", "secret_id": 14592842,
+        "secret_hash": "iPhCz0hiEKKcYiKnWwMgF+iE0K4tHJTBECUI1m+w7wJpZCyyOMgPzYhV28m6OGG4",
+        "hmsl_hash": "35764f7687c768b9e42ce14f6b7f4eece8d1cd71d4c63c8fd614b23a8e8c1c7d",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.747147Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/9", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 10, "detector": {"name": "generic_password", "display_name":
+        "Generic Password", "nature": "generic", "family": "other", "category": "other",
+        "detector_group_name": "generic_password", "detector_group_display_name":
+        "Generic Password"}, "date": "2022-06-20T16:04:33Z", "secret_id": 14592843,
+        "secret_hash": "1rC83I0fTz8CLTr6Tz7usCc9nbtqZqUU2qXEU2V6CGzNxOl3fma8ieOEhD7igl+v",
+        "hmsl_hash": "9f54d16410ea8fae5f1389bcfa2d48539da4491cf4998d5d8cbcb9b4b946255f",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.749479Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        51, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/10", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Generic Password"}, {"id": 17, "detector": {"name": "sendgrid", "display_name":
+        "SendGrid Key", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "sendgrid_key", "detector_group_display_name": "SendGrid
+        Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592850, "secret_hash":
+        "IRfE2CM4LTU9zkWZl7wtWYTnBxQiaOHtAcZ3uhDrcvPg22qYOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "046f4d07330d592e729e6a072661070a3686a0616bf1e72209789656ca471b17", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/17",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 18, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592851, "secret_hash":
+        "Uuk6ATzxus6ReU1GDCXUwr7vwE8ViniGIZwfovTm021h+oKmOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "99185204219cfb8df5e777a66f95fd7df357fed56ab23836bbaf6ea2514f961a", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/18",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 19, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592852, "secret_hash":
+        "GPMde0PsT+7OW6y5RryDp/j+pXQkud3HsGpajUFu0Tzqx9pZOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "694403f25caf188319a9b5df5776a6795ac760ad443807047f0771e3119ccd56", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/19",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 20, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592853, "secret_hash":
+        "bBXl1L03BPejq0HJOOIJN/egKAz5enmLatAafFYLw00oSifLOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "cf9bc1eaab8460fbeaaf779e9756c8a586a8f366debb06d2e937e4d85365ad9e", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/20",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 21, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2023-05-16T12:28:32Z", "secret_id": 14592854, "secret_hash":
+        "Xy7y/46z9WKji2j3qEcqzGFPKjkOeenb1PfQsvoEj05SynaIL4Qc71cZRqNcojMG", "hmsl_hash":
+        "dbbfaacc45fe15df6fc8445e5c8a9af230c5ec380ba8944a440009d4b58e8b68", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.757884Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/21",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 23, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2022-07-19T09:52:09Z", "secret_id": 7970364, "secret_hash":
+        "CBz9BMCUQDF3+MCOXcTqfTSvrVZTp8XQF+z38O1amQpnfh2zOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "049d5bbb613a172b0eb21c73a827ae34a30233dbfc9e9b75377a4743082bd447", "occurrences_count":
+        527, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.760032Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 0, "severity_rule_id":
+        10872, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/23",
+        "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "SendGrid Key"}, {"id": 24, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2022-07-19T09:52:09Z", "secret_id": 7970365, "secret_hash": "DQ6dPu9BXyq1FZTNVzfsEpxI24qF82fR4BvL62o1Q7AVIqBId9tR0/CjGaYu0TLp",
+        "hmsl_hash": "19c5c04da7b3d2372f1ab65fa2f311aff6ee3a0bfe37d4608797d5546814c335",
+        "occurrences_count": 190, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.760032Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "high", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        14, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/24", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 25, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592856, "secret_hash":
+        "6tsYM/861fChIu3lkD9zTIE4r+Ye4PBnYxO1wHC4R2WAM9tMiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "3321c774dd4bff3b29cbae9b5ccfc64033ca13a397039769ea185509a247b8b2", "occurrences_count":
+        6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/25",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 26, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592857, "secret_hash":
+        "MitOZYWU/47TOCVlJ8xs0iLON2e7+dG8ZogVwnscopqJ56XGiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "ca5b862ee181bfd49edd91e65ee018b8109e624b6679d0a780eed0591bc03f14", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/26",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 27, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592858, "secret_hash":
+        "bhbBm4t+But3lH43U3ossWK1Xe5Xh8AC0io3FirV6kuFeJYwiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "47286022d32f48fe490e4c2fb25e73cdba391b974662e10aac440bbd32154890", "occurrences_count":
+        6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/27",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 28, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592859, "secret_hash":
+        "ZnxXuxqfCDl+HlqBWZKEO7H2L1fXnhwHImxR1f28xgkJuUB1iIVhmFkAG+mbE/6F", "hmsl_hash":
+        "84e555e48b1ed023a553264e9724fe9fa0b5421f8209d5a986f8985c58915ead", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/28",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 29, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592860, "secret_hash":
+        "qeoBkkmxoCbogO0cHEb8YDWNgokqR0foCqyClIti/qc9PkCHiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "f82922f64e2a32d86e7c939c405d9949701e6479ac42d22e4d6549ebec6bce3b", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/29",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 30, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2022-09-01T12:15:30Z", "secret_id": 14592861,
+        "secret_hash": "UcHRteKCwroK47xMicSu6b7x3bMi6jvwgYV4DzuatWRC3HXYOMgPzYhV28m6OGG4",
+        "hmsl_hash": "6e9d452d4b21ac2c8f0cbefb99199985801619e77ad5e35f65d651320d9450a5",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.766850Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/30", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}]'
+    headers:
+      CF-RAY:
+      - 9efb60ae1abb0283-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:31:46 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '22810'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0zMA%3D%3D&per_page=20&status=TRIGGERED%2CASSIGNED>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '346'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '20'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_incidents_multi_value_validity.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_multi_value_validity.yaml
@@ -1,0 +1,372 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=20&validity=valid%2Cfailed_to_check
+  response:
+    body:
+      string: '[{"id": 52, "detector": {"name": "aws_iam", "display_name": "AWS IAM
+        Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2024-12-17T10:19:33Z", "secret_id": 14592883, "secret_hash":
+        "jfpGRuRzwwkh+0rO1sdbA98K4zuSMBfQHlBIXMm5dQVFAmmDL4Qc71cZRqNcojMG", "hmsl_hash":
+        "e50cad6b8e0ca71b4e13b0091d440308990047320f621fadabfb37916010e8ad", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.777462Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/52",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 57, "detector": {"name": "gitguardian_test_token_checked",
+        "display_name": "GitGuardian Test Token Checked", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token_checked",
+        "detector_group_display_name": "GitGuardian Test Token Checked"}, "date":
+        "2021-12-10T10:36:08Z", "secret_id": 7970357, "secret_hash": "cfDzN5RpdE7fN0bd474gxh8fBT9kKunY+sHOlD+OeXGzGAkSCxpDOKaZihAFaYMH",
+        "hmsl_hash": "49b26d210036e493d068e32207ab35c98242c41d82db746b1342ef497560195e",
+        "occurrences_count": 187, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.015423Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 27, "severity_rule_id":
+        10866, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/57",
+        "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Test Token Checked"}, {"id": 59, "detector": {"name": "mysql_assignment",
+        "display_name": "MySQL Credentials", "nature": "specific", "family": "identifiers",
+        "category": "data_storage", "detector_group_name": "mysql_credentials", "detector_group_display_name":
+        "MySQL Credentials"}, "date": "2021-12-10T10:36:08Z", "secret_id": 7970366,
+        "secret_hash": "Gu1fKeBEFfI+t8NmzRmnYiaCXTNCM0k35NQ2cV/8G4nstGRImIOAGaePxkIreo8A",
+        "hmsl_hash": "24b34d3f5c513364d23c9f153915d1e651b1aca4cb93e44d51155eb54cf24a6f",
+        "occurrences_count": 70, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.015423Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "failed_to_check", "severity": "critical", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 45, "severity_rule_id": 10868, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/59", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "MySQL Credentials"}, {"id": 60, "detector": {"name": "private_key_rsa", "display_name":
+        "RSA Private Key", "nature": "specific", "family": "cryptographic_key", "category":
+        "private_key", "detector_group_name": "private_key_rsa", "detector_group_display_name":
+        "RSA Private Key"}, "date": "2021-05-05T14:31:57Z", "secret_id": 7970362,
+        "secret_hash": "3lQN40NaBaFf+NUSRQGq6y2ha0EiHzjsIhK9oetj9ed8muBM7vN5xZFHxYj+duJV",
+        "hmsl_hash": "6b660a152543f2f62279f94b5c799ef5abb168f5e4339e17fec0e3a97b5406fc",
+        "occurrences_count": 31, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.060154Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 40, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/60", "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "RSA Private Key"}, {"id": 65, "detector": {"name": "private_key_openssh",
+        "display_name": "OpenSSH Private Key", "nature": "specific", "family": "cryptographic_key",
+        "category": "private_key", "detector_group_name": "private_key_openssh", "detector_group_display_name":
+        "OpenSSH Private Key"}, "date": "2020-11-26T22:36:15Z", "secret_id": 14592888,
+        "secret_hash": "D2WvSYX1LNJDT66f7bb4tKtxUxUMWx+FW16LunaqBTuXd1ggkTr0t/OLrv3FkQLP",
+        "hmsl_hash": "cdf6519a37024b28740d825fe1face441a89d4e5c779d9399ccff50700ea6093",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.245157Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 40, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/65", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "OpenSSH Private Key"}, {"id": 68, "detector": {"name": "postgres_uri", "display_name":
+        "PostgreSQL Credentials", "nature": "specific", "family": "identifiers", "category":
+        "data_storage", "detector_group_name": "postgresql_credentials", "detector_group_display_name":
+        "PostgreSQL Credentials"}, "date": "2024-08-28T12:15:48Z", "secret_id": 14592891,
+        "secret_hash": "lF+MxnMY2/ZkB4HO/TO6YHoHoGaOW/4i4lKmY1kaxc7XeNG3CUnJ9mpXO6ItKClD",
+        "hmsl_hash": "48b6704e05b6ac160f89d32be5951a29c8d6e08162853e0841313b16d446e308",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.251954Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 49, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/68", "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "PostgreSQL Credentials"}, {"id": 81, "detector": {"name":
+        "private_key_openssh", "display_name": "OpenSSH Private Key", "nature": "specific",
+        "family": "cryptographic_key", "category": "private_key", "detector_group_name":
+        "private_key_openssh", "detector_group_display_name": "OpenSSH Private Key"},
+        "date": "2020-11-26T22:38:44Z", "secret_id": 14592905, "secret_hash": "pD3O1Z7qbPTEK2sKWieYk65Q3a9YRdPLxzKPyyjUk1eaYSAjkTr0t/OLrv3FkQLP",
+        "hmsl_hash": "69b63b3291a518c91902862ea95020a1775780d1211fbee28de98f6de7a22e55",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.321296Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 40, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/81", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "OpenSSH Private Key"}, {"id": 88, "detector": {"name": "mongo_uri", "display_name":
+        "MongoDB Credentials", "nature": "specific", "family": "identifiers", "category":
+        "data_storage", "detector_group_name": "mongodb_credentials", "detector_group_display_name":
+        "MongoDB Credentials"}, "date": "2023-03-03T10:06:36Z", "secret_id": 14592912,
+        "secret_hash": "mJBjMBDuNLpJtlB6/6u6wfLVQz9YfTsokTuuIFwYETubAnfffeuh40iUuZt2nZY1",
+        "hmsl_hash": "18145ff0d87c092e28483d86a8cc7152ae71ce78fda60a9aeb2aa1fae6483d8e",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.368852Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 84, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/88", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "MongoDB Credentials"}, {"id": 123, "detector": {"name": "aws_iam", "display_name":
+        "AWS IAM Keys", "nature": "specific", "family": "credentials", "category":
+        "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2024-10-08T08:06:58Z", "secret_id": 14592939, "secret_hash":
+        "Ic0b2F+nC6t10UFsL2q4RoCOnxbICIPG8le5eLah1r7yCUW4L4Qc71cZRqNcojMG", "hmsl_hash":
+        "79daedb7dbd145002662f320d5b3497fe9f99eee48534675db9f85425e87c90f", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.922766Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/123",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 133, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2023-06-20T17:37:11Z", "secret_id": 14592949, "secret_hash":
+        "xREUeCg4rijhFTi2xfwsH3UKQ1nmE772jLaXnIwSSQX13b29L4Qc71cZRqNcojMG", "hmsl_hash":
+        "cf6f1f93b8a8c05eaec32d63ea56648a7f72805a9cbb9250ba543bcf32e25685", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.018836Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/133",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 142, "detector": {"name": "gitguardian_test_token_checked",
+        "display_name": "GitGuardian Test Token Checked", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token_checked",
+        "detector_group_display_name": "GitGuardian Test Token Checked"}, "date":
+        "2024-08-20T12:45:39Z", "secret_id": 14592957, "secret_hash": "F0v+rUbWNYEaACUQ7e+WD6aGK44ETtBdLu7hJcwYHwAmM46HCxpDOKaZihAFaYMH",
+        "hmsl_hash": "4a715e13b9ac2f1822fa5e59bb2b74ed57214806134df7b76b86e13f2b525b03",
+        "occurrences_count": 6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.191605Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 60, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/142",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "GitGuardian Test Token Checked"}, {"id": 143, "detector":
+        {"name": "mssql_uri", "display_name": "MSSQL Credentials", "nature": "specific",
+        "family": "identifiers", "category": "data_storage", "detector_group_name":
+        "mssql_credentials", "detector_group_display_name": "MSSQL Credentials"},
+        "date": "2023-02-07T09:10:20Z", "secret_id": 14592958, "secret_hash": "rbZDKn/4BlHueVX5rt4aqKdBNU4Imx3PEoAYOYPW7ez+6oD5SOKbj7dSz86r4tjg",
+        "hmsl_hash": "42073f1dd8515706fa82e308821ce6041bb54867e08637073188a0ab58e3a0ed",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.197186Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 84, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/143", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "MSSQL Credentials"}, {"id": 144, "detector": {"name": "private_key_rsa",
+        "display_name": "RSA Private Key", "nature": "specific", "family": "cryptographic_key",
+        "category": "private_key", "detector_group_name": "private_key_rsa", "detector_group_display_name":
+        "RSA Private Key"}, "date": "2019-08-27T13:49:27Z", "secret_id": 14592959,
+        "secret_hash": "Asl87g6YNF0Eg9O5vuHiufJwUcx3N8BLJwdgXTqNbsTgRNRP7vN5xZFHxYj+duJV",
+        "hmsl_hash": "082e33472a66c8f92ad328cec850af560b4151e9279c023eae97fed0fbec9ef7",
+        "occurrences_count": 23, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.198512Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 40, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/144", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "RSA Private Key"}, {"id": 150, "detector": {"name": "private_key_rsa", "display_name":
+        "RSA Private Key", "nature": "specific", "family": "cryptographic_key", "category":
+        "private_key", "detector_group_name": "private_key_rsa", "detector_group_display_name":
+        "RSA Private Key"}, "date": "2023-03-03T12:22:41Z", "secret_id": 14592965,
+        "secret_hash": "CuE9V4B3m6qXIGeiHuGTt4ArL0YZ8/zhxBtyQ5BxbACxYtV77vN5xZFHxYj+duJV",
+        "hmsl_hash": "6ceb5f733b0d2ac2f5ad791774a394506e711c4a87cc3e4db4d4fac7cdf02e39",
+        "occurrences_count": 6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.228591Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 40, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/150", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "RSA Private Key"}, {"id": 151, "detector": {"name": "private_key_rsa", "display_name":
+        "RSA Private Key", "nature": "specific", "family": "cryptographic_key", "category":
+        "private_key", "detector_group_name": "private_key_rsa", "detector_group_display_name":
+        "RSA Private Key"}, "date": "2023-03-03T12:22:41Z", "secret_id": 14592966,
+        "secret_hash": "OgPnWBLzMtToimbkAVK+rQANyGlRbK/HfJ2SljRmtAJzIUDV7vN5xZFHxYj+duJV",
+        "hmsl_hash": "3676511484824d2ac6eb79564d520de56a8096f3d5a82538c3bf19d4da28070b",
+        "occurrences_count": 6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.228591Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 40, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/151", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "RSA Private Key"}, {"id": 152, "detector": {"name": "private_key_rsa", "display_name":
+        "RSA Private Key", "nature": "specific", "family": "cryptographic_key", "category":
+        "private_key", "detector_group_name": "private_key_rsa", "detector_group_display_name":
+        "RSA Private Key"}, "date": "2023-03-03T12:22:41Z", "secret_id": 14592967,
+        "secret_hash": "CGOhyo4C8c3ez6u83GtxIGKtTL2S0qXMEYWqB85KUQrSEK2S7vN5xZFHxYj+duJV",
+        "hmsl_hash": "681241c9b9a3c912fbb646c364c3581b9b4f60c3b6072ddb858d80dc077c3fbd",
+        "occurrences_count": 6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.228591Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 40, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/152", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "RSA Private Key"}, {"id": 153, "detector": {"name": "private_key_rsa", "display_name":
+        "RSA Private Key", "nature": "specific", "family": "cryptographic_key", "category":
+        "private_key", "detector_group_name": "private_key_rsa", "detector_group_display_name":
+        "RSA Private Key"}, "date": "2023-03-03T12:22:41Z", "secret_id": 14592968,
+        "secret_hash": "sSRGBc0f6EmyrCha1/ZancNIk/PktDGcSR6pMNjUvcmTi00b7vN5xZFHxYj+duJV",
+        "hmsl_hash": "d52a4a1cf8ff25f8db4b179bff876c5af86763b5404a1acf9abdc4a0e5601ae5",
+        "occurrences_count": 6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.228591Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 40, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/153", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "RSA Private Key"}, {"id": 154, "detector": {"name": "private_key_rsa", "display_name":
+        "RSA Private Key", "nature": "specific", "family": "cryptographic_key", "category":
+        "private_key", "detector_group_name": "private_key_rsa", "detector_group_display_name":
+        "RSA Private Key"}, "date": "2023-03-03T12:22:41Z", "secret_id": 14592969,
+        "secret_hash": "Dprh43QI8+tyHgURzFexd4Y1VF7zxneSq3RoNHlqctHC8L8d7vN5xZFHxYj+duJV",
+        "hmsl_hash": "24c1586f483de5bb60d7d3a84e40946caf6bd1fafd02e5404da21e05b51a0ddc",
+        "occurrences_count": 6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.228591Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 40, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/154", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "RSA Private Key"}, {"id": 163, "detector": {"name": "mongo_assignment", "display_name":
+        "MongoDB Credentials", "nature": "specific", "family": "identifiers", "category":
+        "data_storage", "detector_group_name": "mongodb_credentials", "detector_group_display_name":
+        "MongoDB Credentials"}, "date": "2019-02-08T16:07:48Z", "secret_id": 14592978,
+        "secret_hash": "C3gnyszrLlSvO/OeLPO+jKK3YINX0nxmhewzX/eAFEnZ7EUqMHFU8eOMXjXgylmC",
+        "hmsl_hash": "c13f266a750e709a57596c9bda6ea8b0e9dc9357e5a069935095c36980b2e0fd",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.301115Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 84, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/163", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "MongoDB Credentials"}, {"id": 164, "detector": {"name": "gitguardian_prm_key",
+        "display_name": "GitGuardian Internal Monitoring Key", "nature": "specific",
+        "family": "token", "category": "monitoring", "detector_group_name": "gitguardian_prm_key",
+        "detector_group_display_name": "GitGuardian Internal Monitoring Key"}, "date":
+        "2020-07-13T14:36:30Z", "secret_id": 14592979, "secret_hash": "tMxCCJ2Jw+yHkTkj+mV6Q4KRx/JwlWQCqcUrP27AkuioOTkXhDo2sD+4lbVkOcLB",
+        "hmsl_hash": "f27dd7388c3b707115128aa98efabb86d5fa7c2ed789fd7c123c66fc7021c6ed",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.359134Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 42, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/164", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Internal Monitoring Key"}]'
+    headers:
+      CF-RAY:
+      - 9efb60b7092f2c0b-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:31:48 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '23448'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0xNjQ%3D&per_page=20&validity=valid%2Cfailed_to_check>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '100'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '20'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_assignee_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_assignee_filter.yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=20&status=ASSIGNED
+  response:
+    body:
+      string: '[]'
+    headers:
+      CF-RAY:
+      - 9efb6ddf5ff5d125-CDG
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:46 GMT
+      Server:
+      - cloudflare
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '151'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '20'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_cursor.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_cursor.yaml
@@ -1,0 +1,177 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=1
+  response:
+    body:
+      string: '[{"id": 1, "detector": {"name": "stripe", "display_name": "Stripe Keys",
+        "nature": "specific", "family": "token", "category": "payment_system", "detector_group_name":
+        "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
+        "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
+        "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
+        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
+        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
+        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
+        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "Stripe Keys"}]'
+    headers:
+      CF-RAY:
+      - 9ef488d96c25d877-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:35:51 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1195'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0x&per_page=1>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '68'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '1'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0x&per_page=1
+  response:
+    body:
+      string: '[{"id": 2, "detector": {"name": "slackbototken", "display_name": "Slack
+        Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash":
+        "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4", "hmsl_hash":
+        "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3", "occurrences_count":
+        2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/2",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Slack Bot Token"}]'
+    headers:
+      CF-RAY:
+      - 9ef488dbae346fbe-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:35:51 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1137'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0y&per_page=1>;
+        rel="next", <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cj0xJnA9Mg%3D%3D&per_page=1>;
+        rel="prev"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '72'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '1'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_date_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_date_filter.yaml
@@ -1,0 +1,146 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=5&date_before=2026-01-01T00%3A00%3A00Z&date_after=2024-01-01T00%3A00%3A00Z
+  response:
+    body:
+      string: '[{"id": 2, "detector": {"name": "slackbototken", "display_name": "Slack
+        Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash":
+        "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4", "hmsl_hash":
+        "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3", "occurrences_count":
+        2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/2",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Slack Bot Token"}, {"id": 5, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-05-24T12:18:15Z", "secret_id": 14592838,
+        "secret_hash": "Z5EChCcGXgX/eXhBjNhs4sGINbMdnzWjcD4m3l7naZmf7qCBOMgPzYhV28m6OGG4",
+        "hmsl_hash": "dc66b2a9c718f0d32581426943c736bfed9bcfd865c77712ca43d96faf97f731",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 9, "detector": {"name": "slackbototken", "display_name":
+        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2024-10-17T13:35:42Z", "secret_id": 14592842, "secret_hash":
+        "iPhCz0hiEKKcYiKnWwMgF+iE0K4tHJTBECUI1m+w7wJpZCyyOMgPzYhV28m6OGG4", "hmsl_hash":
+        "35764f7687c768b9e42ce14f6b7f4eece8d1cd71d4c63c8fd614b23a8e8c1c7d", "occurrences_count":
+        2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.747147Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/9",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Slack Bot Token"}, {"id": 31, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2024-02-19T18:20:22Z", "secret_id": 14592862, "secret_hash":
+        "MTwOa4AC8TReqOFMxheHde6NFJU3x7jjFIVroYu+vnbjFmSaL4Qc71cZRqNcojMG", "hmsl_hash":
+        "1ad609288e2035eaeb06724530512ceb58d201cb452c0c17ab21a87a0517eed6", "occurrences_count":
+        6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.771752Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/31",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 32, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2024-02-19T18:20:22Z", "secret_id": 14592863, "secret_hash":
+        "sOy8Tz/DPtKtfM4Yw5IkE78u3en7BMrbHC1D+fszvUHrxAiRL4Qc71cZRqNcojMG", "hmsl_hash":
+        "5accd84b32f945186495e448c8334cb297d99a8eee06afe4810712ae3a2efda3", "occurrences_count":
+        2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.771752Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/32",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}]'
+    headers:
+      CF-RAY:
+      - 9ef486fae97a8156-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:34 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '5647'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0zMg%3D%3D&date_after=2024-01-01T00%3A00%3A00Z&date_before=2026-01-01T00%3A00%3A00Z&per_page=5>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '68'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_declarative_secret_status.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_declarative_secret_status.yaml
@@ -1,0 +1,146 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=5&declarative_secret_status=revoked
+  response:
+    body:
+      string: '[{"id": 120, "detector": {"name": "aws_iam", "display_name": "AWS IAM
+        Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2022-09-21T07:47:10Z", "secret_id": 14592936, "secret_hash":
+        "HCWrG3nEt9czkeRivsO5t2mdGFXFrkwOSPchO87xypH14P2ML4Qc71cZRqNcojMG", "hmsl_hash":
+        "44126737df445f6b9468541f77e5c5bdac71b057644a7fe1c8c219940948acc4", "occurrences_count":
+        1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:03.840266Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        7263, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/120",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 385, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2023-07-06T12:36:07Z", "secret_id": 9181441, "secret_hash":
+        "mKn4Nj0bR4rIic8L5Vdx8VllYYtf+CISEyDv7GToL66gKwIWL4Qc71cZRqNcojMG", "hmsl_hash":
+        "838d881ae00bfb022f27c3b2e57e4927d7a2ef12c4a2f75b8b6730c80dba47b3", "occurrences_count":
+        1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:07.901475Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/385",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "AWS IAM Keys"}, {"id": 455, "detector":
+        {"name": "aws_iam", "display_name": "AWS IAM Keys", "nature": "specific",
+        "family": "credentials", "category": "cloud_provider", "detector_group_name":
+        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2023-09-14T06:56:47Z",
+        "secret_id": 14593254, "secret_hash": "kZ78fTN4Cp9siyqtBD6gQM2qgUEC/x7J8+fyI3hFOr4M3FM3L4Qc71cZRqNcojMG",
+        "hmsl_hash": "4ba981a3cf490ed7f92e695a83c1f41ceb8f91541f62da24884ddb040cb6c083",
+        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:09.608272Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        "2026-01-26T14:38:12.774362Z", "resolver_id": 492181, "resolver_api_token_id":
+        null, "secret_revoked": true, "validity": "valid", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 97, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "revoked", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/455", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "AWS IAM Keys"}, {"id": 518, "detector": {"name": "aws_iam", "display_name":
+        "AWS IAM Keys", "nature": "specific", "family": "credentials", "category":
+        "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2023-10-19T12:06:07Z", "secret_id": 14593309, "secret_hash":
+        "aQL+3fwIPTpy/G2vW31cL2nAoP8QUXwn3RsexMv3kL2xtBnKL4Qc71cZRqNcojMG", "hmsl_hash":
+        "c1150af7814de655b6069ae54839018ab8350dec4151a441fa5d40bd0b489fd5", "occurrences_count":
+        9, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:11.066572Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        7263, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/518",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 1111, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2022-03-23T10:02:06Z", "secret_id": 12926048, "secret_hash":
+        "7wxBEx1JaqGpNsz3u4B9GxBD0pWDE6HKl9tNKlZS5obd/XweL4Qc71cZRqNcojMG", "hmsl_hash":
+        "9503f4886643c28a05a5930db549738dfb06711db073d1ddfdf1ad1b860fc56e", "occurrences_count":
+        1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:39.549708Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        7263, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1111",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "AWS IAM Keys"}]'
+    headers:
+      CF-RAY:
+      - 9ef4870c583499dc-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:37 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '5783'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0xMTEx&declarative_secret_status=revoked&per_page=5>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '146'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_detector_group_name.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_detector_group_name.yaml
@@ -1,0 +1,148 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=5&detector_group_name=slackbot_token
+  response:
+    body:
+      string: '[{"id": 2, "detector": {"name": "slackbototken", "display_name": "Slack
+        Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash":
+        "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4", "hmsl_hash":
+        "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3", "occurrences_count":
+        2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/2",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Slack Bot Token"}, {"id": 5, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-05-24T12:18:15Z", "secret_id": 14592838,
+        "secret_hash": "Z5EChCcGXgX/eXhBjNhs4sGINbMdnzWjcD4m3l7naZmf7qCBOMgPzYhV28m6OGG4",
+        "hmsl_hash": "dc66b2a9c718f0d32581426943c736bfed9bcfd865c77712ca43d96faf97f731",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 9, "detector": {"name": "slackbototken", "display_name":
+        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2024-10-17T13:35:42Z", "secret_id": 14592842, "secret_hash":
+        "iPhCz0hiEKKcYiKnWwMgF+iE0K4tHJTBECUI1m+w7wJpZCyyOMgPzYhV28m6OGG4", "hmsl_hash":
+        "35764f7687c768b9e42ce14f6b7f4eece8d1cd71d4c63c8fd614b23a8e8c1c7d", "occurrences_count":
+        2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.747147Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/9",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Slack Bot Token"}, {"id": 30, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2022-09-01T12:15:30Z", "secret_id": 14592861,
+        "secret_hash": "UcHRteKCwroK47xMicSu6b7x3bMi6jvwgYV4DzuatWRC3HXYOMgPzYhV28m6OGG4",
+        "hmsl_hash": "6e9d452d4b21ac2c8f0cbefb99199985801619e77ad5e35f65d651320d9450a5",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.766850Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/30", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 66, "detector": {"name": "slackbototken", "display_name":
+        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2020-01-22T16:27:45Z", "secret_id": 14592889, "secret_hash":
+        "nV1M0zZt+z5hJwJWUBIrwV51arxFuS6Su4vfoVFWMQOOQyxjOMgPzYhV28m6OGG4", "hmsl_hash":
+        "a670081af75ed42cafef61b1e66c4e2c647463a2ae6e2dfe0a2a0b9b5ec91c0e", "occurrences_count":
+        6, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:03.251612Z", "ignored_at":
+        "2025-07-30T14:24:19.005229Z", "ignorer_id": null, "ignorer_api_token_id":
+        "41447876-2e7c-4494-b19d-fcda2e53268c", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
+        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
+        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/66",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Slack Bot Token"}]'
+    headers:
+      CF-RAY:
+      - 9ef48703ee6f701a-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:36 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '5748'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD02Ng%3D%3D&detector_group_name=slackbot_token&per_page=5>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '111'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_feedback.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_feedback.yaml
@@ -1,0 +1,113 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=5&feedback=true
+  response:
+    body:
+      string: '[{"id": 6987, "detector": {"name": "aws_iam", "display_name": "AWS
+        IAM Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2025-02-06T13:11:21Z", "secret_id": 14955862, "secret_hash":
+        "kk/auvq83sqNMAD36RivDckUaWd4ApXgmnqrw+x7idvGjJAzL4Qc71cZRqNcojMG", "hmsl_hash":
+        "4ff38bc8f1670f5a260989ea723e576278bafa82a2524902093bddbf3b8c054e", "occurrences_count":
+        5, "status": "TRIGGERED", "triggered_at": "2025-02-06T13:16:24.742696Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [{"created_at": "2025-07-10T09:52:12.844648Z",
+        "updated_at": "2025-07-10T09:52:12.844658Z", "email": "candidate.playground+eu4@gitguardian.com",
+        "member_id": 937472, "answers": [{"type": "boolean", "field_ref": "revoked_yes_no",
+        "field_label": "Has this secret been revoked?", "boolean": true}, {"type":
+        "text", "field_ref": "remarks_text", "field_label": "Additional remarks",
+        "text": ""}]}], "risk_score": 97, "severity_rule_id": 10860, "is_vaulted":
+        false, "declarative_secret_status": "active", "resolve_reason": null, "ignore_reason":
+        null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/6987",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "AWS IAM Keys"}, {"id": 286920, "detector": {"name": "generic_high_entropy_secret",
+        "display_name": "Generic High Entropy Secret", "nature": "generic", "family":
+        "other", "category": "other", "detector_group_name": "generic_high_entropy_secret",
+        "detector_group_display_name": "Generic High Entropy Secret"}, "date": "2025-09-23T14:49:55Z",
+        "secret_id": 20803772, "secret_hash": "MOfkjSPfFFdio2Jr+E5Jzb/2j5hKrE6hk1wdg3C9wydzfQv0p+KkPCNpyNbtXqJM",
+        "hmsl_hash": "c95719c30ec3b52e90326d04712dae47fb3b80357926d3da17f5e918a97ef9ed",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-09-23T14:56:34.672998Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [{"created_at":
+        "2025-09-26T13:41:25.581098Z", "updated_at": "2025-09-26T13:41:25.581115Z",
+        "email": "pierre.dethoisy@gitguardian.com", "member_id": 309802, "answers":
+        [{"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
+        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
+        "field_label": "Additional remarks", "text": "hello, first message"}]}], "risk_score":
+        83, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/286920", "tags":
+        [], "custom_tags": [], "destination_tickets": [], "incident_name": "Amazon
+        AWS Credentials"}]'
+    headers:
+      CF-RAY:
+      - 9ef48709df860b18-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:37 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '3020'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '79'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_ignorer_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_ignorer_filter.yaml
@@ -1,0 +1,530 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=20&status=IGNORED
+  response:
+    body:
+      string: '[{"id": 1, "detector": {"name": "stripe", "display_name": "Stripe Keys",
+        "nature": "specific", "family": "token", "category": "payment_system", "detector_group_name":
+        "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
+        "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
+        "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
+        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
+        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
+        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
+        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "Stripe Keys"}, {"id": 62, "detector":
+        {"name": "generic_high_entropy_secret", "display_name": "Generic High Entropy
+        Secret", "nature": "generic", "family": "other", "category": "other", "detector_group_name":
+        "generic_high_entropy_secret", "detector_group_display_name": "Generic High
+        Entropy Secret"}, "date": "2021-05-05T14:31:57Z", "secret_id": 7970372, "secret_hash":
+        "E0P08MxvQ0WZh0WYjvO9IPqXps/WBpCKl5ky7B6EaoHJVYxpp+KkPCNpyNbtXqJM", "hmsl_hash":
+        "92bbc73f409d7552c3889f8fabf7bb81d6ed1002010c81fa5c402c48ca907db2", "occurrences_count":
+        19, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:03.060154Z", "ignored_at":
+        "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 7, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/62", "tags":
+        ["FALSE_POSITIVE", "FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags":
+        [], "destination_tickets": [], "incident_name": "Generic High Entropy Secret"},
+        {"id": 66, "detector": {"name": "slackbototken", "display_name": "Slack Bot
+        Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2020-01-22T16:27:45Z", "secret_id": 14592889, "secret_hash":
+        "nV1M0zZt+z5hJwJWUBIrwV51arxFuS6Su4vfoVFWMQOOQyxjOMgPzYhV28m6OGG4", "hmsl_hash":
+        "a670081af75ed42cafef61b1e66c4e2c647463a2ae6e2dfe0a2a0b9b5ec91c0e", "occurrences_count":
+        6, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:03.251612Z", "ignored_at":
+        "2025-07-30T14:24:19.005229Z", "ignorer_id": null, "ignorer_api_token_id":
+        "41447876-2e7c-4494-b19d-fcda2e53268c", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
+        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
+        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/66",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Slack Bot Token"}, {"id": 79, "detector": {"name": "generic_terraform_variable",
+        "display_name": "Generic Terraform Variable Secret", "nature": "generic",
+        "family": "other", "category": "other", "detector_group_name": "generic_terraform_variable",
+        "detector_group_display_name": "Generic Terraform Variable Secret"}, "date":
+        "2023-03-14T00:33:11Z", "secret_id": 14592903, "secret_hash": "F4uzB9Mc2KXzFdf7yLcnXOuu1ghVQbj2RoQ577Y6+rq2CVD9G3w5187y9MPmpVZx",
+        "hmsl_hash": "8c2589fbf3405dddced25128d773be5bc921bca7b3861d8786d0080321d7110a",
+        "occurrences_count": 24, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:03.270897Z",
+        "ignored_at": "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 7, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/79", "tags":
+        ["FALSE_POSITIVE", "FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Generic Terraform Variable Secret"}, {"id": 179, "detector":
+        {"name": "generic_password", "display_name": "Generic Password", "nature":
+        "generic", "family": "other", "category": "other", "detector_group_name":
+        "generic_password", "detector_group_display_name": "Generic Password"}, "date":
+        "2021-08-30T15:51:42Z", "secret_id": 14592995, "secret_hash": "wz0gASuuiXlK4FKKh/bYND0E6N3c/BY0REO27cRD9ZZ7pMA2fma8ieOEhD7igl+v",
+        "hmsl_hash": "dadb024dfeb09add6534a5e1be832a3307ad29a2a2494b8f7c90437ab52b7cd6",
+        "occurrences_count": 4, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:04.467468Z",
+        "ignored_at": "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 7, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/179", "tags":
+        ["FALSE_POSITIVE", "FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Generic Password"}, {"id": 180, "detector": {"name":
+        "generic_password", "display_name": "Generic Password", "nature": "generic",
+        "family": "other", "category": "other", "detector_group_name": "generic_password",
+        "detector_group_display_name": "Generic Password"}, "date": "2021-08-30T15:51:42Z",
+        "secret_id": 14592996, "secret_hash": "f5xTPMMJbam57hBHEv5fHlMYBQl4MfPkk5uMsjcY2TwF+U2yfma8ieOEhD7igl+v",
+        "hmsl_hash": "db7cda617fc9a0ceb14de1707cc3847974d298ca5fb71024574c16c29a3fc22a",
+        "occurrences_count": 3, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:04.467468Z",
+        "ignored_at": "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 7, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/180", "tags":
+        ["FALSE_POSITIVE", "FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Generic Password"}, {"id": 198, "detector": {"name":
+        "generic_password", "display_name": "Generic Password", "nature": "generic",
+        "family": "other", "category": "other", "detector_group_name": "generic_password",
+        "detector_group_display_name": "Generic Password"}, "date": "2024-08-22T09:38:10Z",
+        "secret_id": 14593009, "secret_hash": "r6+cW2T3+RPDyw/VfOF+TPj8HyX53dNCN9EnJeLcjARY+lU4fma8ieOEhD7igl+v",
+        "hmsl_hash": "c27a45b0ea3e2513340676331d4cbb7e6f31dadfa4f44bcec7367c12179307f5",
+        "occurrences_count": 10, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:04.719652Z",
+        "ignored_at": "2025-03-06T17:18:10.404562Z", "ignorer_id": 319222, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 7, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/198", "tags":
+        ["FALSE_POSITIVE", "FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Generic Password"}, {"id": 227, "detector": {"name":
+        "generic_high_entropy_secret", "display_name": "Generic High Entropy Secret",
+        "nature": "generic", "family": "other", "category": "other", "detector_group_name":
+        "generic_high_entropy_secret", "detector_group_display_name": "Generic High
+        Entropy Secret"}, "date": "2024-06-11T14:23:52Z", "secret_id": 14589070, "secret_hash":
+        "fjZ3jyx2auRab756YeJR8bzqlM2E3wrNg+2Mwj/Esf3MFc8Bp+KkPCNpyNbtXqJM", "hmsl_hash":
+        "534acd03d083a37e0f4a0b567111580cd5a643cc1ac70d24d16c6bce2657e601", "occurrences_count":
+        18, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:05.087393Z", "ignored_at":
+        "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "high", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 0, "severity_rule_id": 10284, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/227", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FALSE_POSITIVE", "FROM_HISTORICAL_SCAN",
+        "IS_COMPANY_CONTEXT", "TEST_FILE", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "SendGrid Token"}, {"id": 422,
+        "detector": {"name": "generic_password", "display_name": "Generic Password",
+        "nature": "generic", "family": "other", "category": "other", "detector_group_name":
+        "generic_password", "detector_group_display_name": "Generic Password"}, "date":
+        "2023-03-06T04:27:29Z", "secret_id": 14593217, "secret_hash": "fH/D7uyKXL4l/wGUt9hYDiKD2KKucBCDTwoJDQk14bAGaVllfma8ieOEhD7igl+v",
+        "hmsl_hash": "495ef58eb13281619e87d36ebbdb266de976aff7ec2884554f832a806f8a4f4d",
+        "occurrences_count": 22, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:08.556172Z",
+        "ignored_at": "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 0, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/422", "tags":
+        ["FALSE_POSITIVE", "FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Generic Password"}, {"id": 426, "detector": {"name":
+        "generic_password", "display_name": "Generic Password", "nature": "generic",
+        "family": "other", "category": "other", "detector_group_name": "generic_password",
+        "detector_group_display_name": "Generic Password"}, "date": "2020-12-14T17:26:35Z",
+        "secret_id": 14593221, "secret_hash": "r0IbxB09R6E9Tdr5Xc8McfILDTMuce6g/XUNS6cd56olQ75mfma8ieOEhD7igl+v",
+        "hmsl_hash": "fa551f7cc08d0375b5caac8ceb361f1c0aac68b2b227b46490ab8bf74fe3b3a3",
+        "occurrences_count": 7, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:08.393298Z",
+        "ignored_at": "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 7, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/426", "tags":
+        ["FALSE_POSITIVE", "FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Generic Password"}, {"id": 624, "detector": {"name":
+        "generic_password", "display_name": "Generic Password", "nature": "generic",
+        "family": "other", "category": "other", "detector_group_name": "generic_password",
+        "detector_group_display_name": "Generic Password"}, "date": "2022-12-22T09:23:46Z",
+        "secret_id": 14593401, "secret_hash": "2Bg5LocdONb1TycjSLnI3oVkzqCyCkfboRlzoq2FD3ZrdaI6fma8ieOEhD7igl+v",
+        "hmsl_hash": "60e9aa8e6c5f70201ad4a87daa186f9f1f0c191dbfc9df43dca8c4d9d88d0bef",
+        "occurrences_count": 2, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:16.720377Z",
+        "ignored_at": "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 7, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/624", "tags":
+        ["FALSE_POSITIVE", "FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Generic Password"}, {"id": 776, "detector": {"name":
+        "generic_password", "display_name": "Generic Password", "nature": "generic",
+        "family": "other", "category": "other", "detector_group_name": "generic_password",
+        "detector_group_display_name": "Generic Password"}, "date": "2023-03-03T12:25:11Z",
+        "secret_id": 14593527, "secret_hash": "u2wWbraery0GZ5ZDgaKzy4vL+HQ1tKJITJG/yxLdihQoGqCUfma8ieOEhD7igl+v",
+        "hmsl_hash": "1d0e0950b0a366949b432ae647e989938ec0c2cbba7b4cb7f66d23dfa5448055",
+        "occurrences_count": 7, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:22.678748Z",
+        "ignored_at": "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 7, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/776", "tags":
+        ["FALSE_POSITIVE", "FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Generic Password"}, {"id": 852, "detector": {"name":
+        "generic_high_entropy_secret", "display_name": "Generic High Entropy Secret",
+        "nature": "generic", "family": "other", "category": "other", "detector_group_name":
+        "generic_high_entropy_secret", "detector_group_display_name": "Generic High
+        Entropy Secret"}, "date": "2021-10-28T08:52:53Z", "secret_id": 7970370, "secret_hash":
+        "/9Jx8+5p1ES4Xv+4bmo4dVbUZdiD9aPM/p3NguJ/Vq/sbAcCp+KkPCNpyNbtXqJM", "hmsl_hash":
+        "1c0679275244bac0e363bb1536259d50e21ac47774cc19631d7c554cb4e617ec", "occurrences_count":
+        5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:24.952734Z", "ignored_at":
+        "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 7, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/852", "tags":
+        ["FALSE_POSITIVE", "FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags":
+        [], "destination_tickets": [], "incident_name": "Generic High Entropy Secret"},
+        {"id": 1000, "detector": {"name": "generic_password", "display_name": "Generic
+        Password", "nature": "generic", "family": "other", "category": "other", "detector_group_name":
+        "generic_password", "detector_group_display_name": "Generic Password"}, "date":
+        "2023-03-06T04:19:11Z", "secret_id": 14593742, "secret_hash": "jFiFCjvAC2jMKuDtyh84KDc2UPFXcBkjXs6XAMmMVy7Jjz0gfma8ieOEhD7igl+v",
+        "hmsl_hash": "c580fade721cbdda6b882e7212b4a53fc2253e4a69fccf7786c19cb868d5c8e7",
+        "occurrences_count": 109, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:32.642553Z",
+        "ignored_at": "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 7, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1000", "tags":
+        ["FALSE_POSITIVE", "FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Generic Password"}, {"id": 1072, "detector": {"name":
+        "generic_password", "display_name": "Generic Password", "nature": "generic",
+        "family": "other", "category": "other", "detector_group_name": "generic_password",
+        "detector_group_display_name": "Generic Password"}, "date": "2023-02-05T22:20:54Z",
+        "secret_id": 14593811, "secret_hash": "xWYIw4eU3ZqlH+xIcv9KagLuZWV0NETIKkxpnObp9PJMtP6Kfma8ieOEhD7igl+v",
+        "hmsl_hash": "367b5e85457267797179d466e17413e56ad19d9c1a12500fe87e6a77bc25a47f",
+        "occurrences_count": 4, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:38.888955Z",
+        "ignored_at": "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 7, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1072", "tags":
+        ["FALSE_POSITIVE", "FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Generic Password"}, {"id": 1081, "detector": {"name":
+        "generic_password", "display_name": "Generic Password", "nature": "generic",
+        "family": "other", "category": "other", "detector_group_name": "generic_password",
+        "detector_group_display_name": "Generic Password"}, "date": "2023-01-12T13:25:57Z",
+        "secret_id": 14593820, "secret_hash": "ULO+2cM2kBOUZKHgYACs99IOIRTPb68MNCXEBQ0d0Em9jvDKfma8ieOEhD7igl+v",
+        "hmsl_hash": "04a1ccf3575d9cd5fbc75399543fd040bced703bf175175721eff00533a98600",
+        "occurrences_count": 9, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:39.482840Z",
+        "ignored_at": "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 7, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1081", "tags":
+        ["FALSE_POSITIVE", "FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Generic Password"}, {"id": 1107, "detector": {"name":
+        "generic_password", "display_name": "Generic Password", "nature": "generic",
+        "family": "other", "category": "other", "detector_group_name": "generic_password",
+        "detector_group_display_name": "Generic Password"}, "date": "2023-03-06T05:14:42Z",
+        "secret_id": 14593842, "secret_hash": "WE+GlGSUW54mas4LpbsJ4sSb8owCLtsu3L2pu1frRqpwpu2xfma8ieOEhD7igl+v",
+        "hmsl_hash": "3de415d6755f3c4404ea89bf20200344344c200538e9eb7a79ebdcca4eb8de44",
+        "occurrences_count": 2, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:39.711268Z",
+        "ignored_at": "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 7, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1107", "tags":
+        ["FALSE_POSITIVE", "FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Generic Password"}, {"id": 1163, "detector": {"name":
+        "authentication_tuple", "display_name": "Authentication Tuple", "nature":
+        "generic", "family": "other", "category": "other", "detector_group_name":
+        "authentication_tuple", "detector_group_display_name": "Authentication Tuple"},
+        "date": "2023-01-14T21:38:45Z", "secret_id": 14593893, "secret_hash": "rLH1WuC/WtEvrNpgeEqNlvqM6B1mHpjvIfJcvt7EiGaG4yk6owwkpy6zKO2CufGR",
+        "hmsl_hash": "ba8179c6fd7aabd9714f4f5523dde1244878871127e00e8563c94eec136e0edd",
+        "occurrences_count": 1, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:42.390701Z",
+        "ignored_at": "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 7, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1163", "tags":
+        ["FALSE_POSITIVE", "FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Authentication Tuple"}, {"id": 1193, "detector": {"name":
+        "authentication_tuple", "display_name": "Authentication Tuple", "nature":
+        "generic", "family": "other", "category": "other", "detector_group_name":
+        "authentication_tuple", "detector_group_display_name": "Authentication Tuple"},
+        "date": "2023-01-14T21:45:02Z", "secret_id": 14593919, "secret_hash": "XOg8TKMKJbkSuq1VIOO8hr8re/ShY53Z4x2X7ZtWgRFw6hQUowwkpy6zKO2CufGR",
+        "hmsl_hash": "e428efe790abdddf877e0235787f922143123216081cf17f579568c9ef6517bc",
+        "occurrences_count": 3, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:43.231473Z",
+        "ignored_at": "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 7, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1193", "tags":
+        ["FALSE_POSITIVE", "FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Authentication Tuple"}, {"id": 1194, "detector": {"name":
+        "authentication_tuple", "display_name": "Authentication Tuple", "nature":
+        "generic", "family": "other", "category": "other", "detector_group_name":
+        "authentication_tuple", "detector_group_display_name": "Authentication Tuple"},
+        "date": "2023-01-14T21:45:02Z", "secret_id": 14593920, "secret_hash": "nrHWMb2GxEktp0dvRqbujh2j8DBYpoFsIxfMxz5coMyzedm7owwkpy6zKO2CufGR",
+        "hmsl_hash": "70d5379b85d729d5835516f6314eb620f91c633360f2febe38ef146450446770",
+        "occurrences_count": 3, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:43.231473Z",
+        "ignored_at": "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 7, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1194", "tags":
+        ["FALSE_POSITIVE", "FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Authentication Tuple"}]'
+    headers:
+      CF-RAY:
+      - 9efb6de7dd36d6e2-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:48 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '24203'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0xMTk0&per_page=20&status=IGNORED>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '233'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '20'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=5&ignorer_id=492181
+  response:
+    body:
+      string: '[{"id": 62, "detector": {"name": "generic_high_entropy_secret", "display_name":
+        "Generic High Entropy Secret", "nature": "generic", "family": "other", "category":
+        "other", "detector_group_name": "generic_high_entropy_secret", "detector_group_display_name":
+        "Generic High Entropy Secret"}, "date": "2021-05-05T14:31:57Z", "secret_id":
+        7970372, "secret_hash": "E0P08MxvQ0WZh0WYjvO9IPqXps/WBpCKl5ky7B6EaoHJVYxpp+KkPCNpyNbtXqJM",
+        "hmsl_hash": "92bbc73f409d7552c3889f8fabf7bb81d6ed1002010c81fa5c402c48ca907db2",
+        "occurrences_count": 19, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:03.060154Z",
+        "ignored_at": "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 7, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/62", "tags":
+        ["FALSE_POSITIVE", "FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags":
+        [], "destination_tickets": [], "incident_name": "Generic High Entropy Secret"},
+        {"id": 79, "detector": {"name": "generic_terraform_variable", "display_name":
+        "Generic Terraform Variable Secret", "nature": "generic", "family": "other",
+        "category": "other", "detector_group_name": "generic_terraform_variable",
+        "detector_group_display_name": "Generic Terraform Variable Secret"}, "date":
+        "2023-03-14T00:33:11Z", "secret_id": 14592903, "secret_hash": "F4uzB9Mc2KXzFdf7yLcnXOuu1ghVQbj2RoQ577Y6+rq2CVD9G3w5187y9MPmpVZx",
+        "hmsl_hash": "8c2589fbf3405dddced25128d773be5bc921bca7b3861d8786d0080321d7110a",
+        "occurrences_count": 24, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:03.270897Z",
+        "ignored_at": "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 7, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/79", "tags":
+        ["FALSE_POSITIVE", "FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Generic Terraform Variable Secret"}, {"id": 179, "detector":
+        {"name": "generic_password", "display_name": "Generic Password", "nature":
+        "generic", "family": "other", "category": "other", "detector_group_name":
+        "generic_password", "detector_group_display_name": "Generic Password"}, "date":
+        "2021-08-30T15:51:42Z", "secret_id": 14592995, "secret_hash": "wz0gASuuiXlK4FKKh/bYND0E6N3c/BY0REO27cRD9ZZ7pMA2fma8ieOEhD7igl+v",
+        "hmsl_hash": "dadb024dfeb09add6534a5e1be832a3307ad29a2a2494b8f7c90437ab52b7cd6",
+        "occurrences_count": 4, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:04.467468Z",
+        "ignored_at": "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 7, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/179", "tags":
+        ["FALSE_POSITIVE", "FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Generic Password"}, {"id": 180, "detector": {"name":
+        "generic_password", "display_name": "Generic Password", "nature": "generic",
+        "family": "other", "category": "other", "detector_group_name": "generic_password",
+        "detector_group_display_name": "Generic Password"}, "date": "2021-08-30T15:51:42Z",
+        "secret_id": 14592996, "secret_hash": "f5xTPMMJbam57hBHEv5fHlMYBQl4MfPkk5uMsjcY2TwF+U2yfma8ieOEhD7igl+v",
+        "hmsl_hash": "db7cda617fc9a0ceb14de1707cc3847974d298ca5fb71024574c16c29a3fc22a",
+        "occurrences_count": 3, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:04.467468Z",
+        "ignored_at": "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 7, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/180", "tags":
+        ["FALSE_POSITIVE", "FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Generic Password"}, {"id": 227, "detector": {"name":
+        "generic_high_entropy_secret", "display_name": "Generic High Entropy Secret",
+        "nature": "generic", "family": "other", "category": "other", "detector_group_name":
+        "generic_high_entropy_secret", "detector_group_display_name": "Generic High
+        Entropy Secret"}, "date": "2024-06-11T14:23:52Z", "secret_id": 14589070, "secret_hash":
+        "fjZ3jyx2auRab756YeJR8bzqlM2E3wrNg+2Mwj/Esf3MFc8Bp+KkPCNpyNbtXqJM", "hmsl_hash":
+        "534acd03d083a37e0f4a0b567111580cd5a643cc1ac70d24d16c6bce2657e601", "occurrences_count":
+        18, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:05.087393Z", "ignored_at":
+        "2025-11-06T17:18:56.471707Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "high", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 0, "severity_rule_id": 10284, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/227", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FALSE_POSITIVE", "FROM_HISTORICAL_SCAN",
+        "IS_COMPANY_CONTEXT", "TEST_FILE", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "SendGrid Token"}]'
+    headers:
+      CF-RAY:
+      - 9efb6dec3987d155-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:49 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '6212'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0yMjc%3D&ignorer_id=492181&per_page=5>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '149'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_ordering.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_ordering.yaml
@@ -1,0 +1,146 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=5&ordering=-risk_score
+  response:
+    body:
+      string: '[{"id": 5208, "detector": {"name": "digitalocean_token", "display_name":
+        "DigitalOcean Token", "nature": "specific", "family": "token", "category":
+        "cloud_provider", "detector_group_name": "digitalocean_token", "detector_group_display_name":
+        "DigitalOcean Token"}, "date": "2023-03-03T16:38:13Z", "secret_id": 14597820,
+        "secret_hash": "gpSu+iGVzqTb04w0hQpy/EQ3yZXU/M0KWTkiYW0DN6GchufVQg9f/tAi7MYoYTK8",
+        "hmsl_hash": "e2a9fad8ba3b356d7db9f2bb50c54fc8a8fb58dc32d29a7bff287f09ec9aa402",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:10:13.203243Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 100, "severity_rule_id":
+        10861, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/5208",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "DigitalOcean Token"}, {"id": 5207, "detector": {"name":
+        "digitalocean_token", "display_name": "DigitalOcean Token", "nature": "specific",
+        "family": "token", "category": "cloud_provider", "detector_group_name": "digitalocean_token",
+        "detector_group_display_name": "DigitalOcean Token"}, "date": "2023-03-03T16:38:13Z",
+        "secret_id": 14597819, "secret_hash": "vClMsNqM/WdfLMx7H6mUnp1i9W87jp+J+ffYMGCEbQIsIKP1Qg9f/tAi7MYoYTK8",
+        "hmsl_hash": "8726444fd47d2df39f484439152c7c7b0a642e171a89091b98aee1f8cb3e8444",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:10:13.203243Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 100, "severity_rule_id":
+        10861, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/5207",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "DigitalOcean Token"}, {"id": 1142573, "detector": {"name":
+        "gitlab_personal_token_v2", "display_name": "GitLab Token", "nature": "specific",
+        "family": "token", "category": "version_control_platform", "detector_group_name":
+        "gitlab_token", "detector_group_display_name": "GitLab Token"}, "date": "2026-01-20T12:25:14Z",
+        "secret_id": 26269042, "secret_hash": "Q6uP7xLag23NOueTB3xz7eMJDKIKv5pc5XJ+O+d7h5JJ1KTWxGkRAPRx8mJAAtol",
+        "hmsl_hash": "2b222492a399350a135305392017aa5e95d97c8dd558ebe4e61723ad935abf09",
+        "occurrences_count": 1, "status": "RESOLVED", "triggered_at": "2026-01-20T12:30:17.920656Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        "2026-01-26T14:38:12.774362Z", "resolver_id": 492181, "resolver_api_token_id":
+        null, "secret_revoked": true, "validity": "invalid", "severity": "critical",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 99, "severity_rule_id": 7263, "is_vaulted": false, "declarative_secret_status":
+        "revoked", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1142573",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitLab Token"}, {"id": 6431, "detector": {"name": "github_oauth_app_keys",
+        "display_name": "GitHub OAuth App Keys", "nature": "specific", "family": "credentials",
+        "category": "version_control_platform", "detector_group_name": "github_oauth_app_keys",
+        "detector_group_display_name": "GitHub OAuth App Keys"}, "date": "2023-03-06T02:22:30Z",
+        "secret_id": 14598994, "secret_hash": "rguvfdbCkXIEiTcPcvvaKSTDL7C5GooKsnQSRXZ2KYadm7wi26bvJ9LImJ7n1yqO",
+        "hmsl_hash": "984f3c5814706bf57aad59c4a55aa353b4f87e111faf7d8262d6452445f5528c",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:12:04.175957Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 99, "severity_rule_id":
+        10862, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/6431",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "GitHub OAuth App Keys"}, {"id": 6430, "detector": {"name":
+        "bitbucket_keys", "display_name": "Bitbucket Keys", "nature": "specific",
+        "family": "credentials", "category": "version_control_platform", "detector_group_name":
+        "bitbucket_keys", "detector_group_display_name": "Bitbucket Keys"}, "date":
+        "2023-03-06T02:22:30Z", "secret_id": 14598993, "secret_hash": "yVPk7/jXGjdN/GD51ZJVnAQGVLZp9OYkO5cNnoGIrw5N2hr6zxp9ieZfVrZIohiA",
+        "hmsl_hash": "be8bf8e2501a998c2910851ea4aa8dd70fafb9fdb942bdff1c168fab708c0596",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:12:04.175957Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 99, "severity_rule_id":
+        10862, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/6430",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Bitbucket Keys"}]'
+    headers:
+      CF-RAY:
+      - 9ef487113db5023e-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:38 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '5823'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD05OQ%3D%3D&ordering=-risk_score&per_page=5>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '399'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_resolver_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_resolver_filter.yaml
@@ -1,0 +1,511 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=20&status=RESOLVED
+  response:
+    body:
+      string: '[{"id": 120, "detector": {"name": "aws_iam", "display_name": "AWS IAM
+        Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2022-09-21T07:47:10Z", "secret_id": 14592936, "secret_hash":
+        "HCWrG3nEt9czkeRivsO5t2mdGFXFrkwOSPchO87xypH14P2ML4Qc71cZRqNcojMG", "hmsl_hash":
+        "44126737df445f6b9468541f77e5c5bdac71b057644a7fe1c8c219940948acc4", "occurrences_count":
+        1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:03.840266Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        7263, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/120",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 385, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2023-07-06T12:36:07Z", "secret_id": 9181441, "secret_hash":
+        "mKn4Nj0bR4rIic8L5Vdx8VllYYtf+CISEyDv7GToL66gKwIWL4Qc71cZRqNcojMG", "hmsl_hash":
+        "838d881ae00bfb022f27c3b2e57e4927d7a2ef12c4a2f75b8b6730c80dba47b3", "occurrences_count":
+        1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:07.901475Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/385",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "AWS IAM Keys"}, {"id": 455, "detector":
+        {"name": "aws_iam", "display_name": "AWS IAM Keys", "nature": "specific",
+        "family": "credentials", "category": "cloud_provider", "detector_group_name":
+        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2023-09-14T06:56:47Z",
+        "secret_id": 14593254, "secret_hash": "kZ78fTN4Cp9siyqtBD6gQM2qgUEC/x7J8+fyI3hFOr4M3FM3L4Qc71cZRqNcojMG",
+        "hmsl_hash": "4ba981a3cf490ed7f92e695a83c1f41ceb8f91541f62da24884ddb040cb6c083",
+        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:09.608272Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        "2026-01-26T14:38:12.774362Z", "resolver_id": 492181, "resolver_api_token_id":
+        null, "secret_revoked": true, "validity": "valid", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 97, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "revoked", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/455", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "AWS IAM Keys"}, {"id": 518, "detector": {"name": "aws_iam", "display_name":
+        "AWS IAM Keys", "nature": "specific", "family": "credentials", "category":
+        "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2023-10-19T12:06:07Z", "secret_id": 14593309, "secret_hash":
+        "aQL+3fwIPTpy/G2vW31cL2nAoP8QUXwn3RsexMv3kL2xtBnKL4Qc71cZRqNcojMG", "hmsl_hash":
+        "c1150af7814de655b6069ae54839018ab8350dec4151a441fa5d40bd0b489fd5", "occurrences_count":
+        9, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:11.066572Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        7263, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/518",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 1111, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2022-03-23T10:02:06Z", "secret_id": 12926048, "secret_hash":
+        "7wxBEx1JaqGpNsz3u4B9GxBD0pWDE6HKl9tNKlZS5obd/XweL4Qc71cZRqNcojMG", "hmsl_hash":
+        "9503f4886643c28a05a5930db549738dfb06711db073d1ddfdf1ad1b860fc56e", "occurrences_count":
+        1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:39.549708Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        7263, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1111",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "AWS IAM Keys"}, {"id": 1112,
+        "detector": {"name": "aws_iam", "display_name": "AWS IAM Keys", "nature":
+        "specific", "family": "credentials", "category": "cloud_provider", "detector_group_name":
+        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2022-09-14T07:50:20Z",
+        "secret_id": 14593846, "secret_hash": "dEfda3BVSUK9yc1JYPEqSufAdUxQUQ9AqXCVJ1nQKyznAYCnL4Qc71cZRqNcojMG",
+        "hmsl_hash": "0847969d69f0208c61843d6e844e9a0aec67df7d818ac44b906f5671dd538794",
+        "occurrences_count": 1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:39.804910Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        "2026-01-26T14:38:12.774362Z", "resolver_id": 492181, "resolver_api_token_id":
+        null, "secret_revoked": true, "validity": "invalid", "severity": "critical",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 97, "severity_rule_id": 7263, "is_vaulted": false, "declarative_secret_status":
+        "revoked", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1112", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "AWS IAM Keys"}, {"id": 1127, "detector": {"name": "aws_iam", "display_name":
+        "AWS IAM Keys", "nature": "specific", "family": "credentials", "category":
+        "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2022-03-30T08:47:37Z", "secret_id": 12926050, "secret_hash":
+        "YmgRGFT6I+h4cZmIad8T2ngAZHPJwBnQmwGYkNUtxILnsq3sL4Qc71cZRqNcojMG", "hmsl_hash":
+        "228e0ca46f9fa4054cb46fb38f51b231a2e3beae92816cdcc0c3488a1defaad6", "occurrences_count":
+        1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:40.034335Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        7263, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1127",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "AWS IAM Keys"}, {"id": 1133,
+        "detector": {"name": "aws_iam", "display_name": "AWS IAM Keys", "nature":
+        "specific", "family": "credentials", "category": "cloud_provider", "detector_group_name":
+        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2024-11-14T12:51:09Z",
+        "secret_id": 14593866, "secret_hash": "R537Ef9PliP3LiwSWXTwpqduJh5qQkIKfZNpFJ02bsNGPQmQL4Qc71cZRqNcojMG",
+        "hmsl_hash": "ce9b28f901d377c282df4288e6c8c05307054a96b62524baf2079eb6c4090916",
+        "occurrences_count": 1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:40.480815Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        "2026-01-26T14:38:12.774362Z", "resolver_id": 492181, "resolver_api_token_id":
+        null, "secret_revoked": true, "validity": "valid", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 97, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "revoked", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1133", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "AWS IAM Keys"}, {"id": 1757, "detector": {"name": "aws_iam", "display_name":
+        "AWS IAM Keys", "nature": "specific", "family": "credentials", "category":
+        "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2022-10-26T17:51:02Z", "secret_id": 5040480, "secret_hash":
+        "9iOcecIDUnwTswf4LBKhEr1f7h+yKuXPUh8Ts6MQ0Em4ZtnDL4Qc71cZRqNcojMG", "hmsl_hash":
+        "9d34dc7a860e4868c3093156278fc8e65f0ceabd9d8fd087022bd09d20f6c6ad", "occurrences_count":
+        1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:07:03.136672Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        7263, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1757",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "AWS IAM Keys"}, {"id": 3047,
+        "detector": {"name": "googleaiza", "display_name": "Google API Key", "nature":
+        "specific", "family": "token", "category": "cloud_provider", "detector_group_name":
+        "google_api_key", "detector_group_display_name": "Google API Key"}, "date":
+        "2023-03-06T06:15:08Z", "secret_id": 14595668, "secret_hash": "hOsYRGFZYgEMtt8IykkkyDQUWPsEL66J7d2ZxxnknyptY1GWiwQ5Z8PP16EaJtIX",
+        "hmsl_hash": "e4679dc3146a5f4a8e4f0e41ebbfcb9f3c11435351bd1513bba2bd8995181917",
+        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2025-01-07T18:07:56.955958Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        "2026-01-26T14:38:12.774362Z", "resolver_id": 492181, "resolver_api_token_id":
+        null, "secret_revoked": true, "validity": "invalid", "severity": "critical",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 35, "severity_rule_id": 7264, "is_vaulted": false, "declarative_secret_status":
+        "revoked", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/3047", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Google API Key"}, {"id": 3058, "detector": {"name": "aws_iam", "display_name":
+        "AWS IAM Keys", "nature": "specific", "family": "credentials", "category":
+        "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2024-02-21T10:19:16Z", "secret_id": 14595679, "secret_hash":
+        "Z4O16Yr7a50gGt+IWrs9ybaWTmn7rDFAM31qdsAbgnsu6/brL4Qc71cZRqNcojMG", "hmsl_hash":
+        "226827e2dc929a1d7905cc33111c5ea08f32f5273becf252afe7f6bcd56ef9b5", "occurrences_count":
+        1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:07:57.203004Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "valid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/3058",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 3424, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2023-05-17T17:02:25Z", "secret_id": 14596034, "secret_hash":
+        "iwSfsJC/X5Yo1lqZPybLDjgPaZ9U9bHMwslPa2SwSxxwYEmHL4Qc71cZRqNcojMG", "hmsl_hash":
+        "d93f14e10e7b9b087a35b56fdbf1d752cfc66121eefa53848a0e8b6cfdcbc5c0", "occurrences_count":
+        1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:08:09.299477Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "valid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/3424",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 3552, "detector": {"name": "googleaiza",
+        "display_name": "Google API Key", "nature": "specific", "family": "token",
+        "category": "cloud_provider", "detector_group_name": "google_api_key", "detector_group_display_name":
+        "Google API Key"}, "date": "2024-12-16T14:16:53Z", "secret_id": 14596155,
+        "secret_hash": "urErWWrnIwEZP2CVz/sEu8nMMEfWwqSyu2nyvfkwkqv/XPoUiwQ5Z8PP16EaJtIX",
+        "hmsl_hash": "33c264f708db1f8b4eb8fd101fea535dbf2cb5724efb4a0de15ce08a258191d5",
+        "occurrences_count": 1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:08:17.005864Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        "2026-01-26T14:38:12.774362Z", "resolver_id": 492181, "resolver_api_token_id":
+        null, "secret_revoked": true, "validity": "valid", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 35, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "revoked", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/3552", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Google API Key"}, {"id": 4916, "detector": {"name": "googleaiza", "display_name":
+        "Google API Key", "nature": "specific", "family": "token", "category": "cloud_provider",
+        "detector_group_name": "google_api_key", "detector_group_display_name": "Google
+        API Key"}, "date": "2023-03-03T16:37:10Z", "secret_id": 14597552, "secret_hash":
+        "ePhT7M4bXQUWNg5MI5NULUe2Wrgqlz7bWjf0S1C/CHTg8E/ViwQ5Z8PP16EaJtIX", "hmsl_hash":
+        "4e027e3460e4470a63b8df94976afe8d2290f2532352f855cc65b049edc60b1b", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2025-01-07T18:09:52.071958Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "valid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 35, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/4916",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Google API Key"}, {"id": 5219, "detector": {"name":
+        "hugging_face_user_access_token", "display_name": "Hugging Face user access
+        token", "nature": "specific", "family": "token", "category": "ai", "detector_group_name":
+        "hugging_face_user_access_token", "detector_group_display_name": "Hugging
+        Face user access token"}, "date": "2023-03-06T06:46:50Z", "secret_id": 14597831,
+        "secret_hash": "ABG9j3Gc1Ga0Z8wO5/uyDJS5VFxPfp2Bt/e/H6O7dbDX/sD9hllfLWtVgu5XKTCB",
+        "hmsl_hash": "7c67491392f8489bd4d6d3d0f6142997f66c9ce3445988e74fd902a12cfa39c6",
+        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2025-01-07T18:10:13.789232Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        "2026-01-26T14:38:12.774362Z", "resolver_id": 492181, "resolver_api_token_id":
+        null, "secret_revoked": true, "validity": "invalid", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 72, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "revoked", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/5219", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Hugging Face user access token"}, {"id": 5682, "detector": {"name": "ssh_password",
+        "display_name": "SSH Credentials", "nature": "specific", "family": "identifiers",
+        "category": "remote_access", "detector_group_name": "ssh_credentials", "detector_group_display_name":
+        "SSH Credentials"}, "date": "2023-03-06T07:26:27Z", "secret_id": 14598251,
+        "secret_hash": "O8ThlmYyUWplHKwRSXWSlgd+vpidkkBoXdMu0xDMbTd1VFroD/WgMIq6X4jxHXAX",
+        "hmsl_hash": "e83ebb352a9a48b7a054f032dd3ce40adb894c0d693c244c38cc1880d5e4c882",
+        "occurrences_count": 1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:10:53.096788Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        "2026-01-26T14:38:12.774362Z", "resolver_id": 492181, "resolver_api_token_id":
+        null, "secret_revoked": true, "validity": "invalid", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 70, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "revoked", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/5682", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "SSH Credentials"}, {"id": 5860, "detector": {"name": "googleaiza", "display_name":
+        "Google API Key", "nature": "specific", "family": "token", "category": "cloud_provider",
+        "detector_group_name": "google_api_key", "detector_group_display_name": "Google
+        API Key"}, "date": "2023-03-06T04:37:00Z", "secret_id": 14598416, "secret_hash":
+        "GgKEC2DFA9Gca6JfuMBLT0uPu3YQS3GJVCuJKxUBwJbWes5+iwQ5Z8PP16EaJtIX", "hmsl_hash":
+        "d22ea3b2eca6e25abdcf13a3cc67402081b65ee96ba414bd35d9d3daee8e7c9d", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2025-01-07T18:11:16.311453Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "valid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 35, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/5860",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Google API Key"}, {"id": 6663, "detector": {"name":
+        "aws_iam", "display_name": "AWS IAM Keys", "nature": "specific", "family":
+        "credentials", "category": "cloud_provider", "detector_group_name": "aws_iam",
+        "detector_group_display_name": "AWS IAM Keys"}, "date": "2025-01-14T14:28:59Z",
+        "secret_id": 14663989, "secret_hash": "mKvfyERvoW7Jo+/nDXJ/tcfbWqS4tGEO+1j6vf7vlmpyzHHhL4Qc71cZRqNcojMG",
+        "hmsl_hash": "04d0ef9d0b87b0ad5c9e1da99a7e6015bfab50127cbea8d9ff09356021f65998",
+        "occurrences_count": 7, "status": "RESOLVED", "triggered_at": "2025-01-14T14:34:01.621378Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        "2026-01-26T14:38:12.774362Z", "resolver_id": 492181, "resolver_api_token_id":
+        null, "secret_revoked": true, "validity": "invalid", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 97, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "revoked", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/6663", "tags":
+        [], "custom_tags": [], "destination_tickets": [], "incident_name": "AWS IAM
+        Keys"}, {"id": 7795, "detector": {"name": "aws_iam", "display_name": "AWS
+        IAM Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2025-03-02T22:03:35Z", "secret_id": 14666434, "secret_hash":
+        "eidUux6ZARNdCqWb7YiUgULR5OJP8H7A5vjO09YbeSwfcPDjL4Qc71cZRqNcojMG", "hmsl_hash":
+        "e7655d449d0df4e8c9a3c0128380aa9a3bd6c51b583ccf74514695d2db8a8f2e", "occurrences_count":
+        3, "status": "RESOLVED", "triggered_at": "2025-03-02T22:08:37.247868Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/7795",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "AWS IAM Keys"}, {"id": 10664, "detector": {"name": "postgres_uri", "display_name":
+        "PostgreSQL Credentials", "nature": "specific", "family": "identifiers", "category":
+        "data_storage", "detector_group_name": "postgresql_credentials", "detector_group_display_name":
+        "PostgreSQL Credentials"}, "date": "2025-03-19T10:32:23Z", "secret_id": 15500323,
+        "secret_hash": "Uyl6tRtTCVRPOnnJZ69gL+5cOoN68g6Z0Jt/bpWhto3/tQvBCUnJ9mpXO6ItKClD",
+        "hmsl_hash": "fd16c9cb65961a8874bd3ddc29c50aba806625dd6a8d1524d960429c3e3d15b6",
+        "occurrences_count": 1, "status": "RESOLVED", "triggered_at": "2025-03-19T10:37:25.032105Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        "2026-01-26T14:38:12.774362Z", "resolver_id": 492181, "resolver_api_token_id":
+        null, "secret_revoked": true, "validity": "invalid", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 84, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "revoked", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/10664", "tags":
+        ["INTERNALLY_LEAKED"], "custom_tags": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
+        "key": "confrence", "value": "grrcon"}, {"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        "key": "confrence test", "value": "hacktivity"}], "destination_tickets": [],
+        "incident_name": "PostgreSQL Credentials"}]'
+    headers:
+      CF-RAY:
+      - 9efb6deeca6501cc-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:49 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '23380'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0xMDY2NA%3D%3D&per_page=20&status=RESOLVED>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '148'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '20'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=5&resolver_id=492181
+  response:
+    body:
+      string: '[{"id": 120, "detector": {"name": "aws_iam", "display_name": "AWS IAM
+        Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2022-09-21T07:47:10Z", "secret_id": 14592936, "secret_hash":
+        "HCWrG3nEt9czkeRivsO5t2mdGFXFrkwOSPchO87xypH14P2ML4Qc71cZRqNcojMG", "hmsl_hash":
+        "44126737df445f6b9468541f77e5c5bdac71b057644a7fe1c8c219940948acc4", "occurrences_count":
+        1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:03.840266Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        7263, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/120",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 385, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2023-07-06T12:36:07Z", "secret_id": 9181441, "secret_hash":
+        "mKn4Nj0bR4rIic8L5Vdx8VllYYtf+CISEyDv7GToL66gKwIWL4Qc71cZRqNcojMG", "hmsl_hash":
+        "838d881ae00bfb022f27c3b2e57e4927d7a2ef12c4a2f75b8b6730c80dba47b3", "occurrences_count":
+        1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:07.901475Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/385",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "AWS IAM Keys"}, {"id": 455, "detector":
+        {"name": "aws_iam", "display_name": "AWS IAM Keys", "nature": "specific",
+        "family": "credentials", "category": "cloud_provider", "detector_group_name":
+        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2023-09-14T06:56:47Z",
+        "secret_id": 14593254, "secret_hash": "kZ78fTN4Cp9siyqtBD6gQM2qgUEC/x7J8+fyI3hFOr4M3FM3L4Qc71cZRqNcojMG",
+        "hmsl_hash": "4ba981a3cf490ed7f92e695a83c1f41ceb8f91541f62da24884ddb040cb6c083",
+        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:09.608272Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        "2026-01-26T14:38:12.774362Z", "resolver_id": 492181, "resolver_api_token_id":
+        null, "secret_revoked": true, "validity": "valid", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 97, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "revoked", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/455", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "AWS IAM Keys"}, {"id": 518, "detector": {"name": "aws_iam", "display_name":
+        "AWS IAM Keys", "nature": "specific", "family": "credentials", "category":
+        "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2023-10-19T12:06:07Z", "secret_id": 14593309, "secret_hash":
+        "aQL+3fwIPTpy/G2vW31cL2nAoP8QUXwn3RsexMv3kL2xtBnKL4Qc71cZRqNcojMG", "hmsl_hash":
+        "c1150af7814de655b6069ae54839018ab8350dec4151a441fa5d40bd0b489fd5", "occurrences_count":
+        9, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:11.066572Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        7263, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/518",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 1111, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2022-03-23T10:02:06Z", "secret_id": 12926048, "secret_hash":
+        "7wxBEx1JaqGpNsz3u4B9GxBD0pWDE6HKl9tNKlZS5obd/XweL4Qc71cZRqNcojMG", "hmsl_hash":
+        "9503f4886643c28a05a5930db549738dfb06711db073d1ddfdf1ad1b860fc56e", "occurrences_count":
+        1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:39.549708Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        7263, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1111",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "AWS IAM Keys"}]'
+    headers:
+      CF-RAY:
+      - 9efb6df26ef1f170-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:49 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '5783'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0xMTEx&per_page=5&resolver_id=492181>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '91'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_risk_score.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_risk_score.yaml
@@ -1,0 +1,149 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=5&risk_score_min=50&risk_score_max=100
+  response:
+    body:
+      string: '[{"id": 10, "detector": {"name": "generic_password", "display_name":
+        "Generic Password", "nature": "generic", "family": "other", "category": "other",
+        "detector_group_name": "generic_password", "detector_group_display_name":
+        "Generic Password"}, "date": "2022-06-20T16:04:33Z", "secret_id": 14592843,
+        "secret_hash": "1rC83I0fTz8CLTr6Tz7usCc9nbtqZqUU2qXEU2V6CGzNxOl3fma8ieOEhD7igl+v",
+        "hmsl_hash": "9f54d16410ea8fae5f1389bcfa2d48539da4491cf4998d5d8cbcb9b4b946255f",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.749479Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        51, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/10", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Generic Password"}, {"id": 49, "detector": {"name": "generic_high_entropy_secret",
+        "display_name": "Generic High Entropy Secret", "nature": "generic", "family":
+        "other", "category": "other", "detector_group_name": "generic_high_entropy_secret",
+        "detector_group_display_name": "Generic High Entropy Secret"}, "date": "2020-08-21T22:38:38Z",
+        "secret_id": 14592880, "secret_hash": "fZeBBRr92fcSZCIP3SOUx7xdH4Ey7nIYN9aC/b82XCFI2Zkdp+KkPCNpyNbtXqJM",
+        "hmsl_hash": "d5df365d05f4347dacc4306fa0455a7e51308d9207cee0f001be81116caf257c",
+        "occurrences_count": 3, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.775031Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        52, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/49", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Generic High Entropy Secret"}, {"id": 50, "detector": {"name": "generic_high_entropy_secret",
+        "display_name": "Generic High Entropy Secret", "nature": "generic", "family":
+        "other", "category": "other", "detector_group_name": "generic_high_entropy_secret",
+        "detector_group_display_name": "Generic High Entropy Secret"}, "date": "2020-08-21T22:38:38Z",
+        "secret_id": 14592881, "secret_hash": "HngOla3Nk23smSHeNiu9iztN+e8aXkgHzQOKfV9xKeg8uOrYp+KkPCNpyNbtXqJM",
+        "hmsl_hash": "4f6cc3c744bcc6e2f86433dbefb0cc3162482fbafb14a2a9f4dfc9f6cab0adef",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.775031Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        52, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/50", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Generic High Entropy Secret"}, {"id": 52, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2024-12-17T10:19:33Z", "secret_id": 14592883, "secret_hash":
+        "jfpGRuRzwwkh+0rO1sdbA98K4zuSMBfQHlBIXMm5dQVFAmmDL4Qc71cZRqNcojMG", "hmsl_hash":
+        "e50cad6b8e0ca71b4e13b0091d440308990047320f621fadabfb37916010e8ad", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.777462Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/52",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 63, "detector": {"name": "generic_high_entropy_secret",
+        "display_name": "Generic High Entropy Secret", "nature": "generic", "family":
+        "other", "category": "other", "detector_group_name": "generic_high_entropy_secret",
+        "detector_group_display_name": "Generic High Entropy Secret"}, "date": "2021-05-05T14:31:57Z",
+        "secret_id": 14592887, "secret_hash": "W/U1NCGx2+b+iRrgmYqimfAEJlA/47yLfg5+sf09HV/KvDzLp+KkPCNpyNbtXqJM",
+        "hmsl_hash": "c6118a0f7d5e768ab4e9b74698cc5de3b2bb1903538d0a889fe9e447ca0b7346",
+        "occurrences_count": 8, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.060154Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        51, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/63", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Generic High Entropy Secret"}]'
+    headers:
+      CF-RAY:
+      - 9ef4870efd38bb22-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:38 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '5834'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD02Mw%3D%3D&per_page=5&risk_score_max=100&risk_score_min=50>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '91'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_severity_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_severity_filter.yaml
@@ -1,0 +1,152 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=5&severity=high
+  response:
+    body:
+      string: '[{"id": 23, "detector": {"name": "sendgrid", "display_name": "SendGrid
+        Key", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "sendgrid_key", "detector_group_display_name": "SendGrid
+        Key"}, "date": "2022-07-19T09:52:09Z", "secret_id": 7970364, "secret_hash":
+        "CBz9BMCUQDF3+MCOXcTqfTSvrVZTp8XQF+z38O1amQpnfh2zOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "049d5bbb613a172b0eb21c73a827ae34a30233dbfc9e9b75377a4743082bd447", "occurrences_count":
+        527, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.760032Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 0, "severity_rule_id":
+        10872, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/23",
+        "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "SendGrid Key"}, {"id": 24, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2022-07-19T09:52:09Z", "secret_id": 7970365, "secret_hash": "DQ6dPu9BXyq1FZTNVzfsEpxI24qF82fR4BvL62o1Q7AVIqBId9tR0/CjGaYu0TLp",
+        "hmsl_hash": "19c5c04da7b3d2372f1ab65fa2f311aff6ee3a0bfe37d4608797d5546814c335",
+        "occurrences_count": 190, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.760032Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "high", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        14, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/24", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 64, "detector": {"name": "generic_high_entropy_secret",
+        "display_name": "Generic High Entropy Secret", "nature": "generic", "family":
+        "other", "category": "other", "detector_group_name": "generic_high_entropy_secret",
+        "detector_group_display_name": "Generic High Entropy Secret"}, "date": "2024-06-05T08:52:39Z",
+        "secret_id": 14589069, "secret_hash": "Acx1sg7Sj4xnn7Z+BTdKp60Xz4GrCmR1Rab2IuaDHCsmnEjMp+KkPCNpyNbtXqJM",
+        "hmsl_hash": "95ff63fdc1a4a0b1fdcbee9b8f628b140d2d6c7da1d2050f5f822263401d3bfb",
+        "occurrences_count": 40, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.153475Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "high", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        0, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/64", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "IS_COMPANY_CONTEXT",
+        "TEST_FILE", "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Meta Facebook Credentials"}, {"id": 122, "detector":
+        {"name": "generic_password", "display_name": "Generic Password", "nature":
+        "generic", "family": "other", "category": "other", "detector_group_name":
+        "generic_password", "detector_group_display_name": "Generic Password"}, "date":
+        "2023-01-12T15:18:48Z", "secret_id": 14592938, "secret_hash": "grMUjNXkz+3KpugZrfscb34PsMn332maZU8rfwg5ExJgckP0fma8ieOEhD7igl+v",
+        "hmsl_hash": "885b7f778a33b34faa2299bced3d148ba2b58c663822c4080a05c48b51030827",
+        "occurrences_count": 219, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.906038Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "high", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        9, "severity_rule_id": 10877, "is_vaulted": true, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/122", "tags":
+        ["FROM_HISTORICAL_SCAN", "SENSITIVE_FILE", "INTERNALLY_LEAKED"], "custom_tags":
+        [], "destination_tickets": [], "incident_name": "PostgreSQL Identifiers"},
+        {"id": 160, "detector": {"name": "username_password", "display_name": "Username
+        Password", "nature": "generic", "family": "other", "category": "other", "detector_group_name":
+        "username_password", "detector_group_display_name": "Username Password"},
+        "date": "2024-09-24T07:18:21Z", "secret_id": 14592975, "secret_hash": "h7BYoSnMoSkemlgx3+vR3VMfD/+iB+KFkbtkwB7pvx4U5NJmP4G6lsSULyTx/pbN",
+        "hmsl_hash": "b8b5b99f1062d935ce673413a2492db38be49c41def15ce0f99a16640a58be14",
+        "occurrences_count": 8, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.258176Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "high", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        24, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/160", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE"],
+        "custom_tags": [], "destination_tickets": [], "incident_name": "Username Password"}]'
+    headers:
+      CF-RAY:
+      - 9ef486f5290f0207-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:34 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '6090'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0xNjA%3D&per_page=5&severity=high>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '282'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_status_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_status_filter.yaml
@@ -1,0 +1,148 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=5&status=TRIGGERED
+  response:
+    body:
+      string: '[{"id": 2, "detector": {"name": "slackbototken", "display_name": "Slack
+        Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash":
+        "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4", "hmsl_hash":
+        "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3", "occurrences_count":
+        2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/2",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592836, "secret_hash": "UkaGM2d1NaALSIkUqCBkEgY+xnpQYM3vPZeWQp9v/O680MxYd9tR0/CjGaYu0TLp",
+        "hmsl_hash": "2cc5873afae5ee7747e26e2d73f7b8abe0ac63e7971442ceb50be7c4bf5c77c9",
+        "occurrences_count": 13, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/3", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 4, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
+        "hmsl_hash": "8d750888a3f74d018e742b42dfb51c60907b26c49fdad4ebdabe1350eedfe0fb",
+        "occurrences_count": 10, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/4", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 5, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-05-24T12:18:15Z", "secret_id": 14592838,
+        "secret_hash": "Z5EChCcGXgX/eXhBjNhs4sGINbMdnzWjcD4m3l7naZmf7qCBOMgPzYhV28m6OGG4",
+        "hmsl_hash": "dc66b2a9c718f0d32581426943c736bfed9bcfd865c77712ca43d96faf97f731",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 8, "detector": {"name": "sendgrid", "display_name":
+        "SendGrid Key", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "sendgrid_key", "detector_group_display_name": "SendGrid
+        Key"}, "date": "2019-02-11T12:36:02Z", "secret_id": 14592841, "secret_hash":
+        "56VyXyYsEkRVqTiCem+I1NhoZNp0IQKqlPItH+mlIkMmFjfwOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "31198eeb074a1722b082a6ea94edc8a133b115d7201acb47361741b236966830", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.746711Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/8",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}]'
+    headers:
+      CF-RAY:
+      - 9ef486f2ebd57026-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:33 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '5781'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD04&per_page=5&status=TRIGGERED>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '96'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_tags_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_tags_filter.yaml
@@ -1,0 +1,511 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=20
+  response:
+    body:
+      string: '[{"id": 1, "detector": {"name": "stripe", "display_name": "Stripe Keys",
+        "nature": "specific", "family": "token", "category": "payment_system", "detector_group_name":
+        "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
+        "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
+        "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
+        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
+        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
+        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
+        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "Stripe Keys"}, {"id": 2, "detector":
+        {"name": "slackbototken", "display_name": "Slack Bot Token", "nature": "specific",
+        "family": "token", "category": "messaging_system", "detector_group_name":
+        "slackbot_token", "detector_group_display_name": "Slack Bot Token"}, "date":
+        "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash": "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4",
+        "hmsl_hash": "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592836, "secret_hash": "UkaGM2d1NaALSIkUqCBkEgY+xnpQYM3vPZeWQp9v/O680MxYd9tR0/CjGaYu0TLp",
+        "hmsl_hash": "2cc5873afae5ee7747e26e2d73f7b8abe0ac63e7971442ceb50be7c4bf5c77c9",
+        "occurrences_count": 13, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/3", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 4, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
+        "hmsl_hash": "8d750888a3f74d018e742b42dfb51c60907b26c49fdad4ebdabe1350eedfe0fb",
+        "occurrences_count": 10, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/4", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 5, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-05-24T12:18:15Z", "secret_id": 14592838,
+        "secret_hash": "Z5EChCcGXgX/eXhBjNhs4sGINbMdnzWjcD4m3l7naZmf7qCBOMgPzYhV28m6OGG4",
+        "hmsl_hash": "dc66b2a9c718f0d32581426943c736bfed9bcfd865c77712ca43d96faf97f731",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 8, "detector": {"name": "sendgrid", "display_name":
+        "SendGrid Key", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "sendgrid_key", "detector_group_display_name": "SendGrid
+        Key"}, "date": "2019-02-11T12:36:02Z", "secret_id": 14592841, "secret_hash":
+        "56VyXyYsEkRVqTiCem+I1NhoZNp0IQKqlPItH+mlIkMmFjfwOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "31198eeb074a1722b082a6ea94edc8a133b115d7201acb47361741b236966830", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.746711Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/8",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 9, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-10-17T13:35:42Z", "secret_id": 14592842,
+        "secret_hash": "iPhCz0hiEKKcYiKnWwMgF+iE0K4tHJTBECUI1m+w7wJpZCyyOMgPzYhV28m6OGG4",
+        "hmsl_hash": "35764f7687c768b9e42ce14f6b7f4eece8d1cd71d4c63c8fd614b23a8e8c1c7d",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.747147Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/9", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 10, "detector": {"name": "generic_password", "display_name":
+        "Generic Password", "nature": "generic", "family": "other", "category": "other",
+        "detector_group_name": "generic_password", "detector_group_display_name":
+        "Generic Password"}, "date": "2022-06-20T16:04:33Z", "secret_id": 14592843,
+        "secret_hash": "1rC83I0fTz8CLTr6Tz7usCc9nbtqZqUU2qXEU2V6CGzNxOl3fma8ieOEhD7igl+v",
+        "hmsl_hash": "9f54d16410ea8fae5f1389bcfa2d48539da4491cf4998d5d8cbcb9b4b946255f",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.749479Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        51, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/10", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Generic Password"}, {"id": 17, "detector": {"name": "sendgrid", "display_name":
+        "SendGrid Key", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "sendgrid_key", "detector_group_display_name": "SendGrid
+        Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592850, "secret_hash":
+        "IRfE2CM4LTU9zkWZl7wtWYTnBxQiaOHtAcZ3uhDrcvPg22qYOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "046f4d07330d592e729e6a072661070a3686a0616bf1e72209789656ca471b17", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/17",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 18, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592851, "secret_hash":
+        "Uuk6ATzxus6ReU1GDCXUwr7vwE8ViniGIZwfovTm021h+oKmOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "99185204219cfb8df5e777a66f95fd7df357fed56ab23836bbaf6ea2514f961a", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/18",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 19, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592852, "secret_hash":
+        "GPMde0PsT+7OW6y5RryDp/j+pXQkud3HsGpajUFu0Tzqx9pZOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "694403f25caf188319a9b5df5776a6795ac760ad443807047f0771e3119ccd56", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/19",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 20, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592853, "secret_hash":
+        "bBXl1L03BPejq0HJOOIJN/egKAz5enmLatAafFYLw00oSifLOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "cf9bc1eaab8460fbeaaf779e9756c8a586a8f366debb06d2e937e4d85365ad9e", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/20",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 21, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2023-05-16T12:28:32Z", "secret_id": 14592854, "secret_hash":
+        "Xy7y/46z9WKji2j3qEcqzGFPKjkOeenb1PfQsvoEj05SynaIL4Qc71cZRqNcojMG", "hmsl_hash":
+        "dbbfaacc45fe15df6fc8445e5c8a9af230c5ec380ba8944a440009d4b58e8b68", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.757884Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/21",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 23, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2022-07-19T09:52:09Z", "secret_id": 7970364, "secret_hash":
+        "CBz9BMCUQDF3+MCOXcTqfTSvrVZTp8XQF+z38O1amQpnfh2zOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "049d5bbb613a172b0eb21c73a827ae34a30233dbfc9e9b75377a4743082bd447", "occurrences_count":
+        527, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.760032Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 0, "severity_rule_id":
+        10872, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/23",
+        "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "SendGrid Key"}, {"id": 24, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2022-07-19T09:52:09Z", "secret_id": 7970365, "secret_hash": "DQ6dPu9BXyq1FZTNVzfsEpxI24qF82fR4BvL62o1Q7AVIqBId9tR0/CjGaYu0TLp",
+        "hmsl_hash": "19c5c04da7b3d2372f1ab65fa2f311aff6ee3a0bfe37d4608797d5546814c335",
+        "occurrences_count": 190, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.760032Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "high", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        14, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/24", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 25, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592856, "secret_hash":
+        "6tsYM/861fChIu3lkD9zTIE4r+Ye4PBnYxO1wHC4R2WAM9tMiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "3321c774dd4bff3b29cbae9b5ccfc64033ca13a397039769ea185509a247b8b2", "occurrences_count":
+        6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/25",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 26, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592857, "secret_hash":
+        "MitOZYWU/47TOCVlJ8xs0iLON2e7+dG8ZogVwnscopqJ56XGiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "ca5b862ee181bfd49edd91e65ee018b8109e624b6679d0a780eed0591bc03f14", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/26",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 27, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592858, "secret_hash":
+        "bhbBm4t+But3lH43U3ossWK1Xe5Xh8AC0io3FirV6kuFeJYwiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "47286022d32f48fe490e4c2fb25e73cdba391b974662e10aac440bbd32154890", "occurrences_count":
+        6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/27",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 28, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592859, "secret_hash":
+        "ZnxXuxqfCDl+HlqBWZKEO7H2L1fXnhwHImxR1f28xgkJuUB1iIVhmFkAG+mbE/6F", "hmsl_hash":
+        "84e555e48b1ed023a553264e9724fe9fa0b5421f8209d5a986f8985c58915ead", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/28",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 29, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592860, "secret_hash":
+        "qeoBkkmxoCbogO0cHEb8YDWNgokqR0foCqyClIti/qc9PkCHiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "f82922f64e2a32d86e7c939c405d9949701e6479ac42d22e4d6549ebec6bce3b", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/29",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}]'
+    headers:
+      CF-RAY:
+      - 9efb6de20fdbeba6-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:47 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '22866'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0yOQ%3D%3D&per_page=20>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '110'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '20'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=5&tags=FROM_HISTORICAL_SCAN
+  response:
+    body:
+      string: '[{"id": 1, "detector": {"name": "stripe", "display_name": "Stripe Keys",
+        "nature": "specific", "family": "token", "category": "payment_system", "detector_group_name":
+        "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
+        "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
+        "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
+        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
+        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
+        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
+        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "Stripe Keys"}, {"id": 2, "detector":
+        {"name": "slackbototken", "display_name": "Slack Bot Token", "nature": "specific",
+        "family": "token", "category": "messaging_system", "detector_group_name":
+        "slackbot_token", "detector_group_display_name": "Slack Bot Token"}, "date":
+        "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash": "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4",
+        "hmsl_hash": "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592836, "secret_hash": "UkaGM2d1NaALSIkUqCBkEgY+xnpQYM3vPZeWQp9v/O680MxYd9tR0/CjGaYu0TLp",
+        "hmsl_hash": "2cc5873afae5ee7747e26e2d73f7b8abe0ac63e7971442ceb50be7c4bf5c77c9",
+        "occurrences_count": 13, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/3", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 4, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
+        "hmsl_hash": "8d750888a3f74d018e742b42dfb51c60907b26c49fdad4ebdabe1350eedfe0fb",
+        "occurrences_count": 10, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/4", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 5, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-05-24T12:18:15Z", "secret_id": 14592838,
+        "secret_hash": "Z5EChCcGXgX/eXhBjNhs4sGINbMdnzWjcD4m3l7naZmf7qCBOMgPzYhV28m6OGG4",
+        "hmsl_hash": "dc66b2a9c718f0d32581426943c736bfed9bcfd865c77712ca43d96faf97f731",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}]'
+    headers:
+      CF-RAY:
+      - 9efb6de55e9a7026-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:47 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '5855'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD01&per_page=5&tags=FROM_HISTORICAL_SCAN>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '88'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_triggered_at_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_triggered_at_filter.yaml
@@ -1,0 +1,149 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=5&triggered_at_before=2026-01-01T00%3A00%3A00Z&triggered_at_after=2024-01-01T00%3A00%3A00Z
+  response:
+    body:
+      string: '[{"id": 1, "detector": {"name": "stripe", "display_name": "Stripe Keys",
+        "nature": "specific", "family": "token", "category": "payment_system", "detector_group_name":
+        "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
+        "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
+        "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
+        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
+        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
+        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
+        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "Stripe Keys"}, {"id": 2, "detector":
+        {"name": "slackbototken", "display_name": "Slack Bot Token", "nature": "specific",
+        "family": "token", "category": "messaging_system", "detector_group_name":
+        "slackbot_token", "detector_group_display_name": "Slack Bot Token"}, "date":
+        "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash": "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4",
+        "hmsl_hash": "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592836, "secret_hash": "UkaGM2d1NaALSIkUqCBkEgY+xnpQYM3vPZeWQp9v/O680MxYd9tR0/CjGaYu0TLp",
+        "hmsl_hash": "2cc5873afae5ee7747e26e2d73f7b8abe0ac63e7971442ceb50be7c4bf5c77c9",
+        "occurrences_count": 13, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/3", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 4, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
+        "hmsl_hash": "8d750888a3f74d018e742b42dfb51c60907b26c49fdad4ebdabe1350eedfe0fb",
+        "occurrences_count": 10, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/4", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 5, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-05-24T12:18:15Z", "secret_id": 14592838,
+        "secret_hash": "Z5EChCcGXgX/eXhBjNhs4sGINbMdnzWjcD4m3l7naZmf7qCBOMgPzYhV28m6OGG4",
+        "hmsl_hash": "dc66b2a9c718f0d32581426943c736bfed9bcfd865c77712ca43d96faf97f731",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}]'
+    headers:
+      CF-RAY:
+      - 9ef486fd2861d4f2-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:35 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '5855'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD01&per_page=5&triggered_at_after=2024-01-01T00%3A00%3A00Z&triggered_at_before=2026-01-01T00%3A00%3A00Z>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '82'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_validity_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_validity_filter.yaml
@@ -1,0 +1,146 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=5&validity=valid
+  response:
+    body:
+      string: '[{"id": 52, "detector": {"name": "aws_iam", "display_name": "AWS IAM
+        Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2024-12-17T10:19:33Z", "secret_id": 14592883, "secret_hash":
+        "jfpGRuRzwwkh+0rO1sdbA98K4zuSMBfQHlBIXMm5dQVFAmmDL4Qc71cZRqNcojMG", "hmsl_hash":
+        "e50cad6b8e0ca71b4e13b0091d440308990047320f621fadabfb37916010e8ad", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.777462Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/52",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 57, "detector": {"name": "gitguardian_test_token_checked",
+        "display_name": "GitGuardian Test Token Checked", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token_checked",
+        "detector_group_display_name": "GitGuardian Test Token Checked"}, "date":
+        "2021-12-10T10:36:08Z", "secret_id": 7970357, "secret_hash": "cfDzN5RpdE7fN0bd474gxh8fBT9kKunY+sHOlD+OeXGzGAkSCxpDOKaZihAFaYMH",
+        "hmsl_hash": "49b26d210036e493d068e32207ab35c98242c41d82db746b1342ef497560195e",
+        "occurrences_count": 187, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.015423Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 27, "severity_rule_id":
+        10866, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/57",
+        "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Test Token Checked"}, {"id": 123, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2024-10-08T08:06:58Z", "secret_id": 14592939, "secret_hash":
+        "Ic0b2F+nC6t10UFsL2q4RoCOnxbICIPG8le5eLah1r7yCUW4L4Qc71cZRqNcojMG", "hmsl_hash":
+        "79daedb7dbd145002662f320d5b3497fe9f99eee48534675db9f85425e87c90f", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.922766Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/123",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 133, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2023-06-20T17:37:11Z", "secret_id": 14592949, "secret_hash":
+        "xREUeCg4rijhFTi2xfwsH3UKQ1nmE772jLaXnIwSSQX13b29L4Qc71cZRqNcojMG", "hmsl_hash":
+        "cf6f1f93b8a8c05eaec32d63ea56648a7f72805a9cbb9250ba543bcf32e25685", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.018836Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/133",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 142, "detector": {"name": "gitguardian_test_token_checked",
+        "display_name": "GitGuardian Test Token Checked", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token_checked",
+        "detector_group_display_name": "GitGuardian Test Token Checked"}, "date":
+        "2024-08-20T12:45:39Z", "secret_id": 14592957, "secret_hash": "F0v+rUbWNYEaACUQ7e+WD6aGK44ETtBdLu7hJcwYHwAmM46HCxpDOKaZihAFaYMH",
+        "hmsl_hash": "4a715e13b9ac2f1822fa5e59bb2b74ed57214806134df7b76b86e13f2b525b03",
+        "occurrences_count": 6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.191605Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 60, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/142",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "GitGuardian Test Token Checked"}]'
+    headers:
+      CF-RAY:
+      - 9ef486f8a860034a-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:34 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '5848'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0xNDI%3D&per_page=5&validity=valid>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '91'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_basic.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_basic.yaml
@@ -1,0 +1,83 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/3759/occurrences?per_page=5
+  response:
+    body:
+      string: '[{"id": 9846, "incident_id": 3759, "date": "2023-03-03T15:22:18Z",
+        "filepath": "peer/peer-0.10.0.tar.gz/peer/local_settings.py", "kind": "historical",
+        "presence": "removed", "matches": [{"name": "apikey", "indice_start": 295,
+        "indice_end": 335, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        14, "post_line_end": 14}], "tags": ["FROM_HISTORICAL_SCAN"], "sha": "2c9877a3019d6c2e261054f8e2fe6c11032ed880",
+        "url": "https://github.com/pypi-data/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
+        "source": {"id": 455, "type": "github", "name": "pypi-data/pypi-code-2", "url":
+        "https://github.com/pypi-data/pypi-code-2"}, "actor": {"id": 11, "type": "github_user",
+        "name": "orf", "email": "tom@tomforb.es", "url": "https://github.com/orf"},
+        "attachment_reasons": ["by_dev_from_perimeter"]}]'
+    headers:
+      CF-RAY:
+      - 9ef487219adb341e-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:41 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '833'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '81'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_get_all.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_get_all.yaml
@@ -1,0 +1,83 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/3759/occurrences?per_page=5
+  response:
+    body:
+      string: '[{"id": 9846, "incident_id": 3759, "date": "2023-03-03T15:22:18Z",
+        "filepath": "peer/peer-0.10.0.tar.gz/peer/local_settings.py", "kind": "historical",
+        "presence": "removed", "matches": [{"name": "apikey", "indice_start": 295,
+        "indice_end": 335, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        14, "post_line_end": 14}], "tags": ["FROM_HISTORICAL_SCAN"], "sha": "2c9877a3019d6c2e261054f8e2fe6c11032ed880",
+        "url": "https://github.com/pypi-data/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
+        "source": {"id": 455, "type": "github", "name": "pypi-data/pypi-code-2", "url":
+        "https://github.com/pypi-data/pypi-code-2"}, "actor": {"id": 11, "type": "github_user",
+        "name": "orf", "email": "tom@tomforb.es", "url": "https://github.com/orf"},
+        "attachment_reasons": ["by_dev_from_perimeter"]}]'
+    headers:
+      CF-RAY:
+      - 9ef4873d9aeb6fa5-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:45 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '833'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '49'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_attachment_reason.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_attachment_reason.yaml
@@ -1,0 +1,83 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/3759/occurrences?per_page=5&attachment_reason=by_dev_from_perimeter%2Con_github_org_in_perimeter
+  response:
+    body:
+      string: '[{"id": 9846, "incident_id": 3759, "date": "2023-03-03T15:22:18Z",
+        "filepath": "peer/peer-0.10.0.tar.gz/peer/local_settings.py", "kind": "historical",
+        "presence": "removed", "matches": [{"name": "apikey", "indice_start": 295,
+        "indice_end": 335, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        14, "post_line_end": 14}], "tags": ["FROM_HISTORICAL_SCAN"], "sha": "2c9877a3019d6c2e261054f8e2fe6c11032ed880",
+        "url": "https://github.com/pypi-data/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
+        "source": {"id": 455, "type": "github", "name": "pypi-data/pypi-code-2", "url":
+        "https://github.com/pypi-data/pypi-code-2"}, "actor": {"id": 11, "type": "github_user",
+        "name": "orf", "email": "tom@tomforb.es", "url": "https://github.com/orf"},
+        "attachment_reasons": ["by_dev_from_perimeter"]}]'
+    headers:
+      CF-RAY:
+      - 9ef4872e2f98d30d-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:43 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '833'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '96'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_cursor.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_cursor.yaml
@@ -1,0 +1,529 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=20
+  response:
+    body:
+      string: '[{"id": 1, "detector": {"name": "stripe", "display_name": "Stripe Keys",
+        "nature": "specific", "family": "token", "category": "payment_system", "detector_group_name":
+        "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
+        "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
+        "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
+        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
+        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
+        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
+        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "Stripe Keys"}, {"id": 2, "detector":
+        {"name": "slackbototken", "display_name": "Slack Bot Token", "nature": "specific",
+        "family": "token", "category": "messaging_system", "detector_group_name":
+        "slackbot_token", "detector_group_display_name": "Slack Bot Token"}, "date":
+        "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash": "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4",
+        "hmsl_hash": "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592836, "secret_hash": "UkaGM2d1NaALSIkUqCBkEgY+xnpQYM3vPZeWQp9v/O680MxYd9tR0/CjGaYu0TLp",
+        "hmsl_hash": "2cc5873afae5ee7747e26e2d73f7b8abe0ac63e7971442ceb50be7c4bf5c77c9",
+        "occurrences_count": 13, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/3", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 4, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
+        "hmsl_hash": "8d750888a3f74d018e742b42dfb51c60907b26c49fdad4ebdabe1350eedfe0fb",
+        "occurrences_count": 10, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/4", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 5, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-05-24T12:18:15Z", "secret_id": 14592838,
+        "secret_hash": "Z5EChCcGXgX/eXhBjNhs4sGINbMdnzWjcD4m3l7naZmf7qCBOMgPzYhV28m6OGG4",
+        "hmsl_hash": "dc66b2a9c718f0d32581426943c736bfed9bcfd865c77712ca43d96faf97f731",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 8, "detector": {"name": "sendgrid", "display_name":
+        "SendGrid Key", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "sendgrid_key", "detector_group_display_name": "SendGrid
+        Key"}, "date": "2019-02-11T12:36:02Z", "secret_id": 14592841, "secret_hash":
+        "56VyXyYsEkRVqTiCem+I1NhoZNp0IQKqlPItH+mlIkMmFjfwOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "31198eeb074a1722b082a6ea94edc8a133b115d7201acb47361741b236966830", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.746711Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/8",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 9, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-10-17T13:35:42Z", "secret_id": 14592842,
+        "secret_hash": "iPhCz0hiEKKcYiKnWwMgF+iE0K4tHJTBECUI1m+w7wJpZCyyOMgPzYhV28m6OGG4",
+        "hmsl_hash": "35764f7687c768b9e42ce14f6b7f4eece8d1cd71d4c63c8fd614b23a8e8c1c7d",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.747147Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/9", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 10, "detector": {"name": "generic_password", "display_name":
+        "Generic Password", "nature": "generic", "family": "other", "category": "other",
+        "detector_group_name": "generic_password", "detector_group_display_name":
+        "Generic Password"}, "date": "2022-06-20T16:04:33Z", "secret_id": 14592843,
+        "secret_hash": "1rC83I0fTz8CLTr6Tz7usCc9nbtqZqUU2qXEU2V6CGzNxOl3fma8ieOEhD7igl+v",
+        "hmsl_hash": "9f54d16410ea8fae5f1389bcfa2d48539da4491cf4998d5d8cbcb9b4b946255f",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.749479Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        51, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/10", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Generic Password"}, {"id": 17, "detector": {"name": "sendgrid", "display_name":
+        "SendGrid Key", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "sendgrid_key", "detector_group_display_name": "SendGrid
+        Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592850, "secret_hash":
+        "IRfE2CM4LTU9zkWZl7wtWYTnBxQiaOHtAcZ3uhDrcvPg22qYOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "046f4d07330d592e729e6a072661070a3686a0616bf1e72209789656ca471b17", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/17",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 18, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592851, "secret_hash":
+        "Uuk6ATzxus6ReU1GDCXUwr7vwE8ViniGIZwfovTm021h+oKmOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "99185204219cfb8df5e777a66f95fd7df357fed56ab23836bbaf6ea2514f961a", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/18",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 19, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592852, "secret_hash":
+        "GPMde0PsT+7OW6y5RryDp/j+pXQkud3HsGpajUFu0Tzqx9pZOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "694403f25caf188319a9b5df5776a6795ac760ad443807047f0771e3119ccd56", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/19",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 20, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592853, "secret_hash":
+        "bBXl1L03BPejq0HJOOIJN/egKAz5enmLatAafFYLw00oSifLOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "cf9bc1eaab8460fbeaaf779e9756c8a586a8f366debb06d2e937e4d85365ad9e", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/20",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 21, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2023-05-16T12:28:32Z", "secret_id": 14592854, "secret_hash":
+        "Xy7y/46z9WKji2j3qEcqzGFPKjkOeenb1PfQsvoEj05SynaIL4Qc71cZRqNcojMG", "hmsl_hash":
+        "dbbfaacc45fe15df6fc8445e5c8a9af230c5ec380ba8944a440009d4b58e8b68", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.757884Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/21",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 23, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2022-07-19T09:52:09Z", "secret_id": 7970364, "secret_hash":
+        "CBz9BMCUQDF3+MCOXcTqfTSvrVZTp8XQF+z38O1amQpnfh2zOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "049d5bbb613a172b0eb21c73a827ae34a30233dbfc9e9b75377a4743082bd447", "occurrences_count":
+        527, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.760032Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 0, "severity_rule_id":
+        10872, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/23",
+        "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "SendGrid Key"}, {"id": 24, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2022-07-19T09:52:09Z", "secret_id": 7970365, "secret_hash": "DQ6dPu9BXyq1FZTNVzfsEpxI24qF82fR4BvL62o1Q7AVIqBId9tR0/CjGaYu0TLp",
+        "hmsl_hash": "19c5c04da7b3d2372f1ab65fa2f311aff6ee3a0bfe37d4608797d5546814c335",
+        "occurrences_count": 190, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.760032Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "high", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        14, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/24", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 25, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592856, "secret_hash":
+        "6tsYM/861fChIu3lkD9zTIE4r+Ye4PBnYxO1wHC4R2WAM9tMiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "3321c774dd4bff3b29cbae9b5ccfc64033ca13a397039769ea185509a247b8b2", "occurrences_count":
+        6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/25",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 26, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592857, "secret_hash":
+        "MitOZYWU/47TOCVlJ8xs0iLON2e7+dG8ZogVwnscopqJ56XGiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "ca5b862ee181bfd49edd91e65ee018b8109e624b6679d0a780eed0591bc03f14", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/26",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 27, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592858, "secret_hash":
+        "bhbBm4t+But3lH43U3ossWK1Xe5Xh8AC0io3FirV6kuFeJYwiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "47286022d32f48fe490e4c2fb25e73cdba391b974662e10aac440bbd32154890", "occurrences_count":
+        6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/27",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 28, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592859, "secret_hash":
+        "ZnxXuxqfCDl+HlqBWZKEO7H2L1fXnhwHImxR1f28xgkJuUB1iIVhmFkAG+mbE/6F", "hmsl_hash":
+        "84e555e48b1ed023a553264e9724fe9fa0b5421f8209d5a986f8985c58915ead", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/28",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 29, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592860, "secret_hash":
+        "qeoBkkmxoCbogO0cHEb8YDWNgokqR0foCqyClIti/qc9PkCHiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "f82922f64e2a32d86e7c939c405d9949701e6479ac42d22e4d6549ebec6bce3b", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/29",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}]'
+    headers:
+      CF-RAY:
+      - 9ef488dddb962a43-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:35:52 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '22866'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0yOQ%3D%3D&per_page=20>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '103'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '20'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/1/occurrences?per_page=1
+  response:
+    body:
+      string: '[{"id": 1, "incident_id": 1, "date": "2022-09-21T12:48:20Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
+        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+    headers:
+      CF-RAY:
+      - 9ef488e15b2a7909-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:35:52 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '858'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets/1/occurrences?cursor=cD0x&per_page=1>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '67'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '1'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/1/occurrences?cursor=cD0x&per_page=1
+  response:
+    body:
+      string: '[{"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290", "url":
+        "https://github.com/guillaume-malle/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+    headers:
+      CF-RAY:
+      - 9ef488e36af2bb60-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:35:53 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '860'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets/1/occurrences?cursor=cD0yMTI%3D&per_page=1>;
+        rel="next", <https://api.gitguardian.com/v1/public-incidents/secrets/1/occurrences?cursor=cj0xJnA9MjEy&per_page=1>;
+        rel="prev"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '91'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '1'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_date_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_date_filter.yaml
@@ -1,0 +1,83 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/3759/occurrences?per_page=5&date_after=2020-01-01T00%3A00%3A00Z
+  response:
+    body:
+      string: '[{"id": 9846, "incident_id": 3759, "date": "2023-03-03T15:22:18Z",
+        "filepath": "peer/peer-0.10.0.tar.gz/peer/local_settings.py", "kind": "historical",
+        "presence": "removed", "matches": [{"name": "apikey", "indice_start": 295,
+        "indice_end": 335, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        14, "post_line_end": 14}], "tags": ["FROM_HISTORICAL_SCAN"], "sha": "2c9877a3019d6c2e261054f8e2fe6c11032ed880",
+        "url": "https://github.com/pypi-data/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
+        "source": {"id": 455, "type": "github", "name": "pypi-data/pypi-code-2", "url":
+        "https://github.com/pypi-data/pypi-code-2"}, "actor": {"id": 11, "type": "github_user",
+        "name": "orf", "email": "tom@tomforb.es", "url": "https://github.com/orf"},
+        "attachment_reasons": ["by_dev_from_perimeter"]}]'
+    headers:
+      CF-RAY:
+      - 9efb6df54f6f0159-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:50 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '833'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '60'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_filepath.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_filepath.yaml
@@ -1,0 +1,595 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=20
+  response:
+    body:
+      string: '[{"id": 1, "detector": {"name": "stripe", "display_name": "Stripe Keys",
+        "nature": "specific", "family": "token", "category": "payment_system", "detector_group_name":
+        "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
+        "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
+        "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
+        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
+        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
+        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
+        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "Stripe Keys"}, {"id": 2, "detector":
+        {"name": "slackbototken", "display_name": "Slack Bot Token", "nature": "specific",
+        "family": "token", "category": "messaging_system", "detector_group_name":
+        "slackbot_token", "detector_group_display_name": "Slack Bot Token"}, "date":
+        "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash": "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4",
+        "hmsl_hash": "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592836, "secret_hash": "UkaGM2d1NaALSIkUqCBkEgY+xnpQYM3vPZeWQp9v/O680MxYd9tR0/CjGaYu0TLp",
+        "hmsl_hash": "2cc5873afae5ee7747e26e2d73f7b8abe0ac63e7971442ceb50be7c4bf5c77c9",
+        "occurrences_count": 13, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/3", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 4, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
+        "hmsl_hash": "8d750888a3f74d018e742b42dfb51c60907b26c49fdad4ebdabe1350eedfe0fb",
+        "occurrences_count": 10, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/4", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 5, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-05-24T12:18:15Z", "secret_id": 14592838,
+        "secret_hash": "Z5EChCcGXgX/eXhBjNhs4sGINbMdnzWjcD4m3l7naZmf7qCBOMgPzYhV28m6OGG4",
+        "hmsl_hash": "dc66b2a9c718f0d32581426943c736bfed9bcfd865c77712ca43d96faf97f731",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 8, "detector": {"name": "sendgrid", "display_name":
+        "SendGrid Key", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "sendgrid_key", "detector_group_display_name": "SendGrid
+        Key"}, "date": "2019-02-11T12:36:02Z", "secret_id": 14592841, "secret_hash":
+        "56VyXyYsEkRVqTiCem+I1NhoZNp0IQKqlPItH+mlIkMmFjfwOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "31198eeb074a1722b082a6ea94edc8a133b115d7201acb47361741b236966830", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.746711Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/8",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 9, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-10-17T13:35:42Z", "secret_id": 14592842,
+        "secret_hash": "iPhCz0hiEKKcYiKnWwMgF+iE0K4tHJTBECUI1m+w7wJpZCyyOMgPzYhV28m6OGG4",
+        "hmsl_hash": "35764f7687c768b9e42ce14f6b7f4eece8d1cd71d4c63c8fd614b23a8e8c1c7d",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.747147Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/9", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 10, "detector": {"name": "generic_password", "display_name":
+        "Generic Password", "nature": "generic", "family": "other", "category": "other",
+        "detector_group_name": "generic_password", "detector_group_display_name":
+        "Generic Password"}, "date": "2022-06-20T16:04:33Z", "secret_id": 14592843,
+        "secret_hash": "1rC83I0fTz8CLTr6Tz7usCc9nbtqZqUU2qXEU2V6CGzNxOl3fma8ieOEhD7igl+v",
+        "hmsl_hash": "9f54d16410ea8fae5f1389bcfa2d48539da4491cf4998d5d8cbcb9b4b946255f",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.749479Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        51, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/10", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Generic Password"}, {"id": 17, "detector": {"name": "sendgrid", "display_name":
+        "SendGrid Key", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "sendgrid_key", "detector_group_display_name": "SendGrid
+        Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592850, "secret_hash":
+        "IRfE2CM4LTU9zkWZl7wtWYTnBxQiaOHtAcZ3uhDrcvPg22qYOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "046f4d07330d592e729e6a072661070a3686a0616bf1e72209789656ca471b17", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/17",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 18, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592851, "secret_hash":
+        "Uuk6ATzxus6ReU1GDCXUwr7vwE8ViniGIZwfovTm021h+oKmOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "99185204219cfb8df5e777a66f95fd7df357fed56ab23836bbaf6ea2514f961a", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/18",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 19, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592852, "secret_hash":
+        "GPMde0PsT+7OW6y5RryDp/j+pXQkud3HsGpajUFu0Tzqx9pZOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "694403f25caf188319a9b5df5776a6795ac760ad443807047f0771e3119ccd56", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/19",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 20, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592853, "secret_hash":
+        "bBXl1L03BPejq0HJOOIJN/egKAz5enmLatAafFYLw00oSifLOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "cf9bc1eaab8460fbeaaf779e9756c8a586a8f366debb06d2e937e4d85365ad9e", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/20",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 21, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2023-05-16T12:28:32Z", "secret_id": 14592854, "secret_hash":
+        "Xy7y/46z9WKji2j3qEcqzGFPKjkOeenb1PfQsvoEj05SynaIL4Qc71cZRqNcojMG", "hmsl_hash":
+        "dbbfaacc45fe15df6fc8445e5c8a9af230c5ec380ba8944a440009d4b58e8b68", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.757884Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/21",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 23, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2022-07-19T09:52:09Z", "secret_id": 7970364, "secret_hash":
+        "CBz9BMCUQDF3+MCOXcTqfTSvrVZTp8XQF+z38O1amQpnfh2zOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "049d5bbb613a172b0eb21c73a827ae34a30233dbfc9e9b75377a4743082bd447", "occurrences_count":
+        527, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.760032Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 0, "severity_rule_id":
+        10872, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/23",
+        "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "SendGrid Key"}, {"id": 24, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2022-07-19T09:52:09Z", "secret_id": 7970365, "secret_hash": "DQ6dPu9BXyq1FZTNVzfsEpxI24qF82fR4BvL62o1Q7AVIqBId9tR0/CjGaYu0TLp",
+        "hmsl_hash": "19c5c04da7b3d2372f1ab65fa2f311aff6ee3a0bfe37d4608797d5546814c335",
+        "occurrences_count": 190, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.760032Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "high", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        14, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/24", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 25, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592856, "secret_hash":
+        "6tsYM/861fChIu3lkD9zTIE4r+Ye4PBnYxO1wHC4R2WAM9tMiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "3321c774dd4bff3b29cbae9b5ccfc64033ca13a397039769ea185509a247b8b2", "occurrences_count":
+        6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/25",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 26, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592857, "secret_hash":
+        "MitOZYWU/47TOCVlJ8xs0iLON2e7+dG8ZogVwnscopqJ56XGiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "ca5b862ee181bfd49edd91e65ee018b8109e624b6679d0a780eed0591bc03f14", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/26",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 27, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592858, "secret_hash":
+        "bhbBm4t+But3lH43U3ossWK1Xe5Xh8AC0io3FirV6kuFeJYwiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "47286022d32f48fe490e4c2fb25e73cdba391b974662e10aac440bbd32154890", "occurrences_count":
+        6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/27",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 28, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592859, "secret_hash":
+        "ZnxXuxqfCDl+HlqBWZKEO7H2L1fXnhwHImxR1f28xgkJuUB1iIVhmFkAG+mbE/6F", "hmsl_hash":
+        "84e555e48b1ed023a553264e9724fe9fa0b5421f8209d5a986f8985c58915ead", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/28",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 29, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592860, "secret_hash":
+        "qeoBkkmxoCbogO0cHEb8YDWNgokqR0foCqyClIti/qc9PkCHiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "f82922f64e2a32d86e7c939c405d9949701e6479ac42d22e4d6549ebec6bce3b", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/29",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}]'
+    headers:
+      CF-RAY:
+      - 9efb6e106b682a7d-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:54 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '22866'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0yOQ%3D%3D&per_page=20>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '82'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '20'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/1/occurrences?per_page=5
+  response:
+    body:
+      string: '[{"id": 1, "incident_id": 1, "date": "2022-09-21T12:48:20Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
+        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290", "url":
+        "https://github.com/guillaume-malle/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url":
+        "https://github.com/guillaume-malle/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 2733, "incident_id": 1, "date": "2023-03-14T13:42:20Z", "filepath":
+        "stripe1.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 23, "indice_end": 55, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 1, "post_line_end": 1}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "2b9ef5781791f7f4a54af30a254bab215cf97e51", "url":
+        "https://github.com/ssokgg/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
+        "source": {"id": 11, "type": "github", "name": "ssokgg/tetris1", "url": "https://github.com/ssokgg/tetris1"},
+        "actor": {"id": 85, "type": "github_user", "name": "ssokgg", "email": "sandra.sok@gitguardian.com",
+        "url": "https://github.com/ssokgg"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url":
+        "https://github.com/guillaume-malle/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+    headers:
+      CF-RAY:
+      - 9efb6e140fce03f3-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:55 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '4235'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '66'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/1/occurrences?per_page=5&filepath=hello.py
+  response:
+    body:
+      string: '[{"id": 1, "incident_id": 1, "date": "2022-09-21T12:48:20Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
+        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290", "url":
+        "https://github.com/guillaume-malle/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url":
+        "https://github.com/guillaume-malle/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url":
+        "https://github.com/guillaume-malle/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+    headers:
+      CF-RAY:
+      - 9efb6e161dbbd13b-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:55 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '3431'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '47'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_ordering.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_ordering.yaml
@@ -1,0 +1,83 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/3759/occurrences?per_page=5&ordering=-date
+  response:
+    body:
+      string: '[{"id": 9846, "incident_id": 3759, "date": "2023-03-03T15:22:18Z",
+        "filepath": "peer/peer-0.10.0.tar.gz/peer/local_settings.py", "kind": "historical",
+        "presence": "removed", "matches": [{"name": "apikey", "indice_start": 295,
+        "indice_end": 335, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        14, "post_line_end": 14}], "tags": ["FROM_HISTORICAL_SCAN"], "sha": "2c9877a3019d6c2e261054f8e2fe6c11032ed880",
+        "url": "https://github.com/pypi-data/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
+        "source": {"id": 455, "type": "github", "name": "pypi-data/pypi-code-2", "url":
+        "https://github.com/pypi-data/pypi-code-2"}, "actor": {"id": 11, "type": "github_user",
+        "name": "orf", "email": "tom@tomforb.es", "url": "https://github.com/orf"},
+        "attachment_reasons": ["by_dev_from_perimeter"]}]'
+    headers:
+      CF-RAY:
+      - 9ef487393de6bb46-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:44 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '833'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '49'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_presence.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_presence.yaml
@@ -1,0 +1,604 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=20
+  response:
+    body:
+      string: '[{"id": 1, "detector": {"name": "stripe", "display_name": "Stripe Keys",
+        "nature": "specific", "family": "token", "category": "payment_system", "detector_group_name":
+        "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
+        "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
+        "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
+        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
+        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
+        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
+        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "Stripe Keys"}, {"id": 2, "detector":
+        {"name": "slackbototken", "display_name": "Slack Bot Token", "nature": "specific",
+        "family": "token", "category": "messaging_system", "detector_group_name":
+        "slackbot_token", "detector_group_display_name": "Slack Bot Token"}, "date":
+        "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash": "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4",
+        "hmsl_hash": "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592836, "secret_hash": "UkaGM2d1NaALSIkUqCBkEgY+xnpQYM3vPZeWQp9v/O680MxYd9tR0/CjGaYu0TLp",
+        "hmsl_hash": "2cc5873afae5ee7747e26e2d73f7b8abe0ac63e7971442ceb50be7c4bf5c77c9",
+        "occurrences_count": 13, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/3", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 4, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
+        "hmsl_hash": "8d750888a3f74d018e742b42dfb51c60907b26c49fdad4ebdabe1350eedfe0fb",
+        "occurrences_count": 10, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/4", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 5, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-05-24T12:18:15Z", "secret_id": 14592838,
+        "secret_hash": "Z5EChCcGXgX/eXhBjNhs4sGINbMdnzWjcD4m3l7naZmf7qCBOMgPzYhV28m6OGG4",
+        "hmsl_hash": "dc66b2a9c718f0d32581426943c736bfed9bcfd865c77712ca43d96faf97f731",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 8, "detector": {"name": "sendgrid", "display_name":
+        "SendGrid Key", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "sendgrid_key", "detector_group_display_name": "SendGrid
+        Key"}, "date": "2019-02-11T12:36:02Z", "secret_id": 14592841, "secret_hash":
+        "56VyXyYsEkRVqTiCem+I1NhoZNp0IQKqlPItH+mlIkMmFjfwOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "31198eeb074a1722b082a6ea94edc8a133b115d7201acb47361741b236966830", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.746711Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/8",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 9, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-10-17T13:35:42Z", "secret_id": 14592842,
+        "secret_hash": "iPhCz0hiEKKcYiKnWwMgF+iE0K4tHJTBECUI1m+w7wJpZCyyOMgPzYhV28m6OGG4",
+        "hmsl_hash": "35764f7687c768b9e42ce14f6b7f4eece8d1cd71d4c63c8fd614b23a8e8c1c7d",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.747147Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/9", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 10, "detector": {"name": "generic_password", "display_name":
+        "Generic Password", "nature": "generic", "family": "other", "category": "other",
+        "detector_group_name": "generic_password", "detector_group_display_name":
+        "Generic Password"}, "date": "2022-06-20T16:04:33Z", "secret_id": 14592843,
+        "secret_hash": "1rC83I0fTz8CLTr6Tz7usCc9nbtqZqUU2qXEU2V6CGzNxOl3fma8ieOEhD7igl+v",
+        "hmsl_hash": "9f54d16410ea8fae5f1389bcfa2d48539da4491cf4998d5d8cbcb9b4b946255f",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.749479Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        51, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/10", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Generic Password"}, {"id": 17, "detector": {"name": "sendgrid", "display_name":
+        "SendGrid Key", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "sendgrid_key", "detector_group_display_name": "SendGrid
+        Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592850, "secret_hash":
+        "IRfE2CM4LTU9zkWZl7wtWYTnBxQiaOHtAcZ3uhDrcvPg22qYOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "046f4d07330d592e729e6a072661070a3686a0616bf1e72209789656ca471b17", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/17",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 18, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592851, "secret_hash":
+        "Uuk6ATzxus6ReU1GDCXUwr7vwE8ViniGIZwfovTm021h+oKmOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "99185204219cfb8df5e777a66f95fd7df357fed56ab23836bbaf6ea2514f961a", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/18",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 19, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592852, "secret_hash":
+        "GPMde0PsT+7OW6y5RryDp/j+pXQkud3HsGpajUFu0Tzqx9pZOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "694403f25caf188319a9b5df5776a6795ac760ad443807047f0771e3119ccd56", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/19",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 20, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592853, "secret_hash":
+        "bBXl1L03BPejq0HJOOIJN/egKAz5enmLatAafFYLw00oSifLOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "cf9bc1eaab8460fbeaaf779e9756c8a586a8f366debb06d2e937e4d85365ad9e", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/20",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 21, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2023-05-16T12:28:32Z", "secret_id": 14592854, "secret_hash":
+        "Xy7y/46z9WKji2j3qEcqzGFPKjkOeenb1PfQsvoEj05SynaIL4Qc71cZRqNcojMG", "hmsl_hash":
+        "dbbfaacc45fe15df6fc8445e5c8a9af230c5ec380ba8944a440009d4b58e8b68", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.757884Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/21",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 23, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2022-07-19T09:52:09Z", "secret_id": 7970364, "secret_hash":
+        "CBz9BMCUQDF3+MCOXcTqfTSvrVZTp8XQF+z38O1amQpnfh2zOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "049d5bbb613a172b0eb21c73a827ae34a30233dbfc9e9b75377a4743082bd447", "occurrences_count":
+        527, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.760032Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 0, "severity_rule_id":
+        10872, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/23",
+        "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "SendGrid Key"}, {"id": 24, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2022-07-19T09:52:09Z", "secret_id": 7970365, "secret_hash": "DQ6dPu9BXyq1FZTNVzfsEpxI24qF82fR4BvL62o1Q7AVIqBId9tR0/CjGaYu0TLp",
+        "hmsl_hash": "19c5c04da7b3d2372f1ab65fa2f311aff6ee3a0bfe37d4608797d5546814c335",
+        "occurrences_count": 190, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.760032Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "high", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        14, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/24", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 25, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592856, "secret_hash":
+        "6tsYM/861fChIu3lkD9zTIE4r+Ye4PBnYxO1wHC4R2WAM9tMiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "3321c774dd4bff3b29cbae9b5ccfc64033ca13a397039769ea185509a247b8b2", "occurrences_count":
+        6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/25",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 26, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592857, "secret_hash":
+        "MitOZYWU/47TOCVlJ8xs0iLON2e7+dG8ZogVwnscopqJ56XGiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "ca5b862ee181bfd49edd91e65ee018b8109e624b6679d0a780eed0591bc03f14", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/26",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 27, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592858, "secret_hash":
+        "bhbBm4t+But3lH43U3ossWK1Xe5Xh8AC0io3FirV6kuFeJYwiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "47286022d32f48fe490e4c2fb25e73cdba391b974662e10aac440bbd32154890", "occurrences_count":
+        6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/27",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 28, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592859, "secret_hash":
+        "ZnxXuxqfCDl+HlqBWZKEO7H2L1fXnhwHImxR1f28xgkJuUB1iIVhmFkAG+mbE/6F", "hmsl_hash":
+        "84e555e48b1ed023a553264e9724fe9fa0b5421f8209d5a986f8985c58915ead", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/28",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 29, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592860, "secret_hash":
+        "qeoBkkmxoCbogO0cHEb8YDWNgokqR0foCqyClIti/qc9PkCHiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "f82922f64e2a32d86e7c939c405d9949701e6479ac42d22e4d6549ebec6bce3b", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/29",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}]'
+    headers:
+      CF-RAY:
+      - 9efb6e012ff30350-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:52 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '22866'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0yOQ%3D%3D&per_page=20>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '88'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '20'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/1/occurrences?per_page=5
+  response:
+    body:
+      string: '[{"id": 1, "incident_id": 1, "date": "2022-09-21T12:48:20Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
+        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290", "url":
+        "https://github.com/guillaume-malle/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url":
+        "https://github.com/guillaume-malle/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 2733, "incident_id": 1, "date": "2023-03-14T13:42:20Z", "filepath":
+        "stripe1.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 23, "indice_end": 55, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 1, "post_line_end": 1}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "2b9ef5781791f7f4a54af30a254bab215cf97e51", "url":
+        "https://github.com/ssokgg/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
+        "source": {"id": 11, "type": "github", "name": "ssokgg/tetris1", "url": "https://github.com/ssokgg/tetris1"},
+        "actor": {"id": 85, "type": "github_user", "name": "ssokgg", "email": "sandra.sok@gitguardian.com",
+        "url": "https://github.com/ssokgg"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url":
+        "https://github.com/guillaume-malle/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+    headers:
+      CF-RAY:
+      - 9efb6e046bcd71e6-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:52 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '4235'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '86'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/1/occurrences?per_page=5&presence=present
+  response:
+    body:
+      string: '[{"id": 1, "incident_id": 1, "date": "2022-09-21T12:48:20Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
+        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290", "url":
+        "https://github.com/guillaume-malle/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url":
+        "https://github.com/guillaume-malle/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 2733, "incident_id": 1, "date": "2023-03-14T13:42:20Z", "filepath":
+        "stripe1.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 23, "indice_end": 55, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 1, "post_line_end": 1}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "2b9ef5781791f7f4a54af30a254bab215cf97e51", "url":
+        "https://github.com/ssokgg/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
+        "source": {"id": 11, "type": "github", "name": "ssokgg/tetris1", "url": "https://github.com/ssokgg/tetris1"},
+        "actor": {"id": 85, "type": "github_user", "name": "ssokgg", "email": "sandra.sok@gitguardian.com",
+        "url": "https://github.com/ssokgg"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url":
+        "https://github.com/guillaume-malle/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+    headers:
+      CF-RAY:
+      - 9efb6e069af66f5d-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:53 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '4235'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '78'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_severity.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_severity.yaml
@@ -1,0 +1,83 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/3759/occurrences?per_page=5&severity=critical%2Chigh
+  response:
+    body:
+      string: '[{"id": 9846, "incident_id": 3759, "date": "2023-03-03T15:22:18Z",
+        "filepath": "peer/peer-0.10.0.tar.gz/peer/local_settings.py", "kind": "historical",
+        "presence": "removed", "matches": [{"name": "apikey", "indice_start": 295,
+        "indice_end": 335, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        14, "post_line_end": 14}], "tags": ["FROM_HISTORICAL_SCAN"], "sha": "2c9877a3019d6c2e261054f8e2fe6c11032ed880",
+        "url": "https://github.com/pypi-data/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
+        "source": {"id": 455, "type": "github", "name": "pypi-data/pypi-code-2", "url":
+        "https://github.com/pypi-data/pypi-code-2"}, "actor": {"id": 11, "type": "github_user",
+        "name": "orf", "email": "tom@tomforb.es", "url": "https://github.com/orf"},
+        "attachment_reasons": ["by_dev_from_perimeter"]}]'
+    headers:
+      CF-RAY:
+      - 9ef48730bf7fd171-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:43 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '833'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '61'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_sha.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_sha.yaml
@@ -1,0 +1,565 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=20
+  response:
+    body:
+      string: '[{"id": 1, "detector": {"name": "stripe", "display_name": "Stripe Keys",
+        "nature": "specific", "family": "token", "category": "payment_system", "detector_group_name":
+        "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
+        "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
+        "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
+        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
+        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
+        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
+        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "Stripe Keys"}, {"id": 2, "detector":
+        {"name": "slackbototken", "display_name": "Slack Bot Token", "nature": "specific",
+        "family": "token", "category": "messaging_system", "detector_group_name":
+        "slackbot_token", "detector_group_display_name": "Slack Bot Token"}, "date":
+        "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash": "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4",
+        "hmsl_hash": "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592836, "secret_hash": "UkaGM2d1NaALSIkUqCBkEgY+xnpQYM3vPZeWQp9v/O680MxYd9tR0/CjGaYu0TLp",
+        "hmsl_hash": "2cc5873afae5ee7747e26e2d73f7b8abe0ac63e7971442ceb50be7c4bf5c77c9",
+        "occurrences_count": 13, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/3", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 4, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
+        "hmsl_hash": "8d750888a3f74d018e742b42dfb51c60907b26c49fdad4ebdabe1350eedfe0fb",
+        "occurrences_count": 10, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/4", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 5, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-05-24T12:18:15Z", "secret_id": 14592838,
+        "secret_hash": "Z5EChCcGXgX/eXhBjNhs4sGINbMdnzWjcD4m3l7naZmf7qCBOMgPzYhV28m6OGG4",
+        "hmsl_hash": "dc66b2a9c718f0d32581426943c736bfed9bcfd865c77712ca43d96faf97f731",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 8, "detector": {"name": "sendgrid", "display_name":
+        "SendGrid Key", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "sendgrid_key", "detector_group_display_name": "SendGrid
+        Key"}, "date": "2019-02-11T12:36:02Z", "secret_id": 14592841, "secret_hash":
+        "56VyXyYsEkRVqTiCem+I1NhoZNp0IQKqlPItH+mlIkMmFjfwOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "31198eeb074a1722b082a6ea94edc8a133b115d7201acb47361741b236966830", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.746711Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/8",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 9, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-10-17T13:35:42Z", "secret_id": 14592842,
+        "secret_hash": "iPhCz0hiEKKcYiKnWwMgF+iE0K4tHJTBECUI1m+w7wJpZCyyOMgPzYhV28m6OGG4",
+        "hmsl_hash": "35764f7687c768b9e42ce14f6b7f4eece8d1cd71d4c63c8fd614b23a8e8c1c7d",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.747147Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/9", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 10, "detector": {"name": "generic_password", "display_name":
+        "Generic Password", "nature": "generic", "family": "other", "category": "other",
+        "detector_group_name": "generic_password", "detector_group_display_name":
+        "Generic Password"}, "date": "2022-06-20T16:04:33Z", "secret_id": 14592843,
+        "secret_hash": "1rC83I0fTz8CLTr6Tz7usCc9nbtqZqUU2qXEU2V6CGzNxOl3fma8ieOEhD7igl+v",
+        "hmsl_hash": "9f54d16410ea8fae5f1389bcfa2d48539da4491cf4998d5d8cbcb9b4b946255f",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.749479Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        51, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/10", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Generic Password"}, {"id": 17, "detector": {"name": "sendgrid", "display_name":
+        "SendGrid Key", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "sendgrid_key", "detector_group_display_name": "SendGrid
+        Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592850, "secret_hash":
+        "IRfE2CM4LTU9zkWZl7wtWYTnBxQiaOHtAcZ3uhDrcvPg22qYOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "046f4d07330d592e729e6a072661070a3686a0616bf1e72209789656ca471b17", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/17",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 18, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592851, "secret_hash":
+        "Uuk6ATzxus6ReU1GDCXUwr7vwE8ViniGIZwfovTm021h+oKmOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "99185204219cfb8df5e777a66f95fd7df357fed56ab23836bbaf6ea2514f961a", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/18",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 19, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592852, "secret_hash":
+        "GPMde0PsT+7OW6y5RryDp/j+pXQkud3HsGpajUFu0Tzqx9pZOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "694403f25caf188319a9b5df5776a6795ac760ad443807047f0771e3119ccd56", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/19",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 20, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592853, "secret_hash":
+        "bBXl1L03BPejq0HJOOIJN/egKAz5enmLatAafFYLw00oSifLOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "cf9bc1eaab8460fbeaaf779e9756c8a586a8f366debb06d2e937e4d85365ad9e", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/20",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 21, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2023-05-16T12:28:32Z", "secret_id": 14592854, "secret_hash":
+        "Xy7y/46z9WKji2j3qEcqzGFPKjkOeenb1PfQsvoEj05SynaIL4Qc71cZRqNcojMG", "hmsl_hash":
+        "dbbfaacc45fe15df6fc8445e5c8a9af230c5ec380ba8944a440009d4b58e8b68", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.757884Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/21",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 23, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2022-07-19T09:52:09Z", "secret_id": 7970364, "secret_hash":
+        "CBz9BMCUQDF3+MCOXcTqfTSvrVZTp8XQF+z38O1amQpnfh2zOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "049d5bbb613a172b0eb21c73a827ae34a30233dbfc9e9b75377a4743082bd447", "occurrences_count":
+        527, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.760032Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 0, "severity_rule_id":
+        10872, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/23",
+        "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "SendGrid Key"}, {"id": 24, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2022-07-19T09:52:09Z", "secret_id": 7970365, "secret_hash": "DQ6dPu9BXyq1FZTNVzfsEpxI24qF82fR4BvL62o1Q7AVIqBId9tR0/CjGaYu0TLp",
+        "hmsl_hash": "19c5c04da7b3d2372f1ab65fa2f311aff6ee3a0bfe37d4608797d5546814c335",
+        "occurrences_count": 190, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.760032Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "high", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        14, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/24", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 25, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592856, "secret_hash":
+        "6tsYM/861fChIu3lkD9zTIE4r+Ye4PBnYxO1wHC4R2WAM9tMiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "3321c774dd4bff3b29cbae9b5ccfc64033ca13a397039769ea185509a247b8b2", "occurrences_count":
+        6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/25",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 26, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592857, "secret_hash":
+        "MitOZYWU/47TOCVlJ8xs0iLON2e7+dG8ZogVwnscopqJ56XGiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "ca5b862ee181bfd49edd91e65ee018b8109e624b6679d0a780eed0591bc03f14", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/26",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 27, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592858, "secret_hash":
+        "bhbBm4t+But3lH43U3ossWK1Xe5Xh8AC0io3FirV6kuFeJYwiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "47286022d32f48fe490e4c2fb25e73cdba391b974662e10aac440bbd32154890", "occurrences_count":
+        6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/27",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 28, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592859, "secret_hash":
+        "ZnxXuxqfCDl+HlqBWZKEO7H2L1fXnhwHImxR1f28xgkJuUB1iIVhmFkAG+mbE/6F", "hmsl_hash":
+        "84e555e48b1ed023a553264e9724fe9fa0b5421f8209d5a986f8985c58915ead", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/28",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 29, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592860, "secret_hash":
+        "qeoBkkmxoCbogO0cHEb8YDWNgokqR0foCqyClIti/qc9PkCHiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "f82922f64e2a32d86e7c939c405d9949701e6479ac42d22e4d6549ebec6bce3b", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/29",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}]'
+    headers:
+      CF-RAY:
+      - 9efb6e08dafef864-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:53 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '22866'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0yOQ%3D%3D&per_page=20>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '98'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '20'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/1/occurrences?per_page=5
+  response:
+    body:
+      string: '[{"id": 1, "incident_id": 1, "date": "2022-09-21T12:48:20Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
+        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290", "url":
+        "https://github.com/guillaume-malle/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url":
+        "https://github.com/guillaume-malle/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 2733, "incident_id": 1, "date": "2023-03-14T13:42:20Z", "filepath":
+        "stripe1.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 23, "indice_end": 55, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 1, "post_line_end": 1}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "2b9ef5781791f7f4a54af30a254bab215cf97e51", "url":
+        "https://github.com/ssokgg/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
+        "source": {"id": 11, "type": "github", "name": "ssokgg/tetris1", "url": "https://github.com/ssokgg/tetris1"},
+        "actor": {"id": 85, "type": "github_user", "name": "ssokgg", "email": "sandra.sok@gitguardian.com",
+        "url": "https://github.com/ssokgg"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url":
+        "https://github.com/guillaume-malle/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+    headers:
+      CF-RAY:
+      - 9efb6e0c7c0a9ebc-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:54 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '4235'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '56'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/1/occurrences?per_page=5&sha=7474a92c9f
+  response:
+    body:
+      string: '[{"id": 1, "incident_id": 1, "date": "2022-09-21T12:48:20Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
+        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+    headers:
+      CF-RAY:
+      - 9efb6e0e79b64bb5-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:54 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '858'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '52'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_source_id.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_source_id.yaml
@@ -1,0 +1,595 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=20
+  response:
+    body:
+      string: '[{"id": 1, "detector": {"name": "stripe", "display_name": "Stripe Keys",
+        "nature": "specific", "family": "token", "category": "payment_system", "detector_group_name":
+        "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
+        "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
+        "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
+        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
+        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
+        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
+        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "Stripe Keys"}, {"id": 2, "detector":
+        {"name": "slackbototken", "display_name": "Slack Bot Token", "nature": "specific",
+        "family": "token", "category": "messaging_system", "detector_group_name":
+        "slackbot_token", "detector_group_display_name": "Slack Bot Token"}, "date":
+        "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash": "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4",
+        "hmsl_hash": "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592836, "secret_hash": "UkaGM2d1NaALSIkUqCBkEgY+xnpQYM3vPZeWQp9v/O680MxYd9tR0/CjGaYu0TLp",
+        "hmsl_hash": "2cc5873afae5ee7747e26e2d73f7b8abe0ac63e7971442ceb50be7c4bf5c77c9",
+        "occurrences_count": 13, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/3", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 4, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2019-11-19T14:11:01Z", "secret_id": 14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
+        "hmsl_hash": "8d750888a3f74d018e742b42dfb51c60907b26c49fdad4ebdabe1350eedfe0fb",
+        "occurrences_count": 10, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/4", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 5, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-05-24T12:18:15Z", "secret_id": 14592838,
+        "secret_hash": "Z5EChCcGXgX/eXhBjNhs4sGINbMdnzWjcD4m3l7naZmf7qCBOMgPzYhV28m6OGG4",
+        "hmsl_hash": "dc66b2a9c718f0d32581426943c736bfed9bcfd865c77712ca43d96faf97f731",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 8, "detector": {"name": "sendgrid", "display_name":
+        "SendGrid Key", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "sendgrid_key", "detector_group_display_name": "SendGrid
+        Key"}, "date": "2019-02-11T12:36:02Z", "secret_id": 14592841, "secret_hash":
+        "56VyXyYsEkRVqTiCem+I1NhoZNp0IQKqlPItH+mlIkMmFjfwOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "31198eeb074a1722b082a6ea94edc8a133b115d7201acb47361741b236966830", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.746711Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/8",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 9, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-10-17T13:35:42Z", "secret_id": 14592842,
+        "secret_hash": "iPhCz0hiEKKcYiKnWwMgF+iE0K4tHJTBECUI1m+w7wJpZCyyOMgPzYhV28m6OGG4",
+        "hmsl_hash": "35764f7687c768b9e42ce14f6b7f4eece8d1cd71d4c63c8fd614b23a8e8c1c7d",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.747147Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/9", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 10, "detector": {"name": "generic_password", "display_name":
+        "Generic Password", "nature": "generic", "family": "other", "category": "other",
+        "detector_group_name": "generic_password", "detector_group_display_name":
+        "Generic Password"}, "date": "2022-06-20T16:04:33Z", "secret_id": 14592843,
+        "secret_hash": "1rC83I0fTz8CLTr6Tz7usCc9nbtqZqUU2qXEU2V6CGzNxOl3fma8ieOEhD7igl+v",
+        "hmsl_hash": "9f54d16410ea8fae5f1389bcfa2d48539da4491cf4998d5d8cbcb9b4b946255f",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.749479Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        51, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/10", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Generic Password"}, {"id": 17, "detector": {"name": "sendgrid", "display_name":
+        "SendGrid Key", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "sendgrid_key", "detector_group_display_name": "SendGrid
+        Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592850, "secret_hash":
+        "IRfE2CM4LTU9zkWZl7wtWYTnBxQiaOHtAcZ3uhDrcvPg22qYOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "046f4d07330d592e729e6a072661070a3686a0616bf1e72209789656ca471b17", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/17",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 18, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592851, "secret_hash":
+        "Uuk6ATzxus6ReU1GDCXUwr7vwE8ViniGIZwfovTm021h+oKmOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "99185204219cfb8df5e777a66f95fd7df357fed56ab23836bbaf6ea2514f961a", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/18",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 19, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592852, "secret_hash":
+        "GPMde0PsT+7OW6y5RryDp/j+pXQkud3HsGpajUFu0Tzqx9pZOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "694403f25caf188319a9b5df5776a6795ac760ad443807047f0771e3119ccd56", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/19",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 20, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2019-01-08T19:14:00Z", "secret_id": 14592853, "secret_hash":
+        "bBXl1L03BPejq0HJOOIJN/egKAz5enmLatAafFYLw00oSifLOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "cf9bc1eaab8460fbeaaf779e9756c8a586a8f366debb06d2e937e4d85365ad9e", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.753585Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/20",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}, {"id": 21, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2023-05-16T12:28:32Z", "secret_id": 14592854, "secret_hash":
+        "Xy7y/46z9WKji2j3qEcqzGFPKjkOeenb1PfQsvoEj05SynaIL4Qc71cZRqNcojMG", "hmsl_hash":
+        "dbbfaacc45fe15df6fc8445e5c8a9af230c5ec380ba8944a440009d4b58e8b68", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.757884Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/21",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 23, "detector": {"name": "sendgrid",
+        "display_name": "SendGrid Key", "nature": "specific", "family": "token", "category":
+        "messaging_system", "detector_group_name": "sendgrid_key", "detector_group_display_name":
+        "SendGrid Key"}, "date": "2022-07-19T09:52:09Z", "secret_id": 7970364, "secret_hash":
+        "CBz9BMCUQDF3+MCOXcTqfTSvrVZTp8XQF+z38O1amQpnfh2zOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "049d5bbb613a172b0eb21c73a827ae34a30233dbfc9e9b75377a4743082bd447", "occurrences_count":
+        527, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.760032Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 0, "severity_rule_id":
+        10872, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/23",
+        "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "SendGrid Key"}, {"id": 24, "detector": {"name": "gitguardian_test_token",
+        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
+        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
+        "2022-07-19T09:52:09Z", "secret_id": 7970365, "secret_hash": "DQ6dPu9BXyq1FZTNVzfsEpxI24qF82fR4BvL62o1Q7AVIqBId9tR0/CjGaYu0TLp",
+        "hmsl_hash": "19c5c04da7b3d2372f1ab65fa2f311aff6ee3a0bfe37d4608797d5546814c335",
+        "occurrences_count": 190, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.760032Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "high", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        14, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/24", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}, {"id": 25, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592856, "secret_hash":
+        "6tsYM/861fChIu3lkD9zTIE4r+Ye4PBnYxO1wHC4R2WAM9tMiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "3321c774dd4bff3b29cbae9b5ccfc64033ca13a397039769ea185509a247b8b2", "occurrences_count":
+        6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/25",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 26, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592857, "secret_hash":
+        "MitOZYWU/47TOCVlJ8xs0iLON2e7+dG8ZogVwnscopqJ56XGiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "ca5b862ee181bfd49edd91e65ee018b8109e624b6679d0a780eed0591bc03f14", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/26",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 27, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592858, "secret_hash":
+        "bhbBm4t+But3lH43U3ossWK1Xe5Xh8AC0io3FirV6kuFeJYwiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "47286022d32f48fe490e4c2fb25e73cdba391b974662e10aac440bbd32154890", "occurrences_count":
+        6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/27",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 28, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592859, "secret_hash":
+        "ZnxXuxqfCDl+HlqBWZKEO7H2L1fXnhwHImxR1f28xgkJuUB1iIVhmFkAG+mbE/6F", "hmsl_hash":
+        "84e555e48b1ed023a553264e9724fe9fa0b5421f8209d5a986f8985c58915ead", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/28",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 29, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2018-12-10T21:48:19Z", "secret_id": 14592860, "secret_hash":
+        "qeoBkkmxoCbogO0cHEb8YDWNgokqR0foCqyClIti/qc9PkCHiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "f82922f64e2a32d86e7c939c405d9949701e6479ac42d22e4d6549ebec6bce3b", "occurrences_count":
+        7, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.761962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/29",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}]'
+    headers:
+      CF-RAY:
+      - 9efb6df75827ce93-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:51 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '22866'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0yOQ%3D%3D&per_page=20>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '387'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '20'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/1/occurrences?per_page=5
+  response:
+    body:
+      string: '[{"id": 1, "incident_id": 1, "date": "2022-09-21T12:48:20Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
+        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290", "url":
+        "https://github.com/guillaume-malle/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url":
+        "https://github.com/guillaume-malle/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 2733, "incident_id": 1, "date": "2023-03-14T13:42:20Z", "filepath":
+        "stripe1.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 23, "indice_end": 55, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 1, "post_line_end": 1}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "2b9ef5781791f7f4a54af30a254bab215cf97e51", "url":
+        "https://github.com/ssokgg/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
+        "source": {"id": 11, "type": "github", "name": "ssokgg/tetris1", "url": "https://github.com/ssokgg/tetris1"},
+        "actor": {"id": 85, "type": "github_user", "name": "ssokgg", "email": "sandra.sok@gitguardian.com",
+        "url": "https://github.com/ssokgg"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url":
+        "https://github.com/guillaume-malle/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+    headers:
+      CF-RAY:
+      - 9efb6dfc981e7018-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:51 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '4235'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '87'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/1/occurrences?per_page=5&source_id=1
+  response:
+    body:
+      string: '[{"id": 1, "incident_id": 1, "date": "2022-09-21T12:48:20Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
+        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290", "url":
+        "https://github.com/guillaume-malle/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url":
+        "https://github.com/guillaume-malle/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url":
+        "https://github.com/guillaume-malle/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+    headers:
+      CF-RAY:
+      - 9efb6dfecbd77808-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:51 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '3431'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '71'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_status.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_status.yaml
@@ -1,0 +1,83 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/3759/occurrences?per_page=5&status=TRIGGERED%2CASSIGNED
+  response:
+    body:
+      string: '[{"id": 9846, "incident_id": 3759, "date": "2023-03-03T15:22:18Z",
+        "filepath": "peer/peer-0.10.0.tar.gz/peer/local_settings.py", "kind": "historical",
+        "presence": "removed", "matches": [{"name": "apikey", "indice_start": 295,
+        "indice_end": 335, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        14, "post_line_end": 14}], "tags": ["FROM_HISTORICAL_SCAN"], "sha": "2c9877a3019d6c2e261054f8e2fe6c11032ed880",
+        "url": "https://github.com/pypi-data/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
+        "source": {"id": 455, "type": "github", "name": "pypi-data/pypi-code-2", "url":
+        "https://github.com/pypi-data/pypi-code-2"}, "actor": {"id": 11, "type": "github_user",
+        "name": "orf", "email": "tom@tomforb.es", "url": "https://github.com/orf"},
+        "attachment_reasons": ["by_dev_from_perimeter"]}]'
+    headers:
+      CF-RAY:
+      - 9ef48732c9be702e-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:43 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '833'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '42'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_tags.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_tags.yaml
@@ -1,0 +1,83 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/3759/occurrences?per_page=5&tags=FROM_HISTORICAL_SCAN%2CINTERNALLY_LEAKED
+  response:
+    body:
+      string: '[{"id": 9846, "incident_id": 3759, "date": "2023-03-03T15:22:18Z",
+        "filepath": "peer/peer-0.10.0.tar.gz/peer/local_settings.py", "kind": "historical",
+        "presence": "removed", "matches": [{"name": "apikey", "indice_start": 295,
+        "indice_end": 335, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        14, "post_line_end": 14}], "tags": ["FROM_HISTORICAL_SCAN"], "sha": "2c9877a3019d6c2e261054f8e2fe6c11032ed880",
+        "url": "https://github.com/pypi-data/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
+        "source": {"id": 455, "type": "github", "name": "pypi-data/pypi-code-2", "url":
+        "https://github.com/pypi-data/pypi-code-2"}, "actor": {"id": 11, "type": "github_user",
+        "name": "orf", "email": "tom@tomforb.es", "url": "https://github.com/orf"},
+        "attachment_reasons": ["by_dev_from_perimeter"]}]'
+    headers:
+      CF-RAY:
+      - 9ef48736dad4d121-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:44 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '833'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '95'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_validity.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_validity.yaml
@@ -1,0 +1,83 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/3759/occurrences?per_page=5&validity=valid%2Cinvalid%2Cno_checker
+  response:
+    body:
+      string: '[{"id": 9846, "incident_id": 3759, "date": "2023-03-03T15:22:18Z",
+        "filepath": "peer/peer-0.10.0.tar.gz/peer/local_settings.py", "kind": "historical",
+        "presence": "removed", "matches": [{"name": "apikey", "indice_start": 295,
+        "indice_end": 335, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        14, "post_line_end": 14}], "tags": ["FROM_HISTORICAL_SCAN"], "sha": "2c9877a3019d6c2e261054f8e2fe6c11032ed880",
+        "url": "https://github.com/pypi-data/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
+        "source": {"id": 455, "type": "github", "name": "pypi-data/pypi-code-2", "url":
+        "https://github.com/pypi-data/pypi-code-2"}, "actor": {"id": 11, "type": "github_user",
+        "name": "orf", "email": "tom@tomforb.es", "url": "https://github.com/orf"},
+        "attachment_reasons": ["by_dev_from_perimeter"]}]'
+    headers:
+      CF-RAY:
+      - 9ef48734ad29d477-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:34:44 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '833'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '80'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/tools/vcr/test_get_public_incident_basic.yaml
+++ b/tests/cassettes/tools/vcr/test_get_public_incident_basic.yaml
@@ -1,0 +1,171 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=1
+  response:
+    body:
+      string: '[{"id": 1, "detector": {"name": "stripe", "display_name": "Stripe Keys",
+        "nature": "specific", "family": "token", "category": "payment_system", "detector_group_name":
+        "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
+        "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
+        "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
+        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
+        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
+        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
+        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "Stripe Keys"}]'
+    headers:
+      CF-RAY:
+      - 9efb89553e898634-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:59:31 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1195'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0x&per_page=1>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '71'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '1'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/1
+  response:
+    body:
+      string: '{"id": 1, "detector": {"name": "stripe", "display_name": "Stripe Keys",
+        "nature": "specific", "family": "token", "category": "payment_system", "detector_group_name":
+        "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
+        "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
+        "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
+        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
+        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
+        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
+        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "Stripe Keys"}'
+    headers:
+      CF-RAY:
+      - 9efb8957dd0a52be-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:59:32 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1193'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '81'
+      x-frame-options:
+      - DENY
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/tools/vcr/test_get_public_incident_unknown_id.yaml
+++ b/tests/cassettes/tools/vcr/test_get_public_incident_unknown_id.yaml
@@ -1,0 +1,68 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/999999999
+  response:
+    body:
+      string: '{"detail": "Not found."}'
+    headers:
+      CF-RAY:
+      - 9efb895a2df26fe8-CDG
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:59:32 GMT
+      Server:
+      - cloudflare
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '35'
+      x-frame-options:
+      - DENY
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/tests/cassettes/tools/vcr/test_list_public_incidents_basic.yaml
+++ b/tests/cassettes/tools/vcr/test_list_public_incidents_basic.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=5&ordering=-date
+  response:
+    body:
+      string: '[{"id": 1656322, "detector": {"name": "generic_password", "display_name":
+        "Generic Password", "nature": "generic", "family": "other", "category": "other",
+        "detector_group_name": "generic_password", "detector_group_display_name":
+        "Generic Password"}, "date": "2026-04-08T13:57:02Z", "secret_id": 30877010,
+        "secret_hash": "xHPjwUsmqt6eA7ncYDxRlt7kV7BnCq1drlnSRHGknhfkmcDLfma8ieOEhD7igl+v",
+        "hmsl_hash": "7c3d0e84bbd9229c2997872cb4d17c04c6ff7220fd5f2812bbd1d1dbe6f5947a",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2026-04-08T14:03:21.364805Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        52, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1656322",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Generic Password"}, {"id": 1622340, "detector": {"name": "generic_password",
+        "display_name": "Generic Password", "nature": "generic", "family": "other",
+        "category": "other", "detector_group_name": "generic_password", "detector_group_display_name":
+        "Generic Password"}, "date": "2026-04-07T20:07:53Z", "secret_id": 30795205,
+        "secret_hash": "kB4u8+jrFoS2fxB1eoQxTY0F3Lh+PlC371M42NbxwiiCVuU9fma8ieOEhD7igl+v",
+        "hmsl_hash": "e6b9fe4ea6d7ad7257e228bc4c6040fe7d23c5a0c5872b80ec42bf08648876a1",
+        "occurrences_count": 8, "status": "TRIGGERED", "triggered_at": "2026-04-07T20:12:57.950362Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        38, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1622340",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Generic Password"}, {"id": 1565465, "detector": {"name": "generic_high_entropy_secret",
+        "display_name": "Generic High Entropy Secret", "nature": "generic", "family":
+        "other", "category": "other", "detector_group_name": "generic_high_entropy_secret",
+        "detector_group_display_name": "Generic High Entropy Secret"}, "date": "2026-03-29T19:45:49Z",
+        "secret_id": 30242300, "secret_hash": "4U/oBUMl1qh7Srz5W44PGp28+z79LJdZ6yTv1DCbpNbOcxetp+KkPCNpyNbtXqJM",
+        "hmsl_hash": "945925d9c2d7d630159586c5cbf7edb6074e906dd69a7eabaa804e365857cab0",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2026-03-29T19:50:52.892358Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        53, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1565465",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Generic High Entropy Secret"}, {"id": 1559615, "detector": {"name": "smtp_assignment",
+        "display_name": "SMTP credentials", "nature": "specific", "family": "identifiers",
+        "category": "messaging_system", "detector_group_name": "smtp_credentials",
+        "detector_group_display_name": "SMTP credentials"}, "date": "2026-03-28T23:24:10Z",
+        "secret_id": 30206041, "secret_hash": "8Kighb5RJJlUPfc3hkc6LGHKUPKBoGmqxqHjr7CUQ07ZiAyAnUgJKbY5bDWilWBS",
+        "hmsl_hash": "1b52928ad2792d1bad89e2a5e837ad513a4b50ced14971df92e46f8bf2764d10",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2026-03-28T23:29:58.247999Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        63, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1559615",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "SMTP credentials"}, {"id": 1554830, "detector": {"name": "generic_high_entropy_secret",
+        "display_name": "Generic High Entropy Secret", "nature": "generic", "family":
+        "other", "category": "other", "detector_group_name": "generic_high_entropy_secret",
+        "detector_group_display_name": "Generic High Entropy Secret"}, "date": "2026-03-27T18:11:26Z",
+        "secret_id": 30166297, "secret_hash": "PGGOlbTiQZGqXXA3Vj88RduN0f+72Aha3hUU4MwsiKW7Qj8dp+KkPCNpyNbtXqJM",
+        "hmsl_hash": "e2d81242e3b11cd65b823f92e2dde252dadd99821d401c06f00a8b08994d6e54",
+        "occurrences_count": 15, "status": "IGNORED", "triggered_at": "2026-03-27T18:16:57.754167Z",
+        "ignored_at": "2026-03-27T18:17:37.519114Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1554830",
+        "tags": ["FALSE_POSITIVE"], "custom_tags": [], "destination_tickets": [],
+        "incident_name": "Generic High Entropy Secret"}]'
+    headers:
+      CF-RAY:
+      - 9efb1c598856700e-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 08:45:07 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '5802'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=bz0xJnA9MjAyNi0wMy0yOCsyMyUzQTI0JTNBMTAlMkIwMCUzQTAw&ordering=-date&per_page=5>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '97'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/tools/vcr/test_list_public_incidents_with_date_and_risk_score_bounds.yaml
+++ b/tests/cassettes/tools/vcr/test_list_public_incidents_with_date_and_risk_score_bounds.yaml
@@ -1,0 +1,216 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=10&date_after=2020-01-01T00%3A00%3A00Z&ordering=-risk_score&risk_score_min=0&risk_score_max=100
+  response:
+    body:
+      string: '[{"id": 5207, "detector": {"name": "digitalocean_token", "display_name":
+        "DigitalOcean Token", "nature": "specific", "family": "token", "category":
+        "cloud_provider", "detector_group_name": "digitalocean_token", "detector_group_display_name":
+        "DigitalOcean Token"}, "date": "2023-03-03T16:38:13Z", "secret_id": 14597819,
+        "secret_hash": "vClMsNqM/WdfLMx7H6mUnp1i9W87jp+J+ffYMGCEbQIsIKP1Qg9f/tAi7MYoYTK8",
+        "hmsl_hash": "8726444fd47d2df39f484439152c7c7b0a642e171a89091b98aee1f8cb3e8444",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:10:13.203243Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 100, "severity_rule_id":
+        10861, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/5207",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "DigitalOcean Token"}, {"id": 5208, "detector": {"name":
+        "digitalocean_token", "display_name": "DigitalOcean Token", "nature": "specific",
+        "family": "token", "category": "cloud_provider", "detector_group_name": "digitalocean_token",
+        "detector_group_display_name": "DigitalOcean Token"}, "date": "2023-03-03T16:38:13Z",
+        "secret_id": 14597820, "secret_hash": "gpSu+iGVzqTb04w0hQpy/EQ3yZXU/M0KWTkiYW0DN6GchufVQg9f/tAi7MYoYTK8",
+        "hmsl_hash": "e2a9fad8ba3b356d7db9f2bb50c54fc8a8fb58dc32d29a7bff287f09ec9aa402",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:10:13.203243Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 100, "severity_rule_id":
+        10861, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/5208",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "DigitalOcean Token"}, {"id": 1142573, "detector": {"name":
+        "gitlab_personal_token_v2", "display_name": "GitLab Token", "nature": "specific",
+        "family": "token", "category": "version_control_platform", "detector_group_name":
+        "gitlab_token", "detector_group_display_name": "GitLab Token"}, "date": "2026-01-20T12:25:14Z",
+        "secret_id": 26269042, "secret_hash": "Q6uP7xLag23NOueTB3xz7eMJDKIKv5pc5XJ+O+d7h5JJ1KTWxGkRAPRx8mJAAtol",
+        "hmsl_hash": "2b222492a399350a135305392017aa5e95d97c8dd558ebe4e61723ad935abf09",
+        "occurrences_count": 1, "status": "RESOLVED", "triggered_at": "2026-01-20T12:30:17.920656Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        "2026-01-26T14:38:12.774362Z", "resolver_id": 492181, "resolver_api_token_id":
+        null, "secret_revoked": true, "validity": "invalid", "severity": "critical",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 99, "severity_rule_id": 7263, "is_vaulted": false, "declarative_secret_status":
+        "revoked", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1142573",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitLab Token"}, {"id": 6431, "detector": {"name": "github_oauth_app_keys",
+        "display_name": "GitHub OAuth App Keys", "nature": "specific", "family": "credentials",
+        "category": "version_control_platform", "detector_group_name": "github_oauth_app_keys",
+        "detector_group_display_name": "GitHub OAuth App Keys"}, "date": "2023-03-06T02:22:30Z",
+        "secret_id": 14598994, "secret_hash": "rguvfdbCkXIEiTcPcvvaKSTDL7C5GooKsnQSRXZ2KYadm7wi26bvJ9LImJ7n1yqO",
+        "hmsl_hash": "984f3c5814706bf57aad59c4a55aa353b4f87e111faf7d8262d6452445f5528c",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:12:04.175957Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 99, "severity_rule_id":
+        10862, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/6431",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "GitHub OAuth App Keys"}, {"id": 6430, "detector": {"name":
+        "bitbucket_keys", "display_name": "Bitbucket Keys", "nature": "specific",
+        "family": "credentials", "category": "version_control_platform", "detector_group_name":
+        "bitbucket_keys", "detector_group_display_name": "Bitbucket Keys"}, "date":
+        "2023-03-06T02:22:30Z", "secret_id": 14598993, "secret_hash": "yVPk7/jXGjdN/GD51ZJVnAQGVLZp9OYkO5cNnoGIrw5N2hr6zxp9ieZfVrZIohiA",
+        "hmsl_hash": "be8bf8e2501a998c2910851ea4aa8dd70fafb9fdb942bdff1c168fab708c0596",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:12:04.175957Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 99, "severity_rule_id":
+        10862, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/6430",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Bitbucket Keys"}, {"id": 120, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2022-09-21T07:47:10Z", "secret_id": 14592936, "secret_hash":
+        "HCWrG3nEt9czkeRivsO5t2mdGFXFrkwOSPchO87xypH14P2ML4Qc71cZRqNcojMG", "hmsl_hash":
+        "44126737df445f6b9468541f77e5c5bdac71b057644a7fe1c8c219940948acc4", "occurrences_count":
+        1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:03.840266Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        7263, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/120",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 1112, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2022-09-14T07:50:20Z", "secret_id": 14593846, "secret_hash":
+        "dEfda3BVSUK9yc1JYPEqSufAdUxQUQ9AqXCVJ1nQKyznAYCnL4Qc71cZRqNcojMG", "hmsl_hash":
+        "0847969d69f0208c61843d6e844e9a0aec67df7d818ac44b906f5671dd538794", "occurrences_count":
+        1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:39.804910Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        7263, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1112",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 6663, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2025-01-14T14:28:59Z", "secret_id": 14663989, "secret_hash":
+        "mKvfyERvoW7Jo+/nDXJ/tcfbWqS4tGEO+1j6vf7vlmpyzHHhL4Qc71cZRqNcojMG", "hmsl_hash":
+        "04d0ef9d0b87b0ad5c9e1da99a7e6015bfab50127cbea8d9ff09356021f65998", "occurrences_count":
+        7, "status": "RESOLVED", "triggered_at": "2025-01-14T14:34:01.621378Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/6663",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "AWS IAM Keys"}, {"id": 518, "detector": {"name": "aws_iam", "display_name":
+        "AWS IAM Keys", "nature": "specific", "family": "credentials", "category":
+        "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2023-10-19T12:06:07Z", "secret_id": 14593309, "secret_hash":
+        "aQL+3fwIPTpy/G2vW31cL2nAoP8QUXwn3RsexMv3kL2xtBnKL4Qc71cZRqNcojMG", "hmsl_hash":
+        "c1150af7814de655b6069ae54839018ab8350dec4151a441fa5d40bd0b489fd5", "occurrences_count":
+        9, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:11.066572Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        7263, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/518",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "AWS IAM Keys"}, {"id": 385, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2023-07-06T12:36:07Z", "secret_id": 9181441, "secret_hash":
+        "mKn4Nj0bR4rIic8L5Vdx8VllYYtf+CISEyDv7GToL66gKwIWL4Qc71cZRqNcojMG", "hmsl_hash":
+        "838d881ae00bfb022f27c3b2e57e4927d7a2ef12c4a2f75b8b6730c80dba47b3", "occurrences_count":
+        1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:07.901475Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/385",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "AWS IAM Keys"}]'
+    headers:
+      CF-RAY:
+      - 9efb6e1e7aaf46a0-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:57 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '11567'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=bz01JnA9OTk%3D&date_after=2020-01-01T00%3A00%3A00Z&ordering=-risk_score&per_page=10&risk_score_max=100&risk_score_min=0>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '198'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '10'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/tools/vcr/test_list_public_incidents_with_multi_value_enum_filters.yaml
+++ b/tests/cassettes/tools/vcr/test_list_public_incidents_with_multi_value_enum_filters.yaml
@@ -1,0 +1,225 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=10&status=TRIGGERED%2CASSIGNED%2CRESOLVED%2CIGNORED&severity=critical%2Chigh%2Cmedium%2Clow%2Cinfo%2Cunknown&validity=valid%2Cinvalid%2Cfailed_to_check%2Cno_checker%2Cunknown&ordering=-date
+  response:
+    body:
+      string: '[{"id": 1656322, "detector": {"name": "generic_password", "display_name":
+        "Generic Password", "nature": "generic", "family": "other", "category": "other",
+        "detector_group_name": "generic_password", "detector_group_display_name":
+        "Generic Password"}, "date": "2026-04-08T13:57:02Z", "secret_id": 30877010,
+        "secret_hash": "xHPjwUsmqt6eA7ncYDxRlt7kV7BnCq1drlnSRHGknhfkmcDLfma8ieOEhD7igl+v",
+        "hmsl_hash": "7c3d0e84bbd9229c2997872cb4d17c04c6ff7220fd5f2812bbd1d1dbe6f5947a",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2026-04-08T14:03:21.364805Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        52, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1656322",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Generic Password"}, {"id": 1622340, "detector": {"name": "generic_password",
+        "display_name": "Generic Password", "nature": "generic", "family": "other",
+        "category": "other", "detector_group_name": "generic_password", "detector_group_display_name":
+        "Generic Password"}, "date": "2026-04-07T20:07:53Z", "secret_id": 30795205,
+        "secret_hash": "kB4u8+jrFoS2fxB1eoQxTY0F3Lh+PlC371M42NbxwiiCVuU9fma8ieOEhD7igl+v",
+        "hmsl_hash": "e6b9fe4ea6d7ad7257e228bc4c6040fe7d23c5a0c5872b80ec42bf08648876a1",
+        "occurrences_count": 8, "status": "TRIGGERED", "triggered_at": "2026-04-07T20:12:57.950362Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        38, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1622340",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Generic Password"}, {"id": 1565465, "detector": {"name": "generic_high_entropy_secret",
+        "display_name": "Generic High Entropy Secret", "nature": "generic", "family":
+        "other", "category": "other", "detector_group_name": "generic_high_entropy_secret",
+        "detector_group_display_name": "Generic High Entropy Secret"}, "date": "2026-03-29T19:45:49Z",
+        "secret_id": 30242300, "secret_hash": "4U/oBUMl1qh7Srz5W44PGp28+z79LJdZ6yTv1DCbpNbOcxetp+KkPCNpyNbtXqJM",
+        "hmsl_hash": "945925d9c2d7d630159586c5cbf7edb6074e906dd69a7eabaa804e365857cab0",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2026-03-29T19:50:52.892358Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        53, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1565465",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Generic High Entropy Secret"}, {"id": 1559615, "detector": {"name": "smtp_assignment",
+        "display_name": "SMTP credentials", "nature": "specific", "family": "identifiers",
+        "category": "messaging_system", "detector_group_name": "smtp_credentials",
+        "detector_group_display_name": "SMTP credentials"}, "date": "2026-03-28T23:24:10Z",
+        "secret_id": 30206041, "secret_hash": "8Kighb5RJJlUPfc3hkc6LGHKUPKBoGmqxqHjr7CUQ07ZiAyAnUgJKbY5bDWilWBS",
+        "hmsl_hash": "1b52928ad2792d1bad89e2a5e837ad513a4b50ced14971df92e46f8bf2764d10",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2026-03-28T23:29:58.247999Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        63, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1559615",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "SMTP credentials"}, {"id": 1554831, "detector": {"name": "generic_high_entropy_secret",
+        "display_name": "Generic High Entropy Secret", "nature": "generic", "family":
+        "other", "category": "other", "detector_group_name": "generic_high_entropy_secret",
+        "detector_group_display_name": "Generic High Entropy Secret"}, "date": "2026-03-27T18:11:26Z",
+        "secret_id": 30166298, "secret_hash": "8qyd9TAXAWR5J4Sxwjiisc+V7HVwl6+ZlRRt7H9d17ys7sMYp+KkPCNpyNbtXqJM",
+        "hmsl_hash": "b0a8f04800887cef654dd948c731a967b6b644c4b3bfdea1ea6400682251c89c",
+        "occurrences_count": 2, "status": "IGNORED", "triggered_at": "2026-03-27T18:16:57.754167Z",
+        "ignored_at": "2026-03-27T18:17:37.519114Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1554831",
+        "tags": ["FALSE_POSITIVE"], "custom_tags": [], "destination_tickets": [],
+        "incident_name": "Generic High Entropy Secret"}, {"id": 1554830, "detector":
+        {"name": "generic_high_entropy_secret", "display_name": "Generic High Entropy
+        Secret", "nature": "generic", "family": "other", "category": "other", "detector_group_name":
+        "generic_high_entropy_secret", "detector_group_display_name": "Generic High
+        Entropy Secret"}, "date": "2026-03-27T18:11:26Z", "secret_id": 30166297, "secret_hash":
+        "PGGOlbTiQZGqXXA3Vj88RduN0f+72Aha3hUU4MwsiKW7Qj8dp+KkPCNpyNbtXqJM", "hmsl_hash":
+        "e2d81242e3b11cd65b823f92e2dde252dadd99821d401c06f00a8b08994d6e54", "occurrences_count":
+        15, "status": "IGNORED", "triggered_at": "2026-03-27T18:16:57.754167Z", "ignored_at":
+        "2026-03-27T18:17:37.519114Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1554830",
+        "tags": ["FALSE_POSITIVE"], "custom_tags": [], "destination_tickets": [],
+        "incident_name": "Generic High Entropy Secret"}, {"id": 1532769, "detector":
+        {"name": "generic_high_entropy_secret", "display_name": "Generic High Entropy
+        Secret", "nature": "generic", "family": "other", "category": "other", "detector_group_name":
+        "generic_high_entropy_secret", "detector_group_display_name": "Generic High
+        Entropy Secret"}, "date": "2026-03-24T13:33:43Z", "secret_id": 29987838, "secret_hash":
+        "Z2VbNCIjdFtG93Q3kYNdR2hbcpLCInG8jb+7nhslcZcd+R7Qp+KkPCNpyNbtXqJM", "hmsl_hash":
+        "201d0f1de1596ef0339e3e77585afea740431bf00690761908402d5883491fd7", "occurrences_count":
+        3, "status": "TRIGGERED", "triggered_at": "2026-03-24T13:40:06.889200Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "no_checker", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 26, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1532769",
+        "tags": ["TEST_FILE"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Generic High Entropy Secret"}, {"id": 1531153, "detector": {"name": "github_personal_access_token_v2",
+        "display_name": "GitHub Personal Access Token", "nature": "specific", "family":
+        "token", "category": "version_control_platform", "detector_group_name": "github_access_token",
+        "detector_group_display_name": "GitHub Personal Access Token"}, "date": "2026-03-24T11:11:40Z",
+        "secret_id": 29982248, "secret_hash": "BPc/RppCYpsDGMfSWRdhBTfbkxDhAYRQIzVwpAv/QcTMaF5aQ7Ami0oNRiGwGL9Y",
+        "hmsl_hash": "34a830ee06e4f30cb0468bea56b78d74c23c2534f8adb2964f690b92828089fe",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2026-03-24T11:17:46.888920Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        7, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1531153",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitHub Personal Access Token"}, {"id": 1511349, "detector": {"name": "stripe",
+        "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
+        "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
+        "Stripe Keys"}, "date": "2026-03-20T13:33:50Z", "secret_id": 29858518, "secret_hash":
+        "pOmE5G+sseSAN7Hndl73KbCSugKMTtYHxfu5pa9tmPFM6+SOiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "395dc4774bf51928c7b50864ec4638b7025eafe1df1831974789912256854544", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2026-03-20T13:39:23.289964Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1511349",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Stripe Keys"}, {"id": 1506118, "detector": {"name": "postgres_assignment_no_port",
+        "display_name": "PostgreSQL Credentials", "nature": "specific", "family":
+        "identifiers", "category": "data_storage", "detector_group_name": "postgresql_credentials",
+        "detector_group_display_name": "PostgreSQL Credentials"}, "date": "2026-03-19T12:29:33Z",
+        "secret_id": 29811650, "secret_hash": "YJkmAUIdJ63b+l5M/RUlnvvo0licUhpvkRFWitAPSfN7mYwdP+BRsGMAB9aU5i+6",
+        "hmsl_hash": "4b88e1f10010d73c70ddd61edcd5f7f91cf80dc04c4b92583e4422ee37fa184c",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2026-03-19T12:34:45.565200Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 49, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1506118",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "PostgreSQL Credentials"}]'
+    headers:
+      CF-RAY:
+      - 9efb6e1b19187011-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:56 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '11696'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0yMDI2LTAzLTE5KzEyJTNBMjklM0EzMyUyQjAwJTNBMDA%3D&ordering=-date&per_page=10&severity=critical%2Chigh%2Cmedium%2Clow%2Cinfo%2Cunknown&status=TRIGGERED%2CASSIGNED%2CRESOLVED%2CIGNORED&validity=valid%2Cinvalid%2Cfailed_to_check%2Cno_checker%2Cunknown>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '222'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '10'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/tools/vcr/test_list_public_occurrences_basic.yaml
+++ b/tests/cassettes/tools/vcr/test_list_public_occurrences_basic.yaml
@@ -1,0 +1,209 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=1
+  response:
+    body:
+      string: '[{"id": 1, "detector": {"name": "stripe", "display_name": "Stripe Keys",
+        "nature": "specific", "family": "token", "category": "payment_system", "detector_group_name":
+        "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
+        "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
+        "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
+        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
+        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
+        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
+        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "Stripe Keys"}]'
+    headers:
+      CF-RAY:
+      - 9ef49a650cf33d13-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:47:50 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1195'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0x&per_page=1>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '175'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '1'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/1/occurrences?per_page=5&ordering=-date
+  response:
+    body:
+      string: '[{"id": 2733, "incident_id": 1, "date": "2023-03-14T13:42:20Z", "filepath":
+        "stripe1.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 23, "indice_end": 55, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 1, "post_line_end": 1}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "2b9ef5781791f7f4a54af30a254bab215cf97e51", "url":
+        "https://github.com/ssokgg/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
+        "source": {"id": 11, "type": "github", "name": "ssokgg/tetris1", "url": "https://github.com/ssokgg/tetris1"},
+        "actor": {"id": 85, "type": "github_user", "name": "ssokgg", "email": "sandra.sok@gitguardian.com",
+        "url": "https://github.com/ssokgg"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url":
+        "https://github.com/guillaume-malle/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 1, "incident_id": 1, "date": "2022-09-21T12:48:20Z", "filepath": "hello.py",
+        "kind": "historical", "presence": "present", "matches": [{"name": "apikey",
+        "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
+        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url":
+        "https://github.com/guillaume-malle/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290", "url":
+        "https://github.com/guillaume-malle/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+    headers:
+      CF-RAY:
+      - 9ef49a67bd922c31-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 20 Apr 2026 13:47:50 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '4235'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '74'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/tools/vcr/test_list_public_occurrences_with_date_range.yaml
+++ b/tests/cassettes/tools/vcr/test_list_public_occurrences_with_date_range.yaml
@@ -1,0 +1,209 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=1
+  response:
+    body:
+      string: '[{"id": 1, "detector": {"name": "stripe", "display_name": "Stripe Keys",
+        "nature": "specific", "family": "token", "category": "payment_system", "detector_group_name":
+        "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
+        "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
+        "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
+        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
+        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
+        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
+        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "Stripe Keys"}]'
+    headers:
+      CF-RAY:
+      - 9efb6e25db9a9a29-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:58 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1195'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0x&per_page=1>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '106'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '1'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/1/occurrences?per_page=10&date_after=2020-01-01T00%3A00%3A00Z&ordering=-date
+  response:
+    body:
+      string: '[{"id": 2733, "incident_id": 1, "date": "2023-03-14T13:42:20Z", "filepath":
+        "stripe1.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 23, "indice_end": 55, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 1, "post_line_end": 1}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "2b9ef5781791f7f4a54af30a254bab215cf97e51", "url":
+        "https://github.com/ssokgg/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
+        "source": {"id": 11, "type": "github", "name": "ssokgg/tetris1", "url": "https://github.com/ssokgg/tetris1"},
+        "actor": {"id": 85, "type": "github_user", "name": "ssokgg", "email": "sandra.sok@gitguardian.com",
+        "url": "https://github.com/ssokgg"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url":
+        "https://github.com/guillaume-malle/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 1, "incident_id": 1, "date": "2022-09-21T12:48:20Z", "filepath": "hello.py",
+        "kind": "historical", "presence": "present", "matches": [{"name": "apikey",
+        "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
+        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url":
+        "https://github.com/guillaume-malle/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290", "url":
+        "https://github.com/guillaume-malle/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+    headers:
+      CF-RAY:
+      - 9efb6e283a3c986b-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:58 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '4235'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '61'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '10'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/tools/vcr/test_list_public_occurrences_with_multi_value_filters.yaml
+++ b/tests/cassettes/tools/vcr/test_list_public_occurrences_with_multi_value_filters.yaml
@@ -1,0 +1,209 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=1
+  response:
+    body:
+      string: '[{"id": 1, "detector": {"name": "stripe", "display_name": "Stripe Keys",
+        "nature": "specific", "family": "token", "category": "payment_system", "detector_group_name":
+        "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
+        "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
+        "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
+        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
+        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
+        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
+        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "Stripe Keys"}]'
+    headers:
+      CF-RAY:
+      - 9efb6e217a3e2a13-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:57 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1195'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0x&per_page=1>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '90'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '1'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/1/occurrences?per_page=10&presence=present&severity=critical%2Chigh%2Cmedium%2Clow%2Cinfo%2Cunknown&status=TRIGGERED%2CASSIGNED%2CRESOLVED%2CIGNORED&validity=valid%2Cinvalid%2Cfailed_to_check%2Cno_checker%2Cunknown&ordering=-date
+  response:
+    body:
+      string: '[{"id": 2733, "incident_id": 1, "date": "2023-03-14T13:42:20Z", "filepath":
+        "stripe1.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 23, "indice_end": 55, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 1, "post_line_end": 1}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "2b9ef5781791f7f4a54af30a254bab215cf97e51", "url":
+        "https://github.com/ssokgg/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
+        "source": {"id": 11, "type": "github", "name": "ssokgg/tetris1", "url": "https://github.com/ssokgg/tetris1"},
+        "actor": {"id": 85, "type": "github_user", "name": "ssokgg", "email": "sandra.sok@gitguardian.com",
+        "url": "https://github.com/ssokgg"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url":
+        "https://github.com/guillaume-malle/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 1, "incident_id": 1, "date": "2022-09-21T12:48:20Z", "filepath": "hello.py",
+        "kind": "historical", "presence": "present", "matches": [{"name": "apikey",
+        "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
+        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url":
+        "https://github.com/guillaume-malle/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
+        {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z", "filepath":
+        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
+        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
+        "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290", "url":
+        "https://github.com/guillaume-malle/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
+        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
+        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
+        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+    headers:
+      CF-RAY:
+      - 9efb6e23af656989-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Apr 2026 09:40:57 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '4235'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.437.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '48'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '10'
+      x-secrets-engine-version:
+      - 2.161.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/client/vcr/test_public_incidents.py
+++ b/tests/client/vcr/test_public_incidents.py
@@ -3,9 +3,34 @@ VCR tests for GitGuardianClient public-incident methods.
 
 These tests cover every query parameter of:
 - list_public_incidents(...)
+- get_public_incident(incident_id)
 """
 
 import pytest
+
+
+class TestGetPublicIncident:
+    """Tests for retrieving a single public secret incident."""
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_get_public_incident_returns_same_id(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key and at least one public incident
+        WHEN we retrieve it by id via get_public_incident
+        THEN the returned payload's id matches and carries the documented core fields
+        """
+        with use_cassette("test_get_public_incident_returns_same_id"):
+            page = await real_client.list_public_incidents(per_page=1)
+            if not page["data"]:
+                pytest.skip("No public incidents available")
+            incident_id = page["data"][0]["id"]
+
+            result = await real_client.get_public_incident(incident_id=incident_id)
+
+            assert result["id"] == incident_id
+            for key in ("status", "severity", "validity", "detector", "date", "occurrences_count"):
+                assert key in result
 
 
 class TestListPublicIncidents:

--- a/tests/client/vcr/test_public_incidents.py
+++ b/tests/client/vcr/test_public_incidents.py
@@ -1,0 +1,376 @@
+"""
+VCR tests for GitGuardianClient public-incident methods.
+
+These tests cover every query parameter of:
+- list_public_incidents(...)
+"""
+
+import pytest
+
+
+class TestListPublicIncidents:
+    """Tests for listing public secret incidents with various filters."""
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_basic(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key with incidents:read scope
+        WHEN we request the list of public incidents
+        THEN we should receive a list response with incident data
+        """
+        with use_cassette("test_list_public_incidents_basic"):
+            result = await real_client.list_public_incidents(per_page=5)
+
+            assert result is not None
+            assert "data" in result
+            assert isinstance(result["data"], list)
+            assert "cursor" in result
+            assert "has_more" in result
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_with_status_filter(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request public incidents with status=TRIGGERED
+        THEN we should receive only triggered incidents
+        """
+        with use_cassette("test_list_public_incidents_with_status_filter"):
+            result = await real_client.list_public_incidents(status="TRIGGERED", per_page=5)
+
+            assert result is not None
+            for incident in result["data"]:
+                assert incident.get("status") == "TRIGGERED"
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_with_severity_filter(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request public incidents with severity=high
+        THEN we should receive incidents (filter applied)
+        """
+        with use_cassette("test_list_public_incidents_with_severity_filter"):
+            result = await real_client.list_public_incidents(severity="high", per_page=5)
+
+            assert result is not None
+            assert "data" in result
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_with_validity_filter(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request public incidents with validity=valid
+        THEN we should receive incidents (filter applied)
+        """
+        with use_cassette("test_list_public_incidents_with_validity_filter"):
+            result = await real_client.list_public_incidents(validity="valid", per_page=5)
+
+            assert result is not None
+            assert "data" in result
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_multi_value_status(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request public incidents with status=[TRIGGERED, ASSIGNED] (multi-value filter)
+        THEN the API accepts comma-separated values and every returned incident has one of those statuses
+        """
+        with use_cassette("test_list_public_incidents_multi_value_status"):
+            result = await real_client.list_public_incidents(
+                status=["TRIGGERED", "ASSIGNED"],
+                per_page=20,
+            )
+
+            assert result is not None
+            assert "data" in result
+            for incident in result["data"]:
+                assert incident.get("status") in {"TRIGGERED", "ASSIGNED"}
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_multi_value_severity(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request public incidents with severity=[critical, high] (multi-value filter)
+        THEN the API accepts comma-separated values and every returned incident has one of those severities
+        """
+        with use_cassette("test_list_public_incidents_multi_value_severity"):
+            result = await real_client.list_public_incidents(
+                severity=["critical", "high"],
+                per_page=20,
+            )
+
+            assert result is not None
+            assert "data" in result
+            for incident in result["data"]:
+                assert incident.get("severity") in {"critical", "high"}
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_multi_value_validity(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request public incidents with validity=[valid, failed_to_check] (multi-value filter)
+        THEN the API accepts comma-separated values and every returned incident has one of those validities
+        """
+        with use_cassette("test_list_public_incidents_multi_value_validity"):
+            result = await real_client.list_public_incidents(
+                validity=["valid", "failed_to_check"],
+                per_page=20,
+            )
+
+            assert result is not None
+            assert "data" in result
+            for incident in result["data"]:
+                assert incident.get("validity") in {"valid", "failed_to_check"}
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_with_date_filter(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request public incidents within a date range
+        THEN we should receive incidents (filter applied)
+        """
+        with use_cassette("test_list_public_incidents_with_date_filter"):
+            result = await real_client.list_public_incidents(
+                date_before="2026-01-01T00:00:00Z",
+                date_after="2024-01-01T00:00:00Z",
+                per_page=5,
+            )
+
+            assert result is not None
+            assert "data" in result
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_with_triggered_at_filter(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request public incidents with triggered_at date bounds
+        THEN we should receive incidents (filter applied)
+        """
+        with use_cassette("test_list_public_incidents_with_triggered_at_filter"):
+            result = await real_client.list_public_incidents(
+                triggered_at_before="2026-01-01T00:00:00Z",
+                triggered_at_after="2024-01-01T00:00:00Z",
+                per_page=5,
+            )
+
+            assert result is not None
+            assert "data" in result
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_with_assignee_filter(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key and at least one incident that has an assignee
+        WHEN we filter by that assignee's id
+        THEN every returned incident is assigned to that user
+        """
+        with use_cassette("test_list_public_incidents_with_assignee_filter"):
+            page = await real_client.list_public_incidents(
+                status="ASSIGNED",
+                per_page=20,
+            )
+            assignee_id = next(
+                (inc["assignee_id"] for inc in page["data"] if inc.get("assignee_id")),
+                None,
+            )
+            if assignee_id is None:
+                pytest.skip("No public incident with an assignee available to exercise the filter")
+
+            result = await real_client.list_public_incidents(assignee_id=assignee_id, per_page=5)
+
+            assert result["data"], "expected at least one incident for a known assignee"
+            for inc in result["data"]:
+                assert inc["assignee_id"] == assignee_id
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_with_tags_filter(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key and at least one tagged public incident
+        WHEN we filter by a real tag value observed on that incident
+        THEN every returned incident carries the filter tag
+        """
+        with use_cassette("test_list_public_incidents_with_tags_filter"):
+            page = await real_client.list_public_incidents(per_page=20)
+            known_tag = next(
+                (tag for inc in page["data"] for tag in (inc.get("tags") or [])),
+                None,
+            )
+            if known_tag is None:
+                pytest.skip("No tagged public incident available to exercise the tags filter")
+
+            result = await real_client.list_public_incidents(tags=known_tag, per_page=5)
+
+            assert result["data"], f"expected at least one incident with tag {known_tag}"
+            for inc in result["data"]:
+                assert known_tag in (inc.get("tags") or [])
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_with_detector_group_name(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request public incidents filtered by detector group name
+        THEN we should receive incidents (filter applied)
+        """
+        with use_cassette("test_list_public_incidents_with_detector_group_name"):
+            result = await real_client.list_public_incidents(
+                detector_group_name="slackbot_token",
+                per_page=5,
+            )
+
+            assert result is not None
+            assert "data" in result
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_with_ignorer_filter(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key and at least one incident ignored by a real user
+        WHEN we filter by that user's ignorer_id
+        THEN every returned incident was ignored by that user
+        """
+        with use_cassette("test_list_public_incidents_with_ignorer_filter"):
+            page = await real_client.list_public_incidents(status="IGNORED", per_page=20)
+            ignorer_id = next(
+                (inc["ignorer_id"] for inc in page["data"] if inc.get("ignorer_id")),
+                None,
+            )
+            if ignorer_id is None:
+                pytest.skip("No public incident with an ignorer available")
+
+            result = await real_client.list_public_incidents(ignorer_id=ignorer_id, per_page=5)
+
+            assert result["data"]
+            for inc in result["data"]:
+                assert inc["ignorer_id"] == ignorer_id
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_with_resolver_filter(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key and at least one incident resolved by a real user
+        WHEN we filter by that user's resolver_id
+        THEN every returned incident was resolved by that user
+        """
+        with use_cassette("test_list_public_incidents_with_resolver_filter"):
+            page = await real_client.list_public_incidents(status="RESOLVED", per_page=20)
+            resolver_id = next(
+                (inc["resolver_id"] for inc in page["data"] if inc.get("resolver_id")),
+                None,
+            )
+            if resolver_id is None:
+                pytest.skip("No public incident with a resolver available")
+
+            result = await real_client.list_public_incidents(resolver_id=resolver_id, per_page=5)
+
+            assert result["data"]
+            for inc in result["data"]:
+                assert inc["resolver_id"] == resolver_id
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_with_feedback(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request public incidents filtered by feedback=True
+        THEN we should receive incidents (filter applied)
+        """
+        with use_cassette("test_list_public_incidents_with_feedback"):
+            result = await real_client.list_public_incidents(feedback=True, per_page=5)
+
+            assert result is not None
+            assert "data" in result
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_with_declarative_secret_status(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request public incidents filtered by declarative secret status
+        THEN we should receive incidents (filter applied)
+        """
+        with use_cassette("test_list_public_incidents_with_declarative_secret_status"):
+            result = await real_client.list_public_incidents(
+                declarative_secret_status="revoked",
+                per_page=5,
+            )
+
+            assert result is not None
+            assert "data" in result
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_with_risk_score(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request public incidents with risk score bounds
+        THEN we should receive incidents (filter applied)
+        """
+        with use_cassette("test_list_public_incidents_with_risk_score"):
+            result = await real_client.list_public_incidents(
+                risk_score_min=50,
+                risk_score_max=100,
+                per_page=5,
+            )
+
+            assert result is not None
+            assert "data" in result
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_with_ordering(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request public incidents ordered by -risk_score
+        THEN we should receive incidents (ordering applied)
+        """
+        with use_cassette("test_list_public_incidents_with_ordering"):
+            result = await real_client.list_public_incidents(ordering="-risk_score", per_page=5)
+
+            assert result is not None
+            assert "data" in result
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_with_cursor(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request a first page, then pass the returned cursor on a second request
+        THEN the second request succeeds (cursor honoured by the API)
+        """
+        with use_cassette("test_list_public_incidents_with_cursor"):
+            first = await real_client.list_public_incidents(per_page=1)
+            if not first.get("cursor"):
+                pytest.skip("Not enough public incidents to test cursor pagination")
+
+            result = await real_client.list_public_incidents(cursor=first["cursor"], per_page=1)
+
+            assert result is not None
+            assert "data" in result
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_get_all(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request public incidents with get_all=True
+        THEN we should receive a PaginatedResult with data and has_more flag
+        """
+        with use_cassette("test_list_public_incidents_get_all"):
+            result = await real_client.list_public_incidents(get_all=True, per_page=5)
+
+            assert result is not None
+            assert "data" in result
+            assert isinstance(result["data"], list)
+            assert "has_more" in result
+            assert isinstance(result["has_more"], bool)
+            assert "cursor" in result

--- a/tests/client/vcr/test_public_occurrences.py
+++ b/tests/client/vcr/test_public_occurrences.py
@@ -1,0 +1,332 @@
+"""
+VCR tests for GitGuardianClient public-occurrence methods.
+
+These tests cover every query parameter of:
+- list_public_occurrences(incident_id, ...)
+"""
+
+import pytest
+
+# Placeholder incident used across cassettes. Replace during cassette recording
+# with a real public incident id available on the recording workspace.
+_INCIDENT_ID = 3759
+
+
+async def _find_incident_with_occurrence_where(real_client, predicate):
+    """Scan public incidents and return the first (incident_id, occurrence) pair
+    whose first occurrence satisfies `predicate`. Returns (None, None) if not found.
+
+    Used to discover a real value (sha, filepath, source id, etc.) before filtering,
+    so the follow-up request hits actual data instead of fabricated IDs.
+    """
+    incidents = await real_client.list_public_incidents(per_page=20)
+    for inc in incidents.get("data", []):
+        if inc.get("occurrences_count", 0) == 0:
+            continue
+        occurrences = await real_client.list_public_occurrences(incident_id=inc["id"], per_page=5)
+        for occ in occurrences.get("data", []):
+            if predicate(occ):
+                return inc["id"], occ
+    return None, None
+
+
+class TestListPublicOccurrences:
+    """Tests for listing public secret occurrences with various filters."""
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_occurrences_basic(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key with incidents:read scope
+        WHEN we request the list of occurrences for a public incident
+        THEN we should receive a list response with occurrence data
+        """
+        with use_cassette("test_list_public_occurrences_basic"):
+            result = await real_client.list_public_occurrences(incident_id=_INCIDENT_ID, per_page=5)
+
+            assert result is not None
+            assert "data" in result
+            assert isinstance(result["data"], list)
+            assert "cursor" in result
+            assert "has_more" in result
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_occurrences_with_date_filter(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request public occurrences with a broad date_after window
+        THEN occurrences are returned and all fall inside the window
+        """
+        with use_cassette("test_list_public_occurrences_with_date_filter"):
+            cutoff = "2020-01-01T00:00:00Z"
+            result = await real_client.list_public_occurrences(
+                incident_id=_INCIDENT_ID,
+                date_after=cutoff,
+                per_page=5,
+            )
+
+            assert result["data"], "expected at least one occurrence for a broad date_after window"
+            for occ in result["data"]:
+                assert occ["date"] >= cutoff
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_occurrences_with_source_id(self, real_client, use_cassette):
+        """
+        GIVEN at least one public incident whose first occurrence has a source
+        WHEN we filter occurrences by that real source_id
+        THEN every returned occurrence shares that source
+        """
+        with use_cassette("test_list_public_occurrences_with_source_id"):
+            incident_id, occ = await _find_incident_with_occurrence_where(
+                real_client, lambda o: bool(o.get("source") and o["source"].get("id"))
+            )
+            if occ is None:
+                pytest.skip("No public occurrence with a source available")
+            source_id = occ["source"]["id"]
+
+            result = await real_client.list_public_occurrences(
+                incident_id=incident_id,
+                source_id=source_id,
+                per_page=5,
+            )
+
+            assert result["data"]
+            for o in result["data"]:
+                assert o["source"]["id"] == source_id
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_occurrences_with_presence(self, real_client, use_cassette):
+        """
+        GIVEN at least one public occurrence with presence=present
+        WHEN we filter occurrences by presence=present on its parent incident
+        THEN every returned occurrence has presence=present
+        """
+        with use_cassette("test_list_public_occurrences_with_presence"):
+            incident_id, _ = await _find_incident_with_occurrence_where(
+                real_client, lambda o: o.get("presence") == "present"
+            )
+            if incident_id is None:
+                pytest.skip("No present public occurrence available")
+
+            result = await real_client.list_public_occurrences(
+                incident_id=incident_id,
+                presence="present",
+                per_page=5,
+            )
+
+            assert result["data"]
+            for o in result["data"]:
+                assert o["presence"] == "present"
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_occurrences_with_sha(self, real_client, use_cassette):
+        """
+        GIVEN a public occurrence with a commit sha
+        WHEN we filter by a real sha prefix (>=3 chars)
+        THEN every returned occurrence has a sha starting with that prefix
+        """
+        with use_cassette("test_list_public_occurrences_with_sha"):
+            incident_id, occ = await _find_incident_with_occurrence_where(
+                real_client, lambda o: bool(o.get("sha")) and len(o["sha"]) >= 3
+            )
+            if occ is None:
+                pytest.skip("No public occurrence with a sha available")
+            sha_prefix = occ["sha"][:10]
+
+            result = await real_client.list_public_occurrences(
+                incident_id=incident_id,
+                sha=sha_prefix,
+                per_page=5,
+            )
+
+            assert result["data"]
+            for o in result["data"]:
+                assert o["sha"].startswith(sha_prefix)
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_occurrences_with_filepath(self, real_client, use_cassette):
+        """
+        GIVEN a public occurrence with a filepath
+        WHEN we filter by a real filepath substring (>=3 chars)
+        THEN every returned occurrence has a matching filepath
+        """
+        with use_cassette("test_list_public_occurrences_with_filepath"):
+            incident_id, occ = await _find_incident_with_occurrence_where(
+                real_client, lambda o: bool(o.get("filepath")) and len(o["filepath"]) >= 3
+            )
+            if occ is None:
+                pytest.skip("No public occurrence with a filepath available")
+            filepath_needle = occ["filepath"][:20]
+
+            result = await real_client.list_public_occurrences(
+                incident_id=incident_id,
+                filepath=filepath_needle,
+                per_page=5,
+            )
+
+            assert result["data"]
+            for o in result["data"]:
+                assert filepath_needle in o["filepath"]
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_occurrences_with_attachment_reason(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request public occurrences filtered by attachment_reason
+        THEN we should receive occurrences (filter applied)
+        """
+        with use_cassette("test_list_public_occurrences_with_attachment_reason"):
+            result = await real_client.list_public_occurrences(
+                incident_id=_INCIDENT_ID,
+                attachment_reason="by_dev_from_perimeter,on_github_org_in_perimeter",
+                per_page=5,
+            )
+
+            assert result is not None
+            assert "data" in result
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_occurrences_with_severity(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request public occurrences filtered by related-incident severity
+        THEN we should receive occurrences (filter applied)
+        """
+        with use_cassette("test_list_public_occurrences_with_severity"):
+            result = await real_client.list_public_occurrences(
+                incident_id=_INCIDENT_ID,
+                severity="critical,high",
+                per_page=5,
+            )
+
+            assert result is not None
+            assert "data" in result
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_occurrences_with_status(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request public occurrences filtered by related-incident status
+        THEN we should receive occurrences (filter applied)
+        """
+        with use_cassette("test_list_public_occurrences_with_status"):
+            result = await real_client.list_public_occurrences(
+                incident_id=_INCIDENT_ID,
+                status="TRIGGERED,ASSIGNED",
+                per_page=5,
+            )
+
+            assert result is not None
+            assert "data" in result
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_occurrences_with_validity(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request public occurrences filtered by related-secret validity
+        THEN we should receive occurrences (filter applied)
+        """
+        with use_cassette("test_list_public_occurrences_with_validity"):
+            result = await real_client.list_public_occurrences(
+                incident_id=_INCIDENT_ID,
+                validity="valid,invalid,no_checker",
+                per_page=5,
+            )
+
+            assert result is not None
+            assert "data" in result
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_occurrences_with_tags(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request public occurrences filtered by tags
+        THEN we should receive occurrences (filter applied)
+        """
+        with use_cassette("test_list_public_occurrences_with_tags"):
+            result = await real_client.list_public_occurrences(
+                incident_id=_INCIDENT_ID,
+                tags="FROM_HISTORICAL_SCAN,INTERNALLY_LEAKED",
+                per_page=5,
+            )
+
+            assert result is not None
+            assert "data" in result
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_occurrences_with_ordering(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request public occurrences ordered by -date
+        THEN we should receive occurrences (ordering applied)
+        """
+        with use_cassette("test_list_public_occurrences_with_ordering"):
+            result = await real_client.list_public_occurrences(
+                incident_id=_INCIDENT_ID,
+                ordering="-date",
+                per_page=5,
+            )
+
+            assert result is not None
+            assert "data" in result
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_occurrences_with_cursor(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key and a public incident with several occurrences
+        WHEN we request a first page, then pass the returned cursor on a second request
+        THEN the second request succeeds (cursor honoured by the API)
+        """
+        with use_cassette("test_list_public_occurrences_with_cursor"):
+            # Find an incident that actually has occurrences to paginate through.
+            incidents = await real_client.list_public_incidents(per_page=20)
+            incident_id = None
+            for inc in incidents["data"]:
+                if inc.get("occurrences_count", 0) > 1:
+                    incident_id = inc["id"]
+                    break
+            if incident_id is None:
+                pytest.skip("No public incident with multiple occurrences available")
+
+            first = await real_client.list_public_occurrences(incident_id=incident_id, per_page=1)
+            if not first.get("cursor"):
+                pytest.skip("Not enough occurrences to test cursor pagination")
+
+            result = await real_client.list_public_occurrences(
+                incident_id=incident_id,
+                cursor=first["cursor"],
+                per_page=1,
+            )
+
+            assert result is not None
+            assert "data" in result
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_occurrences_get_all(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key
+        WHEN we request public occurrences with get_all=True
+        THEN we should receive a PaginatedResult with data and has_more flag
+        """
+        with use_cassette("test_list_public_occurrences_get_all"):
+            result = await real_client.list_public_occurrences(incident_id=_INCIDENT_ID, get_all=True, per_page=5)
+
+            assert result is not None
+            assert "data" in result
+            assert isinstance(result["data"], list)
+            assert "has_more" in result
+            assert isinstance(result["has_more"], bool)
+            assert "cursor" in result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -368,6 +368,8 @@ def mock_gitguardian_client(request):
         "gg_api_core.tools.create_code_fix_request",
         "gg_api_core.tools.assign_incident",
         "gg_api_core.tools.manage_incident",
+        "gg_api_core.tools.list_public_incidents",
+        "gg_api_core.tools.list_public_occurrences",
         "gg_api_core.tools.list_repo_occurrences",
         "gg_api_core.tools.write_custom_tags",
         "gg_api_core.tools.revoke_secret",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -379,6 +379,7 @@ def mock_gitguardian_client(request):
         "gg_api_core.tools.list_detectors",
         "gg_api_core.tools.list_sources",
         "gg_api_core.tools.get_incident",
+        "gg_api_core.tools.get_public_incident",
         "gg_api_core.tools.get_member",
         "gg_api_core.tools.count_incidents",
     ]

--- a/tests/tools/test_get_public_incident.py
+++ b/tests/tools/test_get_public_incident.py
@@ -1,0 +1,142 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+from gg_api_core.tools.get_public_incident import GetPublicIncidentParams, get_public_incident
+
+
+class TestGetPublicIncident:
+    """Tests for the get_public_incident tool."""
+
+    @pytest.mark.asyncio
+    async def test_get_public_incident_success(self, mock_gitguardian_client):
+        """
+        GIVEN: A public incident exists in GitGuardian
+        WHEN: Retrieving the public incident by id
+        THEN: The API is called with the id and the incident payload is returned
+        """
+        mock_response = {
+            "id": 3759,
+            "date": "2019-08-22T14:15:22Z",
+            "detector": {
+                "name": "slack_bot_token",
+                "display_name": "Slack Bot Token",
+                "nature": "specific",
+                "family": "token",
+                "category": "messaging_system",
+                "detector_group_name": "slackbot_token",
+                "detector_group_display_name": "Slack Bot Token",
+            },
+            "status": "IGNORED",
+            "severity": "high",
+            "validity": "valid",
+            "occurrences_count": 4,
+            "risk_score": 80,
+            "assignee_id": 309,
+            "assignee_email": "eric@gitguardian.com",
+            "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"],
+            "share_url": "https://dashboard.gitguardian.com/share/public-incidents/xxx",
+            "gitguardian_url": "https://dashboard.gitguardian.com/workspace/1/public-incidents/3759",
+        }
+        mock_gitguardian_client.get_public_incident = AsyncMock(return_value=mock_response)
+
+        result = await get_public_incident(GetPublicIncidentParams(incident_id=3759))
+
+        mock_gitguardian_client.get_public_incident.assert_called_once_with(incident_id=3759)
+        assert result.incident["id"] == 3759
+        assert result.incident["status"] == "IGNORED"
+        assert result.incident["severity"] == "high"
+        assert result.incident["risk_score"] == 80
+        assert "FROM_HISTORICAL_SCAN" in result.incident["tags"]
+
+    @pytest.mark.asyncio
+    async def test_get_public_incident_full_response(self, mock_gitguardian_client):
+        """
+        GIVEN: A public incident with every documented field populated
+        WHEN: Retrieving it
+        THEN: Every field is passed through unchanged on the returned model
+        """
+        mock_response = {
+            "id": 3759,
+            "detector": {
+                "name": "slack_bot_token",
+                "display_name": "Slack Bot Token",
+                "nature": "specific",
+                "family": "token",
+                "category": "messaging_system",
+                "detector_group_name": "slackbot_token",
+                "detector_group_display_name": "Slack Bot Token",
+            },
+            "date": "2019-08-22T14:15:22Z",
+            "secret_id": 1,
+            "secret_hash": "Ri9FjVgdOlPnBmujoxP4XPJcbe82BhJXB/SAngijw/juCISuOMgPzYhV28m6OG24",
+            "hmsl_hash": "05975add34ddc9a38a0fb57c7d3e676ffed57080516fc16bf8d8f14308fedb86",
+            "occurrences_count": 4,
+            "status": "IGNORED",
+            "triggered_at": "2019-05-12T09:37:49Z",
+            "ignored_at": "2019-08-24T14:15:22Z",
+            "ignore_reason": "test_credential,ignore_actor",
+            "ignorer_id": 309,
+            "ignorer_api_token_id": "fdf075f9-1662-4cf1-9171-af50568158a8",
+            "resolved_at": None,
+            "resolver_id": 395,
+            "resolver_api_token_id": "fdf075f9-1662-4cf1-9171-af50568158a8",
+            "secret_revoked": False,
+            "validity": "valid",
+            "severity": "high",
+            "assignee_id": 309,
+            "assignee_email": "eric@gitguardian.com",
+            "share_url": "https://dashboard.gitguardian.com/share/public-incidents/uuid",
+            "feedback_list": [],
+            "declarative_secret_status": "revoked",
+            "resolve_reason": "revoked",
+            "gitguardian_url": "https://dashboard.gitguardian.com/workspace/1/public-incidents/3759",
+            "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"],
+            "custom_tags": [{"id": "d45a123f", "key": "env", "value": "prod"}],
+            "risk_score": 80,
+            "severity_rule_id": 42,
+            "incident_name": "Slack Bot Token",
+            "is_vaulted": False,
+        }
+        mock_gitguardian_client.get_public_incident = AsyncMock(return_value=mock_response)
+
+        result = await get_public_incident(GetPublicIncidentParams(incident_id=3759))
+
+        assert result.incident == mock_response
+
+    @pytest.mark.asyncio
+    async def test_get_public_incident_not_found(self, mock_gitguardian_client):
+        """
+        GIVEN: A public incident does not exist
+        WHEN: Retrieving it by id
+        THEN: A ToolError is raised carrying the underlying error message
+        """
+        mock_gitguardian_client.get_public_incident = AsyncMock(side_effect=Exception("Public incident not found"))
+
+        with pytest.raises(ToolError) as excinfo:
+            await get_public_incident(GetPublicIncidentParams(incident_id=99999))
+
+        assert "Public incident not found" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_get_public_incident_client_error(self, mock_gitguardian_client):
+        """
+        GIVEN: The HTTP client raises
+        WHEN: Retrieving a public incident
+        THEN: A ToolError is raised
+        """
+        mock_gitguardian_client.get_public_incident = AsyncMock(side_effect=Exception("API connection failed"))
+
+        with pytest.raises(ToolError) as excinfo:
+            await get_public_incident(GetPublicIncidentParams(incident_id=1234))
+
+        assert "API connection failed" in str(excinfo.value)
+
+    def test_get_public_incident_params_requires_incident_id(self):
+        """
+        GIVEN: No incident_id provided
+        WHEN: Creating GetPublicIncidentParams
+        THEN: A validation error is raised
+        """
+        with pytest.raises(ValueError):
+            GetPublicIncidentParams()  # type: ignore[call-arg]

--- a/tests/tools/test_list_public_incidents.py
+++ b/tests/tools/test_list_public_incidents.py
@@ -1,0 +1,166 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from gg_api_core.client import IncidentSeverity, IncidentStatus, IncidentValidity
+from gg_api_core.tools.list_public_incidents import (
+    ListPublicIncidentsParams,
+    list_public_incidents,
+)
+
+
+class TestListPublicIncidents:
+    """Tests for the list_public_incidents tool."""
+
+    @pytest.mark.asyncio
+    async def test_basic_call_passes_pagination_and_defaults(self, mock_gitguardian_client):
+        """
+        GIVEN: Default parameters
+        WHEN: Listing public incidents
+        THEN: The client receives the noise-reducing default filters plus default pagination
+        """
+        mock_response = {
+            "data": [{"id": 3759, "status": "TRIGGERED"}],
+            "cursor": None,
+            "has_more": False,
+        }
+        mock_gitguardian_client.list_public_incidents = AsyncMock(return_value=mock_response)
+
+        result = await list_public_incidents(ListPublicIncidentsParams())
+
+        mock_gitguardian_client.list_public_incidents.assert_called_once()
+        call_kwargs = mock_gitguardian_client.list_public_incidents.call_args.kwargs
+        assert call_kwargs["per_page"] == 20
+        assert call_kwargs["ordering"] == "-date"
+        assert call_kwargs["get_all"] is False
+        # Default filters mirror list_incidents: IGNORED / LOW / INFO / INVALID excluded.
+        assert call_kwargs["status"] == [IncidentStatus.TRIGGERED, IncidentStatus.ASSIGNED, IncidentStatus.RESOLVED]
+        assert call_kwargs["severity"] == [
+            IncidentSeverity.CRITICAL,
+            IncidentSeverity.HIGH,
+            IncidentSeverity.MEDIUM,
+            IncidentSeverity.UNKNOWN,
+        ]
+        assert call_kwargs["validity"] == [
+            IncidentValidity.VALID,
+            IncidentValidity.FAILED_TO_CHECK,
+            IncidentValidity.NO_CHECKER,
+            IncidentValidity.UNKNOWN,
+        ]
+
+        assert result.incidents_count == 1
+        assert result.incidents == mock_response["data"]
+        assert result.cursor is None
+        assert result.has_more is False
+
+    @pytest.mark.asyncio
+    async def test_with_filters_accepts_single_value_and_list(self, mock_gitguardian_client):
+        """
+        GIVEN: Filters passed as a mix of scalars and lists
+        WHEN: Listing public incidents
+        THEN: All filters are coerced to lists, forwarded to the client, and reported in applied_filters
+        """
+        mock_gitguardian_client.list_public_incidents = AsyncMock(
+            return_value={"data": [], "cursor": None, "has_more": False}
+        )
+
+        params = ListPublicIncidentsParams(
+            status=IncidentStatus.TRIGGERED,  # scalar coerced to list
+            severity=[IncidentSeverity.HIGH, IncidentSeverity.CRITICAL],
+            validity=[IncidentValidity.VALID],
+            tags="FROM_HISTORICAL_SCAN,INTERNALLY_LEAKED",
+            risk_score_min=70,
+            risk_score_max=100,
+            assignee_id=42,
+            feedback=True,
+            declarative_secret_status="active",
+            ordering="-risk_score",
+            per_page=50,
+        )
+        result = await list_public_incidents(params)
+
+        call_kwargs = mock_gitguardian_client.list_public_incidents.call_args.kwargs
+        assert call_kwargs["status"] == [IncidentStatus.TRIGGERED]
+        assert call_kwargs["severity"] == [IncidentSeverity.HIGH, IncidentSeverity.CRITICAL]
+        assert call_kwargs["validity"] == [IncidentValidity.VALID]
+        assert call_kwargs["tags"] == "FROM_HISTORICAL_SCAN,INTERNALLY_LEAKED"
+        assert call_kwargs["risk_score_min"] == 70
+        assert call_kwargs["risk_score_max"] == 100
+        assert call_kwargs["assignee_id"] == 42
+        assert call_kwargs["feedback"] is True
+        assert call_kwargs["declarative_secret_status"] == "active"
+        assert call_kwargs["ordering"] == "-risk_score"
+        assert call_kwargs["per_page"] == 50
+
+        assert result.applied_filters["status"] == ["TRIGGERED"]
+        assert result.applied_filters["severity"] == ["high", "critical"]
+        assert result.applied_filters["validity"] == ["valid"]
+        assert result.applied_filters["risk_score_min"] == 70
+        assert result.applied_filters["assignee_id"] == 42
+
+    @pytest.mark.asyncio
+    async def test_defaults_can_be_disabled(self, mock_gitguardian_client):
+        """
+        GIVEN: Explicit None for status/severity/validity
+        WHEN: Listing public incidents
+        THEN: No status/severity/validity filter is sent to the client
+        """
+        mock_gitguardian_client.list_public_incidents = AsyncMock(
+            return_value={"data": [], "cursor": None, "has_more": False}
+        )
+
+        params = ListPublicIncidentsParams(status=None, severity=None, validity=None)
+        await list_public_incidents(params)
+
+        call_kwargs = mock_gitguardian_client.list_public_incidents.call_args.kwargs
+        assert call_kwargs["status"] is None
+        assert call_kwargs["severity"] is None
+        assert call_kwargs["validity"] is None
+
+    @pytest.mark.asyncio
+    async def test_with_cursor_returns_pagination_info(self, mock_gitguardian_client):
+        """
+        GIVEN: A pagination cursor on the response
+        WHEN: Listing public incidents
+        THEN: cursor and has_more are surfaced in the result
+        """
+        mock_gitguardian_client.list_public_incidents = AsyncMock(
+            return_value={"data": [{"id": 1}], "cursor": "next_cursor_xyz", "has_more": True}
+        )
+
+        result = await list_public_incidents(ListPublicIncidentsParams(cursor="prev_cursor"))
+
+        call_kwargs = mock_gitguardian_client.list_public_incidents.call_args.kwargs
+        assert call_kwargs["cursor"] == "prev_cursor"
+        assert result.cursor == "next_cursor_xyz"
+        assert result.has_more is True
+
+    @pytest.mark.asyncio
+    async def test_get_all_forwarded(self, mock_gitguardian_client):
+        """
+        GIVEN: get_all=True
+        WHEN: Listing public incidents
+        THEN: get_all is forwarded to the client method
+        """
+        mock_gitguardian_client.list_public_incidents = AsyncMock(
+            return_value={"data": [{"id": 1}, {"id": 2}], "cursor": None, "has_more": False}
+        )
+
+        result = await list_public_incidents(ListPublicIncidentsParams(get_all=True))
+
+        call_kwargs = mock_gitguardian_client.list_public_incidents.call_args.kwargs
+        assert call_kwargs["get_all"] is True
+        assert result.incidents_count == 2
+
+    @pytest.mark.asyncio
+    async def test_client_error_returns_error_result(self, mock_gitguardian_client):
+        """
+        GIVEN: The client raises an exception
+        WHEN: Listing public incidents
+        THEN: An error result is returned
+        """
+        mock_gitguardian_client.list_public_incidents = AsyncMock(side_effect=Exception("Boom"))
+
+        result = await list_public_incidents(ListPublicIncidentsParams())
+
+        assert hasattr(result, "error")
+        assert "Failed to list public incidents" in result.error

--- a/tests/tools/test_list_public_occurrences.py
+++ b/tests/tools/test_list_public_occurrences.py
@@ -1,0 +1,132 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from gg_api_core.tools.list_public_occurrences import (
+    ListPublicOccurrencesParams,
+    list_public_occurrences,
+)
+
+
+class TestListPublicOccurrences:
+    """Tests for the list_public_occurrences tool."""
+
+    @pytest.mark.asyncio
+    async def test_basic_call_passes_incident_id(self, mock_gitguardian_client):
+        """
+        GIVEN: An incident_id
+        WHEN: Listing public occurrences
+        THEN: The client method is called with that incident_id and default pagination
+        """
+        mock_gitguardian_client.list_public_occurrences = AsyncMock(
+            return_value={"data": [{"id": 12345, "incident_id": 3759}], "cursor": None, "has_more": False}
+        )
+
+        result = await list_public_occurrences(ListPublicOccurrencesParams(incident_id=3759))
+
+        mock_gitguardian_client.list_public_occurrences.assert_called_once()
+        call_kwargs = mock_gitguardian_client.list_public_occurrences.call_args.kwargs
+        assert call_kwargs["incident_id"] == 3759
+        assert call_kwargs["per_page"] == 20
+        assert call_kwargs["ordering"] == "-date"
+        assert call_kwargs["get_all"] is False
+
+        assert result.occurrences_count == 1
+        assert result.applied_filters["incident_id"] == 3759
+
+    @pytest.mark.asyncio
+    async def test_with_filters(self, mock_gitguardian_client):
+        """
+        GIVEN: Multiple occurrence-level filters
+        WHEN: Listing public occurrences
+        THEN: Filters are forwarded to the client and reflected in applied_filters
+        """
+        mock_gitguardian_client.list_public_occurrences = AsyncMock(
+            return_value={"data": [], "cursor": None, "has_more": False}
+        )
+
+        params = ListPublicOccurrencesParams(
+            incident_id=42,
+            source_id=6531,
+            presence="present",
+            sha="fccebf0562",
+            filepath="src/config",
+            attachment_reason="by_dev_from_perimeter,on_github_org_in_perimeter",
+            severity="critical,high",
+            status="TRIGGERED,ASSIGNED",
+            validity="valid",
+            tags="FROM_HISTORICAL_SCAN",
+            ordering="-id",
+            per_page=100,
+        )
+        result = await list_public_occurrences(params)
+
+        call_kwargs = mock_gitguardian_client.list_public_occurrences.call_args.kwargs
+        assert call_kwargs["incident_id"] == 42
+        assert call_kwargs["source_id"] == 6531
+        assert call_kwargs["presence"] == "present"
+        assert call_kwargs["sha"] == "fccebf0562"
+        assert call_kwargs["filepath"] == "src/config"
+        assert call_kwargs["attachment_reason"] == "by_dev_from_perimeter,on_github_org_in_perimeter"
+        assert call_kwargs["severity"] == "critical,high"
+        assert call_kwargs["status"] == "TRIGGERED,ASSIGNED"
+        assert call_kwargs["validity"] == "valid"
+        assert call_kwargs["tags"] == "FROM_HISTORICAL_SCAN"
+        assert call_kwargs["ordering"] == "-id"
+        assert call_kwargs["per_page"] == 100
+
+        assert result.applied_filters["source_id"] == 6531
+        assert result.applied_filters["presence"] == "present"
+        assert result.applied_filters["filepath"] == "src/config"
+
+    @pytest.mark.asyncio
+    async def test_with_cursor_returns_pagination_info(self, mock_gitguardian_client):
+        """
+        GIVEN: A pagination cursor on the response
+        WHEN: Listing public occurrences
+        THEN: cursor and has_more are surfaced in the result
+        """
+        mock_gitguardian_client.list_public_occurrences = AsyncMock(
+            return_value={"data": [{"id": 1}], "cursor": "next_cursor", "has_more": True}
+        )
+
+        result = await list_public_occurrences(ListPublicOccurrencesParams(incident_id=1, cursor="prev_cursor"))
+
+        call_kwargs = mock_gitguardian_client.list_public_occurrences.call_args.kwargs
+        assert call_kwargs["cursor"] == "prev_cursor"
+        assert result.cursor == "next_cursor"
+        assert result.has_more is True
+
+    @pytest.mark.asyncio
+    async def test_get_all_forwarded(self, mock_gitguardian_client):
+        """
+        GIVEN: get_all=True
+        WHEN: Listing public occurrences
+        THEN: get_all is forwarded to the client method
+        """
+        mock_gitguardian_client.list_public_occurrences = AsyncMock(
+            return_value={
+                "data": [{"id": 1}, {"id": 2}],
+                "cursor": None,
+                "has_more": False,
+            }
+        )
+
+        result = await list_public_occurrences(ListPublicOccurrencesParams(incident_id=1, get_all=True))
+
+        call_kwargs = mock_gitguardian_client.list_public_occurrences.call_args.kwargs
+        assert call_kwargs["get_all"] is True
+        assert result.occurrences_count == 2
+
+    @pytest.mark.asyncio
+    async def test_client_error_returns_error_result(self, mock_gitguardian_client):
+        """
+        GIVEN: The client raises an exception
+        WHEN: Listing public occurrences
+        THEN: An error result is returned
+        """
+        mock_gitguardian_client.list_public_occurrences = AsyncMock(side_effect=Exception("Boom"))
+
+        result = await list_public_occurrences(ListPublicOccurrencesParams(incident_id=1))
+
+        assert hasattr(result, "error")
+        assert "Failed to list public occurrences" in result.error

--- a/tests/tools/vcr/test_get_public_incident.py
+++ b/tests/tools/vcr/test_get_public_incident.py
@@ -1,0 +1,64 @@
+"""
+VCR tests for the get_public_incident tool.
+
+These tests exercise the MCP tool wrapper (not just the low-level client) against
+recorded HTTP interactions. Run with a valid GITGUARDIAN_API_KEY to record cassettes:
+    make test-vcr-with-env
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+from gg_api_core.tools.get_public_incident import (
+    GetPublicIncidentParams,
+    GetPublicIncidentResult,
+    get_public_incident,
+)
+
+
+class TestGetPublicIncidentVCR:
+    """VCR tests for the get_public_incident tool."""
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_get_public_incident_basic(self, real_client, use_cassette):
+        """
+        GIVEN: A valid GitGuardian API key and at least one public incident on the workspace
+        WHEN: Calling get_public_incident with that id
+        THEN: The tool returns a GetPublicIncidentResult whose incident payload matches the id
+            and carries the documented core fields (status, severity, validity, detector)
+        """
+        with use_cassette("test_get_public_incident_basic"):
+            with patch(
+                "gg_api_core.tools.get_public_incident.get_client",
+                return_value=real_client,
+            ):
+                page = await real_client.list_public_incidents(per_page=1)
+                if not page["data"]:
+                    pytest.skip("No public incidents available on the recording workspace")
+                incident_id = page["data"][0]["id"]
+
+                result = await get_public_incident(GetPublicIncidentParams(incident_id=incident_id))
+
+                assert isinstance(result, GetPublicIncidentResult)
+                assert result.incident["id"] == incident_id
+                # Core contract fields documented on GET /v1/public-incidents/secrets/{id}
+                for key in ("status", "severity", "validity", "detector", "date", "occurrences_count"):
+                    assert key in result.incident, f"missing {key} on public incident payload"
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_get_public_incident_unknown_id_raises(self, real_client, use_cassette):
+        """
+        GIVEN: An incident id that does not exist
+        WHEN: Calling get_public_incident
+        THEN: A ToolError is raised (wrapping the underlying 404)
+        """
+        with use_cassette("test_get_public_incident_unknown_id"):
+            with patch(
+                "gg_api_core.tools.get_public_incident.get_client",
+                return_value=real_client,
+            ):
+                with pytest.raises(ToolError):
+                    await get_public_incident(GetPublicIncidentParams(incident_id=999999999))

--- a/tests/tools/vcr/test_list_public_incidents.py
+++ b/tests/tools/vcr/test_list_public_incidents.py
@@ -1,0 +1,134 @@
+"""
+VCR tests for the list_public_incidents tool.
+
+These tests exercise the MCP tool wrapper (not just the low-level client)
+and cover every filter parameter exposed by ListPublicIncidentsParams.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from gg_api_core.client import IncidentSeverity, IncidentStatus, IncidentValidity
+from gg_api_core.tools.list_public_incidents import (
+    ListPublicIncidentsParams,
+    ListPublicIncidentsResult,
+    list_public_incidents,
+)
+
+
+class TestListPublicIncidentsVCR:
+    """VCR tests for the list_public_incidents tool."""
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_basic(self, real_client, use_cassette):
+        """
+        GIVEN: A valid GitGuardian API key with incidents:read scope
+        WHEN: Calling list_public_incidents with default parameters
+        THEN: The tool returns a valid ListPublicIncidentsResult
+        """
+        with use_cassette("test_list_public_incidents_basic"):
+            with patch(
+                "gg_api_core.tools.list_public_incidents.get_client",
+                return_value=real_client,
+            ):
+                # The default tool applies status/severity/validity noise-reduction filters;
+                # disable them here to match the baseline cassette, which was recorded without
+                # any filters.
+                params = ListPublicIncidentsParams(
+                    per_page=5,
+                    status=None,
+                    severity=None,
+                    validity=None,
+                )
+                result = await list_public_incidents(params)
+
+                assert result is not None
+                assert isinstance(result, ListPublicIncidentsResult)
+                assert isinstance(result.incidents, list)
+                assert result.applied_filters is not None
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_with_multi_value_enum_filters(self, real_client, use_cassette):
+        """
+        GIVEN: Permissive multi-value list filters for status/severity/validity
+        WHEN: Calling list_public_incidents
+        THEN: The API honors the lists (comma-separated) and the tool returns data
+            whose status/severity/validity all fall inside the requested sets
+        """
+        statuses = [IncidentStatus.TRIGGERED, IncidentStatus.ASSIGNED, IncidentStatus.RESOLVED, IncidentStatus.IGNORED]
+        severities = [
+            IncidentSeverity.CRITICAL,
+            IncidentSeverity.HIGH,
+            IncidentSeverity.MEDIUM,
+            IncidentSeverity.LOW,
+            IncidentSeverity.INFO,
+            IncidentSeverity.UNKNOWN,
+        ]
+        validities = [
+            IncidentValidity.VALID,
+            IncidentValidity.INVALID,
+            IncidentValidity.FAILED_TO_CHECK,
+            IncidentValidity.NO_CHECKER,
+            IncidentValidity.UNKNOWN,
+        ]
+        with use_cassette("test_list_public_incidents_with_multi_value_enum_filters"):
+            with patch(
+                "gg_api_core.tools.list_public_incidents.get_client",
+                return_value=real_client,
+            ):
+                params = ListPublicIncidentsParams(
+                    per_page=10,
+                    status=statuses,
+                    severity=severities,
+                    validity=validities,
+                )
+                result = await list_public_incidents(params)
+
+                assert isinstance(result, ListPublicIncidentsResult)
+                assert result.incidents_count > 0, "expected non-empty result with permissive filters"
+
+                allowed_status = {s.value for s in statuses}
+                allowed_severity = {s.value for s in severities}
+                allowed_validity = {v.value for v in validities}
+                for inc in result.incidents:
+                    assert inc["status"] in allowed_status
+                    assert inc["severity"] in allowed_severity
+                    assert inc["validity"] in allowed_validity
+
+                applied = result.applied_filters
+                assert applied["status"] == [s.value for s in statuses]
+                assert applied["severity"] == [s.value for s in severities]
+                assert applied["validity"] == [v.value for v in validities]
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incidents_with_date_and_risk_score_bounds(self, real_client, use_cassette):
+        """
+        GIVEN: A broad date window, full risk-score range, and ordering=-risk_score
+        WHEN: Calling list_public_incidents with defaults disabled
+        THEN: Incidents are returned and respect the bounds
+        """
+        with use_cassette("test_list_public_incidents_with_date_and_risk_score_bounds"):
+            with patch(
+                "gg_api_core.tools.list_public_incidents.get_client",
+                return_value=real_client,
+            ):
+                params = ListPublicIncidentsParams(
+                    per_page=10,
+                    status=None,
+                    severity=None,
+                    validity=None,
+                    date_after="2020-01-01T00:00:00Z",
+                    risk_score_min=0,
+                    risk_score_max=100,
+                    ordering="-risk_score",
+                )
+                result = await list_public_incidents(params)
+
+                assert isinstance(result, ListPublicIncidentsResult)
+                assert result.incidents_count > 0
+                for inc in result.incidents:
+                    assert 0 <= inc["risk_score"] <= 100
+                    assert inc["date"] >= "2020-01-01T00:00:00Z"

--- a/tests/tools/vcr/test_list_public_occurrences.py
+++ b/tests/tools/vcr/test_list_public_occurrences.py
@@ -1,0 +1,117 @@
+"""
+VCR tests for the list_public_occurrences tool.
+
+These tests exercise the MCP tool wrapper (not just the low-level client)
+and cover every filter parameter exposed by ListPublicOccurrencesParams.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from gg_api_core.tools.list_public_occurrences import (
+    ListPublicOccurrencesParams,
+    ListPublicOccurrencesResult,
+    list_public_occurrences,
+)
+
+
+class TestListPublicOccurrencesVCR:
+    """VCR tests for the list_public_occurrences tool."""
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_occurrences_basic(self, real_client, use_cassette):
+        """
+        GIVEN: A valid GitGuardian API key with incidents:read scope
+        WHEN: Calling list_public_occurrences with only incident_id
+        THEN: The tool returns a valid ListPublicOccurrencesResult
+        """
+        with use_cassette("test_list_public_occurrences_basic"):
+            with patch(
+                "gg_api_core.tools.list_public_occurrences.get_client",
+                return_value=real_client,
+            ):
+                incidents = await real_client.list_public_incidents(per_page=1)
+                if not incidents["data"]:
+                    pytest.skip("No public incidents available")
+                incident_id = incidents["data"][0]["id"]
+
+                params = ListPublicOccurrencesParams(incident_id=incident_id, per_page=5)
+                result = await list_public_occurrences(params)
+
+                assert result is not None
+                assert isinstance(result, ListPublicOccurrencesResult)
+                assert isinstance(result.occurrences, list)
+                assert result.applied_filters["incident_id"] == incident_id
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_occurrences_with_multi_value_filters(self, real_client, use_cassette):
+        """
+        GIVEN: A real public incident, plus permissive multi-value comma-separated filters
+        WHEN: Calling list_public_occurrences
+        THEN: The API accepts the filters and occurrences are returned with attributes inside
+            the requested sets
+        """
+        with use_cassette("test_list_public_occurrences_with_multi_value_filters"):
+            with patch(
+                "gg_api_core.tools.list_public_occurrences.get_client",
+                return_value=real_client,
+            ):
+                incidents = await real_client.list_public_incidents(per_page=1)
+                if not incidents["data"]:
+                    pytest.skip("No public incidents available")
+                incident_id = incidents["data"][0]["id"]
+
+                params = ListPublicOccurrencesParams(
+                    incident_id=incident_id,
+                    per_page=10,
+                    presence="present",
+                    severity="critical,high,medium,low,info,unknown",
+                    status="TRIGGERED,ASSIGNED,RESOLVED,IGNORED",
+                    validity="valid,invalid,failed_to_check,no_checker,unknown",
+                    ordering="-date",
+                )
+                result = await list_public_occurrences(params)
+
+                assert isinstance(result, ListPublicOccurrencesResult)
+                assert result.occurrences_count > 0, "expected non-empty result with permissive filters"
+                for occ in result.occurrences:
+                    assert occ.get("presence") == "present"
+
+                applied = result.applied_filters
+                assert applied["incident_id"] == incident_id
+                assert applied["presence"] == "present"
+                assert applied["severity"] == "critical,high,medium,low,info,unknown"
+                assert applied["status"] == "TRIGGERED,ASSIGNED,RESOLVED,IGNORED"
+                assert applied["validity"] == "valid,invalid,failed_to_check,no_checker,unknown"
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_occurrences_with_date_range(self, real_client, use_cassette):
+        """
+        GIVEN: A real public incident and a broad date window
+        WHEN: Calling list_public_occurrences
+        THEN: Occurrences are returned and fall inside the window
+        """
+        with use_cassette("test_list_public_occurrences_with_date_range"):
+            with patch(
+                "gg_api_core.tools.list_public_occurrences.get_client",
+                return_value=real_client,
+            ):
+                incidents = await real_client.list_public_incidents(per_page=1)
+                if not incidents["data"]:
+                    pytest.skip("No public incidents available")
+                incident_id = incidents["data"][0]["id"]
+
+                params = ListPublicOccurrencesParams(
+                    incident_id=incident_id,
+                    per_page=10,
+                    date_after="2020-01-01T00:00:00Z",
+                )
+                result = await list_public_occurrences(params)
+
+                assert isinstance(result, ListPublicOccurrencesResult)
+                assert result.occurrences_count > 0
+                for occ in result.occurrences:
+                    assert occ["date"] >= "2020-01-01T00:00:00Z"


### PR DESCRIPTION
## Summary
- Adds two MCP tools for GitGuardian Public Monitoring: `list_public_incidents` and `list_public_occurrences`, wrapping `GET /v1/public-incidents/secrets` and `GET /v1/public-incidents/secrets/{id}/occurrences`.
- Both tools expose the full set of documented query filters (status / severity / validity / tags / custom tags / date ranges / triggered_at ranges / assignee / ignorer / resolver / feedback / declarative_secret_status / risk score / detector group / ordering / cursor / get_all for incidents; source_id / presence / sha / filepath / attachment_reason / severity / status / validity / tags / ordering / cursor / get_all for occurrences).
- Registered on both developer and secops servers via `register_developer_tools` with `incidents:read` scope.

## Test plan
- [x] Unit tests (mocked): `tests/tools/test_list_public_incidents.py`, `tests/tools/test_list_public_occurrences.py`
- [x] VCR tests for the client: `tests/client/vcr/test_public_incidents.py` (16 tests), `tests/client/vcr/test_public_occurrences.py` (14 tests) — one test per query param
- [x] VCR tests for the tools: `tests/tools/vcr/test_list_public_incidents.py`, `tests/tools/vcr/test_list_public_occurrences.py` (basic + all-filters-combined)
- [x] Cassettes recorded against the live GitGuardian SaaS API
- [x] Full suite: `525 passed, 3 skipped` in replay mode

## Notes
- `list_public_occurrences` cursor/basic VCR tests fetch a real `incident_id` from `list_public_incidents` first rather than hardcoding one, so they stay green across cassette re-recordings.
- During investigation we found that the public-incidents endpoints are gated by per-member RBAC on `TeamIntegrationScope.PUBLIC_SOURCES`; a PAT whose Membership lacks that team scope gets a silent empty list (no 403). Worth surfacing that hint in the tool response if users hit it — happy to follow up.

Issue: [APPAI-521](https://linear.app/gitguardian/issue/APPAI-521)