### PR TITLE
ci(release): publish sortable main-<sha>-<run> image tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
             type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix={{branch}}-
+            type=sha,prefix={{branch}}-,suffix=-${{ github.run_number }},enable={{is_default_branch}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary

- Adds a `main-<sha7>-<run_number>` tag alongside the existing `main-<sha7>` on every default-branch push.
- The trailing `github.run_number` is monotonically increasing, giving Renovate a sortable component to order versions — without it, raw commit SHAs aren't comparable and Renovate can't tell which tag is newest.
- Existing `main-<sha7>`, `latest`, semver, and PR tags are unchanged, so nothing currently consuming the old form breaks.

## Why

In `applications-configurations`, the `mcpServer.image` for prod and prod-eu was set to `imagePullPolicy: Always` with no tag pin, so every push to main here was deployed immediately to prod with no review window. We're switching prod to a pinned tag and a Renovate MR per new build, but Renovate needs a sortable tag format to do that — hence this change.

The new tag follows the same `main-<sha>-<build>` convention already used by other internal images in `applications-configurations` (e.g. `prm/app-chainguard` → `main-<sha8>-<timestamp>`).

## Test plan

- [ ] Merge → confirm the next `Release` workflow run on `main` publishes both `main-<sha7>` and `main-<sha7>-<run_number>` to `ghcr.io/gitguardian/mcp-server`.
- [ ] Verify with `crane ls ghcr.io/gitguardian/mcp-server | grep main-` (or via the GHCR UI).

Refs: SI-2577