### PR TITLE
fix(find-source-id): support remote git detection without local git binary

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/tools/find_current_source_id.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/find_current_source_id.py
@@ -6,9 +6,18 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from gg_api_core.settings import get_settings
 from gg_api_core.utils import get_client, parse_repo_url
 
 logger = logging.getLogger(__name__)
+
+GIT_REMOTE_SUGGESTION = (
+    "This MCP server runs remotely and cannot access your local filesystem or git repository. "
+    "To find the source_id for the current repository, run "
+    "`git config --get remote.origin.url` in the repository directory yourself "
+    "(e.g. with a shell/Bash tool), then call this tool again passing the output as the "
+    "`remote_url` argument."
+)
 
 
 class SourceCandidate(BaseModel):
@@ -34,6 +43,18 @@ class FindCurrentSourceIdResult(BaseModel):
     )
 
 
+class FindCurrentSourceIdSuggestion(BaseModel):
+    """Returned when the server cannot detect the repository itself.
+
+    The hosted (HTTP) server has no access to the user's filesystem or ``git``
+    binary, so it asks the calling agent to run git locally and call the tool
+    again with the resulting ``remote_url``.
+    """
+
+    suggestion: str = Field(description="Instructions for the agent to obtain the repository remote URL")
+    message: str = Field(description="User-friendly explanation of why detection could not run server-side")
+
+
 class FindCurrentSourceIdError(BaseModel):
     """Error result from finding source ID."""
 
@@ -44,23 +65,33 @@ class FindCurrentSourceIdError(BaseModel):
     suggestion: str | None = Field(default=None, description="Suggestions for resolving the error")
 
 
