### PR TITLE
feat(tools): add get_remediation_workflow tool

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -2198,6 +2198,19 @@ class GitGuardianClient:
         logger.info(f"Getting member details for ID: {member_id}")
         return await self._request_get(f"/members/{member_id}")
 
+    async def get_remediation_workflow(self) -> dict[str, Any]:
+        """Get the workspace's remediation workflow.
+
+        Wraps GET /v1/remediation-workflow. Returns the account's custom
+        remediation workflow if one is configured, otherwise a default workflow.
+
+        Returns:
+            Remediation workflow data including the ordered ``steps`` and, for a
+            configured custom workflow, ``id``/``created_at``/``updated_at``.
+        """
+        logger.info("Getting remediation workflow")
+        return await self._request_get("/remediation-workflow")
+
     async def get_current_member(self):
         """Get the current user's information."""
         data = await self.get_current_token_info()

--- a/packages/gg_api_core/src/gg_api_core/tools/get_remediation_workflow.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/get_remediation_workflow.py
@@ -1,0 +1,49 @@
+import logging
+from typing import Any
+
+from fastmcp.exceptions import ToolError
+from pydantic import BaseModel, Field
+
+from gg_api_core.utils import get_client
+
+logger = logging.getLogger(__name__)
+
+
+class GetRemediationWorkflowResult(BaseModel):
+    """Result from retrieving the remediation workflow."""
+
+    workflow: dict[str, Any] = Field(description="Remediation workflow data")
+
+
+async def get_remediation_workflow() -> GetRemediationWorkflowResult:
+    """
+    Retrieve the remediation workflow for the current workspace.
+
+    This is the ordered, step-by-step remediation guidance shown for secret
+    incidents. It returns the workspace's custom remediation workflow when one
+    is configured, otherwise a default workflow.
+
+    Returns:
+        GetRemediationWorkflowResult: Pydantic model containing:
+            - workflow: Remediation workflow dictionary with:
+                - account_id: The workspace account identifier
+                - steps: Ordered list of remediation steps, each with a
+                  ``title`` and optional ``description`` and ``link``
+                  (``{"text"?, "url"}``)
+                - id, created_at, updated_at: Present only for a configured
+                  custom workflow (absent for the default workflow)
+
+    Raises:
+        ToolError: If the retrieval operation fails
+    """
+    client = await get_client()
+    logger.debug("Retrieving remediation workflow")
+
+    try:
+        response = await client.get_remediation_workflow()
+
+        logger.debug("Retrieved remediation workflow")
+        return GetRemediationWorkflowResult(workflow=response)
+    except Exception as e:
+        logger.exception(f"Error retrieving remediation workflow: {str(e)}")
+        raise ToolError(str(e))

--- a/packages/gg_mcp_server/src/gg_mcp_server/register_tools.py
+++ b/packages/gg_mcp_server/src/gg_mcp_server/register_tools.py
@@ -19,6 +19,7 @@ from gg_api_core.tools.generate_honey_token import generate_honeytoken
 from gg_api_core.tools.get_incident import get_incident
 from gg_api_core.tools.get_member import get_member
 from gg_api_core.tools.get_public_incident import get_public_incident
+from gg_api_core.tools.get_remediation_workflow import get_remediation_workflow
 from gg_api_core.tools.list_detectors import list_detectors
 from gg_api_core.tools.list_honeytokens import list_honeytokens
 from gg_api_core.tools.list_incident_members import list_incident_members
@@ -239,6 +240,14 @@ def register_tools(mcp: AbstractGitGuardianFastMCP) -> None:
         get_member,
         description="Retrieve a specific member by their ID with information including name, email, role, access level, and activity status.",
         required_scopes=["members:read"],
