### PR TITLE
feat(list_sources): add team_id filter

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -2031,6 +2031,7 @@ class GitGuardianClient:
         external_id: str | None = None,
         source_criticality: str | None = None,
         monitored: bool | None = None,
+        team_id: int | None = None,
         per_page: int = 20,
         cursor: str | None = None,
         get_all: bool = False,
@@ -2047,6 +2048,7 @@ class GitGuardianClient:
             external_id: Filter by specific external id
             source_criticality: Filter by source criticality ('critical', 'high', 'medium', 'low', 'unknown')
             monitored: Filter by monitored value (true/false)
+            team_id: Filter by team id (sources within the given team's perimeter)
             per_page: Number of results per page (default: 20, min: 1, max: 100)
             cursor: Pagination cursor (for cursor-based pagination)
             get_all: If True, fetch all results using cursor-based pagination
@@ -2076,6 +2078,8 @@ class GitGuardianClient:
             params["source_criticality"] = source_criticality
         if monitored is not None:
             params["monitored"] = str(monitored).lower()
+        if team_id is not None:
+            params["team_id"] = str(team_id)
         if per_page:
             params["per_page"] = str(per_page)
         if cursor:

--- a/packages/gg_api_core/src/gg_api_core/tools/list_sources.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_sources.py
@@ -87,6 +87,10 @@ class ListSourcesParams(BaseModel):
         default=None,
         description="Filter by monitored status (true/false)",
     )
