### PR TITLE
refactor(settings): centralize env var access via pydantic Settings

### DIFF
--- a/packages/developer_mcp_server/src/developer_mcp_server/run.py
+++ b/packages/developer_mcp_server/src/developer_mcp_server/run.py
@@ -6,9 +6,9 @@ This module provides different ways to run the MCP server:
 """
 
 import logging
-import os
 
 from gg_api_core.sentry_integration import init_sentry
+from gg_api_core.settings import get_settings
 
 from developer_mcp_server.server import mcp
 
@@ -35,8 +35,9 @@ def run_http_with_uvicorn():
     init_sentry()
 
     # Get host and port from environment variables
-    mcp_port = int(os.environ.get("MCP_PORT", "8000"))
-    mcp_host = os.environ.get("MCP_HOST", "127.0.0.1")
+    settings = get_settings()
+    mcp_port = int(settings.mcp_port or "8000")
+    mcp_host = settings.mcp_host
 
     # Use StreamableHTTP transport with stateless JSON mode for scalability
     import uvicorn
@@ -55,9 +56,7 @@ def run_mcp_server():
     If MCP_PORT is set, uses StreamableHTTP transport.
     Otherwise, uses stdio transport (default).
     """
-    mcp_port = os.environ.get("MCP_PORT")
-
-    if mcp_port:
+    if get_settings().mcp_port:
         run_http_with_uvicorn()
     else:
         run_stdio()

--- a/packages/developer_mcp_server/src/developer_mcp_server/server.py
+++ b/packages/developer_mcp_server/src/developer_mcp_server/server.py
@@ -1,12 +1,16 @@
 """GitGuardian MCP server for developers with remediation tools."""
 
 import logging
+import os
 
-from gg_api_core.mcp_server import get_mcp_server
-from gg_api_core.scopes import set_developer_scopes
+# Declare this process's profile before anything in gg_api_core reads Settings.
+# Used by ``Settings.effective_scopes`` to cap the OAuth scope set.
+os.environ.setdefault("SERVER_PROFILE", "developer")
 
