### PR TITLE
Send incident assignee filter as member id

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -2285,7 +2285,7 @@ class GitGuardianClient:
             ordering: Sort field (e.g., '-date' for newest first)
             search: Search term to filter incidents
             status: Filter by status (TRIGGERED, ASSIGNED, RESOLVED, IGNORED)
-            assignee_id: Filter by assignee ID(s), use 0 for unassigned
+            assignee_id: Filter by assignee member ID(s), use 0 for unassigned
             severity: Filter by severity level(s) - uses numeric values (10=critical, 20=high, etc.)
             score__ge: Filter incidents with score >= this value (0-100)
             score__le: Filter incidents with score <= this value (0-100)
@@ -2348,7 +2348,11 @@ class GitGuardianClient:
         if status:
             params["status__in"] = format_param(status)
         if assignee_id is not None:
-            params["assignee__in"] = format_param(assignee_id)
+            # assignee_id is a *member* id (the public-API identity). The MCP
+            # incidents endpoint resolves it to the underlying user id via the
+            # dedicated assignee_member_id filter; the raw assignee__in filter
+            # would expect a user id and silently match nothing.
+            params["assignee_member_id"] = format_param(assignee_id)
         if severity:
             params["severity__in"] = format_param(severity)
         if score__ge is not None:
@@ -2542,7 +2546,11 @@ class GitGuardianClient:
         if status:
             params["status__in"] = format_param(status)
         if assignee_id is not None:
-            params["assignee__in"] = format_param(assignee_id)
+            # assignee_id is a *member* id (the public-API identity). The MCP
+            # incidents endpoint resolves it to the underlying user id via the
+            # dedicated assignee_member_id filter; the raw assignee__in filter
+            # would expect a user id and silently match nothing.
+            params["assignee_member_id"] = format_param(assignee_id)
         if severity:
             params["severity__in"] = format_param(severity)
         if score__ge is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ggmcp"
