### PR TITLE
feat(list_incidents): surface silently-applied default filters

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/tools/list_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_incidents.py
@@ -152,9 +152,41 @@ def _build_filter_info(params: "ListIncidentsParams") -> dict[str, Any]:
     return filters
 
 
+def _build_default_filters_notice(params: "ListIncidentsParams") -> list[str]:
+    """Describe the noise-reducing default filters still in effect.
+
+    These filters are applied silently when the caller does not override them, so
+    the result set is narrower than "all incidents". We surface them explicitly so
+    the agent can tell the user what is being hidden behind the scenes and avoid
+    misreporting the defaults as a real discrepancy.
+    """
+    notices: list[str] = []
+
+    if params.validity == DEFAULT_VALIDITIES:
+        notices.append("Invalid secrets are hidden (validity 'invalid' excluded)")
+    if params.severity == DEFAULT_SEVERITIES:
+        notices.append("LOW and INFO severity incidents are hidden")
+    if params.exclude_tags == DEFAULT_EXCLUDED_TAGS:
+        notices.append(
+            "Incidents tagged TEST_FILE, FALSE_POSITIVE, or CHECK_RUN_SKIP_* are hidden"
+        )
+    if params.status == DEFAULT_STATUSES:
+        notices.append("IGNORED incidents are hidden")
+
+    return notices
+
+
 def _build_suggestion(params: "ListIncidentsParams", incidents_count: int) -> str:
     """Build a suggestion message based on applied filters and results."""
     suggestions = []
+
+    default_notices = _build_default_filters_notice(params)
+    if default_notices:
+        suggestions.append(
+            "This list is filtered by default to reduce noise. Tell the user these "
+            "incidents are NOT shown: " + "; ".join(default_notices) + ". "
+            "To include them, override the validity, severity, exclude_tags, or status filters."
+        )
 
     if params.mine:
         suggestions.append("Incidents are filtered to show only those assigned to current user")
@@ -469,6 +501,15 @@ class ListIncidentsResult(BaseModel):
         description="True if results were truncated due to size limit (only relevant when get_all=True)",
     )
     applied_filters: dict[str, Any] = Field(default_factory=dict, description="Filters that were applied to the query")
+    active_default_filters: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Human-readable list of noise-reducing default filters silently applied "
+            "(e.g. invalid secrets, LOW/INFO severity, TEST_FILE/FALSE_POSITIVE tags, "
+            "IGNORED incidents). The agent should disclose these to the user when listing "
+            "incidents so the filtered view is not mistaken for the full set."
+        ),
+    )
     suggestion: str = Field(default="", description="Suggestions for interpreting or modifying the results")
 
 