+    team_id: int | None = Field(
+        default=None,
+        description="Filter sources by team id. Only sources belonging to the given team's perimeter are returned.",
+    )
     per_page: int = Field(
         default=20,
         description="Number of results per page (default: 20, min: 1, max: 100)",
@@ -148,6 +152,7 @@ async def list_sources(params: ListSourcesParams) -> ListSourcesResult:
             external_id=params.external_id,
             source_criticality=params.source_criticality,
             monitored=params.monitored,
+            team_id=params.team_id,
             per_page=params.per_page,
             cursor=params.cursor,
             get_all=params.get_all,

--- a/tests/cassettes/tools/vcr/test_list_sources_with_team_id_filter.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_with_team_id_filter.yaml
@@ -1,0 +1,189 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/sources?team_id=1&per_page=10
+  response:
+    body:
+      string: '[{"id": 12338, "type": "github", "full_name": "wayne-enterprises-gg/shared-app",
+        "health": "safe", "source_criticality": "low", "default_branch": "master",
+        "default_branch_head": "a219c18ff8e913427c38fc7d90756d6bb1bb5b43", "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": {"date": "2026-02-02T10:49:30.905195Z",
+        "status": "finished", "failing_reason": "", "commits_scanned": 544, "duration":
+        "0.0", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
+        "public", "external_id": "218964926", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/shared-app",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12356,
+        "type": "github", "full_name": "wayne-enterprises-gg/with-readme-repo-gg",
+        "health": "safe", "source_criticality": "medium", "default_branch": "master",
+        "default_branch_head": "21ca725ac5028cf45975b49f7b48928f34f73117", "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:45:43.352734Z",
+        "status": "finished", "failing_reason": "", "commits_scanned": 1, "duration":
+        "3.265244", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
+        "public", "external_id": "234115319", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/with-readme-repo-gg",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12364,
+        "type": "github", "full_name": "wayne-enterprises-gg/business-app", "health":
+        "safe", "source_criticality": "medium", "default_branch": "master", "default_branch_head":
+        "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count": 0, "closed_incidents_count":
+        76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1242, "duration": "9.779904", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
+        "217533545", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 76, "severity_breakdown":
+        {"critical": 3, "high": 73, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
+        "url": "https://github.com/wayne-enterprises-gg/business-app", "provider_metadata":
+        {"archived": false}, "deleted": false}, {"id": 12369, "type": "github", "full_name":
+        "aymericGG/hello-world", "health": "safe", "source_criticality": "high", "default_branch":
+        "master", "default_branch_head": "665b4e495aef1d7b6737a503209407a297d37772",
+        "open_incidents_count": 0, "closed_incidents_count": 3, "last_scan": {"date":
+        "2025-10-09T16:45:43.352983Z", "status": "finished", "failing_reason": "",
+        "commits_scanned": 10, "duration": "0.84662", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "visibility": "public", "external_id": "175174005",
+        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
+        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
+        "closed_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
+        0, "high": 3, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/hello-world",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12370,
+        "type": "github", "full_name": "aymericGG/Project-back", "health": "safe",
+        "source_criticality": "unknown", "default_branch": "", "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2025-10-09T16:45:43.353058Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 0, "duration": "0.01237", "branches_scanned": 0, "progress":
+        100}, "monitored": true, "visibility": "public", "external_id": "253745397",
+        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
+        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
+        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/Project-back",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12371,
+        "type": "github", "full_name": "aymericGG/Project-Front", "health": "safe",
+        "source_criticality": "high", "default_branch": "", "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2025-10-09T16:45:43.353136Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 0, "duration": "0.012344", "branches_scanned": 0, "progress":
+        100}, "monitored": true, "visibility": "public", "external_id": "253745330",
+        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
+        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
+        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/Project-Front",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 9123340,
+        "type": "github", "full_name": "orga-083643/solid-octo", "health": "safe",
+        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
+        "1218ef7297f84f36297c0111ea88b54b9befd365", "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": {"date": "2025-10-09T16:45:43.351408Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 7, "duration": "1.120819", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
+        "630519649", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
+        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
+        "url": "https://github.com/orga-083643/solid-octo", "provider_metadata": {"archived":
+        false}, "deleted": false}, {"id": 9123465, "type": "github", "full_name":
+        "orga-083643/expert-train", "health": "safe", "source_criticality": "unknown",
+        "default_branch": "main", "default_branch_head": "1e3f25567a57f788700cbe9b21a05fb2a3dd23f9",
+        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
+        "2025-10-09T16:45:43.353647Z", "status": "finished", "failing_reason": "",
+        "commits_scanned": 4, "duration": "4.092814", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "visibility": "public", "external_id": "630525080",
+        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
+        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
+        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/expert-train",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 9123810,
+        "type": "github", "full_name": "orga-083643/ideal-journey", "health": "safe",
+        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
+        "ab24e2860796dff2a67c4915b1a6d745b13bdd76", "open_incidents_count": 0, "closed_incidents_count":
+        1, "last_scan": {"date": "2025-10-09T16:45:43.354999Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 3, "duration": "0.866616", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
+        "630531940", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 1, "severity_breakdown":
+        {"critical": 0, "high": 0, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
+        "url": "https://github.com/orga-083643/ideal-journey", "provider_metadata":
+        {"archived": false}, "deleted": false}, {"id": 9123882, "type": "github",
+        "full_name": "orga-083643/analytics-test", "health": "safe", "source_criticality":
+        "unknown", "default_branch": "main", "default_branch_head": "f19d79466ce40e0bb69c9ee0ea08787ead9b5845",
+        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
+        "2025-10-09T16:45:43.352186Z", "status": "finished", "failing_reason": "",
+        "commits_scanned": 7, "duration": "0.942938", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "visibility": "private", "external_id": "630536182",
+        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
+        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
+        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/analytics-test",
+        "provider_metadata": {"archived": false}, "deleted": false}]'
+    headers:
+      CF-RAY:
+      - 9fe2e86a08d7ebb1-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 May 2026 11:54:56 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '8700'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/sources?cursor=cD05MTIzODgy&per_page=10&team_id=1>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.468.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '19558'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '10'
+      x-secrets-engine-version:
+      - 2.162.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/tools/test_list_sources.py
+++ b/tests/tools/test_list_sources.py
@@ -257,6 +257,31 @@ class TestListSources:
         assert len(result.sources) == 1
 
     @pytest.mark.asyncio
+    async def test_list_sources_with_team_id_filter(self, mock_gitguardian_client):
+        """
+        GIVEN: A team_id filter parameter
+        WHEN: Listing sources with team_id filter
+        THEN: The API is called with correct team_id parameter
+        """
+        mock_response = {
+            "data": [
+                {
+                    "id": 1,
+                    "type": "github",
+                }
+            ],
+            "cursor": None,
+            "has_more": False,
+        }
+        mock_gitguardian_client.list_sources = AsyncMock(return_value=mock_response)
+
+        result = await list_sources(ListSourcesParams(team_id=42))
+
+        call_kwargs = mock_gitguardian_client.list_sources.call_args.kwargs
+        assert call_kwargs["team_id"] == 42
+        assert len(result.sources) == 1
+
+    @pytest.mark.asyncio
     async def test_list_sources_with_ordering(self, mock_gitguardian_client):
         """
         GIVEN: An ordering parameter

--- a/tests/tools/vcr/test_list_sources.py
+++ b/tests/tools/vcr/test_list_sources.py
@@ -295,6 +295,32 @@ class TestListSourcesVCR:
 
     @pytest.mark.vcr_test
     @pytest.mark.asyncio
+    async def test_list_sources_with_team_id_filter(self, real_client, use_cassette):
+        """
+        GIVEN: A valid GitGuardian API key with sources:read scope
+        WHEN: Calling list_sources with a team_id filter
+        THEN: The team_id query param is forwarded and a valid response is returned
+        """
+        with use_cassette("test_list_sources_with_team_id_filter"):
+            with patch(
+                "gg_api_core.tools.list_sources.get_client",
+                return_value=real_client,
+            ):
+                params = ListSourcesParams(
+                    team_id=1,
+                    per_page=10,
+                    get_all=False,
+                )
+
+                result = await list_sources(params)
+
+                assert result is not None
+                assert isinstance(result, ListSourcesResult)
+                assert result.sources is not None
+                assert isinstance(result.sources, list)
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
     async def test_list_sources_with_monitored_filter(self, real_client, use_cassette):
         """
         GIVEN: A valid GitGuardian API key with sources:read scope


### PR DESCRIPTION
## Summary

Surfaces the new `team_id` query param of the public `/v1/sources` endpoint through the `list_sources` MCP tool, so agents can scope source lookups to a team's perimeter.

## Changes

- `ListSourcesParams`: new optional `team_id: int | None` field.
- `gg_api_core.client.list_sources`: forward `team_id` as a query param.
- Test: `test_list_sources_with_team_id_filter` mirrors the other per-filter tests.

## Test plan

- [x] `pytest tests/tools/test_list_sources.py` (17 passed)
- [x] `ruff check` clean

Refs: SI-3298
Backend MR: https://gitlab.gitguardian.ovh/gg-code/prm/ward-runs-app/-/merge_requests/24985