-from developer_mcp_server.add_health_check import add_health_check
-from developer_mcp_server.register_tools import DEVELOPER_INSTRUCTIONS, register_developer_tools
+from gg_api_core.mcp_server import get_mcp_server  # noqa: E402
+
+from developer_mcp_server.add_health_check import add_health_check  # noqa: E402
+from developer_mcp_server.register_tools import DEVELOPER_INSTRUCTIONS, register_developer_tools  # noqa: E402
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -21,7 +25,5 @@ mcp = get_mcp_server(
 
 register_developer_tools(mcp)
 add_health_check(mcp)
-
-set_developer_scopes()
 
 logger.info("Developer MCP server instance created and configured")

--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -156,10 +156,9 @@ async def _run_oauth_flow(dashboard_url: str, public_api_url: str) -> str:
         RuntimeError: If OAuth flow fails
     """
     from .oauth import GitGuardianOAuthClient
-    from .scopes import get_scopes_from_env_var
 
     settings = get_settings()
-    scopes = get_scopes_from_env_var()
+    scopes = settings.effective_scopes
     login_path = settings.gitguardian_login_path
     token_name = settings.gitguardian_token_name
 

--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import logging
-import os
 import re
 from collections.abc import Sequence
 from enum import Enum
@@ -12,6 +11,7 @@ from urllib.parse import quote_plus, unquote, urlparse
 import httpx
 
 from gg_api_core.host import is_self_hosted_instance
+from gg_api_core.settings import get_settings
 
 # Setup logger
 logger = logging.getLogger(__name__)
@@ -107,20 +107,6 @@ class PaginatedResult(TypedDict):
     has_more: bool  # True if results were capped by size limit OR more pages exist
 
 
-def is_oauth_enabled() -> bool:
-    """
-    Check if OAuth authentication is enabled via environment variable.
-    """
-    if os.environ.get("ENABLE_LOCAL_OAUTH") is None:
-        # Default value is True
-        return True
-    return os.environ.get("ENABLE_LOCAL_OAUTH", "").lower() == "true"
-
-
-def get_personal_access_token_from_env() -> str | None:
-    return os.environ.get("GITGUARDIAN_PERSONAL_ACCESS_TOKEN")
-
-
 def _derive_urls_from_env() -> tuple[str, str]:
     """Derive dashboard_url and public_api_url from environment.
 
@@ -129,8 +115,7 @@ def _derive_urls_from_env() -> tuple[str, str]:
     """
     # Create a temporary client just to get normalized URLs
     temp_client = GitGuardianClient.__new__(GitGuardianClient)
-    gitguardian_url = os.environ.get("GITGUARDIAN_URL", "https://dashboard.gitguardian.com")
-    temp_client._init_urls(gitguardian_url)
+    temp_client._init_urls(get_settings().gitguardian_url)
     return temp_client.dashboard_url, temp_client.public_api_url
 
 
@@ -173,9 +158,10 @@ async def _run_oauth_flow(dashboard_url: str, public_api_url: str) -> str:
     from .oauth import GitGuardianOAuthClient
     from .scopes import get_scopes_from_env_var
 
+    settings = get_settings()
     scopes = get_scopes_from_env_var()
-    login_path = os.environ.get("GITGUARDIAN_LOGIN_PATH", "auth/login")
-    token_name = os.environ.get("GITGUARDIAN_TOKEN_NAME", "MCP Token")
+    login_path = settings.gitguardian_login_path
+    token_name = settings.gitguardian_token_name
 
     oauth_client = GitGuardianOAuthClient(
         api_url=public_api_url,
@@ -221,7 +207,7 @@ async def acquire_single_tenant_token(
         RuntimeError: If no token source is available
     """
     # 1. Check env var first
-    if env_pat := get_personal_access_token_from_env():
+    if env_pat := get_settings().gitguardian_personal_access_token:
         logger.info("Using PAT from GITGUARDIAN_PERSONAL_ACCESS_TOKEN env var")
         return env_pat
 
@@ -236,7 +222,7 @@ async def acquire_single_tenant_token(
         return stored_token
 
     # 3. Trigger OAuth flow if enabled
-    if is_oauth_enabled():
+    if get_settings().is_oauth_enabled:
         logger.info("No stored token, triggering OAuth flow")
         return await _run_oauth_flow(dashboard_url, public_api_url)
 
@@ -293,7 +279,7 @@ class GitGuardianClient:
 
     def _init_urls(self, gitguardian_url: str | None = None):
         # Use provided raw URL or get from environment with default fallback
-        raw_url = gitguardian_url or os.environ.get("GITGUARDIAN_URL", "https://dashboard.gitguardian.com")
+        raw_url = gitguardian_url or get_settings().gitguardian_url
 
         self.public_api_url = self._normalize_api_url(raw_url)
         logger.info(f"Using API URL: {self.public_api_url}")

--- a/packages/gg_api_core/src/gg_api_core/host.py
+++ b/packages/gg_api_core/src/gg_api_core/host.py
@@ -1,5 +1,6 @@
-import os
 from urllib.parse import urlparse
+
+from .settings import get_settings
 
 SAAS_HOSTNAMES = [
     "dashboard.gitguardian.com",
@@ -46,7 +47,7 @@ def is_self_hosted_instance(gitguardian_url: str | None = None) -> bool:
         bool: True if self-hosted, False if SaaS
     """
     if not gitguardian_url:
-        gitguardian_url = os.environ.get("GITGUARDIAN_URL", "https://dashboard.gitguardian.com")
+        gitguardian_url = get_settings().gitguardian_url
 
     try:
         parsed = urlparse(gitguardian_url)

--- a/packages/gg_api_core/src/gg_api_core/mcp_server.py
+++ b/packages/gg_api_core/src/gg_api_core/mcp_server.py
@@ -13,12 +13,9 @@ from fastmcp.server.dependencies import get_http_headers
 from fastmcp.server.middleware import Middleware
 from fastmcp.tools import Tool
 
-from gg_api_core.client import (
-    GitGuardianClient,
-    get_personal_access_token_from_env,
-    is_oauth_enabled,
-)
+from gg_api_core.client import GitGuardianClient
 from gg_api_core.icons import get_gitguardian_icons
+from gg_api_core.settings import get_settings
 from gg_api_core.utils import get_client
 
 # Configure logger
@@ -377,10 +374,11 @@ class GitGuardianAuthorizationHeaderMCP(AbstractGitGuardianFastMCP):
 def get_mcp_server(*args, **kwargs) -> AbstractGitGuardianFastMCP:
     kwargs.setdefault("icons", get_gitguardian_icons())
 
-    if is_oauth_enabled():
+    settings = get_settings()
+    if settings.is_oauth_enabled:
         return GitGuardianLocalOAuthMCP(*args, **kwargs)
 
-    if personal_access_token := get_personal_access_token_from_env():
+    if personal_access_token := settings.gitguardian_personal_access_token:
         return GitGuardianPATEnvMCP(*args, personal_access_token=personal_access_token, **kwargs)
 
     return GitGuardianAuthorizationHeaderMCP(*args, **kwargs)

--- a/packages/gg_api_core/src/gg_api_core/oauth.py
+++ b/packages/gg_api_core/src/gg_api_core/oauth.py
@@ -3,7 +3,6 @@
 import datetime
 import json
 import logging
-import os
 import threading
 import time
 import webbrowser
@@ -15,6 +14,8 @@ from urllib.parse import parse_qs, urlparse
 from mcp.client.auth import TokenStorage
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 from pydantic import BaseModel, Field
+
+from .settings import get_settings
 
 # Configure logger
 logger = logging.getLogger(__name__)
@@ -68,7 +69,6 @@ class FileTokenStorage:
         """
         if token_file is None:
             # Determine platform-appropriate config directory
-            import os
             import platform
 
             system = platform.system()
@@ -80,7 +80,7 @@ class FileTokenStorage:
                 gitguardian_dir = app_support_dir / "GitGuardian"
             else:  # Linux and other Unix-like systems - follow XDG spec
                 # Use XDG_CONFIG_HOME if defined, otherwise ~/.config
-                xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
+                xdg_config_home = get_settings().xdg_config_home
                 if xdg_config_home:
                     config_dir = Path(xdg_config_home)
                 else:
@@ -455,7 +455,7 @@ class GitGuardianOAuthClient:
         # Special value 'never' or -1 means token never expires
         self.token_lifetime = token_lifetime
         if self.token_lifetime is None:
-            lifetime_env = os.environ.get("GITGUARDIAN_TOKEN_LIFETIME", "30")
+            lifetime_env = get_settings().gitguardian_token_lifetime
             if lifetime_env.lower() == "never":
                 self.token_lifetime = -1  # -1 indicates no expiration
             else:
@@ -545,11 +545,7 @@ class GitGuardianOAuthClient:
         logger.info(f"Starting OAuth authentication with GitGuardian at {server_url}")
 
         # Check if we should use the dashboard authenticated page from environment variable
-        use_dashboard_page = os.environ.get("GITGUARDIAN_USE_DASHBOARD_AUTHENTICATED_PAGE", "").lower() in (
-            "true",
-            "1",
-            "yes",
-        )
+        use_dashboard_page = get_settings().use_dashboard_authenticated_page
 
         # Set up callback server with the use_dashboard_page option
         callback_server = CallbackServer(dashboard_url=self.dashboard_url, use_dashboard_page=use_dashboard_page)
@@ -610,7 +606,7 @@ class GitGuardianOAuthClient:
             )
 
             # Get OAuth client ID from environment variable or use default
-            client_id = os.environ.get("GITGUARDIAN_CLIENT_ID", "ggshield_oauth")
+            client_id = get_settings().gitguardian_client_id
 
             # 2. Create the authorization URL with the appropriate parameters
             auth_url = f"{server_url}/auth/login?"

--- a/packages/gg_api_core/src/gg_api_core/scopes.py
+++ b/packages/gg_api_core/src/gg_api_core/scopes.py
@@ -3,6 +3,7 @@
 import os
 
 from gg_api_core.host import is_local_instance, is_self_hosted_instance
+from gg_api_core.settings import get_settings
 
 # All available GitGuardian API scopes as per documentation
 # https://docs.gitguardian.com/api-docs/authentication#scopes
@@ -116,7 +117,7 @@ def validate_scopes(scopes_str: str) -> list[str]:
 
 def get_scopes_from_env_var() -> list[str]:
     # Support GITGUARDIAN_REQUESTED_SCOPES for backward compatibility from previous versions
-    scopes_str = os.environ.get("GITGUARDIAN_SCOPES") or os.environ.get("GITGUARDIAN_REQUESTED_SCOPES")
+    scopes_str = get_settings().scopes_str
     if not scopes_str:
         return []
     return validate_scopes(scopes_str)

--- a/packages/gg_api_core/src/gg_api_core/scopes.py
+++ b/packages/gg_api_core/src/gg_api_core/scopes.py
@@ -1,9 +1,6 @@
-"""GitGuardian API scope definitions for different server types."""
+"""GitGuardian API scope definitions and server profiles."""
 
-import os
-
-from gg_api_core.host import is_local_instance, is_self_hosted_instance
-from gg_api_core.settings import get_settings
+from enum import Enum
 
 # All available GitGuardian API scopes as per documentation
 # https://docs.gitguardian.com/api-docs/authentication#scopes
@@ -48,96 +45,48 @@ ALL_READ_SCOPES = [
 ]
 
 
-def get_developer_scopes(gitguardian_url: str | None = None) -> list[str]:
+class ServerProfile(str, Enum):
+    """Which gg-mcp server profile is running.
+
+    The profile caps which scopes the OAuth flow may request. Set by each
+    server entry-point (e.g. ``developer_mcp_server/server.py``) via the
+    ``SERVER_PROFILE`` env var, then read through :class:`Settings`.
     """
-    Get developer scopes appropriate for the GitGuardian instance type.
 
-    Args:
-        gitguardian_url: GitGuardian URL to check instance type
+    DEVELOPER = "developer"
+    SECOPS = "secops"
 
-    Returns:
-        list[str]: List of appropriate scopes
-    """
-    if is_self_hosted_instance(gitguardian_url) and not is_local_instance(gitguardian_url):
-        # For non-local self-hosted instances, return minimal scopes
-        return MINIMAL_SCOPES
-    else:
-        return [
-            *ALL_READ_SCOPES,
-            "honeytokens:write",
-        ]
+    def max_scopes(self, *, restricted: bool) -> list[str]:
+        """Return the largest scope set this profile may request.
 
-
-def get_secops_scopes(gitguardian_url: str | None = None) -> list[str]:
-    """
-    Get SecOps scopes appropriate for the GitGuardian instance type.
-
-    Args:
-        gitguardian_url: GitGuardian URL to check instance type
-
-    Returns:
-        list[str]: List of appropriate scopes
-    """
-    if is_self_hosted_instance(gitguardian_url) and not is_local_instance(gitguardian_url):
-        # For non-local self-hosted instances, return minimal scopes
-        return MINIMAL_SCOPES
-    else:
+        Args:
+            restricted: True for non-local self-hosted instances, which
+                are capped to :data:`MINIMAL_SCOPES` regardless of profile.
+        """
+        if restricted:
+            return MINIMAL_SCOPES
+        if self is ServerProfile.DEVELOPER:
+            return [*ALL_READ_SCOPES, "honeytokens:write"]
         return ALL_SCOPES
 
 
 def validate_scopes(scopes_str: str) -> list[str]:
-    """
-    Validate and filter user-provided scopes against ALL_SCOPES.
+    """Parse and validate a comma-separated list of scopes.
 
     Args:
-        scopes_str: Comma-separated string of scopes
+        scopes_str: Comma-separated string of scopes.
 
     Returns:
-        list[str]: List of valid scopes
+        List of valid scopes (in the order they were requested).
 
     Raises:
-        ValueError: If any invalid scopes are provided
+        ValueError: If any requested scope is not in :data:`ALL_SCOPES`.
     """
     if not scopes_str:
         return []
 
-    # Parse the scopes string
-    requested_scopes = [scope.strip() for scope in scopes_str.split(",") if scope.strip()]
-
-    # Check for invalid scopes
-    invalid_scopes = [scope for scope in requested_scopes if scope not in ALL_SCOPES]
-
-    if invalid_scopes:
-        raise ValueError(
-            f"Invalid scopes provided: {', '.join(invalid_scopes)}. Valid scopes are: {', '.join(ALL_SCOPES)}"
-        )
-
-    return requested_scopes
-
-
-def get_scopes_from_env_var() -> list[str]:
-    # Support GITGUARDIAN_REQUESTED_SCOPES for backward compatibility from previous versions
-    scopes_str = get_settings().scopes_str
-    if not scopes_str:
-        return []
-    return validate_scopes(scopes_str)
-
-
-DEVELOPER_SCOPES = get_developer_scopes()
-SECOPS_SCOPES = get_secops_scopes()
-
-
-def set_secops_scopes():
-    # Filter the GITGUARDIAN_SCOPES env variable to only include secops scopes. If empty, use default secops scopes.
-    # Write again the result on the env variable
-    scopes_from_env_var = set(get_scopes_from_env_var())
-    scopes = set(SECOPS_SCOPES) & scopes_from_env_var if scopes_from_env_var else set(SECOPS_SCOPES)
-    os.environ["GITGUARDIAN_SCOPES"] = ",".join(scopes)
-
-
-def set_developer_scopes():
-    # Filter the GITGUARDIAN_SCOPES env variable to only include secops scopes. If empty, use default secops scopes.
-    # Write again the result on the env variable
-    scopes_from_env_var = set(get_scopes_from_env_var())
-    scopes = set(DEVELOPER_SCOPES) & scopes_from_env_var if scopes_from_env_var else set(DEVELOPER_SCOPES)
-    os.environ["GITGUARDIAN_SCOPES"] = ",".join(scopes)
+    requested = [scope.strip() for scope in scopes_str.split(",") if scope.strip()]
+    invalid = [scope for scope in requested if scope not in ALL_SCOPES]
+    if invalid:
+        raise ValueError(f"Invalid scopes provided: {', '.join(invalid)}. Valid scopes are: {', '.join(ALL_SCOPES)}")
+    return requested

--- a/packages/gg_api_core/src/gg_api_core/sentry_integration.py
+++ b/packages/gg_api_core/src/gg_api_core/sentry_integration.py
@@ -15,7 +15,7 @@ Environment Variables:
 import logging
 from typing import Any
 
-from .settings import get_settings
+from .settings import SentrySettings
 
 logger = logging.getLogger(__name__)
 
@@ -37,8 +37,8 @@ def init_sentry() -> bool:
         >>> init_sentry()
         True
     """
-    settings = get_settings()
-    dsn = settings.sentry_dsn
+    sentry_settings = SentrySettings()
+    dsn = sentry_settings.dsn
 
     if not dsn:
         logger.debug("SENTRY_DSN not configured, skipping Sentry initialization")
@@ -51,10 +51,10 @@ def init_sentry() -> bool:
         logger.warning("Sentry SDK not installed")
         return False
 
-    environment = settings.sentry_environment
-    release = settings.sentry_release
-    traces_sample_rate = settings.sentry_traces_sample_rate
-    profiles_sample_rate = settings.sentry_profiles_sample_rate
+    environment = sentry_settings.environment
+    release = sentry_settings.release
+    traces_sample_rate = sentry_settings.traces_sample_rate
+    profiles_sample_rate = sentry_settings.profiles_sample_rate
 
     # Configure logging integration
     logging_integration = LoggingIntegration(

--- a/packages/gg_api_core/src/gg_api_core/sentry_integration.py
+++ b/packages/gg_api_core/src/gg_api_core/sentry_integration.py
@@ -13,8 +13,9 @@ Environment Variables:
 """
 
 import logging
-import os
 from typing import Any
+
+from .settings import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +37,8 @@ def init_sentry() -> bool:
         >>> init_sentry()
         True
     """
-    dsn = os.environ.get("SENTRY_DSN")
+    settings = get_settings()
+    dsn = settings.sentry_dsn
 
     if not dsn:
         logger.debug("SENTRY_DSN not configured, skipping Sentry initialization")
@@ -49,11 +51,10 @@ def init_sentry() -> bool:
         logger.warning("Sentry SDK not installed")
         return False
 
-    # Get optional configuration from environment
-    environment = os.environ.get("SENTRY_ENVIRONMENT", "production")
-    release = os.environ.get("SENTRY_RELEASE")
-    traces_sample_rate = float(os.environ.get("SENTRY_TRACES_SAMPLE_RATE", "0.1"))
-    profiles_sample_rate = float(os.environ.get("SENTRY_PROFILES_SAMPLE_RATE", "0.1"))
+    environment = settings.sentry_environment
+    release = settings.sentry_release
+    traces_sample_rate = settings.sentry_traces_sample_rate
+    profiles_sample_rate = settings.sentry_profiles_sample_rate
 
     # Configure logging integration
     logging_integration = LoggingIntegration(

--- a/packages/gg_api_core/src/gg_api_core/settings.py
+++ b/packages/gg_api_core/src/gg_api_core/settings.py
@@ -1,0 +1,86 @@
+"""Centralised settings for gg-mcp servers.
+
+All environment-variable access goes through :class:`Settings`. Use
+:func:`get_settings` rather than reading ``os.environ`` directly.
+
+Precedence (highest first):
+    1. Real environment variables (exported, inline, container env)
+    2. Field defaults declared below
+
+``get_settings()`` returns a fresh ``Settings`` instance on every call so
+test fixtures using ``patch.dict(os.environ, ...)`` or
+``monkeypatch.setenv`` continue to work without cache invalidation.
+"""
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Environment-backed configuration for gg-mcp."""
+
+    model_config = SettingsConfigDict(
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+    # --- GitGuardian core ---
+    gitguardian_url: str = "https://dashboard.gitguardian.com"
+    gitguardian_personal_access_token: str | None = None
+
+    # GITGUARDIAN_REQUESTED_SCOPES is the legacy name kept for backward compat.
+    gitguardian_scopes: str | None = None
+    gitguardian_requested_scopes: str | None = None
+
+    gitguardian_login_path: str = "auth/login"
+    gitguardian_token_name: str = "MCP Token"
+    gitguardian_token_lifetime: str = "30"
+    gitguardian_client_id: str = "ggshield_oauth"
+    gitguardian_use_dashboard_authenticated_page: str = ""
+
+    # --- MCP transport ---
+    # Kept as str|None so callers can distinguish "unset" (stdio mode) from "set".
+    mcp_port: str | None = None
+    mcp_host: str = "127.0.0.1"
+    multi_tenancy_enabled: str = ""
+    # None ⇒ unset (default: True). Empty/anything-but-"true" ⇒ False.
+    enable_local_oauth: str | None = None
+
+    # --- Sentry ---
+    sentry_dsn: str | None = None
+    sentry_environment: str = "production"
+    sentry_release: str | None = None
+    sentry_traces_sample_rate: float = 0.1
+    sentry_profiles_sample_rate: float = 0.1
+
+    # --- System ---
+    xdg_config_home: str | None = None
+
+    # --- Derived helpers ---
+    @property
+    def is_oauth_enabled(self) -> bool:
+        """OAuth is enabled by default; only an explicit non-"true" value disables it."""
+        if self.enable_local_oauth is None:
+            return True
+        return self.enable_local_oauth.lower() == "true"
+
+    @property
+    def is_multi_tenant(self) -> bool:
+        return self.multi_tenancy_enabled.lower() == "true"
+
+    @property
+    def use_dashboard_authenticated_page(self) -> bool:
+        return self.gitguardian_use_dashboard_authenticated_page.lower() in ("true", "1", "yes")
+
+    @property
+    def scopes_str(self) -> str | None:
+        """GITGUARDIAN_SCOPES with GITGUARDIAN_REQUESTED_SCOPES fallback."""
+        return self.gitguardian_scopes or self.gitguardian_requested_scopes
+
+
+def get_settings() -> Settings:
+    """Build a fresh :class:`Settings` from the current environment.
+
+    Not cached: tests routinely mutate ``os.environ`` and expect each call
+    to observe the latest values.
+    """
+    return Settings()

--- a/packages/gg_api_core/src/gg_api_core/settings.py
+++ b/packages/gg_api_core/src/gg_api_core/settings.py
@@ -12,7 +12,24 @@ test fixtures using ``patch.dict(os.environ, ...)`` or
 ``monkeypatch.setenv`` continue to work without cache invalidation.
 """
 
+from typing import Any
+
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from .scopes import ServerProfile
+
+TRUTHY_ENV_VALUES = frozenset(
+    {
+        "true",
+        "1",
+        "yes",
+    }
+)
+
+
+def string_env_to_bool(value: str) -> bool:
+    return value.lower() in TRUTHY_ENV_VALUES
 
 
 class Settings(BaseSettings):
@@ -45,12 +62,22 @@ class Settings(BaseSettings):
     # None ⇒ unset (default: True). Empty/anything-but-"true" ⇒ False.
     enable_local_oauth: str | None = None
 
+    # --- Server profile ---
+    # Set by each server entry-point (e.g. developer_mcp_server/server.py) to
+    # signal which scope-set the OAuth flow may request. ``None`` means no
+    # profile is active — used by the OAuth helper script and tests.
+    server_profile: ServerProfile | None = None
+
     # --- System ---
     xdg_config_home: str | None = None
 
-    # Note: Sentry config lives in :class:`SentrySettings` (instantiated lazily
-    # inside ``init_sentry``) so a malformed ``SENTRY_*`` value cannot poison
-    # unrelated code paths that build the main ``Settings``.
+    @field_validator("server_profile", mode="before")
+    @classmethod
+    def _empty_profile_is_none(cls, v: Any) -> Any:
+        """Treat ``SERVER_PROFILE=""`` as unset, matching the other env knobs."""
+        if v == "":
+            return None
+        return v
 
     # --- Derived helpers ---
     @property
@@ -58,20 +85,60 @@ class Settings(BaseSettings):
         """OAuth is enabled by default; only an explicit non-"true" value disables it."""
         if self.enable_local_oauth is None:
             return True
-        return self.enable_local_oauth.lower() == "true"
+        return string_env_to_bool(self.enable_local_oauth)
 
     @property
     def is_multi_tenant(self) -> bool:
-        return self.multi_tenancy_enabled.lower() == "true"
+        return string_env_to_bool(self.multi_tenancy_enabled)
 
     @property
     def use_dashboard_authenticated_page(self) -> bool:
-        return self.gitguardian_use_dashboard_authenticated_page.lower() in ("true", "1", "yes")
+        return string_env_to_bool(self.gitguardian_use_dashboard_authenticated_page)
 
     @property
-    def scopes_str(self) -> str | None:
-        """GITGUARDIAN_SCOPES with GITGUARDIAN_REQUESTED_SCOPES fallback."""
-        return self.gitguardian_scopes or self.gitguardian_requested_scopes
+    def requested_scopes(self) -> list[str]:
+        """Scopes the user asked for via env, parsed and validated.
+
+        Reads ``GITGUARDIAN_SCOPES`` (with ``GITGUARDIAN_REQUESTED_SCOPES``
+        as a legacy fallback), splits on commas, and validates each entry
+        against :data:`gg_api_core.scopes.ALL_SCOPES`. Returns an empty
+        list when neither env var is set.
+
+        Raises:
+            ValueError: if any requested scope is not a known scope.
+        """
+        from .scopes import validate_scopes
+
+        raw = self.gitguardian_scopes or self.gitguardian_requested_scopes
+        if not raw:
+            return []
+        return validate_scopes(raw)
+
+    @property
+    def effective_scopes(self) -> list[str]:
+        """Final scope set the OAuth flow should request.
+
+        Inputs (all read from env, in one place):
+            * ``GITGUARDIAN_SCOPES`` — the user's requested scopes
+            * ``GITGUARDIAN_URL`` — non-local self-hosted instances are
+              capped to :data:`MINIMAL_SCOPES`
+            * ``SERVER_PROFILE`` — ``developer`` and ``secops`` cap to
+              different maximum scope sets
+
+        With no profile active, returns the user's requested scopes as-is
+        (used by ``scripts/run_oauth_flow.py``).
+        """
+        # Lazy import: ``host`` reads back from ``Settings``, so importing
+        # it at module top would create a cycle.
+        from .host import is_local_instance, is_self_hosted_instance
+
+        if self.server_profile is None:
+            return self.requested_scopes
+
+        restricted = is_self_hosted_instance(self.gitguardian_url) and not is_local_instance(self.gitguardian_url)
+        allowed = set(self.server_profile.max_scopes(restricted=restricted))
+        requested = set(self.requested_scopes)
+        return sorted(allowed & requested if requested else allowed)
 
 
 class SentrySettings(BaseSettings):

--- a/packages/gg_api_core/src/gg_api_core/settings.py
+++ b/packages/gg_api_core/src/gg_api_core/settings.py
@@ -45,15 +45,12 @@ class Settings(BaseSettings):
     # None ⇒ unset (default: True). Empty/anything-but-"true" ⇒ False.
     enable_local_oauth: str | None = None
 
-    # --- Sentry ---
-    sentry_dsn: str | None = None
-    sentry_environment: str = "production"
-    sentry_release: str | None = None
-    sentry_traces_sample_rate: float = 0.1
-    sentry_profiles_sample_rate: float = 0.1
-
     # --- System ---
     xdg_config_home: str | None = None
+
+    # Note: Sentry config lives in :class:`SentrySettings` (instantiated lazily
+    # inside ``init_sentry``) so a malformed ``SENTRY_*`` value cannot poison
+    # unrelated code paths that build the main ``Settings``.
 
     # --- Derived helpers ---
     @property
@@ -75,6 +72,27 @@ class Settings(BaseSettings):
     def scopes_str(self) -> str | None:
         """GITGUARDIAN_SCOPES with GITGUARDIAN_REQUESTED_SCOPES fallback."""
         return self.gitguardian_scopes or self.gitguardian_requested_scopes
+
+
+class SentrySettings(BaseSettings):
+    """Sentry-specific settings, instantiated lazily by ``init_sentry``.
+
+    Kept separate from :class:`Settings` so that malformed numeric values
+    (e.g. ``SENTRY_TRACES_SAMPLE_RATE=abc``) only break the Sentry code
+    path, not every caller that needs an unrelated setting.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="SENTRY_",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+    dsn: str | None = None
+    environment: str = "production"
+    release: str | None = None
+    traces_sample_rate: float = 0.1
+    profiles_sample_rate: float = 0.1
 
 
 def get_settings() -> Settings:

--- a/packages/gg_api_core/src/gg_api_core/utils.py
+++ b/packages/gg_api_core/src/gg_api_core/utils.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import re
 from urllib.parse import urljoin as urllib_urljoin
 
@@ -7,6 +6,7 @@ from fastmcp.exceptions import ValidationError
 from fastmcp.server.dependencies import get_http_headers
 
 from .client import GitGuardianClient, acquire_single_tenant_token
+from .settings import get_settings
 
 # Setup logger
 logger = logging.getLogger(__name__)
@@ -19,27 +19,6 @@ def urljoin(base: str, url: str) -> str:
 
 # Singleton client instance - only used in single-tenant mode
 _client_singleton: GitGuardianClient | None = None
-
-
-def get_mcp_port_or_none() -> str | None:
-    """Get MCP_PORT environment variable value or None.
-
-    Single source of truth for MCP_PORT access.
-    """
-    return os.environ.get("MCP_PORT")
-
-
-def is_multi_tenant_mode() -> bool:
-    """Check if multi-tenant mode is enabled (explicit opt-in).
-
-    Multi-tenant mode requires explicit opt-in via MULTI_TENANCY_ENABLED=true.
-    When enabled, MCP_PORT must also be set (raises error if not).
-
-    Returns:
-        True if MULTI_TENANCY_ENABLED=true
-        False otherwise (single-tenant is the default)
-    """
-    return os.environ.get("MULTI_TENANCY_ENABLED", "").lower() == "true"
 
 
 async def get_client(personal_access_token: str | None = None, user_agent: str | None = None) -> GitGuardianClient:
@@ -86,9 +65,9 @@ async def get_client(personal_access_token: str | None = None, user_agent: str |
         return GitGuardianClient(personal_access_token=personal_access_token, user_agent=user_agent)
 
     # 2. Multi-tenant mode (explicit opt-in via MULTI_TENANCY_ENABLED=true) : no caching, no automatic refresh
-    if is_multi_tenant_mode():
-        mcp_port = get_mcp_port_or_none()
-        if not mcp_port:
+    settings = get_settings()
+    if settings.is_multi_tenant:
+        if not settings.mcp_port:
             raise ValidationError(
                 "MULTI_TENANCY_ENABLED=true requires MCP_PORT to be set. "
                 "Multi-tenant mode only works with HTTP transport."

--- a/packages/secops_mcp_server/src/secops_mcp_server/run.py
+++ b/packages/secops_mcp_server/src/secops_mcp_server/run.py
@@ -6,9 +6,9 @@ This module provides different ways to run the MCP server:
 """
 
 import logging
-import os
 
 from gg_api_core.sentry_integration import init_sentry
+from gg_api_core.settings import get_settings
 
 from secops_mcp_server.server import mcp
 
@@ -36,8 +36,9 @@ def run_http_with_uvicorn():
 
     init_sentry()
     # Get host and port from environment variables
-    mcp_port = int(os.environ.get("MCP_PORT", "8000"))
-    mcp_host = os.environ.get("MCP_HOST", "127.0.0.1")
+    settings = get_settings()
+    mcp_port = int(settings.mcp_port or "8000")
+    mcp_host = settings.mcp_host
 
     # Use StreamableHTTP transport with stateless JSON mode for scalability
     import uvicorn
@@ -56,9 +57,7 @@ def run_mcp_server():
     If MCP_PORT is set, uses StreamableHTTP transport.
     Otherwise, uses stdio transport (default).
     """
-    mcp_port = os.environ.get("MCP_PORT")
-
-    if mcp_port:
+    if get_settings().mcp_port:
         run_http_with_uvicorn()
     else:
         run_stdio()

--- a/packages/secops_mcp_server/src/secops_mcp_server/server.py
+++ b/packages/secops_mcp_server/src/secops_mcp_server/server.py
@@ -1,29 +1,34 @@
 """GitGuardian MCP server for SecOps teams with incident management tools."""
 
 import logging
-from typing import Any, Literal
+import os
 
-from developer_mcp_server.add_health_check import add_health_check
-from developer_mcp_server.register_tools import register_developer_tools
-from fastmcp.exceptions import ToolError
-from gg_api_core.client import DEFAULT_PAGINATION_MAX_BYTES
-from gg_api_core.mcp_server import get_mcp_server, register_common_tools
-from gg_api_core.scopes import set_secops_scopes
-from gg_api_core.tools.assign_incident import assign_incident
-from gg_api_core.tools.assign_public_incident import assign_public_incident
-from gg_api_core.tools.create_code_fix_request import create_code_fix_request
-from gg_api_core.tools.manage_incident import (
+# Declare this process's profile before anything in gg_api_core reads Settings.
+# Used by ``Settings.effective_scopes`` to cap the OAuth scope set.
+os.environ.setdefault("SERVER_PROFILE", "secops")
+
+from typing import Any, Literal  # noqa: E402
+
+from developer_mcp_server.add_health_check import add_health_check  # noqa: E402
+from developer_mcp_server.register_tools import register_developer_tools  # noqa: E402
+from fastmcp.exceptions import ToolError  # noqa: E402
+from gg_api_core.client import DEFAULT_PAGINATION_MAX_BYTES  # noqa: E402
+from gg_api_core.mcp_server import get_mcp_server, register_common_tools  # noqa: E402
+from gg_api_core.tools.assign_incident import assign_incident  # noqa: E402
+from gg_api_core.tools.assign_public_incident import assign_public_incident  # noqa: E402
+from gg_api_core.tools.create_code_fix_request import create_code_fix_request  # noqa: E402
+from gg_api_core.tools.manage_incident import (  # noqa: E402
     manage_private_incident,
     update_incident_status,
 )
-from gg_api_core.tools.read_custom_tags import read_custom_tags
-from gg_api_core.tools.revoke_secret import revoke_secret
-from gg_api_core.tools.update_public_incident_status import update_public_incident_status
-from gg_api_core.tools.write_custom_tags import (
+from gg_api_core.tools.read_custom_tags import read_custom_tags  # noqa: E402
+from gg_api_core.tools.revoke_secret import revoke_secret  # noqa: E402
+from gg_api_core.tools.update_public_incident_status import update_public_incident_status  # noqa: E402
+from gg_api_core.tools.write_custom_tags import (  # noqa: E402
     update_or_create_incident_custom_tags,
     write_custom_tags,
 )
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field  # noqa: E402
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -111,8 +116,6 @@ class ListHoneytokensParams(BaseModel):
 
 
 # ===== End of Pydantic Models =====
-
-set_secops_scopes()
 
 SECOPS_INSTRUCTIONS = """
 # GitGuardian SecOps Tools

--- a/scripts/run_oauth_flow.py
+++ b/scripts/run_oauth_flow.py
@@ -30,7 +30,8 @@ project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root / "packages" / "gg_api_core" / "src"))
 
 from gg_api_core.oauth import GitGuardianOAuthClient
-from gg_api_core.scopes import get_scopes_from_env_var, ALL_SCOPES
+from gg_api_core.scopes import ALL_SCOPES
+from gg_api_core.settings import get_settings
 
 os.environ["GITGUARDIAN_SCOPES"] = ",".join(ALL_SCOPES)
 
@@ -132,7 +133,7 @@ async def run_oauth_flow():
     dashboard_url = get_dashboard_url(api_url)
 
     # Get scopes from environment or use defaults
-    scopes = get_scopes_from_env_var()
+    scopes = get_settings().requested_scopes
 
     # Get token name
     token_name = os.environ.get("GITGUARDIAN_TOKEN_NAME", "MCP OAuth Test Token")

--- a/tests/test_get_client_safeguards.py
+++ b/tests/test_get_client_safeguards.py
@@ -5,69 +5,70 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastmcp.exceptions import ValidationError
-from gg_api_core.utils import _get_caller_user_agent, get_client, get_mcp_port_or_none, is_multi_tenant_mode
+from gg_api_core.settings import get_settings
+from gg_api_core.utils import _get_caller_user_agent, get_client
 
 
-class TestGetMcpPortOrNone:
-    """Tests for get_mcp_port_or_none() helper."""
+class TestMcpPortSetting:
+    """Tests for Settings.mcp_port."""
 
     def test_returns_none_when_not_set(self):
         """
         GIVEN MCP_PORT is not set
-        WHEN get_mcp_port_or_none is called
+        WHEN get_settings().mcp_port is read
         THEN it returns None
         """
         with patch.dict(os.environ, {}, clear=True):
-            assert get_mcp_port_or_none() is None
+            assert get_settings().mcp_port is None
 
     def test_returns_port_when_set(self):
         """
         GIVEN MCP_PORT is set
-        WHEN get_mcp_port_or_none is called
+        WHEN get_settings().mcp_port is read
         THEN it returns the port value
         """
         with patch.dict(os.environ, {"MCP_PORT": "8080"}, clear=True):
-            assert get_mcp_port_or_none() == "8080"
+            assert get_settings().mcp_port == "8080"
 
 
-class TestIsMultiTenantMode:
-    """Tests for is_multi_tenant_mode() helper function."""
+class TestIsMultiTenant:
+    """Tests for Settings.is_multi_tenant."""
 
     def test_returns_false_by_default(self):
         """
         GIVEN no env vars are set
-        WHEN is_multi_tenant_mode is called
+        WHEN get_settings().is_multi_tenant is read
         THEN it returns False (single-tenant is the default)
         """
         with patch.dict(os.environ, {}, clear=True):
-            assert is_multi_tenant_mode() is False
+            assert get_settings().is_multi_tenant is False
 
     def test_returns_true_when_enabled(self):
         """
         GIVEN MULTI_TENANCY_ENABLED=true
-        WHEN is_multi_tenant_mode is called
+        WHEN get_settings().is_multi_tenant is read
         THEN it returns True
         """
         with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "true"}, clear=True):
-            assert is_multi_tenant_mode() is True
+            assert get_settings().is_multi_tenant is True
 
     def test_returns_false_when_disabled(self):
         """
         GIVEN MULTI_TENANCY_ENABLED=false
-        WHEN is_multi_tenant_mode is called
+        WHEN get_settings().is_multi_tenant is read
         THEN it returns False
         """
         with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "false"}, clear=True):
-            assert is_multi_tenant_mode() is False
+            assert get_settings().is_multi_tenant is False
 
     def test_case_insensitive(self):
         """
         GIVEN MULTI_TENANCY_ENABLED=TRUE (uppercase)
-        WHEN is_multi_tenant_mode is called
+        WHEN get_settings().is_multi_tenant is read
         THEN it returns True
         """
         with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "TRUE"}, clear=True):
-            assert is_multi_tenant_mode() is True
+            assert get_settings().is_multi_tenant is True
 
 
 class TestGetClientExplicitPAT:

--- a/tests/test_oauth_helpers.py
+++ b/tests/test_oauth_helpers.py
@@ -41,11 +41,19 @@ class TestIsOAuthEnabled:
         with patch.dict(os.environ, env, clear=True):
             assert get_settings().is_oauth_enabled is True
 
-    def test_returns_false_for_invalid_values(self):
-        """Test that is_oauth_enabled returns False for any value other than 'true'."""
-        invalid_values = ["1", "yes", "on", "enabled", "True1", "tru", "t"]
+    def test_returns_true_for_truthy_values(self):
+        """Test that is_oauth_enabled returns True for any recognised truthy value."""
+        truthy_values = ["true", "TRUE", "TrUe", "1", "yes", "YES"]
 
-        for value in invalid_values:
+        for value in truthy_values:
+            with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": value}):
+                assert get_settings().is_oauth_enabled is True, f"Expected True for value: {value}"
+
+    def test_returns_false_for_non_truthy_values(self):
+        """Test that is_oauth_enabled returns False for values outside the truthy set."""
+        non_truthy_values = ["on", "enabled", "True1", "tru", "t", "0", "no", "false"]
+
+        for value in non_truthy_values:
             with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": value}):
                 assert get_settings().is_oauth_enabled is False, f"Expected False for value: {value}"
 

--- a/tests/test_oauth_helpers.py
+++ b/tests/test_oauth_helpers.py
@@ -1,45 +1,45 @@
-"""Test OAuth helper functions."""
+"""Test OAuth helper semantics on the Settings class."""
 
 import os
 from unittest.mock import patch
 
-from gg_api_core.client import is_oauth_enabled
+from gg_api_core.settings import get_settings
 
 
 class TestIsOAuthEnabled:
-    """Test the is_oauth_enabled pure function."""
+    """Test the Settings.is_oauth_enabled property."""
 
     def test_returns_true_when_set_to_true(self):
         """Test that is_oauth_enabled returns True when ENABLE_LOCAL_OAUTH=true."""
         with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "true"}):
-            assert is_oauth_enabled() is True
+            assert get_settings().is_oauth_enabled is True
 
     def test_returns_true_when_set_to_true_uppercase(self):
         """Test that is_oauth_enabled is case-insensitive for 'true'."""
         with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "TRUE"}):
-            assert is_oauth_enabled() is True
+            assert get_settings().is_oauth_enabled is True
 
     def test_returns_true_when_set_to_true_mixed_case(self):
         """Test that is_oauth_enabled handles mixed case."""
         with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "TrUe"}):
-            assert is_oauth_enabled() is True
+            assert get_settings().is_oauth_enabled is True
 
     def test_returns_false_when_set_to_false(self):
         """Test that is_oauth_enabled returns False when ENABLE_LOCAL_OAUTH=false."""
         with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "false"}):
-            assert is_oauth_enabled() is False
+            assert get_settings().is_oauth_enabled is False
 
     def test_returns_false_when_set_to_empty_string(self):
         """Test that is_oauth_enabled returns False when ENABLE_LOCAL_OAUTH is empty."""
         with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": ""}):
-            assert is_oauth_enabled() is False
+            assert get_settings().is_oauth_enabled is False
 
     def test_returns_true_when_unset(self):
         """Test that is_oauth_enabled returns True when ENABLE_LOCAL_OAUTH is not set (default behavior for local-first usage)."""
         env = os.environ.copy()
         env.pop("ENABLE_LOCAL_OAUTH", None)
         with patch.dict(os.environ, env, clear=True):
-            assert is_oauth_enabled() is True
+            assert get_settings().is_oauth_enabled is True
 
     def test_returns_false_for_invalid_values(self):
         """Test that is_oauth_enabled returns False for any value other than 'true'."""
@@ -47,24 +47,22 @@ class TestIsOAuthEnabled:
 
         for value in invalid_values:
             with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": value}):
-                assert is_oauth_enabled() is False, f"Expected False for value: {value}"
+                assert get_settings().is_oauth_enabled is False, f"Expected False for value: {value}"
 
     def test_is_pure_function(self):
         """Test that is_oauth_enabled is a pure function (same input = same output)."""
         with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "true"}):
-            # Call multiple times
-            result1 = is_oauth_enabled()
-            result2 = is_oauth_enabled()
-            result3 = is_oauth_enabled()
+            result1 = get_settings().is_oauth_enabled
+            result2 = get_settings().is_oauth_enabled
+            result3 = get_settings().is_oauth_enabled
 
             assert result1 == result2 == result3
             assert result1
 
         with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "false"}):
-            # Call multiple times
-            result1 = is_oauth_enabled()
-            result2 = is_oauth_enabled()
-            result3 = is_oauth_enabled()
+            result1 = get_settings().is_oauth_enabled
+            result2 = get_settings().is_oauth_enabled
+            result3 = get_settings().is_oauth_enabled
 
             assert result1 == result2 == result3
             assert not result1
@@ -74,8 +72,7 @@ class TestIsOAuthEnabled:
         original_value = os.environ.get("ENABLE_LOCAL_OAUTH")
 
         with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "true"}):
-            is_oauth_enabled()
-            # Environment should still be the same
+            _ = get_settings().is_oauth_enabled
             assert os.environ.get("ENABLE_LOCAL_OAUTH") == "true"
 
         # After context exit, should be back to original

--- a/tests/test_scopes_effective.py
+++ b/tests/test_scopes_effective.py
@@ -1,0 +1,124 @@
+"""Test ``Settings.effective_scopes`` — the single readout combining
+``GITGUARDIAN_SCOPES``, ``GITGUARDIAN_URL`` (self-hosted cap), and
+``SERVER_PROFILE``."""
+
+import os
+from unittest.mock import patch
+
+from gg_api_core.scopes import ALL_READ_SCOPES, ALL_SCOPES, MINIMAL_SCOPES, ServerProfile
+from gg_api_core.settings import get_settings
+
+
+class TestEffectiveScopesNoProfile:
+    def test_no_profile_returns_requested_scopes_as_is(self):
+        """
+        GIVEN SERVER_PROFILE is unset
+        WHEN Settings.effective_scopes is read
+        THEN it returns the user's requested scopes unfiltered
+        """
+        with patch.dict(os.environ, {"GITGUARDIAN_SCOPES": "scan,incidents:read"}, clear=True):
+            assert sorted(get_settings().effective_scopes) == ["incidents:read", "scan"]
+
+    def test_no_profile_no_env_returns_empty(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert get_settings().effective_scopes == []
+
+
+class TestEffectiveScopesDeveloperProfile:
+    def test_full_set_when_no_user_scopes_on_saas(self):
+        """
+        GIVEN SERVER_PROFILE=developer and no GITGUARDIAN_SCOPES on SaaS
+        WHEN Settings.effective_scopes is read
+        THEN it returns the developer profile's full max-set
+        """
+        with patch.dict(
+            os.environ,
+            {"SERVER_PROFILE": "developer", "GITGUARDIAN_URL": "https://dashboard.gitguardian.com"},
+            clear=True,
+        ):
+            assert sorted(get_settings().effective_scopes) == sorted({*ALL_READ_SCOPES, "honeytokens:write"})
+
+    def test_intersects_with_user_scopes(self):
+        """
+        GIVEN GITGUARDIAN_SCOPES contains a mix of dev-allowed and dev-forbidden scopes
+        WHEN SERVER_PROFILE=developer
+        THEN only dev-allowed scopes are returned
+        """
+        # ``incidents:write`` is in SECOPS but not in DEVELOPER's allowed set
+        with patch.dict(
+            os.environ,
+            {
+                "SERVER_PROFILE": "developer",
+                "GITGUARDIAN_URL": "https://dashboard.gitguardian.com",
+                "GITGUARDIAN_SCOPES": "scan,incidents:read,incidents:write",
+            },
+            clear=True,
+        ):
+            effective = set(get_settings().effective_scopes)
+            assert "scan" in effective
+            assert "incidents:read" in effective
+            assert "incidents:write" not in effective
+
+
+class TestEffectiveScopesSecopsProfile:
+    def test_full_set_when_no_user_scopes_on_saas(self):
+        with patch.dict(
+            os.environ,
+            {"SERVER_PROFILE": "secops", "GITGUARDIAN_URL": "https://dashboard.gitguardian.com"},
+            clear=True,
+        ):
+            assert sorted(get_settings().effective_scopes) == sorted(ALL_SCOPES)
+
+    def test_passes_through_user_scope_unique_to_secops(self):
+        with patch.dict(
+            os.environ,
+            {
+                "SERVER_PROFILE": "secops",
+                "GITGUARDIAN_URL": "https://dashboard.gitguardian.com",
+                "GITGUARDIAN_SCOPES": "scan,incidents:write",
+            },
+            clear=True,
+        ):
+            assert "incidents:write" in get_settings().effective_scopes
+
+
+class TestEffectiveScopesSelfHostedCap:
+    def test_non_local_self_hosted_caps_to_minimal_regardless_of_profile(self):
+        """
+        GIVEN GITGUARDIAN_URL is a non-local self-hosted instance
+        WHEN any profile is active
+        THEN effective_scopes is capped to MINIMAL_SCOPES
+        """
+        for profile in ("developer", "secops"):
+            with patch.dict(
+                os.environ,
+                {"SERVER_PROFILE": profile, "GITGUARDIAN_URL": "https://gitguardian.mycompany.com"},
+                clear=True,
+            ):
+                assert sorted(get_settings().effective_scopes) == sorted(MINIMAL_SCOPES), (
+                    f"Profile {profile} should be capped to MINIMAL_SCOPES on self-hosted"
+                )
+
+    def test_local_instance_is_not_treated_as_self_hosted(self):
+        """
+        GIVEN GITGUARDIAN_URL points at localhost
+        WHEN SERVER_PROFILE=developer
+        THEN the full developer scope set is allowed (local instances are treated as SaaS-like)
+        """
+        with patch.dict(
+            os.environ,
+            {"SERVER_PROFILE": "developer", "GITGUARDIAN_URL": "http://localhost:3000"},
+            clear=True,
+        ):
+            assert sorted(get_settings().effective_scopes) == sorted({*ALL_READ_SCOPES, "honeytokens:write"})
+
+
+class TestServerProfileEnumParsing:
+    def test_empty_string_treated_as_unset(self):
+        """``SERVER_PROFILE=""`` (e.g. from a test fixture clearing the var) is None, not an error."""
+        with patch.dict(os.environ, {"SERVER_PROFILE": ""}, clear=True):
+            assert get_settings().server_profile is None
+
+    def test_profile_parsed_into_enum(self):
+        with patch.dict(os.environ, {"SERVER_PROFILE": "developer"}, clear=True):
+            assert get_settings().server_profile is ServerProfile.DEVELOPER

--- a/tests/test_server_profiles.py
+++ b/tests/test_server_profiles.py
@@ -23,22 +23,13 @@ def mock_env_no_http():
 
 @pytest.fixture
 def mock_gitguardian_modules():
-    """Mock GitGuardian API modules to avoid actual API calls during import."""
-    with (
-        patch("gg_api_core.utils.get_client") as mock_get_client,
-        patch("gg_api_core.scopes.set_developer_scopes") as mock_set_dev_scopes,
-        patch("gg_api_core.scopes.set_secops_scopes") as mock_set_secops_scopes,
-    ):
-        # Mock client
+    """Mock the GitGuardian client to avoid actual API calls during import."""
+    with patch("gg_api_core.utils.get_client") as mock_get_client:
         mock_client = MagicMock()
         mock_client.get_current_token_info = AsyncMock(return_value={"scopes": ["scan"]})
         mock_get_client.return_value = mock_client
 
-        yield {
-            "get_client": mock_get_client,
-            "set_dev_scopes": mock_set_dev_scopes,
-            "set_secops_scopes": mock_set_secops_scopes,
-        }
+        yield {"get_client": mock_get_client}
 
 
 def clean_module_imports(module_name: str):


### PR DESCRIPTION
## Summary

- Adds a `Settings(BaseSettings)` class in `gg_api_core/settings.py` as the single source of truth for env-backed configuration (GitGuardian URL/PAT/scopes/OAuth/token settings, MCP transport, Sentry, XDG).
- Replaces every `os.environ.get(...)` read across `gg_api_core` (client, host, oauth, scopes, sentry_integration, utils) and the MCP server entrypoints (`developer_mcp_server.run`, `secops_mcp_server.run`) with `get_settings().<field>`.
- Removes thin proxy helpers (`is_oauth_enabled`, `get_personal_access_token_from_env`, `get_mcp_port_or_none`, `is_multi_tenant_mode`) and inlines their callers; their semantics now live as properties on `Settings` (`is_oauth_enabled`, `is_multi_tenant`, `use_dashboard_authenticated_page`, `scopes_str`).

## Design notes

- `get_settings()` is **not** cached: tests routinely mutate `os.environ` via `patch.dict` / `monkeypatch.setenv` and expect each call to observe the latest values. Building a `Settings` instance is cheap (just reads env).
- No `env_file=".env"` in the model config — preserves current behaviour (the MCP server entrypoints never auto-loaded `.env`).
- Two writes to `os.environ["GITGUARDIAN_SCOPES"]` in `scopes.py` are left as-is: they are a deliberate state-passing mechanism between scope-setup and downstream reads; the round-trip still works because `get_settings()` re-reads env on every call.

## Test plan

- [x] `uv run pytest` — 598 passed, 4 skipped
- [x] `uv run ruff check packages/ tests/` — all checks passed
- [x] Existing `TestIsOAuthEnabled` / multi-tenant / MCP-port helper tests retargeted to assert on `get_settings().<property>` directly, preserving the same semantic coverage (unset → default True, case-insensitive, empty string → False, etc.).

Issue: SI-3287