### PR TITLE
feat(release): publish semver Docker tags driven by the pyproject.toml version

### DIFF
--- a/.claude/skills/docker-image-tags/SKILL.md
+++ b/.claude/skills/docker-image-tags/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: docker-image-tags
+description: How releases and Docker image tags work for ghcr.io/gitguardian/mcp-server. Triggers when releasing a new version, changing release.yml, building an image from a branch, or answering "which tag should I deploy / what does latest point to".
+---
+
+# Releases and Docker image tags
+
+Releases are **version-driven, not commit-message-driven**: a release happens
+when a merge to `main` changes `[project] version` in `pyproject.toml`
+(`X.Y.Z` semver enforced). The `tag-version` job in
+`.github/workflows/release.yml` then creates the `vX.Y.Z` git tag, and the
+same workflow run builds the image and creates the GitHub release. CI never
+pushes commits to `main`.
+
+## Tag matrix
+
+| Event | Image tags pushed | Git tag / GitHub release |
+|---|---|---|
+| Merge to `main` **with** version bump | `X.Y.Z`, `X.Y`, `latest`, `main` | `vX.Y.Z` + release |
+| Merge to `main` **without** version bump | `main` | — |
+| `workflow_dispatch` from a non-main branch | `<branch>`, `<branch>-<sha>` | — |
+| Human-pushed `v*.*.*` git tag | `X.Y.Z`, `X.Y`, `latest`, `main` | release |
+
+## Tag semantics
+
+- `latest` — most recent **release** (NOT tip of main). Helm chart defaults use it.
+- `main` — rolling dev image, tip of `main`, release or not. For preprod/smoke-testing.
+- `X.Y.Z` — immutable release tags. Production pins these; Renovate (in GitLab
+  `applications-configurations`, `gim/*/values-1-gim.yaml`) tracks them with
+  strict semver, which ignores `latest`, `main`, `X.Y` and branch tags.
+
+## Gotchas
+
+- To release: bump the version (and `CHANGELOG.md`) in the PR — `cz bump
+  --files-only` does both without committing or tagging. Merging triggers
+  everything.
+- Tags created in CI with `GITHUB_TOKEN` do not trigger workflows: the Docker
+  build must stay in the same workflow run as `tag-version` (a `needs:`
+  dependency), never behind an `on: push: tags` trigger.
+- The `create-github-release` job must stay gated on a release tag existing —
+  no-bump main pushes still build the `main` image and would otherwise try to
+  create a release with an empty tag name.
+- Never tag images with versions that outrank semver releases (e.g. a
+  CalVer-looking `2026.6.0`): Renovate's semver ordering would consider every
+  real `0.x.y` release "older" and stop proposing updates.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,16 +62,20 @@ jobs:
     # Two entry points: a version tag pushed by a human, or a tag freshly
     # created by tag-version (tags pushed with GITHUB_TOKEN do not trigger
     # workflows, hence the same-run dependency instead of a tag trigger).
+    # Manual dispatch from a non-main branch builds a <branch>-<sha> image
+    # (no semver, no latest) for testing.
     if: |
       always() &&
       (
         (github.event_name == 'push' && github.ref_type == 'tag') ||
-        needs.tag-version.outputs.tagged == 'true'
+        needs.tag-version.outputs.tagged == 'true' ||
+        (github.event_name == 'workflow_dispatch' && github.ref_type == 'branch' && github.ref != 'refs/heads/main')
       )
     permissions:
       contents: read
       packages: write
     env:
+      # Empty on branch dispatch: switches image tags to <branch>/<branch>-<sha>.
       RELEASE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || needs.tag-version.outputs.tag }}
 
     steps:
