### PR TITLE
feat(user-agent): tag outgoing API calls with transport mode

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -16,6 +16,12 @@ from gg_api_core.settings import get_settings
 logger = logging.getLogger(__name__)
 
 
+try:
+    DEFAULT_USER_AGENT = f"GitGuardian-MCP-Server/{version('ggmcp')}"
+except PackageNotFoundError:
+    DEFAULT_USER_AGENT = "GitGuardian-MCP-Server"
+
+
 class DownstreamUnauthorizedError(Exception):
     """Raised when the downstream GitGuardian API returns 401.
 
@@ -249,10 +255,7 @@ class GitGuardianClient:
     before this client is instantiated.
     """
 
-    try:
-        DEFAULT_USER_AGENT = f"GitGuardian-MCP-Server/{version('ggmcp')}"
-    except PackageNotFoundError:
-        DEFAULT_USER_AGENT = "GitGuardian-MCP-Server"
+    DEFAULT_USER_AGENT = DEFAULT_USER_AGENT
 
     def __init__(
         self,

--- a/packages/gg_api_core/src/gg_api_core/utils.py
+++ b/packages/gg_api_core/src/gg_api_core/utils.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin as urllib_urljoin
 from fastmcp.exceptions import ValidationError
 from fastmcp.server.dependencies import get_http_headers
 
-from .client import GitGuardianClient, acquire_single_tenant_token
+from .client import DEFAULT_USER_AGENT, GitGuardianClient, acquire_single_tenant_token
 from .settings import get_settings
 
 # Setup logger
@@ -45,8 +45,9 @@ async def get_client(personal_access_token: str | None = None, user_agent: str |
 
     Args:
         personal_access_token: Optional PAT for explicit authentication.
-        user_agent: Optional User-Agent string. If not provided, automatically
-            extracted from incoming HTTP request headers (when available).
+        user_agent: Optional User-Agent string. If not provided, one is built
+            via :func:`_build_user_agent` (server identity + transport marker,
+            plus the caller's User-Agent when the request came over HTTP).
 
     Returns:
         GitGuardianClient: Client instance configured with appropriate authentication
@@ -55,9 +56,9 @@ async def get_client(personal_access_token: str | None = None, user_agent: str |
         ValidationError: In multi-tenant mode, if MCP_PORT not set or Authorization header missing
         RuntimeError: In single-tenant mode, if no token source is available
     """
-    # Extract caller User-Agent from HTTP headers if not explicitly provided
+    # Build the User-Agent for outgoing API calls if not explicitly provided
     if user_agent is None:
-        user_agent = _get_caller_user_agent()
+        user_agent = _build_user_agent()
 
     # 1. Explicit PAT provided - caller manages the token (no caching, no automatic refresh)
     if personal_access_token:
@@ -103,6 +104,28 @@ def _get_caller_user_agent() -> str | None:
     except Exception:
         logger.exception("Error when trying to extract User-Agent from headers")
         return None
+
+
+def _build_user_agent() -> str:
+    """Build the User-Agent sent on outgoing GitGuardian API calls.
+
+    The string always starts with ``GitGuardian-MCP-Server/<version>`` so that
+    monitoring filtering on that substring keeps matching every MCP request,
+    regardless of transport. A ``transport=stdio|http`` marker is appended to
+    tell legacy local (stdio) clients apart from the hosted HTTP server, and
+    when the request arrives over HTTP the calling client's own User-Agent is
+    preserved as ``client=...`` for per-client analytics.
+
+    Examples:
+        - stdio:  ``GitGuardian-MCP-Server/0.5.0 (transport=stdio)``
+        - hosted: ``GitGuardian-MCP-Server/0.5.0 (transport=http; client=Claude-Code/1.2)``
+    """
+    transport = "http" if get_settings().mcp_port else "stdio"
+    parts = [f"transport={transport}"]
+    caller = _get_caller_user_agent()
+    if caller:
+        parts.append(f"client={caller}")
+    return f"{DEFAULT_USER_AGENT} ({'; '.join(parts)})"
 
 
 def _get_token_from_request_headers() -> str:

--- a/tests/test_get_client_safeguards.py
+++ b/tests/test_get_client_safeguards.py
@@ -5,8 +5,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastmcp.exceptions import ValidationError
+from gg_api_core.client import GitGuardianClient
 from gg_api_core.settings import get_settings
 from gg_api_core.utils import _get_caller_user_agent, get_client
+
+# Prefix every outgoing User-Agent carries, regardless of transport.
+UA_PREFIX = GitGuardianClient.DEFAULT_USER_AGENT
 
 
 class TestMcpPortSetting:
@@ -86,7 +90,12 @@ class TestGetClientExplicitPAT:
 
         result = await get_client(personal_access_token="explicit-token")
 
-        mock_client_class.assert_called_once_with(personal_access_token="explicit-token", user_agent=None)
+        mock_client_class.assert_called_once()
+        call_kwargs = mock_client_class.call_args.kwargs
+        assert call_kwargs["personal_access_token"] == "explicit-token"
+        # User-Agent now always carries the server prefix + transport marker
+        assert call_kwargs["user_agent"].startswith(UA_PREFIX)
+        assert "transport=" in call_kwargs["user_agent"]
         assert result == mock_client
 
     @patch("gg_api_core.utils.GitGuardianClient")
@@ -102,7 +111,11 @@ class TestGetClientExplicitPAT:
         with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "true", "MCP_PORT": "8080"}, clear=True):
             result = await get_client(personal_access_token="explicit-token")
 
-        mock_client_class.assert_called_once_with(personal_access_token="explicit-token", user_agent=None)
+        # MCP_PORT is set, so the transport marker is http (no caller header here)
+        mock_client_class.assert_called_once_with(
+            personal_access_token="explicit-token",
+            user_agent=f"{UA_PREFIX} (transport=http)",
+        )
         assert result == mock_client
 
 
@@ -138,7 +151,11 @@ class TestGetClientMultiTenantMode:
         with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "true", "MCP_PORT": "8080"}, clear=True):
             result = await get_client()
 
-        mock_client_class.assert_called_once_with(personal_access_token="request-token", user_agent=None)
+        # No user-agent header on the request, so only the transport marker is added
+        mock_client_class.assert_called_once_with(
+            personal_access_token="request-token",
+            user_agent=f"{UA_PREFIX} (transport=http)",
+        )
         assert result == mock_client
 
     @patch("gg_api_core.utils.get_http_headers")
@@ -148,7 +165,7 @@ class TestGetClientMultiTenantMode:
         GIVEN MULTI_TENANCY_ENABLED=true and MCP_PORT is set
         AND request has both Authorization and User-Agent headers
         WHEN get_client is called
-        THEN the caller's User-Agent is forwarded to GitGuardianClient
+        THEN the caller's User-Agent is preserved as client=... in the UA string
         """
         mock_get_headers.return_value = {
             "authorization": "Bearer request-token",
@@ -162,7 +179,7 @@ class TestGetClientMultiTenantMode:
 
         mock_client_class.assert_called_once_with(
             personal_access_token="request-token",
-            user_agent="GitGuardian-In-App-Agent",
+            user_agent=f"{UA_PREFIX} (transport=http; client=GitGuardian-In-App-Agent)",
         )
         assert result == mock_client
 
@@ -431,7 +448,7 @@ class TestCallerUserAgentExtraction:
         """
         GIVEN an HTTP request with User-Agent header
         WHEN get_client() is called without explicit user_agent (as tool handlers do)
-        THEN the caller's User-Agent is automatically forwarded to GitGuardianClient
+        THEN the caller's User-Agent is preserved as client=... in the built UA
         """
         mock_get_headers.return_value = {
             "authorization": "Bearer request-token",
@@ -444,7 +461,7 @@ class TestCallerUserAgentExtraction:
 
         mock_client_class.assert_called_once_with(
             personal_access_token="request-token",
-            user_agent="GitGuardian-In-App-Agent",
+            user_agent=f"{UA_PREFIX} (transport=http; client=GitGuardian-In-App-Agent)",
         )
 
     @patch("gg_api_core.utils.get_http_headers")


### PR DESCRIPTION
## Why

PR #145 recommends the hosted HTTP MCP setup even for local use. We want to monitor how many **legacy (stdio)** clients remain, and today that's done via the `user-agent` on outgoing GitGuardian API calls.

The problem: in HTTP mode `get_client()` forwarded the **caller's** User-Agent verbatim (`utils.py`), which dropped the `GitGuardian-MCP-Server` prefix. Once people migrate to hosted HTTP, the existing UA-based dashboard would show legacy traffic "dropping" while it's really just becoming invisible — undercounting total MCP usage and misreading the migration.

Confirmed against live Coralogix data (`gim` subsystem, `$d.attributes.user_agent`): **100% of current MCP traffic carries the `GitGuardian-MCP-Server` prefix** — so it's an accurate legacy baseline today, and we want to keep it that way after migration.

## What

`_build_user_agent()` now always emits the server prefix + a transport marker, preserving the caller UA:

- stdio (legacy): `GitGuardian-MCP-Server/0.5.0 (transport=stdio)`
- hosted HTTP: `GitGuardian-MCP-Server/0.5.0 (transport=http; client=Claude-Code/1.2)`

`DEFAULT_USER_AGENT` is hoisted to a module-level constant in `client.py` so it can't be shadowed when the client class is mocked in tests.

## Dashboard impact (non-breaking)

- Existing "MCP traffic" widget (`contains GitGuardian-MCP-Server`) keeps matching legacy **and** hosted — total unbroken.
- **Legacy** = `contains GitGuardian-MCP-Server AND NOT contains transport=http` (also captures today's pre-change UAs, which have no marker).
- **Hosted** = `contains transport=http`.

## Tests

`tests/test_get_client_safeguards.py` updated for the new UA composition. Suite green (`ruff` clean, 25/25 in the touched file).

Issue: #