### PR TITLE
fix(client): log handled 401/403 from API at warning, not error

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -546,7 +546,20 @@ class GitGuardianClient:
                             # If we can't parse the error response, continue with normal error handling
                             pass
 
-                logger.exception(f"HTTP error occurred: {e.response.status_code} - {e.response.reason_phrase}")
+                # 401/403 from the GitGuardian API are expected, handled client
+                # conditions — the caller's token is invalid/expired/revoked or
+                # lacks the required scope — not server faults. Log them at warning
+                # level so they do not surface as Sentry errors (logger.exception
+                # would). The 401 path still raises DownstreamUnauthorizedError,
+                # which middleware rewrites to an MCP 401 so clients can re-auth.
+                if e.response.status_code in (401, 403):
+                    logger.warning(
+                        f"GitGuardian API returned {e.response.status_code} "
+                        f"{e.response.reason_phrase} for {url} - token may be invalid, "
+                        "expired, revoked, or lacking the required scope"
+                    )
+                else:
+                    logger.exception(f"HTTP error occurred: {e.response.status_code} - {e.response.reason_phrase}")
                 logger.debug(f"Error response content: {e.response.text}")
                 logger.debug(f"Failed URL: {url}")
                 if e.response.status_code == 401:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -148,6 +148,44 @@ class TestGitGuardianClient:
                 await client._request_get("/test")
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("status_code", [401, 403])
+    async def test_request_auth_errors_logged_as_warning_not_error(
+        self, client, mock_httpx_client, caplog, status_code
+    ):
+        """Auth failures (401/403) are expected client conditions and must NOT be
+        logged at ERROR level, otherwise they surface as Sentry noise (GIM-MCP-SERVER-3)."""
+        import logging
+
+        from gg_api_core.client import DownstreamUnauthorizedError
+
+        mock_request = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = status_code
+        mock_response.reason_phrase = "Unauthorized" if status_code == 401 else "Forbidden"
+        mock_response.text = "auth error"
+        mock_response.json.return_value = {"detail": "Invalid API key."}
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            str(status_code), request=mock_request, response=mock_response
+        )
+
+        async_client_instance = AsyncMock()
+        async_client_instance.__aenter__.return_value = mock_httpx_client
+        mock_httpx_client.request = AsyncMock(return_value=mock_response)
+
+        # 401 is translated to DownstreamUnauthorizedError; 403 re-raises the original.
+        expected_exc = DownstreamUnauthorizedError if status_code == 401 else httpx.HTTPStatusError
+        with patch("httpx.AsyncClient", return_value=async_client_instance):
+            with caplog.at_level(logging.WARNING, logger="gg_api_core.client"):
+                with pytest.raises(expected_exc):
+                    await client._request_get("/test")
+
+        errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert not errors, f"auth {status_code} should not be logged at ERROR level: {errors}"
+        assert any(r.levelno == logging.WARNING and str(status_code) in r.getMessage() for r in caplog.records), (
+            "expected a WARNING log mentioning the auth status code"
+        )
+
+    @pytest.mark.asyncio
     async def test_create_honeytoken(self, client):
         """Test create_honeytoken method."""
         expected_response = {


### PR DESCRIPTION
## Problem

Sentry **GIM-MCP-SERVER-3** fires frequently (430+ occurrences, bursty — 236 in a single day) with:

> `HTTPStatusError: Client error '401 Unauthorized' for url '.../v1/api_tokens/self'`

These 401s are **expected and already handled** — the GitGuardian API correctly rejecting the user-supplied token. Coralogix shows the `invalid_reason` for MCP-server traffic is `revoked` (~103) and `token does not exist` (~112): users pointing the MCP server at revoked/deleted PATs. Every GitGuardian client (ggshield, satori, vscode) hits the same 401, so this is not server-side breakage.

## Root cause

In `gg_api_core/client.py` `_request()`, the 401 branch already logs a `warning` and raises `DownstreamUnauthorizedError` (middleware rewrites it to an MCP 401 so clients can re-auth). But execution then fell through to **`logger.exception(...)`** (ERROR + traceback), which the Sentry logging integration captures as an event.

Amplifier: in multi-tenant HTTP mode a fresh client is built per request with no cross-request cache, so `/api_tokens/self` is called on essentially every `list_tools`. One client looping with a bad token produces a burst of identical Sentry errors.

## Fix

- Log auth-status codes (401/403) at **warning** level instead of `logger.exception`. Keep `logger.exception` for genuine faults (5xx / unexpected).
- **Control flow is unchanged** — 401 still raises `DownstreamUnauthorizedError`, others still re-raise.

## Test

Added `test_request_auth_errors_logged_as_warning_not_error[401/403]` asserting no ERROR-level record is emitted and a WARNING mentioning the status code is. Full `test_client.py` (35 tests) passes; ruff + mypy clean.

## Notes

Sibling of **SI-3398** (same code path, 403 `service account but not business`).

Refs: SI-3525
Fixes GIM-MCP-SERVER-3