@@ -96,9 +100,11 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=semver,pattern={{version}},value=${{ env.RELEASE_TAG }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ env.RELEASE_TAG }}
-            type=raw,value=latest
+            type=semver,pattern={{version}},value=${{ env.RELEASE_TAG || 'v0.0.0' }},enable=${{ env.RELEASE_TAG != '' }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ env.RELEASE_TAG || 'v0.0.0' }},enable=${{ env.RELEASE_TAG != '' }}
+            type=raw,value=latest,enable=${{ env.RELEASE_TAG != '' }}
+            type=ref,event=branch,enable=${{ env.RELEASE_TAG == '' }}
+            type=sha,prefix={{branch}}-,enable=${{ env.RELEASE_TAG == '' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,20 +63,23 @@ jobs:
     # created by tag-version (tags pushed with GITHUB_TOKEN do not trigger
     # workflows, hence the same-run dependency instead of a tag trigger).
     # Manual dispatch from a non-main branch builds a <branch>-<sha> image
-    # (no semver, no latest) for testing.
+    # (no semver, no latest) for testing. Every push to main also refreshes
+    # the mutable `main` tag (rolling dev image), release or not.
     if: |
       always() &&
       (
         (github.event_name == 'push' && github.ref_type == 'tag') ||
         needs.tag-version.outputs.tagged == 'true' ||
-        (github.event_name == 'workflow_dispatch' && github.ref_type == 'branch' && github.ref != 'refs/heads/main')
+        github.ref == 'refs/heads/main' ||
+        (github.event_name == 'workflow_dispatch' && github.ref_type == 'branch')
       )
     permissions:
       contents: read
       packages: write
     env:
-      # Empty on branch dispatch: switches image tags to <branch>/<branch>-<sha>.
+      # Empty outside releases: switches image tags to main / <branch>-<sha>.
       RELEASE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || needs.tag-version.outputs.tag }}
+      IS_MAIN: ${{ github.ref == 'refs/heads/main' }}
 
     steps:
       - name: Checkout repository
@@ -103,8 +106,9 @@ jobs:
             type=semver,pattern={{version}},value=${{ env.RELEASE_TAG || 'v0.0.0' }},enable=${{ env.RELEASE_TAG != '' }}
             type=semver,pattern={{major}}.{{minor}},value=${{ env.RELEASE_TAG || 'v0.0.0' }},enable=${{ env.RELEASE_TAG != '' }}
             type=raw,value=latest,enable=${{ env.RELEASE_TAG != '' }}
