### PR TITLE
feat(oauth): send canonical oauth2_login auth_mode [SI-3428]

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/oauth.py
+++ b/packages/gg_api_core/src/gg_api_core/oauth.py
@@ -618,7 +618,8 @@ class GitGuardianOAuthClient:
                 "state": state,
                 "code_challenge": code_challenge,
                 "code_challenge_method": "S256",
-                "auth_mode": "ggshield_login",
+                # Canonical auth_mode; "ggshield_login" remains a legacy alias.
+                "auth_mode": "oauth2_login",
                 "name": self.token_name,  # Try with 'name' instead of 'token_name'
                 "token_name": self.token_name,  # Keep original in case it's needed
                 "utm_source": "cli",  # Match the working URL parameters

--- a/packages/gg_api_core/src/gg_api_core/oauth_proxy_auth.py
+++ b/packages/gg_api_core/src/gg_api_core/oauth_proxy_auth.py
@@ -304,8 +304,9 @@ class GitGuardianOAuthThinProxy(PassThroughTokenVerifier):
         params = dict(request.query_params)
         params.setdefault("client_id", self.gg_client_id)
 
-        # Add GG-specific params
-        params.setdefault("auth_mode", "ggshield_login")
+        # Add GG-specific params. "oauth2_login" is the canonical auth_mode the
+        # dashboard expects; "ggshield_login" is its still-accepted legacy alias.
+        params.setdefault("auth_mode", "oauth2_login")
         params.setdefault("utm_source", "mcp")
         params.setdefault("utm_medium", "oauth_proxy")
 


### PR DESCRIPTION
## Summary

The OAuth proxy (`oauth_proxy_auth.py`) and the local CLI flow (`oauth.py`) sent `auth_mode=ggshield_login`. The dashboard's **canonical** value is `oauth2_login` (the dashboard frontend already accepts it and keeps `ggshield_login` as a legacy alias). Send the canonical value.

Ticket: [SI-3428](https://linear.app/gitguardian/issue/SI-3428-oauth-migrate-clients-to-authoauthauthorize-oauth2-login-auth-mode)

## Notes

- `auth_mode` is consumed by the dashboard `/auth/login` page, not the backend API — no backend change needed, and `ggshield_login` keeps working for backward compatibility.
- The `ggshield_oauth` **client_id** is unchanged (that's the ggshield CLI's identity, unrelated).
- Paired with a ward-runs-app frontend MR migrating `/auth/ggshield/authorize` → `/auth/oauth/authorize`.