-async def find_current_source_id(repository_path: str = ".") -> FindCurrentSourceIdResult | FindCurrentSourceIdError:
+async def find_current_source_id(
+    repository_path: str = ".", remote_url: str | None = None
+) -> FindCurrentSourceIdResult | FindCurrentSourceIdError | FindCurrentSourceIdSuggestion:
     """
     Find the GitGuardian source_id for a repository.
 
     This tool:
-    1. Attempts to get the repository name from git remote URL
-    2. If git fails, falls back to using the directory name
-    3. Searches GitGuardian for matching sources
-    4. Returns the source_id if an exact match is found
-    5. If no exact match, returns all search results for the model to choose from
+    1. Determines the repository name from the git remote URL
+    2. Searches GitGuardian for matching sources
+    3. Returns the source_id if an exact match is found
+    4. If no exact match, returns all search results for the model to choose from
+
+    The remote URL is resolved as follows:
+    - If ``remote_url`` is passed, it is used directly (no git/filesystem access required).
+      This is the path to use against the hosted (HTTP) server, which has no access to your
+      local repository: run ``git config --get remote.origin.url`` yourself and pass the result.
+    - Otherwise, when running locally (stdio transport), the tool runs ``git`` in
+      ``repository_path`` and falls back to the directory name if git is unavailable.
+    - Otherwise, when running on the hosted server with no ``remote_url``, the tool returns a
+      suggestion asking the agent to obtain the remote URL and call again.
 
     Args:
         repository_path: Path to the repository directory. Defaults to "." (current directory).
-                        If you're working in a specific repository, provide the full path to ensure
-                        the correct repository is analyzed (e.g., "/home/user/my-project").
-                        Note: If the directory is not a git repository, the tool will use the
-                        directory name as the repository name.
+                        Only used when the tool runs git locally (stdio transport).
+        remote_url: The repository's git remote URL (e.g. the output of
+                    ``git config --get remote.origin.url``). Provide this when the server cannot
+                    access your local repository.
 
     Returns:
         FindCurrentSourceIdResult: Pydantic model containing:
@@ -70,6 +101,11 @@ async def find_current_source_id(repository_path: str = ".") -> FindCurrentSourc
             - message: Status or informational message
             - suggestion: Suggestions for next steps
             - candidates: List of SourceCandidate objects (if no exact match but potential matches found)
+
+        FindCurrentSourceIdSuggestion: Pydantic model returned when the server cannot detect the
+            repository itself and needs the agent to run git locally:
+            - suggestion: Instructions to obtain the remote URL and call again
+            - message: Explanation of why detection could not run server-side
 
         FindCurrentSourceIdError: Pydantic model containing:
             - error: Error message
@@ -82,38 +118,55 @@ async def find_current_source_id(repository_path: str = ".") -> FindCurrentSourc
     logger.debug(f"Finding source_id for repository at path: {repository_path}")
 
     repository_name = None
-    remote_url = None
     detection_method = None
 
     try:
-        # Try Method 1: Get repository name from git remote URL
-        try:
-            result = subprocess.run(
-                ["git", "config", "--get", "remote.origin.url"],
-                capture_output=True,
-                text=True,
-                check=True,
-                timeout=5,
-                cwd=repository_path,
-            )
-            remote_url = result.stdout.strip()
+        if remote_url is not None:
+            # Caller already resolved the remote URL (e.g. ran git locally). Use it directly.
             parsed_url = parse_repo_url(remote_url)
-            if parsed_url:
-                repository_name = parsed_url.split("/")[-1]
-            else:
-                repository_name = None
-            detection_method = "git remote URL"
-            logger.debug(f"Found remote URL: {remote_url}, parsed repository name: {repository_name}")
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-            logger.debug(f"Git remote detection failed: {e}, falling back to directory name")
+            repository_name = parsed_url.split("/")[-1] if parsed_url else None
+            detection_method = "provided remote URL"
+            logger.debug(f"Using provided remote URL: {remote_url}, parsed repository name: {repository_name}")
+        elif get_settings().mcp_port:
+            # Hosted (HTTP) transport: no access to the user's filesystem or git binary.
+            # Ask the agent to resolve the remote URL locally and call again.
+            logger.info("No remote_url provided on HTTP transport; returning suggestion to run git locally")
+            return FindCurrentSourceIdSuggestion(
+                suggestion=GIT_REMOTE_SUGGESTION,
+                message="The repository could not be detected server-side.",
+            )
+        else:
+            # Local (stdio) transport: detect the repository name from git, like before.
+            try:
+                result = subprocess.run(
+                    ["git", "config", "--get", "remote.origin.url"],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    timeout=5,
+                    cwd=repository_path,
+                )
+                detected_url = result.stdout.strip()
+                parsed_url = parse_repo_url(detected_url)
+                repository_name = parsed_url.split("/")[-1] if parsed_url else None
+                detection_method = "git remote URL"
+                logger.debug(f"Found remote URL: {detected_url}, parsed repository name: {repository_name}")
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as e:
+                logger.debug(f"Git remote detection failed: {e}, falling back to directory name")
 
-            # Fallback Method 2: Use the directory name as repository name
-            abs_path = os.path.abspath(repository_path)
-            repository_name = Path(abs_path).name
-            detection_method = "directory name"
-            logger.info(f"Using directory name as repository name: {repository_name}")
+                # Fallback: Use the directory name as repository name
+                abs_path = os.path.abspath(repository_path)
+                repository_name = Path(abs_path).name
+                detection_method = "directory name"
+                logger.info(f"Using directory name as repository name: {repository_name}")
 
         if not repository_name:
+            if detection_method == "provided remote URL":
+                return FindCurrentSourceIdError(
+                    error="Could not determine repository name",
+                    message=f"The provided remote_url '{remote_url}' could not be parsed into a repository name.",
+                    suggestion="Provide a valid git remote URL (e.g. the output of `git config --get remote.origin.url`).",
+                )
             return FindCurrentSourceIdError(
                 error="Could not determine repository name",
                 message="Failed to determine repository name from both git remote and directory name.",

--- a/packages/gg_mcp_server/src/gg_mcp_server/register_tools.py
+++ b/packages/gg_mcp_server/src/gg_mcp_server/register_tools.py
@@ -187,9 +187,11 @@ def register_tools(mcp: AbstractGitGuardianFastMCP) -> None:
     mcp.tool(
         find_current_source_id,
         description="(Internal sources only) Find the GitGuardian source_id for the current repository in the workspace's "
-        "internal perimeter. This tool automatically detects the current git repository and searches for its source_id "
-        "among the sources the workspace monitors. Useful when you need to reference the repository in other internal-incident "
-        "API calls. Does not apply to public GitHub / Public Monitoring.",
+        "internal perimeter, searching among the sources the workspace monitors. Useful when you need to reference the "
+        "repository in other internal-incident API calls. This server runs remotely and cannot access your local "
+        "repository: run `git config --get remote.origin.url` yourself and pass the result as the `remote_url` argument. "
+        "If you call it without `remote_url`, it returns a suggestion telling you to do exactly that. "
+        "Does not apply to public GitHub / Public Monitoring.",
         required_scopes=["sources:read"],
     )
 

--- a/tests/tools/test_find_current_source_id.py
+++ b/tests/tools/test_find_current_source_id.py
@@ -2,7 +2,11 @@ import subprocess
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from gg_api_core.tools.find_current_source_id import find_current_source_id
+from gg_api_core.tools.find_current_source_id import (
+    FindCurrentSourceIdError,
+    FindCurrentSourceIdSuggestion,
+    find_current_source_id,
+)
 
 
 class TestFindCurrentSourceId:
@@ -397,3 +401,90 @@ class TestFindCurrentSourceId:
             assert hasattr(result, "error")
             assert "not found in GitGuardian" in result.error
             assert "directory name" in result.message
+
+    @pytest.mark.asyncio
+    async def test_find_current_source_id_with_remote_url_skips_git(self, mock_gitguardian_client):
+        """
+        GIVEN: A remote_url is passed explicitly (e.g. resolved by the calling agent)
+        WHEN: Finding the source_id
+        THEN: The git subprocess is not invoked and the URL is parsed directly
+        """
+        mock_response = {
+            "id": "source_remote",
+            "full_name": "GitGuardian/ggmcp",
+            "url": "https://github.com/GitGuardian/ggmcp",
+        }
+        mock_gitguardian_client.get_source_by_name = AsyncMock(return_value=mock_response)
+
+        with patch("subprocess.run") as mock_run:
+            result = await find_current_source_id(remote_url="https://github.com/GitGuardian/ggmcp.git")
+
+            # git must not be called when the remote URL is provided
+            mock_run.assert_not_called()
+
+        mock_gitguardian_client.get_source_by_name.assert_called_once_with("ggmcp", return_all_on_no_match=True)
+        assert result.repository_name == "ggmcp"
+        assert result.source_id == "source_remote"
+
+    @pytest.mark.asyncio
+    async def test_find_current_source_id_with_empty_remote_url(self, mock_gitguardian_client):
+        """
+        GIVEN: An empty remote_url that cannot be parsed into a repository name
+        WHEN: Finding the source_id
+        THEN: An error explaining the bad remote_url is returned
+        """
+        with patch("subprocess.run") as mock_run:
+            result = await find_current_source_id(remote_url="")
+            mock_run.assert_not_called()
+
+        assert isinstance(result, FindCurrentSourceIdError)
+        assert "could not be parsed" in result.message
+
+    @pytest.mark.asyncio
+    async def test_find_current_source_id_http_transport_returns_suggestion(self, mock_gitguardian_client):
+        """
+        GIVEN: The server runs over HTTP transport (mcp_port set) and no remote_url is provided
+        WHEN: Finding the source_id
+        THEN: A suggestion is returned asking the agent to run git locally, without touching subprocess
+        """
+        with (
+            patch("gg_api_core.tools.find_current_source_id.get_settings") as mock_settings,
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_settings.return_value = MagicMock(mcp_port="8000")
+
+            result = await find_current_source_id()
+
+            mock_run.assert_not_called()
+
+        assert isinstance(result, FindCurrentSourceIdSuggestion)
+        assert "remote_url" in result.suggestion
+        assert "git config --get remote.origin.url" in result.suggestion
+
+    @pytest.mark.asyncio
+    async def test_find_current_source_id_git_binary_missing_fallback(self, mock_gitguardian_client):
+        """
+        GIVEN: The git binary is not installed (FileNotFoundError) on stdio transport
+        WHEN: Finding the source_id without a remote_url
+        THEN: The tool falls back to the directory name instead of crashing
+        """
+        with (
+            patch("subprocess.run") as mock_run,
+            patch("os.path.abspath") as mock_abspath,
+            patch("pathlib.Path") as mock_path,
+        ):
+            mock_run.side_effect = FileNotFoundError(2, "No such file or directory: 'git'")
+            mock_abspath.return_value = "/some/path/no-git-repo"
+
+            mock_path_instance = MagicMock()
+            mock_path_instance.name = "no-git-repo"
+            mock_path.return_value = mock_path_instance
+
+            mock_response = {"id": "source_nogit", "full_name": "org/no-git-repo"}
+            mock_gitguardian_client.get_source_by_name = AsyncMock(return_value=mock_response)
+
+            result = await find_current_source_id()
+
+        assert result.repository_name == "no-git-repo"
+        assert result.source_id == "source_nogit"
+        assert "directory name" in result.message


### PR DESCRIPTION
## Context

Closes [SI-3440](https://linear.app/gitguardian/issue/SI-3440).

`find_current_source_id` shelled out to `git config --get remote.origin.url` via `subprocess`. This worked when `ggmcp` ran locally over **stdio**, but now that we're moving users to the **hosted HTTP server**, the code runs on our server — where there is no `git` binary and no access to the user's repository. The subprocess raised `FileNotFoundError` (the Sentry crash), and even the directory-name fallback was meaningless server-side.

## Change

- Add an optional `remote_url` parameter. When provided, the tool parses it directly (server-side `parse_repo_url` stays the single source of truth) and skips any subprocess — this is the path the hosted agent takes after running git itself via Bash.
- When `remote_url` is missing **on HTTP transport**, return a new `FindCurrentSourceIdSuggestion` instructing the agent to run `git config --get remote.origin.url` locally and call again with the result.
- **stdio transport is unchanged**: the tool still runs git locally and falls back to the directory name (backward compatible for now).
- Defense-in-depth: the subprocess fallback now also catches `FileNotFoundError` (the original crash) in addition to `CalledProcessError`/`TimeoutExpired`.
- Updated the registered tool description so the LLM knows to pass `remote_url`.

## Tests

Added coverage for: explicit `remote_url` (git not invoked), empty/unparseable `remote_url`, HTTP-transport suggestion path, and the `FileNotFoundError` fallback. All existing stdio tests pass unchanged.