-            type=ref,event=branch,enable=${{ env.RELEASE_TAG == '' }}
-            type=sha,prefix={{branch}}-,enable=${{ env.RELEASE_TAG == '' }}
+            type=raw,value=main,enable=${{ env.IS_MAIN == 'true' }}
+            type=ref,event=branch,enable=${{ env.RELEASE_TAG == '' && env.IS_MAIN != 'true' }}
+            type=sha,prefix={{branch}}-,enable=${{ env.RELEASE_TAG == '' && env.IS_MAIN != 'true' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -245,8 +249,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Create GitHub Release
     needs: [ tag-version, build-and-push-docker, publish-to-pypi ]
+    # The release-tag guard matters: main pushes without a version bump still
+    # build the rolling `main` image but must not create a GitHub release.
     if: |
       always() &&
+      (github.ref_type == 'tag' || needs.tag-version.outputs.tagged == 'true') &&
       needs.build-and-push-docker.result == 'success' &&
       (needs.publish-to-pypi.result == 'success' || needs.publish-to-pypi.result == 'skipped')
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,18 +12,73 @@ env:
   IMAGE_NAME: mcp-server
   REGISTRY: ghcr.io
 
+# Serialize releases: two merges close together must tag sequentially.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  build-and-push-docker:
+  tag-version:
     runs-on: ubuntu-latest
-    name: Build and Push Docker Image
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref_type == 'tag' || github.ref == 'refs/heads/main'))
+    name: Tag New Version
+    # A release happens when a merge on main changes the version in
+    # pyproject.toml. Manual dispatch from main re-runs the same check.
+    if: |
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     permissions:
-      contents: read
-      packages: write
+      contents: write
+    outputs:
+      tagged: ${{ steps.tag.outputs.tagged }}
+      tag: ${{ steps.tag.outputs.tag }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+
+      - name: Tag if pyproject.toml version is new
+        id: tag
+        run: |
+          version=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          if ! echo "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::pyproject.toml version '$version' is not X.Y.Z semver"
+            exit 1
+          fi
+          tag="v${version}"
+          if [ -n "$(git ls-remote --tags origin "refs/tags/${tag}")" ]; then
+            echo "Tag ${tag} already exists, nothing to release."
+            echo "tagged=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git tag "${tag}"
+          git push origin "refs/tags/${tag}"
+          echo "tagged=true" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+  build-and-push-docker:
+    runs-on: ubuntu-latest
+    name: Build and Push Docker Image
+    needs: [ tag-version ]
+    # Two entry points: a version tag pushed by a human, or a tag freshly
+    # created by tag-version (tags pushed with GITHUB_TOKEN do not trigger
+    # workflows, hence the same-run dependency instead of a tag trigger).
+    if: |
+      always() &&
+      (
+        (github.event_name == 'push' && github.ref_type == 'tag') ||
+        needs.tag-version.outputs.tagged == 'true'
+      )
+    permissions:
+      contents: read
+      packages: write
+    env:
+      RELEASE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || needs.tag-version.outputs.tag }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_type == 'tag' && github.ref_name || needs.tag-version.outputs.tag }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -41,14 +96,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,prefix={{branch}}-
-            type=sha,prefix={{branch}}-,suffix=-${{ github.run_number }},enable={{is_default_branch}}
+            type=semver,pattern={{version}},value=${{ env.RELEASE_TAG }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ env.RELEASE_TAG }}
+            type=raw,value=latest
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -188,12 +238,10 @@ jobs:
   create-github-release:
     runs-on: ubuntu-latest
     name: Create GitHub Release
-    needs: [ build-and-push-docker, publish-to-pypi ]
+    needs: [ tag-version, build-and-push-docker, publish-to-pypi ]
     if: |
       always() &&
-      github.event_name == 'push' &&
-      github.ref_type == 'tag' &&
-      (needs.build-and-push-docker.result == 'success' || needs.build-and-push-docker.result == 'skipped') &&
+      needs.build-and-push-docker.result == 'success' &&
       (needs.publish-to-pypi.result == 'success' || needs.publish-to-pypi.result == 'skipped')
     permissions:
       contents: write
@@ -201,10 +249,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_type == 'tag' && github.ref_name || needs.tag-version.outputs.tag }}
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.ref_type == 'tag' && github.ref_name || needs.tag-version.outputs.tag }}
           draft: false
           generate_release_notes: true
           make_latest: true

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -293,8 +293,8 @@ This project uses semantic versioning. To release, bump `[project] version`
 in `pyproject.toml` (and update `CHANGELOG.md`) in your PR. When it merges to
 `main`, the `tag-version` job in `.github/workflows/release.yml` tags
 `vX.Y.Z` and publishes the Docker image (`X.Y.Z`, `X.Y`, `latest`). Merges
-that don't change the version release nothing. See `PUBLISHING.md` for
-manual fallbacks.
+that don't change the version only refresh the rolling `main` image tag.
+See `PUBLISHING.md` for manual fallbacks.
 
 ## Python 3.13 Features
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -289,12 +289,12 @@ secrets before allowing commits and pushes.
 
 ## Releasing
 