+    )
+
+    mcp.tool(
+        get_remediation_workflow,
+        description="Retrieve the workspace remediation workflow — the ordered, step-by-step guidance shown for secret "
+        "incidents. Returns the configured custom workflow if one exists, otherwise the default workflow. Use this to "
+        "remediate an incident following the same instructions a human sees in the dashboard.",
+        required_scopes=["incidents:read"],
     )
 
     mcp.tool(

--- a/tests/cassettes/tools/vcr/test_get_remediation_workflow_custom.yaml
+++ b/tests/cassettes/tools/vcr/test_get_remediation_workflow_custom.yaml
@@ -1,0 +1,86 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/remediation-workflow
+  response:
+    body:
+      string: '{"id": 6, "account_id": 8, "steps": [{"title": "Step 1. Investigate
+        the incident.", "description": "Why did you hardcode this secret? Is it valid?
+        What sensitive resources does it give access to?", "link": {"text": "Contact
+        security", "url": "https://securityportal.company.com"}}, {"title": "Step
+        2. Revoke the secret", "description": "Contact DevOps to revoke the secret.",
+        "link": {"text": "Create a ticket for DevOps (internal portal)", "url": "https://docs.gitguardian.com"}},
+        {"title": "Step 3. Rotate the secret.", "description": "Contact DevOps to
+        rotate the key. Make sure other users of the service are aware of this operation.",
+        "link": {"text": "Create a ticket for DevOps (internal portal)", "url": "https://docs.gitguardian.com"}},
+        {"title": "Step 4. Re-deploy impacted services.", "description": "You can
+        now re-deploy your impacted applications and services."}, {"title": "Step
+        5. Install ggshield in your pre-commit hooks", "description": "Stop hardcoding
+        secrets once and for all. Install **ggshield CLI** on your local workstation,
+        please!", "link": {"text": "Read ggshield docs", "url": "https://docs.gitguardian.com/"}},
+        {"title": "Title", "description": "Body", "link": {"text": "Learn More", "url":
+        "{{revoke_documentation_link}}"}}], "created_at": "2022-12-15T09:58:14.315507Z",
+        "updated_at": "2026-06-23T12:23:58.290253Z"}'
+    headers:
+      CF-RAY:
+      - a10379974b10cea9-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:25:22 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1290'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '44'
+      x-frame-options:
+      - DENY
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/tools/vcr/test_get_remediation_workflow.py
+++ b/tests/tools/vcr/test_get_remediation_workflow.py
@@ -1,0 +1,50 @@
+"""
+VCR tests for the get_remediation_workflow tool.
+
+These tests use recorded HTTP interactions to verify tool behavior
+without requiring a live API connection.
+
+Note: These tests require VCR cassettes to be recorded. Run with a valid
+GITGUARDIAN_API_KEY to record cassettes:
+    make test-vcr-with-env
+"""
+
+from unittest.mock import patch
+
+import pytest
+from gg_api_core.tools.get_remediation_workflow import (
+    GetRemediationWorkflowResult,
+    get_remediation_workflow,
+)
+
+
+class TestGetRemediationWorkflowVCR:
+    """VCR tests for the get_remediation_workflow tool."""
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_get_remediation_workflow_custom(self, real_client, use_cassette):
+        """
+        GIVEN: A workspace with a configured custom remediation workflow
+        WHEN: Calling get_remediation_workflow
+        THEN: Returns the custom workflow with its steps, id and timestamps
+        """
+        with use_cassette("test_get_remediation_workflow_custom"):
+            with patch(
+                "gg_api_core.tools.get_remediation_workflow.get_client",
+                return_value=real_client,
+            ):
+                result = await get_remediation_workflow()
+
+                assert result is not None
+                assert isinstance(result, GetRemediationWorkflowResult)
+                assert isinstance(result.workflow, dict)
+                # Configured custom workflow exposes id and timestamps
+                assert "id" in result.workflow
+                assert "account_id" in result.workflow
+                assert "created_at" in result.workflow
+                assert "updated_at" in result.workflow
+                # Steps are an ordered list with at least a title each
+                steps = result.workflow["steps"]
+                assert isinstance(steps, list) and len(steps) >= 1
+                assert all("title" in step for step in steps)


### PR DESCRIPTION
## What

Adds a new read-only MCP tool **`get_remediation_workflow`** that wraps the GitGuardian public API endpoint `GET /v1/remediation-workflow`.

It returns the workspace's remediation workflow — the ordered, step-by-step guidance shown for secret incidents — returning the configured **custom** workflow if one exists, otherwise the **default** workflow. This lets the agent remediate an incident following the same instructions a human sees in the dashboard.

## Why

Part of SI-3519 ("Expose custom remediation guidance to the agent"). The public API endpoint was added in the backend (gim MR !25969); this surfaces it through the MCP server so the agent has the same remediation guidance as the UI.

## Changes

- `client.get_remediation_workflow()` — `GET /remediation-workflow` (no params; account inferred from token).
- New tool `packages/gg_api_core/.../tools/get_remediation_workflow.py` (no-arg, modeled on `get_member`).
- Registered in `register_tools.py`, gated by `required_scopes=["incidents:read"]`.
- VCR tests (`tests/tools/vcr/test_get_remediation_workflow.py`) covering both the **custom** and **default** workflow shapes, with hand-authored cassettes (the endpoint is not yet deployed to record against live).

## Response shape

```
{
  "account_id": int,
  "steps": [ { "title": str, "description"?: str, "link"?: {"text"?: str, "url": str} } ],
  "id"?: int, "created_at"?: str, "updated_at"?: str   // present only for a configured custom workflow
}
```

## Verification

- `pytest tests/tools/vcr/test_get_remediation_workflow.py -m vcr_test` → 2 passed
- `ruff check`, `ruff format --check`, `mypy` → clean

> Note: cassettes are hand-authored because `GET /v1/remediation-workflow` isn't deployed to SaaS/preprod yet. Once it's live, they can be re-recorded with `make test-vcr-with-env`.