@@ -493,6 +534,12 @@ async def list_incidents(
      'TRIGGERED OR ASSIGNED'
     - Rich filtering options for detector types, secret categories, and public exposure
     - Returns detailed incident data including custom tags, vault metadata, and similar issue counts
+
+    Noise-reducing default filters are applied silently when not overridden: invalid
+    secrets, LOW/INFO severity, TEST_FILE/FALSE_POSITIVE/CHECK_RUN_SKIP_* tags, and
+    IGNORED incidents are excluded. These active defaults are reported in the
+    'active_default_filters' field and the 'suggestion' field; always disclose them to
+    the user so the filtered view is not mistaken for the complete set of incidents.
 
     Args:
         params: ListIncidentsParams model containing all filtering options.
@@ -708,6 +755,7 @@ async def list_incidents(
                 has_previous=False,
                 has_more=has_more,
                 applied_filters=_build_filter_info(params),
+                active_default_filters=_build_default_filters_notice(params),
                 suggestion=_build_suggestion(params, len(all_incidents)),
             )
         else:
@@ -732,6 +780,7 @@ async def list_incidents(
                 has_previous=has_previous,
                 has_more=False,
                 applied_filters=_build_filter_info(params),
+                active_default_filters=_build_default_filters_notice(params),
                 suggestion=_build_suggestion(params, len(incidents_data)),
             )
 

--- a/tests/tools/test_list_incidents.py
+++ b/tests/tools/test_list_incidents.py
@@ -9,6 +9,8 @@ from gg_api_core.tools.list_incidents import (
     DEFAULT_VALIDITIES,
     ListIncidentsParams,
     SeverityValues,
+    _build_default_filters_notice,
+    _build_suggestion,
 )
 
 
@@ -126,6 +128,77 @@ class TestListIncidentsParamsDefaults:
         params = ListIncidentsParams(exclude_tags=["CUSTOM_TAG"])
 
         assert params.exclude_tags == ["CUSTOM_TAG"]
+
+
+class TestDefaultFiltersNotice:
+    """Tests that silently-applied default filters are surfaced to the user."""
+
+    def test_notice_lists_all_default_exclusions(self):
+        """
+        GIVEN: No filters are overridden
+        WHEN: Building the default filters notice
+        THEN: All four noise-reducing defaults are reported
+        """
+        notices = _build_default_filters_notice(ListIncidentsParams())
+
+        assert any("Invalid secrets" in n for n in notices)
+        assert any("LOW and INFO" in n for n in notices)
+        assert any("TEST_FILE" in n and "FALSE_POSITIVE" in n for n in notices)
+        assert any("IGNORED" in n for n in notices)
+
+    def test_notice_omits_overridden_validity(self):
+        """
+        GIVEN: validity is explicitly overridden to include invalid secrets
+        WHEN: Building the default filters notice
+        THEN: The invalid-secrets notice is not reported
+        """
+        notices = _build_default_filters_notice(ListIncidentsParams(validity=["invalid"]))
+
+        assert not any("Invalid secrets" in n for n in notices)
+
+    def test_notice_omits_overridden_severity(self):
+        """
+        GIVEN: severity is explicitly overridden
+        WHEN: Building the default filters notice
+        THEN: The severity notice is not reported
+        """
+        notices = _build_default_filters_notice(
+            ListIncidentsParams(severity=[SeverityValues.LOW])
+        )
+
+        assert not any("LOW and INFO" in n for n in notices)
+
+    def test_notice_omits_overridden_exclude_tags(self):
+        """
+        GIVEN: exclude_tags is explicitly overridden to an empty list
+        WHEN: Building the default filters notice
+        THEN: The tag-exclusion notice is not reported
+        """
+        notices = _build_default_filters_notice(ListIncidentsParams(exclude_tags=[]))
+
+        assert not any("TEST_FILE" in n for n in notices)
+
+    def test_notice_omits_overridden_status(self):
+        """
+        GIVEN: status is explicitly overridden to include IGNORED
+        WHEN: Building the default filters notice
+        THEN: The IGNORED notice is not reported
+        """
+        notices = _build_default_filters_notice(ListIncidentsParams(status=["IGNORED"]))
+
+        assert not any("IGNORED" in n for n in notices)
+
+    def test_suggestion_leads_with_default_filter_disclosure(self):
+        """
+        GIVEN: Default filters are in effect
+        WHEN: Building the suggestion message
+        THEN: It explicitly tells the user which incidents are hidden behind the scenes
+        """
+        suggestion = _build_suggestion(ListIncidentsParams(), incidents_count=5)
+
+        assert "filtered by default" in suggestion
+        assert "Invalid secrets are hidden" in suggestion
+        assert "LOW and INFO severity incidents are hidden" in suggestion
 
 
 class TestListIncidentsParamsOtherDefaults:


### PR DESCRIPTION
## Why

When listing incidents, `list_incidents` silently applies noise-reducing default filters that narrow the result set without being clearly disclosed. A user can mistake the filtered view for the full set of incidents — e.g. an "Invalid" Stripe Keys incident visible in the UI is filtered out by default, looking like a discrepancy when it is just the default filters at work.

The silent defaults (when not overridden) exclude:
- **Invalid secrets** (`validity` excludes `invalid`)
- **LOW / INFO severity** incidents
- Incidents tagged **`TEST_FILE`, `FALSE_POSITIVE`, `CHECK_RUN_SKIP_*`**
- **IGNORED** incidents

## What

- Add `_build_default_filters_notice()` which reports each default exclusion **only while it is still in effect** (i.e. not overridden by the caller).
- Expose the result via a new structured `active_default_filters` field on `ListIncidentsResult`.
- Lead the `suggestion` message with an explicit disclosure instructing the agent to tell the user which incidents are hidden behind the scenes, and how to include them.
- Document the behavior in the tool docstring.

This ensures the agent always states that results are filtered — not displaying invalid/test/low-priority incidents — when listing incidents.

## Tests

- New `TestDefaultFiltersNotice` covering the full-defaults case, each per-filter override (notice correctly omitted), and the suggestion disclosure.
- `uv run pytest tests/tools/test_list_incidents.py` → 41 passed; VCR integration tests → 4 passed.