-This project uses semantic versioning. To release a new version:
-
-1. Update the version in `pyproject.toml`
-2. Update the CHANGELOG.md file
-3. Tag the release in git
-4. Build and publish the package
+This project uses semantic versioning. To release, bump `[project] version`
+in `pyproject.toml` (and update `CHANGELOG.md`) in your PR. When it merges to
+`main`, the `tag-version` job in `.github/workflows/release.yml` tags
+`vX.Y.Z` and publishes the Docker image (`X.Y.Z`, `X.Y`, `latest`). Merges
+that don't change the version release nothing. See `PUBLISHING.md` for
+manual fallbacks.
 
 ## Python 3.13 Features
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -50,6 +50,27 @@ The workflow needs these permissions (already configured in the workflow):
 - `id-token: write` - For PyPI trusted publishing
 - `contents: write` - For creating GitHub releases
 
+## Docker Image Tag Matrix
+
+What `release.yml` pushes to `ghcr.io/gitguardian/mcp-server`, per event:
+
+| Event | Image tags pushed | Git tag / GitHub release |
+|---|---|---|
+| Merge to `main` **with** `pyproject.toml` version bump | `X.Y.Z`, `X.Y`, `latest`, `main` | `vX.Y.Z` + release |
+| Merge to `main` **without** version bump | `main` | — |
+| `workflow_dispatch` from a non-main branch | `<branch>`, `<branch>-<sha>` | — |
+| Human-pushed `v*.*.*` git tag | `X.Y.Z`, `X.Y`, `latest`, `main` | release |
+
+Semantics:
+
+- **`latest`** — most recent release. Only moves when a version is released.
+  This is what the Helm chart defaults point at.
+- **`main`** — rolling dev image, tip of the `main` branch (release or not).
+  Use for preprod/smoke-testing ahead of releases.
+- **`X.Y.Z`** — immutable release tags. Production pins these (Renovate
+  tracks them with strict semver, which ignores `latest`, `main`, `X.Y`
+  and branch tags).
+
 ## Publishing a New Version
 
 ### Method 1: Bump the version in pyproject.toml (Default)

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -52,7 +52,21 @@ The workflow needs these permissions (already configured in the workflow):
 
 ## Publishing a New Version
 
-### Method 1: Using commitizen (Recommended)
+### Method 1: Bump the version in pyproject.toml (Default)
+
+A release is triggered by changing `[project] version` in `pyproject.toml`
+and merging to `main`. The `tag-version` job in `release.yml` then:
+
+- reads the version from `pyproject.toml` and checks it is `X.Y.Z` semver
+- if the tag `vX.Y.Z` does not exist yet, creates and pushes it
+- the same workflow run builds and pushes the Docker image tagged
+  `X.Y.Z`, `X.Y`, and `latest`, and creates the GitHub release
+- merges that don't touch the version are no-ops (no tag, no image)
+
+So: bump the version (and ideally `CHANGELOG.md`) in your PR — you can use
+`cz bump --files-only` to do both — merge, and watch the Release workflow.
+
+### Method 2: Using commitizen manually
 
 ```bash
 # Bump version and create tag
@@ -68,7 +82,7 @@ This will:
 - Create a git tag (`v0.5.1`, etc.)
 - Trigger the publish workflow
 
-### Method 2: Manual Tag
+### Method 3: Manual Tag
 
 ```bash
 # Update version in pyproject.toml manually
