### PR TITLE
fix(oauth-proxy): make advertised authorization-server metadata accurate [SI-3422]

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/oauth_proxy_auth.py
+++ b/packages/gg_api_core/src/gg_api_core/oauth_proxy_auth.py
@@ -241,16 +241,22 @@ class GitGuardianOAuthThinProxy(PassThroughTokenVerifier):
         base = str(self.base_url).rstrip("/")
         return JSONResponse(
             {
-                "issuer": f"{base}/",
+                # RFC 8414 §3.3: the issuer MUST equal the value used to build
+                # the well-known URL (this server's base, no trailing slash).
+                "issuer": base,
                 "authorization_endpoint": f"{base}/authorize",
                 "token_endpoint": f"{base}/token",
                 "registration_endpoint": f"{base}/register",
                 "scopes_supported": self.scopes_supported,
                 "response_types_supported": ["code"],
                 "grant_types_supported": ["authorization_code"],
+                # Mirror what the GG backend actually accepts at /register and
+                # /token (its DCR serializer only permits "none" and
+                # "client_secret_post"). Advertising client_secret_basic would
+                # let a confidential client pick a method registration rejects.
                 "token_endpoint_auth_methods_supported": [
+                    "none",
                     "client_secret_post",
-                    "client_secret_basic",
                 ],
                 "code_challenge_methods_supported": ["S256"],
             },
@@ -263,7 +269,8 @@ class GitGuardianOAuthThinProxy(PassThroughTokenVerifier):
         return JSONResponse(
             {
                 "resource": str(self._resource_url),
-                "authorization_servers": [f"{base}/"],
+                # Must match the AS metadata issuer exactly (no trailing slash).
+                "authorization_servers": [base],
                 "scopes_supported": self.scopes_supported,
                 "bearer_methods_supported": ["header"],
             },

--- a/tests/test_oauth_proxy_middleware.py
+++ b/tests/test_oauth_proxy_middleware.py
@@ -1,9 +1,12 @@
 """Tests for the OAuth-proxy ASGI middleware that converts downstream 401s."""
 
+import json
+
 import pytest
 from gg_api_core.oauth_proxy_auth import (
     AdvertiseAuthorizationServerMetadataMiddleware,
     TranslateDownstreamUnauthorizedMiddleware,
+    create_oauth_proxy,
     mark_downstream_unauthorized,
 )
 
@@ -126,3 +129,37 @@ async def test_advertise_appends_as_metadata_to_existing_header():
     assert www_auth.count("resource_metadata=") == 1
     assert "should-not-be-used" not in www_auth
     assert ", as_metadata=" in www_auth
+
+
+@pytest.mark.asyncio
+async def test_authorization_server_metadata_is_accurate():
+    """AS metadata advertises only the auth methods the GG backend accepts and
+    a spec-compliant issuer (no trailing slash)."""
+    proxy = create_oauth_proxy(base_url="https://mcp.example.com")
+    proxy.get_routes("/mcp")  # sets the resource URL via set_mcp_path
+
+    resp = await proxy._handle_authorization_server_metadata(request=None)
+    meta = json.loads(resp.body)
+
+    # RFC 8414 §3.3: issuer == base used to build the well-known URL, no slash.
+    assert meta["issuer"] == "https://mcp.example.com"
+    # Mirrors ClientRegistrationRequestSerializer — no client_secret_basic.
+    assert meta["token_endpoint_auth_methods_supported"] == [
+        "none",
+        "client_secret_post",
+    ]
+    assert meta["authorization_endpoint"] == "https://mcp.example.com/authorize"
+    assert meta["code_challenge_methods_supported"] == ["S256"]
+
+
+@pytest.mark.asyncio
+async def test_resource_metadata_authorization_servers_match_issuer():
+    """RFC 9728 authorization_servers must match the AS metadata issuer exactly."""
+    proxy = create_oauth_proxy(base_url="https://mcp.example.com")
+    proxy.get_routes("/mcp")
+
+    as_meta = json.loads((await proxy._handle_authorization_server_metadata(request=None)).body)
+    rm_meta = json.loads((await proxy._handle_resource_metadata(request=None)).body)
+
+    assert rm_meta["authorization_servers"] == [as_meta["issuer"]]
+    assert rm_meta["authorization_servers"] == ["https://mcp.example.com"]


### PR DESCRIPTION
## Summary

Align the OAuth-proxy's RFC 8414 authorization-server metadata with what the GG backend actually supports.

Ticket: [SI-3422](https://linear.app/gitguardian/issue/SI-3422-oauth2-support-several-redirect-uri-in-post-register)

## Changes

- **Advertise `none`** in `token_endpoint_auth_methods_supported` — public clients (PKCE, no secret) are supported. PKCE stays mandatory and is advertised separately via `code_challenge_methods_supported = ["S256"]`, so `none` does **not** imply unauthenticated clients.
- **Drop `client_secret_basic`** — the backend DCR serializer only accepts `none` and `client_secret_post`, so no client can ever register with `basic`. The proxy's metadata now matches the backend's own `/.well-known/oauth-authorization-server` (which already advertises exactly `["none", "client_secret_post"]`).
- **Spec-compliant issuer** — emit the issuer without a trailing slash (RFC 8414 §3.3: issuer must equal the value used to build the well-known URL) and keep the protected-resource metadata's `authorization_servers` in lockstep with it.

Adds tests pinning the advertised auth methods, the issuer, and AS/resource-metadata issuer consistency.

## Not the Cursor fix

These are metadata-accuracy fixes. They are **not** what unblocks Cursor Desktop: a capture of Cursor's real DCR request proved Cursor ignores `token_endpoint_auth_methods_supported` and always registers as a public client sending several `redirect_uris` at once. That rejection is fixed backend-side in `ward-runs-app` (filter the redirect_uris batch rather than reject it wholesale) under the same ticket.