-version = "0.6.2"
+version = "0.6.3"
 description = "MCP server for GitGuardian"
 authors = [
     { name = "GitGuardian", email = "support@gitguardian.com" },

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_unassigned.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_unassigned.yaml
@@ -17,10 +17,10 @@ interactions:
       X-Privacy-Mode:
       - 'true'
     method: GET
-    uri: https://api.gitguardian.com/v1/incidents-for-mcp?page=1&page_size=5&assignee__in=0
+    uri: https://api.gitguardian.com/v1/incidents-for-mcp?page=1&page_size=5&assignee_member_id=0
   response:
     body:
-      string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?assignee__in=0&page=2&page_size=5",
+      string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?assignee_member_id=0&page=2&page_size=5",
         "previous": null, "results": [{"id": 29487335, "account": 8, "criterion":
         "Stripe Webhook Secret", "date": "2026-04-02T16:22:33.518000Z", "last_trigger_published_at":
         "2026-04-02T16:22:33.518000Z", "last_triggered_at": "2026-04-02T16:22:34.233032Z",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -622,3 +622,55 @@ class TestCursorPagination:
         cursor = client._extract_next_cursor(headers)
 
         assert cursor is None
+
+
+class TestIncidentsForMCPAssigneeFilter:
+    """The MCP incidents endpoint identifies assignees by *member* id, which it
+    resolves to user ids server-side via the dedicated assignee_member_id filter.
+    The client must therefore send assignee_member_id, not the raw assignee__in
+    filter (which expects a user id and would silently match nothing)."""
+
+    @pytest.mark.asyncio
+    async def test_list_incidents_for_mcp_maps_assignee_to_member_id(self, client):
+        """
+        GIVEN an assignee_id (a member id)
+        WHEN calling list_incidents_for_mcp
+        THEN the request uses the assignee_member_id query param, not assignee__in
+        """
+        client._request_get = AsyncMock(return_value={"results": []})
+
+        await client.list_incidents_for_mcp(assignee_id=938094)
+
+        params = client._request_get.call_args.kwargs["params"]
+        assert params["assignee_member_id"] == "938094"
+        assert "assignee__in" not in params
+
+    @pytest.mark.asyncio
+    async def test_count_incidents_for_mcp_maps_assignee_to_member_id(self, client):
+        """
+        GIVEN an assignee_id (a member id)
+        WHEN calling count_incidents_for_mcp
+        THEN the request uses the assignee_member_id query param, not assignee__in
+        """
+        client._request_get = AsyncMock(return_value={"count": 0})
+
+        await client.count_incidents_for_mcp(assignee_id=938094)
+
+        params = client._request_get.call_args.kwargs["params"]
+        assert params["assignee_member_id"] == "938094"
+        assert "assignee__in" not in params
+
+    @pytest.mark.asyncio
+    async def test_list_incidents_for_mcp_unassigned_uses_member_id_filter(self, client):
+        """
+        GIVEN assignee_id=0 (unassigned)
+        WHEN calling list_incidents_for_mcp
+        THEN the assignee_member_id query param carries the 0 sentinel
+        """
+        client._request_get = AsyncMock(return_value={"results": []})
+
+        await client.list_incidents_for_mcp(assignee_id=0)
+
+        params = client._request_get.call_args.kwargs["params"]
+        assert params["assignee_member_id"] == "0"
+        assert "assignee__in" not in params

--- a/tests/tools/test_list_incidents.py
+++ b/tests/tools/test_list_incidents.py
@@ -2,6 +2,9 @@
 Tests for the list_incidents tool.
 """
 
+from unittest.mock import AsyncMock, patch
+
+import pytest
 from gg_api_core.tools.list_incidents import (
     DEFAULT_EXCLUDED_TAGS,
     DEFAULT_SEVERITIES,
@@ -9,6 +12,7 @@ from gg_api_core.tools.list_incidents import (
     DEFAULT_VALIDITIES,
     ListIncidentsParams,
     SeverityValues,
+    list_incidents,
 )
 
 
@@ -414,3 +418,45 @@ class TestListIncidentsParamsCoercion:
         assert params.presence == ["present"]
         assert params.source_type == ["github"]
         assert params.source_criticality == ["high"]
+
+
+class TestListIncidentsMine:
+    """Tests for the 'mine' assignee filter."""
+
+    @pytest.mark.asyncio
+    async def test_mine_uses_current_member_id_as_assignee(self):
+        """
+        GIVEN: mine=True
+        WHEN: listing incidents
+        THEN: the current member's id is fetched and passed as assignee_id
+              (which the client maps to the assignee_member_id filter)
+        """
+        mock_client = AsyncMock()
+        mock_client.get_current_member.return_value = {"id": 938094}
+        mock_client.list_incidents_for_mcp.return_value = {"results": [], "next": None, "previous": None}
+
+        params = ListIncidentsParams(mine=True)
+
+        with patch("gg_api_core.tools.list_incidents.get_client", return_value=mock_client):
+            await list_incidents(params)
+
+        call_kwargs = mock_client.list_incidents_for_mcp.call_args.kwargs
+        assert call_kwargs["assignee_id"] == 938094
+
+    @pytest.mark.asyncio
+    async def test_mine_conflict_with_assignee_id(self):
+        """
+        GIVEN: mine=True and a conflicting explicit assignee_id
+        WHEN: listing incidents
+        THEN: an error is returned instead of a silent mismatch
+        """
+        mock_client = AsyncMock()
+        mock_client.get_current_member.return_value = {"id": 938094}
+
+        params = ListIncidentsParams(mine=True, assignee_id=50)
+
+        with patch("gg_api_core.tools.list_incidents.get_client", return_value=mock_client):
+            result = await list_incidents(params)
+
+        assert hasattr(result, "error")
+        mock_client.list_incidents_for_mcp.assert_not_called()


### PR DESCRIPTION
## Summary
`list_incidents` / `count_incidents` (and the `mine=true` filter) returned no results. The MCP passes the token's **member id** as `assignee_id`, but the client mapped it to the `incidents-for-mcp` `assignee__in` filter, which matches **user ids** — so it silently matched nothing, even though `get_incident` reports the same member id as the incident's `assignee_id`.

Fixes [SI-3486](https://linear.app/gitguardian/issue/SI-3486/mcp-list-by-mine-true-not-working).

## Changes
Route `assignee_id` to a new additive `assignee_member_id` query param on the `incidents-for-mcp` list/count endpoints, which the API resolves from member id to user id (consistent with the rest of the public API).

## ⚠️ Deployment ordering
Requires the companion **ward-runs-app** change ([!25837](https://gitlab.gitguardian.ovh/gg-code/prm/ward-runs-app/-/merge_requests/25837)) to be deployed **first**. django-filters silently ignores unknown query params, so an older API would drop the assignee filter and return over-broad (unfiltered) results during the rollout window.

## Testing
- Client-level tests assert `assignee_member_id` is sent (not `assignee__in`), including the `0`=unassigned case.
- Tool-level tests cover `mine=true` resolving the current member id and the mine/assignee_id conflict.
- Updated the affected VCR cassette.