@@ -77,7 +91,7 @@ git tag v0.5.1
 git push origin v0.5.1
 ```
 
-### Method 3: Manual Workflow Trigger
+### Method 4: Manual Workflow Trigger
 
 For testing or special cases:
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -61,7 +61,8 @@ and merging to `main`. The `tag-version` job in `release.yml` then:
 - if the tag `vX.Y.Z` does not exist yet, creates and pushes it
 - the same workflow run builds and pushes the Docker image tagged
   `X.Y.Z`, `X.Y`, and `latest`, and creates the GitHub release
-- merges that don't touch the version are no-ops (no tag, no image)
+- merges that don't touch the version only refresh the mutable `main`
+  image tag (rolling dev image — never `latest`, no git tag, no release)
 
 So: bump the version (and ideally `CHANGELOG.md`) in your PR — you can use
 `cz bump --files-only` to do both — merge, and watch the Release workflow.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -95,12 +95,13 @@ git push origin v0.5.1
 
 For testing or special cases:
 
-1. Go to: https://github.com/GitGuardian/ggmcp/actions/workflows/publish.yml
-2. Click "Run workflow"
-3. Choose options:
-   - ✅ Publish to PyPI
-   - ✅ Publish to MCP Registry
-4. Click "Run workflow"
+1. Go to: https://github.com/GitGuardian/ggmcp/actions/workflows/release.yml
+2. Click "Run workflow" and pick a ref:
+   - **a branch other than `main`**: builds and pushes a test image tagged
+     `<branch>` and `<branch>-<short-sha>` (no semver tags, no `latest`,
+     no git tag, no GitHub release)
+   - **`main`**: re-runs the release check (tags and publishes only if the
+     `pyproject.toml` version has no `vX.Y.Z` tag yet)
 
 ## What Happens During Publishing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ggmcp"
-version = "0.5.0"
+version = "0.6.0"
 description = "MCP server for GitGuardian"
 authors = [
     { name = "GitGuardian", email = "support@gitguardian.com" },
@@ -37,7 +37,7 @@ dependencies = [
     "gg-mcp-server",
     "developer-mcp-server",
     "secops-mcp-server",
-    "mcp~=1.24",  # CVE-2025-66416 / GHSA-9h52-p55h-vw2f: DNS rebinding vulnerability
+    "mcp~=1.24", # CVE-2025-66416 / GHSA-9h52-p55h-vw2f: DNS rebinding vulnerability
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,8 +138,8 @@ pretty = true
 [tool.commitizen]
 name = "cz_conventional_commits"
 tag_format = "v$version"
+# Read and bump [project] version directly (without this, cz bump fails with
+# NO_VERSION_SPECIFIED and makes version_files redundant).
+version_provider = "pep621"
 update_changelog_on_bump = true
 gpg_sign = true
-version_files = [
-    "pyproject.toml:version",
-]


### PR DESCRIPTION
## What

Replaces the `main-<sha>-<run>` Docker image tags with explicit semver releases.

**Release trigger: bump `[project] version` in `pyproject.toml` in your PR.** When it merges to `main`, the new `tag-version` job:

- reads the version from `pyproject.toml` (fails if not `X.Y.Z` semver)
- if tag `vX.Y.Z` doesn't exist yet, creates and pushes it (tag only — CI never pushes commits to `main`)
- the same workflow run builds the Docker image tagged `X.Y.Z`, `X.Y`, `latest` and creates the GitHub release (tags pushed with `GITHUB_TOKEN` don't trigger workflows, hence the same-run dependency)
- merges that don't change the version only refresh the mutable `main` image tag (rolling dev image, separate from `latest` which only moves on releases)

<img width="738" height="199" alt="image" src="https://github.com/user-attachments/assets/2bf70668-5bd4-449b-b909-d7afdef1f36c" />

## Commitizen config fix (drive-by)

`version_provider = "pep621"` was missing: any `cz bump` failed with `NO_VERSION_SPECIFIED` before this PR. Verified working (`0.5.0 → 0.6.0`).

## Deployment side (separate, after merge)

In `applications-configurations`, switch `gim/prod/values-1-gim.yaml` and `gim/prod-eu/values-1-gim.yaml` to the existing semver-capable Renovate convention:

```yaml
    # renovate-docker-generic: depName=gitguardian/mcp-server registry=https://ghcr.io versioning=semver
    tag: 0.6.0  # first CI-released version (pyproject is bumped to 0.6.0 in this PR)
```

Strict semver versioning makes Renovate ignore `latest`, `main`, `X.Y` and the old `main-*` tags. The existing no-automerge prod packageRule matches on depName and keeps working.

Note: a manually pushed `2026.6.0` tag briefly existed on ghcr.io and has been deleted — it would have outranked `0.x.y` under semver ordering and blocked Renovate updates.


