### PR TITLE
test(cassettes): refresh all VCR cassettes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,10 @@ GITGUARDIAN_SCOPES=honeytokens:read honeytokens:write incidents:read incidents:w
 # Optional: Override the GitGuardian instance URL
 GITGUARDIAN_URL=https://dashboard.gitguardian.com
 
+# API Key for VCR tests against the public API
+GITGUARDIAN_API_KEY=--fill-me--
+GITGUARDIAN_API_KEY_ID=--fill-me--
+
 # Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 LOG_LEVEL=INFO
 

--- a/tests/cassettes/client/vcr/test_assign_public_incident_by_email.yaml
+++ b/tests/cassettes/client/vcr/test_assign_public_incident_by_email.yaml
@@ -20,14 +20,60 @@ interactions:
     uri: https://api.gitguardian.com/v1/api_tokens/self
   response:
     body:
-      string: '{"id": "8a262c6a-832d-49e5-8744-23c743ff25ac", "name": "ggmcp CI",
+      string: '{"id": "d0ca9877-641f-4c37-8857-c08e0ae148c4", "name": "ggmcp CI (April)",
         "type": "personal_access_token", "scopes": ["scan", "incidents:read", "incidents:write",
-        "members:read"], "member_id": 480870, "workspace_id": 8, "created_at": "2025-12-07T14:13:08.044416Z",
-        "last_used_at": "2026-04-27T08:43:00Z", "expire_at": null, "revoked_at": null,
+        "incidents:share", "members:read", "members:write", "audit_logs:read", "teams:read",
+        "teams:write", "honeytokens:read", "honeytokens:write", "api_tokens:read",
+        "api_tokens:write", "ip_allowlist:read", "ip_allowlist:write", "sources:read",
+        "sources:write", "nhi:send-inventory", "nhi:write-vault", "custom_tags:read",
+        "custom_tags:write", "secrets:read", "secrets:write", "scan:create-incidents",
+        "public-perimeter:read", "nhi:ownership:read", "nhi:ownership:write", "sources:scan"],
+        "member_id": 480870, "workspace_id": 8, "created_at": "2026-04-20T13:31:42.422943Z",
+        "last_used_at": "2026-06-23T12:52:00Z", "expire_at": null, "revoked_at": null,
         "status": "active", "creator_id": 480870}'
     headers:
-      content-type:
+      CF-RAY:
+      - a103a182fb1788f4-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
       - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:52:37 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '802'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '20'
+      x-frame-options:
+      - DENY
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
@@ -52,14 +98,60 @@ interactions:
     uri: https://api.gitguardian.com/v1/api_tokens/self
   response:
     body:
-      string: '{"id": "8a262c6a-832d-49e5-8744-23c743ff25ac", "name": "ggmcp CI",
+      string: '{"id": "d0ca9877-641f-4c37-8857-c08e0ae148c4", "name": "ggmcp CI (April)",
         "type": "personal_access_token", "scopes": ["scan", "incidents:read", "incidents:write",
-        "members:read"], "member_id": 480870, "workspace_id": 8, "created_at": "2025-12-07T14:13:08.044416Z",
-        "last_used_at": "2026-04-27T08:43:00Z", "expire_at": null, "revoked_at": null,
+        "incidents:share", "members:read", "members:write", "audit_logs:read", "teams:read",
+        "teams:write", "honeytokens:read", "honeytokens:write", "api_tokens:read",
+        "api_tokens:write", "ip_allowlist:read", "ip_allowlist:write", "sources:read",
+        "sources:write", "nhi:send-inventory", "nhi:write-vault", "custom_tags:read",
+        "custom_tags:write", "secrets:read", "secrets:write", "scan:create-incidents",
+        "public-perimeter:read", "nhi:ownership:read", "nhi:ownership:write", "sources:scan"],
+        "member_id": 480870, "workspace_id": 8, "created_at": "2026-04-20T13:31:42.422943Z",
+        "last_used_at": "2026-06-23T12:52:00Z", "expire_at": null, "revoked_at": null,
         "status": "active", "creator_id": 480870}'
     headers:
-      content-type:
+      CF-RAY:
+      - a103a184ac45dd47-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
       - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:52:37 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '802'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '26'
+      x-frame-options:
+      - DENY
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
@@ -84,12 +176,53 @@ interactions:
     uri: https://api.gitguardian.com/v1/members/480870
   response:
     body:
-      string: '{"id": 480870, "email": "ci@gitguardian.com", "name": "GG CI", "role":
-        "manager", "access_level": "manager", "active": true, "created_at": "2024-01-01T00:00:00Z",
-        "last_login_at": "2026-04-27T08:43:00Z"}'
+      string: '{"id": 480870, "role": "manager", "access_level": "manager", "email":
+        "timothe.delion@gitguardian.com", "name": "Timoth\u00e9 DELION", "created_at":
+        "2023-06-26T12:41:18.599497Z", "last_login": "2026-06-23T12:20:54.639679Z",
+        "active": true}'
     headers:
-      content-type:
+      CF-RAY:
+      - a103a186781d2a4f-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
       - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:52:37 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '221'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '38'
+      x-frame-options:
+      - DENY
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
@@ -111,24 +244,78 @@ interactions:
       X-Privacy-Mode:
       - 'true'
     method: GET
-    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=1
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=1&status=TRIGGERED
   response:
     body:
-      string: '[{"id": 3759, "detector": {"name": "slack_bot_token", "display_name":
-        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+      string: '[{"id": 5, "detector": {"name": "slackbototken", "display_name": "Slack
+        Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
         "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
-        Bot Token"}, "date": "2024-08-22T14:15:22Z", "occurrences_count": 4, "status":
-        "TRIGGERED", "validity": "valid", "severity": "high", "assignee_id": null,
-        "assignee_email": null, "tags": ["FROM_HISTORICAL_SCAN"], "risk_score": 80,
-        "share_url": "[REDACTED]", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/3759"}]'
+        Bot Token"}, "date": "2024-05-24T12:18:15Z", "secret_id": 14592838, "secret_hash":
+        "Z5EChCcGXgX/eXhBjNhs4sGINbMdnzWjcD4m3l7naZmf7qCBOMgPzYhV28m6OGG4", "hmsl_hash":
+        "dc66b2a9c718f0d32581426943c736bfed9bcfd865c77712ca43d96faf97f731", "occurrences_count":
+        2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}]'
     headers:
-      content-type:
+      CF-RAY:
+      - a103a1888bd4eba6-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
       - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:52:38 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1145'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD01&per_page=1&status=TRIGGERED>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '78'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '1'
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{"email": "ci@gitguardian.com"}'
+    body: '{"email": "timothe.delion@gitguardian.com"}'
     headers:
       Accept:
       - '*/*'
@@ -137,7 +324,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '31'
+      - '42'
       Content-Type:
       - application/json
       Host:
@@ -147,19 +334,68 @@ interactions:
       X-Privacy-Mode:
       - 'true'
     method: POST
-    uri: https://api.gitguardian.com/v1/public-incidents/secrets/3759/assign
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/5/assign
   response:
     body:
-      string: '{"id": 3759, "detector": {"name": "slack_bot_token", "display_name":
-        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+      string: '{"id": 5, "detector": {"name": "slackbototken", "display_name": "Slack
+        Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
         "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
-        Bot Token"}, "date": "2024-08-22T14:15:22Z", "occurrences_count": 4, "status":
-        "ASSIGNED", "validity": "valid", "severity": "high", "assignee_id": 480870,
-        "assignee_email": "ci@gitguardian.com", "tags": ["FROM_HISTORICAL_SCAN"],
-        "risk_score": 80, "share_url": "[REDACTED]", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/3759"}'
+        Bot Token"}, "date": "2024-05-24T12:18:15Z", "secret_id": 14592838, "secret_hash":
+        "Z5EChCcGXgX/eXhBjNhs4sGINbMdnzWjcD4m3l7naZmf7qCBOMgPzYhV28m6OGG4", "hmsl_hash":
+        "dc66b2a9c718f0d32581426943c736bfed9bcfd865c77712ca43d96faf97f731", "occurrences_count":
+        2, "status": "ASSIGNED", "triggered_at": "2025-01-07T18:06:02.739857Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": 480870,
+        "assignee_email": "timothe.delion@gitguardian.com", "share_url": "[REDACTED]",
+        "feedback_list": [], "risk_score": 44, "severity_rule_id": null, "is_vaulted":
+        false, "declarative_secret_status": "active", "resolve_reason": null, "ignore_reason":
+        null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/5",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Slack Bot Token"}'
     headers:
-      content-type:
+      CF-RAY:
+      - a103a18b183c5858-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
       - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:52:38 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - POST, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1172'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '172'
+      x-frame-options:
+      - DENY
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK

--- a/tests/cassettes/client/vcr/test_assign_public_incident_by_member_id.yaml
+++ b/tests/cassettes/client/vcr/test_assign_public_incident_by_member_id.yaml
@@ -20,14 +20,60 @@ interactions:
     uri: https://api.gitguardian.com/v1/api_tokens/self
   response:
     body:
-      string: '{"id": "8a262c6a-832d-49e5-8744-23c743ff25ac", "name": "ggmcp CI",
+      string: '{"id": "d0ca9877-641f-4c37-8857-c08e0ae148c4", "name": "ggmcp CI (April)",
         "type": "personal_access_token", "scopes": ["scan", "incidents:read", "incidents:write",
-        "members:read"], "member_id": 480870, "workspace_id": 8, "created_at": "2025-12-07T14:13:08.044416Z",
-        "last_used_at": "2026-04-27T08:43:00Z", "expire_at": null, "revoked_at": null,
+        "incidents:share", "members:read", "members:write", "audit_logs:read", "teams:read",
+        "teams:write", "honeytokens:read", "honeytokens:write", "api_tokens:read",
+        "api_tokens:write", "ip_allowlist:read", "ip_allowlist:write", "sources:read",
+        "sources:write", "nhi:send-inventory", "nhi:write-vault", "custom_tags:read",
+        "custom_tags:write", "secrets:read", "secrets:write", "scan:create-incidents",
+        "public-perimeter:read", "nhi:ownership:read", "nhi:ownership:write", "sources:scan"],
+        "member_id": 480870, "workspace_id": 8, "created_at": "2026-04-20T13:31:42.422943Z",
+        "last_used_at": "2026-06-23T12:52:00Z", "expire_at": null, "revoked_at": null,
         "status": "active", "creator_id": 480870}'
     headers:
-      content-type:
+      CF-RAY:
+      - a103a17ce9f914c6-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
       - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:52:36 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '802'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '26'
+      x-frame-options:
+      - DENY
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
@@ -49,19 +95,73 @@ interactions:
       X-Privacy-Mode:
       - 'true'
     method: GET
-    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=1
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=1&status=TRIGGERED
   response:
     body:
-      string: '[{"id": 3759, "detector": {"name": "slack_bot_token", "display_name":
-        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
-        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
-        Bot Token"}, "date": "2024-08-22T14:15:22Z", "occurrences_count": 4, "status":
-        "TRIGGERED", "validity": "valid", "severity": "high", "assignee_id": null,
-        "assignee_email": null, "tags": ["FROM_HISTORICAL_SCAN"], "risk_score": 80,
-        "share_url": "[REDACTED]", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/3759"}]'
+      string: '[{"id": 4, "detector": {"name": "gitguardian_test_token", "display_name":
+        "GitGuardian Development Secret", "nature": "specific", "family": "token",
+        "category": "internal", "detector_group_name": "gitguardian_test_token", "detector_group_display_name":
+        "GitGuardian Development Secret"}, "date": "2019-11-19T14:11:01Z", "secret_id":
+        14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
+        "hmsl_hash": "8d750888a3f74d018e742b42dfb51c60907b26c49fdad4ebdabe1350eedfe0fb",
+        "occurrences_count": 10, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/4", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}]'
     headers:
-      content-type:
+      CF-RAY:
+      - a103a17e7d9849ca-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
       - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:52:36 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1195'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD00&per_page=1&status=TRIGGERED>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '82'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '1'
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
@@ -75,7 +175,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '21'
+      - '20'
       Content-Type:
       - application/json
       Host:
@@ -85,19 +185,68 @@ interactions:
       X-Privacy-Mode:
       - 'true'
     method: POST
-    uri: https://api.gitguardian.com/v1/public-incidents/secrets/3759/assign
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/4/assign
   response:
     body:
-      string: '{"id": 3759, "detector": {"name": "slack_bot_token", "display_name":
-        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
-        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
-        Bot Token"}, "date": "2024-08-22T14:15:22Z", "occurrences_count": 4, "status":
-        "ASSIGNED", "validity": "valid", "severity": "high", "assignee_id": 480870,
-        "assignee_email": "ci@gitguardian.com", "tags": ["FROM_HISTORICAL_SCAN"],
-        "risk_score": 80, "share_url": "[REDACTED]", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/3759"}'
+      string: '{"id": 4, "detector": {"name": "gitguardian_test_token", "display_name":
+        "GitGuardian Development Secret", "nature": "specific", "family": "token",
+        "category": "internal", "detector_group_name": "gitguardian_test_token", "detector_group_display_name":
+        "GitGuardian Development Secret"}, "date": "2019-11-19T14:11:01Z", "secret_id":
+        14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
+        "hmsl_hash": "8d750888a3f74d018e742b42dfb51c60907b26c49fdad4ebdabe1350eedfe0fb",
+        "occurrences_count": 10, "status": "ASSIGNED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": 480870,
+        "assignee_email": "timothe.delion@gitguardian.com", "share_url": "[REDACTED]",
+        "feedback_list": [], "risk_score": 44, "severity_rule_id": null, "is_vaulted":
+        false, "declarative_secret_status": "active", "resolve_reason": null, "ignore_reason":
+        null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/4",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "GitGuardian Development Secret"}'
     headers:
-      content-type:
+      CF-RAY:
+      - a103a18068b4b843-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
       - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:52:36 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - POST, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1222'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '155'
+      x-frame-options:
+      - DENY
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK

--- a/tests/cassettes/client/vcr/test_assign_public_incident_send_email_false.yaml
+++ b/tests/cassettes/client/vcr/test_assign_public_incident_send_email_false.yaml
@@ -20,14 +20,60 @@ interactions:
     uri: https://api.gitguardian.com/v1/api_tokens/self
   response:
     body:
-      string: '{"id": "8a262c6a-832d-49e5-8744-23c743ff25ac", "name": "ggmcp CI",
+      string: '{"id": "d0ca9877-641f-4c37-8857-c08e0ae148c4", "name": "ggmcp CI (April)",
         "type": "personal_access_token", "scopes": ["scan", "incidents:read", "incidents:write",
-        "members:read"], "member_id": 480870, "workspace_id": 8, "created_at": "2025-12-07T14:13:08.044416Z",
-        "last_used_at": "2026-04-27T08:43:00Z", "expire_at": null, "revoked_at": null,
+        "incidents:share", "members:read", "members:write", "audit_logs:read", "teams:read",
+        "teams:write", "honeytokens:read", "honeytokens:write", "api_tokens:read",
+        "api_tokens:write", "ip_allowlist:read", "ip_allowlist:write", "sources:read",
+        "sources:write", "nhi:send-inventory", "nhi:write-vault", "custom_tags:read",
+        "custom_tags:write", "secrets:read", "secrets:write", "scan:create-incidents",
+        "public-perimeter:read", "nhi:ownership:read", "nhi:ownership:write", "sources:scan"],
+        "member_id": 480870, "workspace_id": 8, "created_at": "2026-04-20T13:31:42.422943Z",
+        "last_used_at": "2026-06-23T12:52:00Z", "expire_at": null, "revoked_at": null,
         "status": "active", "creator_id": 480870}'
     headers:
-      content-type:
+      CF-RAY:
+      - a103a18dbe1dd580-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
       - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:52:39 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '802'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '187'
+      x-frame-options:
+      - DENY
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
@@ -49,19 +95,72 @@ interactions:
       X-Privacy-Mode:
       - 'true'
     method: GET
-    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=1
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=1&status=TRIGGERED
   response:
     body:
-      string: '[{"id": 3759, "detector": {"name": "slack_bot_token", "display_name":
-        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
-        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
-        Bot Token"}, "date": "2024-08-22T14:15:22Z", "occurrences_count": 4, "status":
-        "TRIGGERED", "validity": "valid", "severity": "high", "assignee_id": null,
-        "assignee_email": null, "tags": ["FROM_HISTORICAL_SCAN"], "risk_score": 80,
-        "share_url": "[REDACTED]", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/3759"}]'
+      string: '[{"id": 8, "detector": {"name": "sendgrid", "display_name": "SendGrid
+        Key", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "sendgrid_key", "detector_group_display_name": "SendGrid
+        Key"}, "date": "2019-02-11T12:36:02Z", "secret_id": 14592841, "secret_hash":
+        "56VyXyYsEkRVqTiCem+I1NhoZNp0IQKqlPItH+mlIkMmFjfwOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "31198eeb074a1722b082a6ea94edc8a133b115d7201acb47361741b236966830", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.746711Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/8",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "SendGrid Key"}]'
     headers:
-      content-type:
+      CF-RAY:
+      - a103a19079fd1310-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
       - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:52:39 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1121'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD04&per_page=1&status=TRIGGERED>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '112'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '1'
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
@@ -75,7 +174,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '21'
+      - '20'
       Content-Type:
       - application/json
       Host:
@@ -85,19 +184,68 @@ interactions:
       X-Privacy-Mode:
       - 'true'
     method: POST
-    uri: https://api.gitguardian.com/v1/public-incidents/secrets/3759/assign?send_email=false
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/8/assign?send_email=false
   response:
     body:
-      string: '{"id": 3759, "detector": {"name": "slack_bot_token", "display_name":
-        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
-        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
-        Bot Token"}, "date": "2024-08-22T14:15:22Z", "occurrences_count": 4, "status":
-        "ASSIGNED", "validity": "valid", "severity": "high", "assignee_id": 480870,
-        "assignee_email": "ci@gitguardian.com", "tags": ["FROM_HISTORICAL_SCAN"],
-        "risk_score": 80, "share_url": "[REDACTED]", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/3759"}'
+      string: '{"id": 8, "detector": {"name": "sendgrid", "display_name": "SendGrid
+        Key", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "sendgrid_key", "detector_group_display_name": "SendGrid
+        Key"}, "date": "2019-02-11T12:36:02Z", "secret_id": 14592841, "secret_hash":
+        "56VyXyYsEkRVqTiCem+I1NhoZNp0IQKqlPItH+mlIkMmFjfwOwbZvYHhb+uS0r+s", "hmsl_hash":
+        "31198eeb074a1722b082a6ea94edc8a133b115d7201acb47361741b236966830", "occurrences_count":
+        1, "status": "ASSIGNED", "triggered_at": "2025-01-07T18:06:02.746711Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": 480870, "assignee_email":
+        "timothe.delion@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/8", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "SendGrid Key"}'
     headers:
-      content-type:
+      CF-RAY:
+      - a103a192ab772a20-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
       - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:52:39 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - POST, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1148'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '149'
+      x-frame-options:
+      - DENY
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK

--- a/tests/cassettes/client/vcr/test_count_incidents_for_mcp_basic.yaml
+++ b/tests/cassettes/client/vcr/test_count_incidents_for_mcp_basic.yaml
@@ -20,40 +20,46 @@ interactions:
     uri: https://api.gitguardian.com/v1/incidents-for-mcp/count
   response:
     body:
-      string: '{"count": 12098}'
+      string: '{"count": 12620}'
     headers:
+      CF-RAY:
+      - a103949e6c701310-CDG
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '15'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:43:49 GMT
+      Server:
+      - cloudflare
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
-      content-length:
-      - '15'
+      cf-cache-status:
+      - DYNAMIC
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:05 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '82'
+      - '72'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_count_incidents_for_mcp_with_combined_filters.yaml
+++ b/tests/cassettes/client/vcr/test_count_incidents_for_mcp_with_combined_filters.yaml
@@ -20,40 +20,46 @@ interactions:
     uri: https://api.gitguardian.com/v1/incidents-for-mcp/count?status__in=TRIGGERED%2CASSIGNED&severity__in=10%2C20&validity__in=valid
   response:
     body:
-      string: '{"count": 143}'
+      string: '{"count": 150}'
     headers:
+      CF-RAY:
+      - a10394a44ed579d6-CDG
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '13'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:43:51 GMT
+      Server:
+      - cloudflare
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
-      content-length:
-      - '13'
+      cf-cache-status:
+      - DYNAMIC
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:07 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '52'
+      - '1075'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_count_incidents_for_mcp_with_date_filter.yaml
+++ b/tests/cassettes/client/vcr/test_count_incidents_for_mcp_with_date_filter.yaml
@@ -20,32 +20,38 @@ interactions:
     uri: https://api.gitguardian.com/v1/incidents-for-mcp/count?date__le=2025-12-31&date__ge=2024-01-01
   response:
     body:
-      string: '{"count": 6155}'
+      string: '{"count": 6230}'
     headers:
+      CF-RAY:
+      - a10394b34df67f64-CDG
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:43:52 GMT
+      Server:
+      - cloudflare
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
-      content-length:
-      - '14'
+      cf-cache-status:
+      - DYNAMIC
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:08 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
@@ -53,7 +59,7 @@ interactions:
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_count_incidents_for_mcp_with_search.yaml
+++ b/tests/cassettes/client/vcr/test_count_incidents_for_mcp_with_search.yaml
@@ -20,40 +20,46 @@ interactions:
     uri: https://api.gitguardian.com/v1/incidents-for-mcp/count?search=aws
   response:
     body:
-      string: '{"count": 1104}'
+      string: '{"count": 1114}'
     headers:
+      CF-RAY:
+      - a10394b55b5e9952-CDG
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:43:54 GMT
+      Server:
+      - cloudflare
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
-      content-length:
-      - '14'
+      cf-cache-status:
+      - DYNAMIC
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:08 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '143'
+      - '1424'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_count_incidents_for_mcp_with_severity_filter.yaml
+++ b/tests/cassettes/client/vcr/test_count_incidents_for_mcp_with_severity_filter.yaml
@@ -20,40 +20,46 @@ interactions:
     uri: https://api.gitguardian.com/v1/incidents-for-mcp/count?severity__in=10%2C20
   response:
     body:
-      string: '{"count": 5866}'
+      string: '{"count": 5968}'
     headers:
+      CF-RAY:
+      - a10394a27be0d2bc-CDG
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:43:49 GMT
+      Server:
+      - cloudflare
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
-      content-length:
-      - '14'
+      cf-cache-status:
+      - DYNAMIC
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:07 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '52'
+      - '58'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_count_incidents_for_mcp_with_status_filter.yaml
+++ b/tests/cassettes/client/vcr/test_count_incidents_for_mcp_with_status_filter.yaml
@@ -20,40 +20,46 @@ interactions:
     uri: https://api.gitguardian.com/v1/incidents-for-mcp/count?status__in=TRIGGERED
   response:
     body:
-      string: '{"count": 6189}'
+      string: '{"count": 6614}'
     headers:
+      CF-RAY:
+      - a10394a04c757240-CDG
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:43:49 GMT
+      Server:
+      - cloudflare
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
-      content-length:
-      - '14'
+      cf-cache-status:
+      - DYNAMIC
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:06 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '48'
+      - '102'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_get_audit_logs.yaml
+++ b/tests/cassettes/client/vcr/test_get_audit_logs.yaml
@@ -20,93 +20,95 @@ interactions:
     uri: https://api.gitguardian.com/v1/audit_logs?per_page=10
   response:
     body:
-      string: '[{"id": 20321653, "api_token_id": null, "member_id": 937958, "member_email":
-        "daniele.brusca@gitguardian.com", "member_name": "Daniele BRUSCA", "date":
-        "2026-04-03T08:20:24.694817Z", "data": {"scopes": ["scan", "incidents:read",
-        "incidents:write", "incidents:share", "members:read", "members:write", "audit_logs:read",
-        "teams:read", "teams:write", "honeytokens:read", "honeytokens:write", "api_tokens:read",
-        "api_tokens:write", "ip_allowlist:read", "ip_allowlist:write", "sources:read",
-        "sources:write", "nhi:send-inventory", "nhi:write-vault", "custom_tags:read",
-        "custom_tags:write", "secrets:read", "secrets:write", "scan:create-incidents",
-        "public-perimeter:read", "nhi:ownership:read", "nhi:ownership:write", "health_checks:read",
-        "health_checks:write"], "expire_at": "2026-04-13T08:20:24.655856+00:00"},
-        "event_name": "personal_access_token.created", "action_type": "CREATE", "target_ids":
-        ["ce80d253-c672-4c2e-ad86-c2a127fbe0ff"], "ip_address": "54.212.233.107"},
-        {"id": 20321531, "api_token_id": null, "member_id": 1121302, "member_email":
-        "candidate.playground+eu5@gitguardian.com", "member_name": "Candidate EU5",
-        "date": "2026-04-03T08:16:13.796999Z", "data": null, "event_name": "secret_incident.viewed",
-        "action_type": "READ", "target_ids": ["11038927"], "ip_address": "92.170.72.162"},
-        {"id": 20321452, "api_token_id": null, "member_id": 1121302, "member_email":
-        "candidate.playground+eu5@gitguardian.com", "member_name": "Candidate EU5",
-        "date": "2026-04-03T08:10:59.237953Z", "data": {"type": "basic"}, "event_name":
-        "user.logged_in", "action_type": "OTHER", "target_ids": ["1119171"], "ip_address":
-        "92.170.72.162"}, {"id": 20320840, "api_token_id": null, "member_id": 701514,
-        "member_email": "pierre.leclezio@gitguardian.com", "member_name": "Pierre
-        LE CLEZIO", "date": "2026-04-03T07:38:22.311430Z", "data": {"type": "saml_sso"},
-        "event_name": "user.logged_in", "action_type": "OTHER", "target_ids": ["700455"],
-        "ip_address": "35.161.89.114"}, {"id": 20319386, "api_token_id": null, "member_id":
-        1754656, "member_email": "candidate.playground+eu@gitguardian.com", "member_name":
-        "CandidateEU DemoAccess", "date": "2026-04-03T06:31:23.572560Z", "data": null,
-        "event_name": "user.logged_out", "action_type": "OTHER", "target_ids": ["1751937"],
-        "ip_address": "35.83.131.170"}, {"id": 20319205, "api_token_id": null, "member_id":
-        1754656, "member_email": "candidate.playground+eu@gitguardian.com", "member_name":
-        "CandidateEU DemoAccess", "date": "2026-04-03T06:24:50.609968Z", "data": {"type":
-        "basic"}, "event_name": "user.logged_in", "action_type": "OTHER", "target_ids":
-        ["1751937"], "ip_address": "35.83.131.170"}, {"id": 20318988, "api_token_id":
-        null, "member_id": 1222731, "member_email": "anh.trinh.ext@gitguardian.com",
-        "member_name": "Anh TRINH", "date": "2026-04-03T06:16:35.002089Z", "data":
-        null, "event_name": "user.logged_out", "action_type": "OTHER", "target_ids":
-        ["1220552"], "ip_address": "35.83.131.170"}, {"id": 20318965, "api_token_id":
-        null, "member_id": 1222731, "member_email": "anh.trinh.ext@gitguardian.com",
-        "member_name": "Anh TRINH", "date": "2026-04-03T06:14:58.839802Z", "data":
-        {"type": "saml_sso"}, "event_name": "user.logged_in", "action_type": "OTHER",
-        "target_ids": ["1220552"], "ip_address": "35.83.131.170"}, {"id": 20318962,
+      string: '[{"id": 23983381, "api_token_id": null, "member_id": 480870, "member_email":
+        "timothe.delion@gitguardian.com", "member_name": "Timoth\u00e9 DELION", "date":
+        "2026-06-23T12:23:58.297394Z", "data": null, "event_name": "custom_remediation_workflow.updated",
+        "action_type": "UPDATE", "target_ids": ["6"], "ip_address": "92.128.35.47"},
+        {"id": 23983251, "api_token_id": null, "member_id": 480870, "member_email":
+        "timothe.delion@gitguardian.com", "member_name": "Timoth\u00e9 DELION", "date":
+        "2026-06-23T12:20:54.649674Z", "data": {"type": "saml_sso"}, "event_name":
+        "user.logged_in", "action_type": "OTHER", "target_ids": ["480218"], "ip_address":
+        "92.128.35.47"}, {"id": 23982412, "api_token_id": null, "member_id": 1301278,
+        "member_email": "zach.mccullough@gitguardian.com", "member_name": "Zachary
+        MCCULLOUGH", "date": "2026-06-23T11:59:32.903530Z", "data": {"type": "saml_sso"},
+        "event_name": "user.logged_in", "action_type": "OTHER", "target_ids": ["1299091"],
+        "ip_address": "73.8.249.128"}, {"id": 23982141, "api_token_id": null, "member_id":
+        363444, "member_email": "patrick.flanagan@gitguardian.com", "member_name":
+        "Patrick FLANAGAN", "date": "2026-06-23T11:47:23.624224Z", "data": {"issue_token":
+        73062}, "event_name": "secret_incident.shared_incident_viewed", "action_type":
+        "READ", "target_ids": ["34205503"], "ip_address": "185.175.151.131"}, {"id":
+        23982136, "api_token_id": null, "member_id": 363444, "member_email": "patrick.flanagan@gitguardian.com",
+        "member_name": "Patrick FLANAGAN", "date": "2026-06-23T11:47:02.338330Z",
+        "data": {"issue_id": 34205503, "expire_at": "2026-07-23T11:47:02.322847+00:00"},
+        "event_name": "incident_token.created", "action_type": "CREATE", "target_ids":
+        ["73062"], "ip_address": "185.175.151.131"}, {"id": 23982131, "api_token_id":
+        null, "member_id": 363444, "member_email": "patrick.flanagan@gitguardian.com",
+        "member_name": "Patrick FLANAGAN", "date": "2026-06-23T11:46:58.538857Z",
+        "data": null, "event_name": "secret_incident.viewed", "action_type": "READ",
+        "target_ids": ["34205503"], "ip_address": "185.175.151.131"}, {"id": 23981642,
         "api_token_id": null, "member_id": 1754656, "member_email": "candidate.playground+eu@gitguardian.com",
-        "member_name": "CandidateEU DemoAccess", "date": "2026-04-03T06:14:34.508430Z",
-        "data": null, "event_name": "user.logged_out", "action_type": "OTHER", "target_ids":
-        ["1751937"], "ip_address": "35.83.131.170"}, {"id": 20318944, "api_token_id":
-        null, "member_id": 1754656, "member_email": "candidate.playground+eu@gitguardian.com",
-        "member_name": "CandidateEU DemoAccess", "date": "2026-04-03T06:12:43.256657Z",
-        "data": {"type": "basic"}, "event_name": "user.logged_in", "action_type":
-        "OTHER", "target_ids": ["1751937"], "ip_address": "35.83.131.170"}]'
+        "member_name": "CandidateEU DemoAccess", "date": "2026-06-23T11:26:44.352505Z",
+        "data": null, "event_name": "secret_incident.viewed", "action_type": "READ",
+        "target_ids": ["32828142"], "ip_address": "82.169.214.153"}, {"id": 23981549,
+        "api_token_id": null, "member_id": 1754656, "member_email": "candidate.playground+eu@gitguardian.com",
+        "member_name": "CandidateEU DemoAccess", "date": "2026-06-23T11:22:57.870942Z",
+        "data": null, "event_name": "secret_incident.viewed", "action_type": "READ",
+        "target_ids": ["32985083"], "ip_address": "82.169.214.153"}, {"id": 23981372,
+        "api_token_id": null, "member_id": 1754656, "member_email": "candidate.playground+eu@gitguardian.com",
+        "member_name": "CandidateEU DemoAccess", "date": "2026-06-23T11:13:34.045630Z",
+        "data": null, "event_name": "secret_incident.viewed", "action_type": "READ",
+        "target_ids": ["34205503"], "ip_address": "82.169.214.153"}, {"id": 23981370,
+        "api_token_id": null, "member_id": 1754656, "member_email": "candidate.playground+eu@gitguardian.com",
+        "member_name": "CandidateEU DemoAccess", "date": "2026-06-23T11:13:31.746525Z",
+        "data": {"issue_id": 34205503, "issue_hash": "HdPZ4cjZuziAqsakdlsUnJDapTz3ns5pX8vPzfhvGQvpWWWX25LITKmJimoqGr3z"},
+        "event_name": "endpoint_discovered_secret.promoted_to_incident", "action_type":
+        "CREATE", "target_ids": ["2013275"], "ip_address": "82.169.214.153"}]'
     headers:
+      CF-RAY:
+      - a10394ca3b85f3b3-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:43:56 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '3680'
+      - '3310'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:10 GMT
       link:
-      - <https://api.gitguardian.com/v1/audit_logs?cursor=cD0yMDMxODk0NA%3D%3D&per_page=10>;
+      - <https://api.gitguardian.com/v1/audit_logs?cursor=cD0yMzk4MTM3MA%3D%3D&per_page=10>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '31'
+      - '149'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_get_audit_logs_with_limit.yaml
+++ b/tests/cassettes/client/vcr/test_get_audit_logs_with_limit.yaml
@@ -20,73 +20,74 @@ interactions:
     uri: https://api.gitguardian.com/v1/audit_logs?per_page=5
   response:
     body:
-      string: '[{"id": 20321653, "api_token_id": null, "member_id": 937958, "member_email":
-        "daniele.brusca@gitguardian.com", "member_name": "Daniele BRUSCA", "date":
-        "2026-04-03T08:20:24.694817Z", "data": {"scopes": ["scan", "incidents:read",
-        "incidents:write", "incidents:share", "members:read", "members:write", "audit_logs:read",
-        "teams:read", "teams:write", "honeytokens:read", "honeytokens:write", "api_tokens:read",
-        "api_tokens:write", "ip_allowlist:read", "ip_allowlist:write", "sources:read",
-        "sources:write", "nhi:send-inventory", "nhi:write-vault", "custom_tags:read",
-        "custom_tags:write", "secrets:read", "secrets:write", "scan:create-incidents",
-        "public-perimeter:read", "nhi:ownership:read", "nhi:ownership:write", "health_checks:read",
-        "health_checks:write"], "expire_at": "2026-04-13T08:20:24.655856+00:00"},
-        "event_name": "personal_access_token.created", "action_type": "CREATE", "target_ids":
-        ["ce80d253-c672-4c2e-ad86-c2a127fbe0ff"], "ip_address": "54.212.233.107"},
-        {"id": 20321531, "api_token_id": null, "member_id": 1121302, "member_email":
-        "candidate.playground+eu5@gitguardian.com", "member_name": "Candidate EU5",
-        "date": "2026-04-03T08:16:13.796999Z", "data": null, "event_name": "secret_incident.viewed",
-        "action_type": "READ", "target_ids": ["11038927"], "ip_address": "92.170.72.162"},
-        {"id": 20321452, "api_token_id": null, "member_id": 1121302, "member_email":
-        "candidate.playground+eu5@gitguardian.com", "member_name": "Candidate EU5",
-        "date": "2026-04-03T08:10:59.237953Z", "data": {"type": "basic"}, "event_name":
-        "user.logged_in", "action_type": "OTHER", "target_ids": ["1119171"], "ip_address":
-        "92.170.72.162"}, {"id": 20320840, "api_token_id": null, "member_id": 701514,
-        "member_email": "pierre.leclezio@gitguardian.com", "member_name": "Pierre
-        LE CLEZIO", "date": "2026-04-03T07:38:22.311430Z", "data": {"type": "saml_sso"},
-        "event_name": "user.logged_in", "action_type": "OTHER", "target_ids": ["700455"],
-        "ip_address": "35.161.89.114"}, {"id": 20319386, "api_token_id": null, "member_id":
-        1754656, "member_email": "candidate.playground+eu@gitguardian.com", "member_name":
-        "CandidateEU DemoAccess", "date": "2026-04-03T06:31:23.572560Z", "data": null,
-        "event_name": "user.logged_out", "action_type": "OTHER", "target_ids": ["1751937"],
-        "ip_address": "35.83.131.170"}]'
+      string: '[{"id": 23983381, "api_token_id": null, "member_id": 480870, "member_email":
+        "timothe.delion@gitguardian.com", "member_name": "Timoth\u00e9 DELION", "date":
+        "2026-06-23T12:23:58.297394Z", "data": null, "event_name": "custom_remediation_workflow.updated",
+        "action_type": "UPDATE", "target_ids": ["6"], "ip_address": "92.128.35.47"},
+        {"id": 23983251, "api_token_id": null, "member_id": 480870, "member_email":
+        "timothe.delion@gitguardian.com", "member_name": "Timoth\u00e9 DELION", "date":
+        "2026-06-23T12:20:54.649674Z", "data": {"type": "saml_sso"}, "event_name":
+        "user.logged_in", "action_type": "OTHER", "target_ids": ["480218"], "ip_address":
+        "92.128.35.47"}, {"id": 23982412, "api_token_id": null, "member_id": 1301278,
+        "member_email": "zach.mccullough@gitguardian.com", "member_name": "Zachary
+        MCCULLOUGH", "date": "2026-06-23T11:59:32.903530Z", "data": {"type": "saml_sso"},
+        "event_name": "user.logged_in", "action_type": "OTHER", "target_ids": ["1299091"],
+        "ip_address": "73.8.249.128"}, {"id": 23982141, "api_token_id": null, "member_id":
+        363444, "member_email": "patrick.flanagan@gitguardian.com", "member_name":
+        "Patrick FLANAGAN", "date": "2026-06-23T11:47:23.624224Z", "data": {"issue_token":
+        73062}, "event_name": "secret_incident.shared_incident_viewed", "action_type":
+        "READ", "target_ids": ["34205503"], "ip_address": "185.175.151.131"}, {"id":
+        23982136, "api_token_id": null, "member_id": 363444, "member_email": "patrick.flanagan@gitguardian.com",
+        "member_name": "Patrick FLANAGAN", "date": "2026-06-23T11:47:02.338330Z",
+        "data": {"issue_id": 34205503, "expire_at": "2026-07-23T11:47:02.322847+00:00"},
+        "event_name": "incident_token.created", "action_type": "CREATE", "target_ids":
+        ["73062"], "ip_address": "185.175.151.131"}]'
     headers:
+      CF-RAY:
+      - a10394cd4c7ea8bd-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:43:56 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '2150'
+      - '1620'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:11 GMT
       link:
-      - <https://api.gitguardian.com/v1/audit_logs?cursor=cD0yMDMxOTM4Ng%3D%3D&per_page=5>;
+      - <https://api.gitguardian.com/v1/audit_logs?cursor=cD0yMzk4MjEzNg%3D%3D&per_page=5>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '25'
+      - '30'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_get_current_member.yaml
+++ b/tests/cassettes/client/vcr/test_get_current_member.yaml
@@ -20,39 +20,50 @@ interactions:
     uri: https://api.gitguardian.com/v1/api_tokens/self
   response:
     body:
-      string: '{"id": "8a262c6a-832d-49e5-8744-23c743ff25ac", "name": "ggmcp CI",
-        "type": "personal_access_token", "scopes": ["scan", "incidents:read", "members:read",
-        "audit_logs:read", "teams:read", "honeytokens:read", "honeytokens:write",
-        "api_tokens:read", "sources:read", "nhi:send-inventory", "nhi:write-vault",
-        "custom_tags:read", "custom_tags:write", "secrets:read", "secrets:write",
-        "scan:create-incidents", "public-perimeter:read"], "member_id": 480870, "workspace_id":
-        8, "created_at": "2025-12-07T14:13:08.044416Z", "last_used_at": "2026-04-03T08:43:00Z",
-        "expire_at": null, "revoked_at": null, "status": "active", "creator_id": 480870}'
+      string: '{"id": "d0ca9877-641f-4c37-8857-c08e0ae148c4", "name": "ggmcp CI (April)",
+        "type": "personal_access_token", "scopes": ["scan", "incidents:read", "incidents:write",
+        "incidents:share", "members:read", "members:write", "audit_logs:read", "teams:read",
+        "teams:write", "honeytokens:read", "honeytokens:write", "api_tokens:read",
+        "api_tokens:write", "ip_allowlist:read", "ip_allowlist:write", "sources:read",
+        "sources:write", "nhi:send-inventory", "nhi:write-vault", "custom_tags:read",
+        "custom_tags:write", "secrets:read", "secrets:write", "scan:create-incidents",
+        "public-perimeter:read", "nhi:ownership:read", "nhi:ownership:write", "sources:scan"],
+        "member_id": 480870, "workspace_id": 8, "created_at": "2026-04-20T13:31:42.422943Z",
+        "last_used_at": "2026-06-23T12:45:00Z", "expire_at": null, "revoked_at": null,
+        "status": "active", "creator_id": 480870}'
     headers:
+      CF-RAY:
+      - a1039737c9b1016f-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:35 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '594'
+      - '802'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:25 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
@@ -60,7 +71,7 @@ interactions:
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -89,41 +100,49 @@ interactions:
     body:
       string: '{"id": 480870, "role": "manager", "access_level": "manager", "email":
         "timothe.delion@gitguardian.com", "name": "Timoth\u00e9 DELION", "created_at":
-        "2023-06-26T12:41:18.599497Z", "last_login": "2026-04-02T13:15:43.810850Z",
+        "2023-06-26T12:41:18.599497Z", "last_login": "2026-06-23T12:20:54.639679Z",
         "active": true}'
     headers:
+      CF-RAY:
+      - a10397396d8f00c8-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:35 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '221'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:25 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '34'
+      - '48'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_get_current_token_info.yaml
+++ b/tests/cassettes/client/vcr/test_get_current_token_info.yaml
@@ -20,47 +20,58 @@ interactions:
     uri: https://api.gitguardian.com/v1/api_tokens/self
   response:
     body:
-      string: '{"id": "8a262c6a-832d-49e5-8744-23c743ff25ac", "name": "ggmcp CI",
-        "type": "personal_access_token", "scopes": ["scan", "incidents:read", "members:read",
-        "audit_logs:read", "teams:read", "honeytokens:read", "honeytokens:write",
-        "api_tokens:read", "sources:read", "nhi:send-inventory", "nhi:write-vault",
-        "custom_tags:read", "custom_tags:write", "secrets:read", "secrets:write",
-        "scan:create-incidents", "public-perimeter:read"], "member_id": 480870, "workspace_id":
-        8, "created_at": "2025-12-07T14:13:08.044416Z", "last_used_at": "2026-04-03T08:43:00Z",
-        "expire_at": null, "revoked_at": null, "status": "active", "creator_id": 480870}'
+      string: '{"id": "d0ca9877-641f-4c37-8857-c08e0ae148c4", "name": "ggmcp CI (April)",
+        "type": "personal_access_token", "scopes": ["scan", "incidents:read", "incidents:write",
+        "incidents:share", "members:read", "members:write", "audit_logs:read", "teams:read",
+        "teams:write", "honeytokens:read", "honeytokens:write", "api_tokens:read",
+        "api_tokens:write", "ip_allowlist:read", "ip_allowlist:write", "sources:read",
+        "sources:write", "nhi:send-inventory", "nhi:write-vault", "custom_tags:read",
+        "custom_tags:write", "secrets:read", "secrets:write", "scan:create-incidents",
+        "public-perimeter:read", "nhi:ownership:read", "nhi:ownership:write", "sources:scan"],
+        "member_id": 480870, "workspace_id": 8, "created_at": "2026-04-20T13:31:42.422943Z",
+        "last_used_at": "2026-06-23T12:45:00Z", "expire_at": null, "revoked_at": null,
+        "status": "active", "creator_id": 480870}'
     headers:
+      CF-RAY:
+      - a10397344c6d035a-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:34 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '594'
+      - '802'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:23 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '30'
+      - '24'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_get_custom_tag.yaml
+++ b/tests/cassettes/client/vcr/test_get_custom_tag.yaml
@@ -21,10 +21,11 @@ interactions:
   response:
     body:
       string: '[{"id": "925fe3fa-8810-43a7-8652-8bb3130b671c", "key": "antoine", "value":
-        null}, {"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key": "commiter", "value":
-        "leaky mcgee"}, {"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037", "key": "confrence",
-        "value": "grrcon"}, {"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7", "key":
-        "confrence test", "value": "hacktivity"}, {"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
+        null}, {"id": "2b918aac-f9db-401c-b86e-69839a91ed6a", "key": "BU", "value":
+        "italia"}, {"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key": "commiter",
+        "value": "leaky mcgee"}, {"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037", "key":
+        "confrence", "value": "grrcon"}, {"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        "key": "confrence test", "value": "hacktivity"}, {"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
         "key": "date leaked", "value": "08/09/2023"}, {"id": "a5ad67ad-da66-4b5d-ac94-a079fe470d58",
         "key": "default", "value": "value"}, {"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22",
         "key": "env", "value": "production"}, {"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
@@ -32,53 +33,60 @@ interactions:
         "key": "event", "value": "cab"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
         "key": "format", "value": "public"}, {"id": "6925b698-1dba-4f0f-8c6c-87be4ce3493e",
-        "key": "Generic test", "value": null}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        "key": "Generic test", "value": null}, {"id": "a6772878-f860-4dc1-a45d-7e0b02161c65",
+        "key": "GG test", "value": null}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "e8d2acf7-efa2-4ee5-b2df-1bff3701af31",
         "key": "important_leak", "value": null}, {"id": "21c8f2fd-9a88-42ab-aa1d-16111e371c62",
         "key": "investigation", "value": null}, {"id": "54697103-1a85-4f35-8766-6cf16399f83e",
         "key": "linked incident", "value": null}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}, {"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
-        "key": "location", "value": "slack"}, {"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
-        "key": "location", "value": "sourcecode"}]'
+        "key": "location", "value": "publicrepo"}]'
     headers:
+      CF-RAY:
+      - a10394c65a773ce1-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:43:55 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, POST, PATCH, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '1614'
+      - '1600'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:09 GMT
       link:
-      - <https://api.gitguardian.com/v1/custom_tags?cursor=cD1sb2NhdGlvbiUzQXNvdXJjZWNvZGU%3D>;
+      - <https://api.gitguardian.com/v1/custom_tags?cursor=cD1sb2NhdGlvbiUzQXB1YmxpY3JlcG8%3D>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '27'
+      - '20'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -108,38 +116,46 @@ interactions:
       string: '{"id": "925fe3fa-8810-43a7-8652-8bb3130b671c", "key": "antoine", "value":
         null}'
     headers:
+      CF-RAY:
+      - a10394c808613843-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:43:55 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '74'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:10 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '23'
+      - '25'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_get_honeytoken.yaml
+++ b/tests/cassettes/client/vcr/test_get_honeytoken.yaml
@@ -25,33 +25,29 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/411d33c0-7fad-4fc1-b94e-bb440c8f9c49",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:11.250010Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}, {"id": "858a3a76-f6f2-4c2e-b0bc-323d9a575413",
-        "name": "test_honey_token", "description": "description", "created_at": "2023-05-15T14:09:09.210845Z",
+        "token": "[REDACTED]"}, {"id": "858a3a76-f6f2-4c2e-b0bc-323d9a575413", "name":
+        "test_honey_token", "description": "description", "created_at": "2023-05-15T14:09:09.210845Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/858a3a76-f6f2-4c2e-b0bc-323d9a575413",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:17.165934Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}, {"id": "72a52279-8e9f-40de-a1d4-bc5fcc48795d",
-        "name": "passwordscon", "description": "", "created_at": "2023-05-16T10:03:49.677782Z",
+        "token": "[REDACTED]"}, {"id": "72a52279-8e9f-40de-a1d4-bc5fcc48795d", "name":
+        "passwordscon", "description": "", "created_at": "2023-05-16T10:03:49.677782Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72a52279-8e9f-40de-a1d4-bc5fcc48795d",
         "status": "triggered", "triggered_at": "2023-05-16T10:04:10.262805Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 222, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
-        "key": "location", "value": "test"}], "custom_tags": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
+        ["publicly_exposed"], "custom_tags": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
         "key": "location", "value": "test"}], "token": "[REDACTED]"}, {"id": "8bf5f99a-538d-4cfe-8e74-61cd7081ae25",
         "name": "PasswordsCon2", "description": "For presentation", "created_at":
         "2023-05-16T11:30:36.210395Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8bf5f99a-538d-4cfe-8e74-61cd7081ae25",
         "status": "triggered", "triggered_at": "2023-05-16T12:29:45.638074Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 344, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "45182b59-b659-41ef-9bb8-44a78740fade", "name": "solid-octo-repo", "description":
         "Placed in solid-octo repo, file ... on 16May2023", "created_at": "2023-05-16T11:51:06.384073Z",
@@ -59,47 +55,41 @@ interactions:
         "status": "triggered", "triggered_at": "2026-02-18T14:51:12.499369Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432", "key": "place",
-        "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
+        [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432", "key":
+        "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
         "name": "jira-OPS-124", "description": "honeytoken deployed in jira ticket
         OPS-124", "created_at": "2023-05-16T11:58:57.713307Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "63bbd74e-bb5f-4910-8e63-eed358af3bc8",
         "name": "improved-carnival repo", "description": "", "created_at": "2023-05-16T14:45:09.811724Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/63bbd74e-bb5f-4910-8e63-eed358af3bc8",
         "status": "revoked", "triggered_at": "2023-05-16T14:49:44.284195Z", "revoked_at":
         "2024-06-19T10:46:44.282148Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "72fcdb5c-e128-4ca5-8970-f1f52f95a78a",
         "name": "slack-chan-website", "description": "", "created_at": "2023-05-16T15:35:26.129025Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72fcdb5c-e128-4ca5-8970-f1f52f95a78a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
-        "key": "place", "value": "website"}], "custom_tags": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
         "key": "place", "value": "website"}], "token": "[REDACTED]"}, {"id": "84d43c23-6d4d-47f8-bf62-e7c1b0ae1625",
         "name": "analytic-repo", "description": "", "created_at": "2023-05-16T16:17:11.435058Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84d43c23-6d4d-47f8-bf62-e7c1b0ae1625",
         "status": "revoked", "triggered_at": "2023-05-16T16:27:55.091410Z", "revoked_at":
         "2023-12-11T14:01:44.427581Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "ef11a80c-6d8e-4fb5-8ee2-4556bae695c3",
         "name": "test ht public", "description": "", "created_at": "2023-05-17T17:00:24.966335Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef11a80c-6d8e-4fb5-8ee2-4556bae695c3",
         "status": "triggered", "triggered_at": "2023-05-17T17:02:33.386529Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 5012, "creator_id": 166199, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
-        "key": "location", "value": "slack"}], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
+        ["publicly_exposed"], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
         "key": "location", "value": "slack"}], "token": "[REDACTED]"}, {"id": "db7bf6ea-57cb-4d13-8ed9-dc59b2620e00",
         "name": "Honeytoken demo 17 may", "description": "This is a token for the
         live demo", "created_at": "2023-05-17T17:15:04.921233Z", "gitguardian_url":
@@ -107,173 +97,161 @@ interactions:
         "status": "triggered", "triggered_at": "2023-05-17T17:16:48.960267Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 5018, "creator_id": 166199, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "79db31fc-ffd1-4bc9-b6e4-3ef37a94712a", "name": "QubitConfrence", "description":
         "", "created_at": "2023-05-18T07:58:37.174577Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/79db31fc-ffd1-4bc9-b6e4-3ef37a94712a",
         "status": "triggered", "triggered_at": "2023-05-18T09:30:01.025933Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 215, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263", "name": "NDC-OSLO Demo", "description":
-        "Demo key for NDC Oslo confrence", "created_at": "2023-05-25T07:59:05.651290Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
+        "name": "NDC-OSLO Demo", "description": "Demo key for NDC Oslo confrence",
+        "created_at": "2023-05-25T07:59:05.651290Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
         "status": "triggered", "triggered_at": "2023-05-25T08:38:27.471330Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 221, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b6f2b765-a8e5-458f-b68a-4b5ef934bcc8", "name": "Pycon Italia", "description":
-        "", "created_at": "2023-05-28T09:34:01.581495Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
+        "name": "Pycon Italia", "description": "", "created_at": "2023-05-28T09:34:01.581495Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
         "status": "revoked", "triggered_at": "2023-05-28T09:45:30.255118Z", "revoked_at":
         "2024-12-10T12:17:08.199275Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "bb494eed-6ba4-4b98-b949-ad5f54d929dd", "name": "ggshield-uORy0any",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "bb494eed-6ba4-4b98-b949-ad5f54d929dd", "name": "ggshield-uORy0any",
         "description": "description", "created_at": "2023-05-30T10:30:39.803353Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bb494eed-6ba4-4b98-b949-ad5f54d929dd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1266b395-a545-42c1-b700-24dbae36447c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1266b395-a545-42c1-b700-24dbae36447c",
         "name": "test_honey_token_previous", "description": "description", "created_at":
         "2023-05-30T10:30:40.547255Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1266b395-a545-42c1-b700-24dbae36447c",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:41:43.173510Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "f60db759-7041-4dfe-80fa-91012d97fdd3",
         "name": "ggshield-tsCPoUcx", "description": "description", "created_at": "2023-05-30T10:37:14.527124Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f60db759-7041-4dfe-80fa-91012d97fdd3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
         "name": "ggshield-BA0VsBh3", "description": "description", "created_at": "2023-05-30T10:39:09.968782Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e7f275d-e115-44d3-8854-5c6472494951",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e7f275d-e115-44d3-8854-5c6472494951",
         "name": "ggshield-UXgNYVXL", "description": "description", "created_at": "2023-05-30T10:42:36.847031Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6e7f275d-e115-44d3-8854-5c6472494951",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7494298b-75c5-44e4-898c-77b3b9017113",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7494298b-75c5-44e4-898c-77b3b9017113",
         "name": "test_honey_token_abc", "description": "description", "created_at":
         "2023-05-30T10:42:37.520767Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7494298b-75c5-44e4-898c-77b3b9017113",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:45:41.905071Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "092dba62-9d82-41bd-84aa-95430d540edc", "name": "ggshield-224Lwv95",
-        "description": "description", "created_at": "2023-05-30T10:46:10.997022Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "092dba62-9d82-41bd-84aa-95430d540edc",
+        "name": "ggshield-224Lwv95", "description": "description", "created_at": "2023-05-30T10:46:10.997022Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/092dba62-9d82-41bd-84aa-95430d540edc",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
         "name": "test_honey_token_previous", "description": "description", "created_at":
         "2023-05-30T10:46:11.714531Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:07.762156Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "13f6dbf3-ae1a-4757-95f6-e0fbc830fc55", "name": "ggshield-agateau",
-        "description": null, "created_at": "2023-05-30T13:32:31.845201Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
+        "name": "ggshield-agateau", "description": null, "created_at": "2023-05-30T13:32:31.845201Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T13:33:03.363563Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 160089, "revoker_id":
         160089, "creator_api_token_id": "425e1a78-209e-4cd5-b08f-8450a0026ac0", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "f17302cd-850b-4b54-9054-60d26a76cf38", "name": "test demo 31may",
-        "description": "", "created_at": "2023-05-31T08:10:36.754144Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f17302cd-850b-4b54-9054-60d26a76cf38",
+        "name": "test demo 31may", "description": "", "created_at": "2023-05-31T08:10:36.754144Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "41d76272-ee3d-4639-93e8-29222b662b93",
         "name": "demo31may-public", "description": "", "created_at": "2023-05-31T08:13:48.373887Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/41d76272-ee3d-4639-93e8-29222b662b93",
         "status": "revoked", "triggered_at": "2023-05-31T08:15:09.926931Z", "revoked_at":
         "2024-12-10T12:16:03.693045Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "63728091-d083-47cc-9898-73c2636f2c7f", "name": "ggshield-ZIU1V3Bv", "description":
         null, "created_at": "2023-05-31T08:17:12.607879Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/63728091-d083-47cc-9898-73c2636f2c7f",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-31T08:17:38.021142Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "001c53df-b63c-4b81-a4fb-35e5b38bf328", "name": "DevOxx Poland", "description":
-        "", "created_at": "2023-05-31T12:28:39.713989Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/001c53df-b63c-4b81-a4fb-35e5b38bf328",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "001c53df-b63c-4b81-a4fb-35e5b38bf328",
+        "name": "DevOxx Poland", "description": "", "created_at": "2023-05-31T12:28:39.713989Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/001c53df-b63c-4b81-a4fb-35e5b38bf328",
         "status": "triggered", "triggered_at": "2023-05-31T14:09:21.767459Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 225, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05", "name": "ggshield-cptptJHt",
-        "description": "ggshield test", "created_at": "2023-06-02T08:47:41.149126Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05",
+        "name": "ggshield-cptptJHt", "description": "ggshield test", "created_at":
+        "2023-06-02T08:47:41.149126Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
-        "name": "ggshield-TtJwtxNE", "description": "ggshield test", "created_at":
-        "2023-06-02T08:48:20.148216Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72", "name": "ggshield-TtJwtxNE",
+        "description": "ggshield test", "created_at": "2023-06-02T08:48:20.148216Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "27379093-c6a4-4732-a64a-715c94e74fd7",
-        "name": "ggshield-TvFzKVed", "description": null, "created_at": "2023-06-09T08:01:57.360210Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/27379093-c6a4-4732-a64a-715c94e74fd7",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "27379093-c6a4-4732-a64a-715c94e74fd7", "name": "ggshield-TvFzKVed",
+        "description": null, "created_at": "2023-06-09T08:01:57.360210Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/27379093-c6a4-4732-a64a-715c94e74fd7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "62cb7048-4302-4b52-9163-e2ceff775b39", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc7214d0-c97a-44b3-b576-664f0a81c4f7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc7214d0-c97a-44b3-b576-664f0a81c4f7",
         "name": "repo analytics 19jun", "description": "", "created_at": "2023-06-19T09:11:21.788070Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc7214d0-c97a-44b3-b576-664f0a81c4f7",
         "status": "revoked", "triggered_at": "2023-06-20T17:24:35.145047Z", "revoked_at":
         "2023-12-11T14:50:27.627289Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb", "name": "ggshield-0etjSvZJ",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb", "name": "ggshield-0etjSvZJ",
         "description": "description", "created_at": "2023-07-05T08:27:14.048162Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-05T08:27:15.756813Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0e4f0dbd-b288-4990-9565-3cc7b0171a79",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:53.240550Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 160089, "revoker_id":
         296618, "creator_api_token_id": "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "14566c1f-0b52-4770-ab68-000704242633", "name": "ggshield-Rv2mUej7",
-        "description": "description", "created_at": "2023-07-05T08:55:23.864812Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "14566c1f-0b52-4770-ab68-000704242633",
+        "name": "ggshield-Rv2mUej7", "description": "description", "created_at": "2023-07-05T08:55:23.864812Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/14566c1f-0b52-4770-ab68-000704242633",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c8c94ffa-c0af-48c6-976a-6502a41811af",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c8c94ffa-c0af-48c6-976a-6502a41811af",
         "name": "honeytoken demo eric", "description": "demo here", "created_at":
         "2023-07-05T14:48:53.893911Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c8c94ffa-c0af-48c6-976a-6502a41811af",
         "status": "triggered", "triggered_at": "2023-07-05T14:49:33.528178Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
         "name": "Example TOken ", "description": "ubvcub", "created_at": "2023-07-12T13:16:10.775681Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
-        "key": "file", "value": ".env"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "0c3f182e-98f5-4a64-aadb-664fd7c9de88", "name": "ggshield-ewIAL7lq", "description":
@@ -282,58 +260,55 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
         "name": "ggshield-w1P1Ggsz", "description": "description", "created_at": "2023-07-27T08:56:55.435203Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a20a718-7b9e-4582-abdf-772053bffd72",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a20a718-7b9e-4582-abdf-772053bffd72",
         "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T08:56:56.138738Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a20a718-7b9e-4582-abdf-772053bffd72",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:58.657957Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "51f41814-f029-4ab4-b863-c0fecba025b3", "name": "ggshield-v3LhZCz8",
-        "description": "description", "created_at": "2023-07-27T09:01:36.117217Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51f41814-f029-4ab4-b863-c0fecba025b3",
+        "name": "ggshield-v3LhZCz8", "description": "description", "created_at": "2023-07-27T09:01:36.117217Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/51f41814-f029-4ab4-b863-c0fecba025b3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T09:01:36.764795Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-27T09:01:37.417151Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e842a635-eb7e-4617-8984-ac57fe909ef7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
         "name": "ggshield-5voYnhhy", "description": null, "created_at": "2023-07-27T13:50:51.332176Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T13:52:58.300149Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "521efd01-bbcc-4380-b548-ed7242c017ea",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "521efd01-bbcc-4380-b548-ed7242c017ea",
         "name": "ggshield-HLZpiznn", "description": null, "created_at": "2023-07-27T14:54:03.198466Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/521efd01-bbcc-4380-b548-ed7242c017ea",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0d81797a-6fc0-4a6e-a211-af16828c0c39",
-        "name": "Webinar Public ", "description": "from webinar ", "created_at": "2023-07-27T15:33:07.472730Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0d81797a-6fc0-4a6e-a211-af16828c0c39", "name": "Webinar
+        Public ", "description": "from webinar ", "created_at": "2023-07-27T15:33:07.472730Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0d81797a-6fc0-4a6e-a211-af16828c0c39",
         "status": "triggered", "triggered_at": "2023-07-27T15:34:48.902462Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 204, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "27e9ba01-4bb6-46ed-84c8-ff14366a3bde", "name": "Private network", "description":
@@ -342,60 +317,55 @@ interactions:
         "status": "triggered", "triggered_at": "2023-07-27T16:23:35.804271Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5670c657-618f-41d7-984b-d59656d905e4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5670c657-618f-41d7-984b-d59656d905e4",
         "name": "ggshield-3KTmbo8u", "description": null, "created_at": "2023-07-27T15:44:43.238742Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5670c657-618f-41d7-984b-d59656d905e4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5d3ad22c-e422-48d2-b7f5-6d52801599aa",
-        "name": "demo 31jul", "description": "", "created_at": "2023-07-31T15:27:18.323098Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d3ad22c-e422-48d2-b7f5-6d52801599aa",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5d3ad22c-e422-48d2-b7f5-6d52801599aa", "name": "demo
+        31jul", "description": "", "created_at": "2023-07-31T15:27:18.323098Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d3ad22c-e422-48d2-b7f5-6d52801599aa",
         "status": "revoked", "triggered_at": "2023-07-31T15:33:49.570793Z", "revoked_at":
         "2023-12-11T14:01:40.706751Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a", "name": "test
-        Antonin 1", "description": "", "created_at": "2023-08-03T08:42:25.251504Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fa63d76d-4297-4d41-8e77-b47d1a97a41a",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a", "name": "test Antonin 1", "description":
+        "", "created_at": "2023-08-03T08:42:25.251504Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fa63d76d-4297-4d41-8e77-b47d1a97a41a",
         "status": "revoked", "triggered_at": "2023-08-03T08:59:58.717709Z", "revoked_at":
         "2023-08-03T09:00:05.809852Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "a11570c6-f472-4fda-a493-30d65fd8e651", "name": "test Antonin 2", "description":
-        "", "created_at": "2023-08-03T14:09:46.046004Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a11570c6-f472-4fda-a493-30d65fd8e651",
+        "name": "test Antonin 2", "description": "", "created_at": "2023-08-03T14:09:46.046004Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40",
-        "name": "vBOY test segment", "description": "sdqsdqsdqsdqsd", "created_at":
-        "2023-08-07T12:45:52.890085Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40", "name": "vBOY
+        test segment", "description": "sdqsdqsdqsdqsd", "created_at": "2023-08-07T12:45:52.890085Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-08-07T12:46:45.470113Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "name": "vBOY test segment 2", "description": "sdqsdqsd", "created_at": "2023-08-07T12:47:49.515448Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "86670f84-e117-4f96-aa16-e399a0bb2cf2",
-        "name": "juuj", "description": "", "created_at": "2023-08-08T15:53:23.097840Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86670f84-e117-4f96-aa16-e399a0bb2cf2",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "86670f84-e117-4f96-aa16-e399a0bb2cf2", "name": "juuj",
+        "description": "", "created_at": "2023-08-08T15:53:23.097840Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/86670f84-e117-4f96-aa16-e399a0bb2cf2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
-        "name": "BSidesLV", "description": "Key leaked publically by leakymcgee again",
-        "created_at": "2023-08-10T00:11:42.132386Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "978bf5aa-1f8e-425b-ac4b-b617ddbc178e", "name": "BSidesLV",
+        "description": "Key leaked publically by leakymcgee again", "created_at":
+        "2023-08-10T00:11:42.132386Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
         "status": "triggered", "triggered_at": "2023-08-10T00:13:19.948280Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
-        "key": "date leaked", "value": "08/09/2023"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
-        "key": "format", "value": "public"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
+        ["publicly_exposed"], "custom_tags": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
         "key": "date leaked", "value": "08/09/2023"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
         "key": "format", "value": "public"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
@@ -405,9 +375,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-08-11T18:55:35.503991Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 61, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
+        ["publicly_exposed"], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "90d4c2b6-ecae-4ef9-a754-4561929b9e38",
         "name": "ggshield-mpkTH5jF", "description": "description", "created_at": "2023-08-16T08:28:18.684517Z",
@@ -415,34 +383,31 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
         "name": "ggshield-mzO8qHEz", "description": "description", "created_at": "2023-08-22T08:19:03.821471Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
         "name": "testket ", "description": "eew", "created_at": "2023-08-29T10:21:29.956291Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "46776cb3-6b11-41fc-b431-07609992f0cb",
-        "name": "HoneyTokenaLARTest", "description": "Testworkshop", "created_at":
-        "2023-08-29T12:07:20.692993Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/46776cb3-6b11-41fc-b431-07609992f0cb",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "46776cb3-6b11-41fc-b431-07609992f0cb", "name": "HoneyTokenaLARTest",
+        "description": "Testworkshop", "created_at": "2023-08-29T12:07:20.692993Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/46776cb3-6b11-41fc-b431-07609992f0cb",
         "status": "revoked", "triggered_at": "2023-08-29T12:09:16.581232Z", "revoked_at":
         "2023-08-29T12:42:37.841866Z", "type": "AWS", "open_events_count": 0, "creator_id":
         37699, "revoker_id": 37699, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "edd96a3b-5c71-4346-b5e2-2150e454dc91", "name": "Bsides Krakow", "description":
-        "Demo for leaking a key on GitHub", "created_at": "2023-09-02T13:20:53.501588Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/edd96a3b-5c71-4346-b5e2-2150e454dc91",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "edd96a3b-5c71-4346-b5e2-2150e454dc91",
+        "name": "Bsides Krakow", "description": "Demo for leaking a key on GitHub",
+        "created_at": "2023-09-02T13:20:53.501588Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/edd96a3b-5c71-4346-b5e2-2150e454dc91",
         "status": "triggered", "triggered_at": "2023-09-02T13:22:51.142717Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "de145bd4-b424-49ab-b95b-80126914bf2e",
         "name": "ctf-demo-test-honeytoken-django-app", "description": "", "created_at":
@@ -450,68 +415,59 @@ interactions:
         "status": "revoked", "triggered_at": "2023-09-06T07:42:55.177580Z", "revoked_at":
         "2023-09-06T10:03:30.948628Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "5564ed3c-3eec-4375-9fc8-e0ada71dce02", "name": "ctf-demo-test-honeytoken-micro-api",
-        "description": "", "created_at": "2023-09-05T19:18:08.504776Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/5564ed3c-3eec-4375-9fc8-e0ada71dce02",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5564ed3c-3eec-4375-9fc8-e0ada71dce02",
+        "name": "ctf-demo-test-honeytoken-micro-api", "description": "", "created_at":
+        "2023-09-05T19:18:08.504776Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5564ed3c-3eec-4375-9fc8-e0ada71dce02",
         "status": "revoked", "triggered_at": "2023-09-06T07:44:18.074891Z", "revoked_at":
         "2023-09-06T10:03:48.581110Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "f246c64a-3494-43ae-9d81-500df2f950c3", "name": "demo-honeytoken-ctf-personal-",
-        "description": "", "created_at": "2023-09-06T11:29:57.547211Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/f246c64a-3494-43ae-9d81-500df2f950c3",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f246c64a-3494-43ae-9d81-500df2f950c3",
+        "name": "demo-honeytoken-ctf-personal-", "description": "", "created_at":
+        "2023-09-06T11:29:57.547211Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f246c64a-3494-43ae-9d81-500df2f950c3",
         "status": "revoked", "triggered_at": "2023-09-06T12:18:14.949044Z", "revoked_at":
         "2024-12-10T12:15:49.265110Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
         "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "ff623703-9ca1-4fba-99dc-c20110894ed3",
         "name": "-demo-honeytoken-ctf-django-app-", "description": "", "created_at":
         "2023-09-06T11:33:27.376222Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff623703-9ca1-4fba-99dc-c20110894ed3",
         "status": "triggered", "triggered_at": "2023-09-06T14:19:10.580142Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 4, "creator_id": null, "revoker_id":
+        null, "type": "AWS", "open_events_count": 9, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "a58154f6-e66f-4079-82b7-aabec70c73ff",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "a58154f6-e66f-4079-82b7-aabec70c73ff",
         "name": "demo-honeytoken-ctf-micro-api", "description": "", "created_at":
         "2023-09-06T11:33:37.828240Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a58154f6-e66f-4079-82b7-aabec70c73ff",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-09-06T14:17:20.708816Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b01db549-a2fa-4527-913d-0715a1119530",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "b01db549-a2fa-4527-913d-0715a1119530",
         "name": "demo-honeytoken-ctf-internal-share-", "description": "", "created_at":
         "2023-09-06T11:33:48.881275Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b01db549-a2fa-4527-913d-0715a1119530",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-09-06T14:21:42.509905Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "89a1745a-f796-4ece-99f7-106671aea57c",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "89a1745a-f796-4ece-99f7-106671aea57c",
         "name": "-demo-honeytoken-ctf-micro-api-", "description": "", "created_at":
         "2023-09-06T14:19:32.695323Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/89a1745a-f796-4ece-99f7-106671aea57c",
         "status": "triggered", "triggered_at": "2023-09-06T14:24:18.462424Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "095d655f-a273-400f-ba01-eff8951242ed",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "095d655f-a273-400f-ba01-eff8951242ed",
         "name": "-demo-honeytoken-ctf-internal-share-", "description": "", "created_at":
         "2023-09-06T14:21:55.062468Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/095d655f-a273-400f-ba01-eff8951242ed",
         "status": "triggered", "triggered_at": "2023-09-08T16:58:49.455578Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 6, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "3664c283-d479-41ac-9ad9-30283731ee25",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "3664c283-d479-41ac-9ad9-30283731ee25",
         "name": "Balccon Demo", "description": "Demo key for Balccon ", "created_at":
         "2023-09-08T14:55:02.417580Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3664c283-d479-41ac-9ad9-30283731ee25",
         "status": "triggered", "triggered_at": "2023-09-08T14:56:49.516889Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
-        "key": "location", "value": "sourcecode"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
-        "key": "visability", "value": "public"}], "custom_tags": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
+        ["publicly_exposed"], "custom_tags": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
         "key": "location", "value": "sourcecode"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
         "key": "visability", "value": "public"}], "token": "[REDACTED]"}, {"id": "7ca5ca92-a0a1-48bf-9618-d7194beaa039",
@@ -520,9 +476,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-09-29T16:11:40.077048Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 344, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
-        "key": "confrence", "value": "grrcon"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}], "custom_tags": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
+        ["publicly_exposed"], "custom_tags": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
         "key": "confrence", "value": "grrcon"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}], "token": "[REDACTED]"}, {"id": "2544b3e6-57b2-48e2-a1a5-c4b6551987bb",
         "name": "SBB demo", "description": "Leaking key on GitHub", "created_at":
@@ -530,11 +484,8 @@ interactions:
         "status": "triggered", "triggered_at": "2024-08-17T15:36:55.810693Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key": "commiter",
-        "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca", "key":
-        "file", "value": ".env"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327", "key":
-        "vcs", "value": "github"}], "custom_tags": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda",
-        "key": "commiter", "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
+        [], "custom_tags": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key":
+        "commiter", "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "7d80793b-c702-441e-837e-b1d3da94d576",
         "name": "Hacktivity Key", "description": "Test Key Leak for Hacktivity", "created_at":
@@ -542,9 +493,7 @@ interactions:
         "status": "revoked", "triggered_at": "2023-10-05T14:42:57.752365Z", "revoked_at":
         "2024-12-10T12:17:33.875750Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "576dc1ce-ab72-4604-934f-526cff5a667e", "name": "BsidesCyprus", "description":
@@ -553,8 +502,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-10-07T11:35:53.017981Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 249, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "22fdf53a-e348-464a-a87f-5bcecb1a4e62", "name": "Slack test", "description":
         "blablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablabla
@@ -567,21 +515,20 @@ interactions:
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-06-03T09:50:06.667490Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 363707, "revoker_id":
         353920, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "137c9fee-4b3c-4231-92fd-98debf6557c2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "137c9fee-4b3c-4231-92fd-98debf6557c2",
         "name": "BSides ATL demo for session", "description": "This one will be triggered
         from 2 different spots online", "created_at": "2023-10-14T12:28:51.206659Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/137c9fee-4b3c-4231-92fd-98debf6557c2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 354585, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "cdaea884-25fb-49db-90ec-a18879be36c4",
-        "name": "Demo Honeytoken", "description": "Leaking on Public Demo", "created_at":
-        "2023-10-16T15:13:10.845487Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cdaea884-25fb-49db-90ec-a18879be36c4",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "cdaea884-25fb-49db-90ec-a18879be36c4", "name": "Demo
+        Honeytoken", "description": "Leaking on Public Demo", "created_at": "2023-10-16T15:13:10.845487Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cdaea884-25fb-49db-90ec-a18879be36c4",
         "status": "revoked", "triggered_at": "2023-10-16T15:14:25.574559Z", "revoked_at":
         "2023-10-27T15:01:19.053629Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "48f7c567-93d1-4925-9f77-d3919f120b88", "name": "ggshield-KlAkKRtE", "description":
         "description", "created_at": "2023-10-16T19:49:08.588391Z", "gitguardian_url":
@@ -589,52 +536,50 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
         "name": "Jason test", "description": "Token for Test ", "created_at": "2023-10-24T13:45:31.371710Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f8e0968-664a-49f3-af85-9cc468b960ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "fe392ff1-b3d7-462f-a26f-d094326f40ed",
-        "name": "Jason and team", "description": "akljdlaj", "created_at": "2023-10-24T14:23:20.991107Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fe392ff1-b3d7-462f-a26f-d094326f40ed", "name": "Jason
+        and team", "description": "akljdlaj", "created_at": "2023-10-24T14:23:20.991107Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fe392ff1-b3d7-462f-a26f-d094326f40ed",
         "status": "triggered", "triggered_at": "2024-05-10T22:15:09.224357Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29",
         "name": "Eric Demo Test 01", "description": "", "created_at": "2023-10-31T12:51:44.535200Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d69a098c-8b61-4102-bb2b-9a82958a3e29",
         "status": "revoked", "triggered_at": "2023-10-31T12:52:49.851916Z", "revoked_at":
         "2024-12-10T12:16:28.115539Z", "type": "AWS", "open_events_count": 0, "creator_id":
         136170, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb", "name": "test
-        eric dd 02", "description": "", "created_at": "2023-10-31T14:33:35.801324Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4affa602-902b-47ff-a1f4-721dc3e671bb",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb", "name": "test eric dd 02",
+        "description": "", "created_at": "2023-10-31T14:33:35.801324Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/4affa602-902b-47ff-a1f4-721dc3e671bb",
         "status": "triggered", "triggered_at": "2023-10-31T14:35:33.676298Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 2897, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "8df388e2-aeb5-42ca-b6d5-221a54a40339", "name": "ggshield-P47kTh7j",
-        "description": null, "created_at": "2023-11-09T15:44:33.671666Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/8df388e2-aeb5-42ca-b6d5-221a54a40339",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8df388e2-aeb5-42ca-b6d5-221a54a40339",
+        "name": "ggshield-P47kTh7j", "description": null, "created_at": "2023-11-09T15:44:33.671666Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8df388e2-aeb5-42ca-b6d5-221a54a40339",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "bd51c3d9-0943-43d5-8f87-359ecee03903",
-        "name": "ggshield-73VAsjsO", "description": null, "created_at": "2023-11-14T08:27:44.885242Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bd51c3d9-0943-43d5-8f87-359ecee03903",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "bd51c3d9-0943-43d5-8f87-359ecee03903", "name": "ggshield-73VAsjsO",
+        "description": null, "created_at": "2023-11-14T08:27:44.885242Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/bd51c3d9-0943-43d5-8f87-359ecee03903",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-11-14T08:28:08.188201Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
         "name": "DeepSec Demo", "description": "Demo for DeepSec Confrence ", "created_at":
         "2023-11-16T16:01:21.723176Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
         "status": "triggered", "triggered_at": "2023-11-16T16:01:58.603599Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "ae448808-3865-4797-a008-9eef6344f9da", "name": "Bsides Berlin", "description":
         "test key for a demo", "created_at": "2023-11-18T16:19:36.463172Z", "gitguardian_url":
@@ -642,9 +587,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-11-18T16:20:14.365596Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 105, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
-        "key": "repo", "value": "mackenziejj"}], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
+        ["publicly_exposed"], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
         "key": "repo", "value": "mackenziejj"}], "token": "[REDACTED]"}, {"id": "ecb3d61d-bdab-4636-a436-bef8079a005d",
         "name": "ggshield-ObfCUUCA", "description": "description", "created_at": "2023-11-28T08:50:32.130230Z",
@@ -652,48 +595,41 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d6d5d79d-08fa-4c8a-bd54-c34851866cde",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d6d5d79d-08fa-4c8a-bd54-c34851866cde",
         "name": "test1112", "description": "test publicly exposed honeytoken", "created_at":
         "2023-12-11T16:24:56.253683Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d6d5d79d-08fa-4c8a-bd54-c34851866cde",
         "status": "triggered", "triggered_at": "2023-12-11T16:26:07.733443Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "4046ccf5-7821-47f4-be7d-8240be69631b",
         "name": "ideal-journey-lena", "description": "", "created_at": "2023-12-11T16:29:20.759489Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4046ccf5-7821-47f4-be7d-8240be69631b",
-        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
-        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
+        "status": "triggered", "triggered_at": "2026-05-28T07:56:58.047592Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 5, "creator_id": 319222, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
         "name": "analytics-repo", "description": "", "created_at": "2023-12-11T17:37:24.471286Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
         "status": "triggered", "triggered_at": "2023-12-11T17:46:48.024345Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "b7daf77c-e3e0-4747-a7e2-485a1a6f05e2",
-        "key": "team", "value": "dev"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "b7daf77c-e3e0-4747-a7e2-485a1a6f05e2",
         "key": "team", "value": "dev"}], "token": "[REDACTED]"}, {"id": "52903632-f6ff-460e-8a68-80a942349979",
         "name": "Network Honeytoken", "description": "Aws Honeytoken on Network",
         "created_at": "2023-12-18T13:47:39.151311Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/52903632-f6ff-460e-8a68-80a942349979",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
-        "key": "network", "value": "directory"}], "custom_tags": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
         "key": "network", "value": "directory"}], "token": "[REDACTED]"}, {"id": "6c5d9856-835e-468c-9448-7bf0e77f1e53",
         "name": "improved carnival", "description": "", "created_at": "2023-12-21T13:43:01.544215Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6c5d9856-835e-468c-9448-7bf0e77f1e53",
         "status": "revoked", "triggered_at": "2023-12-21T13:57:59.435706Z", "revoked_at":
         "2023-12-22T09:33:18.668820Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "4dd77510-fc74-411f-9dbe-77619fa920dd",
         "name": "My Postman Public Collection", "description": "Will it ring?", "created_at":
@@ -701,242 +637,231 @@ interactions:
         "status": "triggered", "triggered_at": "2024-01-04T17:52:01.203498Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 811, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
         "name": "ggshield-JZV5XT71", "description": "description", "created_at": "2024-01-09T09:39:34.421404Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "name": "sss", "description": "test", "created_at": "2024-01-09T14:24:10.741214Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
-        "name": "AWS key honeytoken for Slack", "description": "Honeytoken on Slack
-        channel", "created_at": "2024-01-15T16:13:53.656688Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "123ecd19-e66f-4e5c-ad73-12f0a51eda5a", "name": "AWS
+        key honeytoken for Slack", "description": "Honeytoken on Slack channel", "created_at":
+        "2024-01-15T16:13:53.656688Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
         "status": "triggered", "triggered_at": "2024-01-15T16:14:14.960066Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 104, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "23ca2658-aecf-471c-abf0-add09962e320", "key": "ods",
-        "value": "slack"}], "custom_tags": [{"id": "23ca2658-aecf-471c-abf0-add09962e320",
-        "key": "ods", "value": "slack"}], "token": "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a",
+        [], "custom_tags": [{"id": "23ca2658-aecf-471c-abf0-add09962e320", "key":
+        "ods", "value": "slack"}], "token": "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a",
         "name": "BK Test Paris", "description": "Brandon while in Paris office", "created_at":
         "2024-01-17T11:12:14.759334Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/34d5205b-accd-429c-9efa-eda48989c83a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
-        "name": "Lauren Testing", "description": "Lauren wuz here", "created_at":
-        "2024-01-29T17:37:45.379096Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4", "name": "Lauren
+        Testing", "description": "Lauren wuz here", "created_at": "2024-01-29T17:37:45.379096Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 637596, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "07fb5f6f-23f1-42e8-bdb2-c95864412a16",
         "name": "My Little Honeytoken", "description": "for testing", "created_at":
         "2024-02-02T22:18:06.038874Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/07fb5f6f-23f1-42e8-bdb2-c95864412a16",
         "status": "triggered", "triggered_at": "2024-02-09T20:50:13.173911Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b00bfddb-98c2-48e4-ad38-0cb9bc79cad6", "name": "orga_083643/solid-octo",
-        "description": "", "created_at": "2024-02-09T14:45:12.139727Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
+        "name": "orga_083643/solid-octo", "description": "", "created_at": "2024-02-09T14:45:12.139727Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
         "status": "revoked", "triggered_at": "2024-02-09T14:52:11.339548Z", "revoked_at":
         "2024-05-29T13:09:29.773300Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 2508, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "cf0806c4-093d-4165-9ad3-7e7ded211d3f", "name": "DemoKey", "description":
-        "sss", "created_at": "2024-02-15T12:39:23.633481Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cf0806c4-093d-4165-9ad3-7e7ded211d3f",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cf0806c4-093d-4165-9ad3-7e7ded211d3f",
+        "name": "DemoKey", "description": "sss", "created_at": "2024-02-15T12:39:23.633481Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cf0806c4-093d-4165-9ad3-7e7ded211d3f",
         "status": "triggered", "triggered_at": "2024-02-15T12:45:44.649197Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "638f6f82-6679-4399-a336-dd7996f4beae", "name": "demo-2024-02-16dm",
-        "description": "demo", "created_at": "2024-02-16T19:39:33.970811Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/638f6f82-6679-4399-a336-dd7996f4beae",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "638f6f82-6679-4399-a336-dd7996f4beae",
+        "name": "demo-2024-02-16dm", "description": "demo", "created_at": "2024-02-16T19:39:33.970811Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/638f6f82-6679-4399-a336-dd7996f4beae",
         "status": "revoked", "triggered_at": "2024-02-16T19:40:02.759791Z", "revoked_at":
         "2024-02-16T20:10:11.153368Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "6fcc5cf2-4b47-497d-9a80-c2d794b96ebc", "name": "solid-octo",
-        "description": "", "created_at": "2024-02-19T13:06:26.880374Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "6fcc5cf2-4b47-497d-9a80-c2d794b96ebc", "name": "solid-octo", "description":
+        "", "created_at": "2024-02-19T13:06:26.880374Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
-        "key": "team", "value": "octo"}], "custom_tags": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
         "key": "team", "value": "octo"}], "token": "[REDACTED]"}, {"id": "1592023a-2f39-4ba6-a503-4c07132f1eb0",
         "name": "GGnikalston/rock-paper-scissors-f4c01375", "description": "", "created_at":
         "2024-02-20T13:32:45.163630Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1592023a-2f39-4ba6-a503-4c07132f1eb0",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d024b464-cd1e-4daf-9b1d-863dcf517a7a",
-        "name": "Demo -2024-02-22", "description": "", "created_at": "2024-02-22T18:53:26.142516Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d024b464-cd1e-4daf-9b1d-863dcf517a7a", "name": "Demo
+        -2024-02-22", "description": "", "created_at": "2024-02-22T18:53:26.142516Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d024b464-cd1e-4daf-9b1d-863dcf517a7a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 354585, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0a94480f-5361-47f8-bc23-45a331624e9d",
-        "name": "demo ", "description": "demo ", "created_at": "2024-02-22T19:02:29.338420Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0a94480f-5361-47f8-bc23-45a331624e9d",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0a94480f-5361-47f8-bc23-45a331624e9d", "name": "demo
+        ", "description": "demo ", "created_at": "2024-02-22T19:02:29.338420Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/0a94480f-5361-47f8-bc23-45a331624e9d",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T17:03:31.533534Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86136984-d415-41c2-bfc4-59da8f9584fd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86136984-d415-41c2-bfc4-59da8f9584fd",
         "name": "demo-2024-02-23-dm", "description": "", "created_at": "2024-02-23T15:38:04.895275Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86136984-d415-41c2-bfc4-59da8f9584fd",
         "status": "revoked", "triggered_at": "2024-02-23T15:49:03.613445Z", "revoked_at":
         "2024-02-23T15:59:54.768989Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "b38455f9-822c-4f21-8525-0d4f2fa63850", "name": "demo-dwayne-2024-02-23",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "b38455f9-822c-4f21-8525-0d4f2fa63850", "name": "demo-dwayne-2024-02-23",
         "description": "dfnijsbuisbfids", "created_at": "2024-02-23T15:45:47.636481Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b38455f9-822c-4f21-8525-0d4f2fa63850",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T16:28:23.939971Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "612055eb-7fb5-4ba3-ab10-aa481f3d9962",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "612055eb-7fb5-4ba3-ab10-aa481f3d9962",
         "name": "demo-dwayne-2024-02-23-v2", "description": "Demo for video", "created_at":
         "2024-02-23T16:28:49.949332Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/612055eb-7fb5-4ba3-ab10-aa481f3d9962",
         "status": "revoked", "triggered_at": "2024-02-23T16:31:01.657151Z", "revoked_at":
         "2024-02-23T16:52:50.712289Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e", "name": "myname-dwayneptoday",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e", "name": "myname-dwayneptoday",
         "description": "dfsdfsdf", "created_at": "2024-02-23T16:38:14.323313Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T17:03:21.653827Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1bba091c-fc4c-48b5-b558-46c191f67103",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1bba091c-fc4c-48b5-b558-46c191f67103",
         "name": "ggshield-ldC5hqqo", "description": "description", "created_at": "2024-02-27T13:42:36.686028Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1bba091c-fc4c-48b5-b558-46c191f67103",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d7764013-fdd5-4b08-b195-dff5a338906d",
-        "name": "ggshield-LRYYnjOa", "description": "description", "created_at": "2024-02-27T13:42:37.569678Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d7764013-fdd5-4b08-b195-dff5a338906d", "name": "ggshield-LRYYnjOa",
+        "description": "description", "created_at": "2024-02-27T13:42:37.569678Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d7764013-fdd5-4b08-b195-dff5a338906d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "def4a23d-3d12-4fe1-b8e0-02250e74e47a",
-        "name": "ggshield-itglxnie", "description": "description", "created_at": "2024-02-27T13:58:30.205444Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "def4a23d-3d12-4fe1-b8e0-02250e74e47a", "name": "ggshield-itglxnie",
+        "description": "description", "created_at": "2024-02-27T13:58:30.205444Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/def4a23d-3d12-4fe1-b8e0-02250e74e47a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "33d149f1-68f4-4446-ae4f-def0ce962724",
-        "name": "ggshield-2Mf02eVA", "description": "description", "created_at": "2024-02-27T13:58:31.125075Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "33d149f1-68f4-4446-ae4f-def0ce962724", "name": "ggshield-2Mf02eVA",
+        "description": "description", "created_at": "2024-02-27T13:58:31.125075Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/33d149f1-68f4-4446-ae4f-def0ce962724",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5ff5eee1-fc18-4474-86fa-c46321c903c8",
-        "name": "ggshield-rmnfzrW2", "description": "description", "created_at": "2024-02-27T14:02:45.009113Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5ff5eee1-fc18-4474-86fa-c46321c903c8", "name": "ggshield-rmnfzrW2",
+        "description": "description", "created_at": "2024-02-27T14:02:45.009113Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5ff5eee1-fc18-4474-86fa-c46321c903c8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "4dd6c06e-e2c0-4593-9be0-b0418ba7a370",
-        "name": "ggshield-5YTKZZTB", "description": "description", "created_at": "2024-02-27T14:02:45.717261Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "4dd6c06e-e2c0-4593-9be0-b0418ba7a370", "name": "ggshield-5YTKZZTB",
+        "description": "description", "created_at": "2024-02-27T14:02:45.717261Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4dd6c06e-e2c0-4593-9be0-b0418ba7a370",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "eba79796-4f46-4e10-b876-280f75138cc9",
-        "name": "ggshield-z3Y6zgih", "description": "description", "created_at": "2024-02-27T14:06:02.196977Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "eba79796-4f46-4e10-b876-280f75138cc9", "name": "ggshield-z3Y6zgih",
+        "description": "description", "created_at": "2024-02-27T14:06:02.196977Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/eba79796-4f46-4e10-b876-280f75138cc9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0ebc8091-454b-461e-a6f8-fd17bf412c76",
-        "name": "ggshield-jqk54PrI", "description": "description", "created_at": "2024-02-27T14:06:03.018091Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0ebc8091-454b-461e-a6f8-fd17bf412c76", "name": "ggshield-jqk54PrI",
+        "description": "description", "created_at": "2024-02-27T14:06:03.018091Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ebc8091-454b-461e-a6f8-fd17bf412c76",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "664af568-cfc7-4726-9fb4-0b61606b7386",
-        "name": "ggshield-horgQNnR", "description": "description", "created_at": "2024-02-27T14:19:39.357690Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "664af568-cfc7-4726-9fb4-0b61606b7386", "name": "ggshield-horgQNnR",
+        "description": "description", "created_at": "2024-02-27T14:19:39.357690Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/664af568-cfc7-4726-9fb4-0b61606b7386",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5d915aca-6f6f-4b4e-a996-2c1f53016114",
-        "name": "ggshield-LNgN8R1S", "description": "description", "created_at": "2024-02-27T14:19:40.283320Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5d915aca-6f6f-4b4e-a996-2c1f53016114", "name": "ggshield-LNgN8R1S",
+        "description": "description", "created_at": "2024-02-27T14:19:40.283320Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d915aca-6f6f-4b4e-a996-2c1f53016114",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245",
-        "name": "Test key ", "description": "ss", "created_at": "2024-02-29T13:49:52.467489Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245", "name": "Test
+        key ", "description": "ss", "created_at": "2024-02-29T13:49:52.467489Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e",
-        "name": "test-lena-1903", "description": "", "created_at": "2024-03-19T09:13:00.819618Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/443045cc-7fa4-441d-a161-b060bd7fbb3e",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e", "name": "test-lena-1903",
+        "description": "", "created_at": "2024-03-19T09:13:00.819618Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/443045cc-7fa4-441d-a161-b060bd7fbb3e",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-05-29T09:51:31.597203Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 319222, "revoker_id":
         319222, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
         "name": "ggshield-Psfrcoxl", "description": "description", "created_at": "2024-03-27T08:48:20.857237Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5a01f826-4f8f-4235-8867-ce58ac88ce1c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5a01f826-4f8f-4235-8867-ce58ac88ce1c",
         "name": "ggshield-inUFY47O", "description": "description", "created_at": "2024-03-27T08:48:21.791104Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5a01f826-4f8f-4235-8867-ce58ac88ce1c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d72113d0-c346-42c7-bd88-fd5fe0e716f3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d72113d0-c346-42c7-bd88-fd5fe0e716f3",
         "name": "ggshield-eY0ZOlXS", "description": "description", "created_at": "2024-04-30T09:25:38.689800Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d72113d0-c346-42c7-bd88-fd5fe0e716f3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "7f2873cd-3759-4727-a683-31cac57fe5d8",
-        "name": "ggshield-TvlX76OG", "description": "description", "created_at": "2024-04-30T09:25:39.573115Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "7f2873cd-3759-4727-a683-31cac57fe5d8", "name": "ggshield-TvlX76OG",
+        "description": "description", "created_at": "2024-04-30T09:25:39.573115Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7f2873cd-3759-4727-a683-31cac57fe5d8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "72e98633-9179-4a3e-8908-ea2319d19b3b",
-        "name": "ggshield-XYKDhLUY", "description": "description", "created_at": "2024-04-30T10:19:12.369644Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "72e98633-9179-4a3e-8908-ea2319d19b3b", "name": "ggshield-XYKDhLUY",
+        "description": "description", "created_at": "2024-04-30T10:19:12.369644Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72e98633-9179-4a3e-8908-ea2319d19b3b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
         "name": "ggshield-HRoZzrBq", "description": "description", "created_at": "2024-04-30T10:19:13.126568Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
         "name": "Test key", "description": "Access key", "created_at": "2024-05-22T12:16:55.833940Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c7101eaa-ea38-495d-b3b4-c016db23e859",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "a67f962c-9dde-40c2-b404-e7cd4449cc82",
         "name": "pouet", "description": "", "created_at": "2024-05-22T12:19:03.143437Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a67f962c-9dde-40c2-b404-e7cd4449cc82",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
-        "key": "visability", "value": "public"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
         "key": "visability", "value": "public"}], "token": "[REDACTED]"}, {"id": "9cca01c5-535f-4f89-a214-6c4c5579fd07",
@@ -944,487 +869,473 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9cca01c5-535f-4f89-a214-6c4c5579fd07",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
-        "name": "test lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
-        "status": "triggered", "triggered_at": "2024-06-06T08:19:18.422045Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 319222, "revoker_id":
-        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca", "key": "machine",
-        "value": "ggprdgim01"}], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99", "name": "test
+        lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
         "key": "machine", "value": "ggprdgim01"}], "token": "[REDACTED]"}, {"id":
         "a411fa2c-a465-4099-8353-3c42365aca50", "name": "test MINT", "description":
         "test MINT", "created_at": "2024-06-10T14:40:08.522247Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/a411fa2c-a465-4099-8353-3c42365aca50",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "12c4562e-deb8-4d14-bb23-e344e79b6f04",
-        "name": "ggshield-Wq4EyTMI", "description": "description", "created_at": "2024-06-25T08:36:52.179380Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "12c4562e-deb8-4d14-bb23-e344e79b6f04", "name": "ggshield-Wq4EyTMI",
+        "description": "description", "created_at": "2024-06-25T08:36:52.179380Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/12c4562e-deb8-4d14-bb23-e344e79b6f04",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3407738b-2095-47bb-9cbd-dd16de158d67",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3407738b-2095-47bb-9cbd-dd16de158d67",
         "name": "ggshield-65KCwJls", "description": "description", "created_at": "2024-06-25T08:36:52.873146Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3407738b-2095-47bb-9cbd-dd16de158d67",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
         "name": "ggshield-fb77weow", "description": "description", "created_at": "2024-06-26T09:27:38.724573Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9223e352-43b6-4e06-8d12-682d669cedd7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9223e352-43b6-4e06-8d12-682d669cedd7",
         "name": "ggshield-TRO3H56N", "description": "description", "created_at": "2024-06-26T09:27:39.479744Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9223e352-43b6-4e06-8d12-682d669cedd7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "17e088b8-2463-48f8-957b-41d017f1dc83",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "17e088b8-2463-48f8-957b-41d017f1dc83",
         "name": "ggshield-s7IOqS0q", "description": "description", "created_at": "2024-06-26T09:42:26.454643Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/17e088b8-2463-48f8-957b-41d017f1dc83",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e332d717-641d-4ea4-81fc-e98115178454",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e332d717-641d-4ea4-81fc-e98115178454",
         "name": "ggshield-JaAf9b0W", "description": "description", "created_at": "2024-06-26T09:42:27.174527Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e332d717-641d-4ea4-81fc-e98115178454",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26514e1f-4237-474b-b907-037b88427f29",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26514e1f-4237-474b-b907-037b88427f29",
         "name": "ggshield-Uuc8EiUn", "description": "description", "created_at": "2024-06-26T11:51:19.747630Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/26514e1f-4237-474b-b907-037b88427f29",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
         "name": "ggshield-GL7wc5WW", "description": "description", "created_at": "2024-06-26T11:51:20.402145Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
         "name": "test ericf", "description": "", "created_at": "2024-07-09T09:34:04.089955Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
         "status": "triggered", "triggered_at": "2024-07-09T09:34:57.541777Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "a507d04c-bb61-4f2a-93ea-601b8aa27940",
         "name": "ggshield-w1cOSspy", "description": "description", "created_at": "2024-07-31T15:31:09.349255Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a507d04c-bb61-4f2a-93ea-601b8aa27940",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dafa04c5-299a-4a13-9c35-c523e51763f3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dafa04c5-299a-4a13-9c35-c523e51763f3",
         "name": "ggshield-b7VHMqbK", "description": "description", "created_at": "2024-07-31T15:31:10.071786Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dafa04c5-299a-4a13-9c35-c523e51763f3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
         "name": "ggshield-Fu1nGsc9", "description": "description", "created_at": "2024-08-05T09:03:52.745860Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "83888e42-dc57-471c-9a08-f023e3dc2949",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "83888e42-dc57-471c-9a08-f023e3dc2949",
         "name": "ggshield-5suF2vRt", "description": "description", "created_at": "2024-08-05T09:03:53.434873Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/83888e42-dc57-471c-9a08-f023e3dc2949",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e8aad547-96a7-40a4-a05d-710cf536f3a7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e8aad547-96a7-40a4-a05d-710cf536f3a7",
         "name": "ggshield-Vqz4LULC", "description": "description", "created_at": "2024-08-05T09:21:25.593516Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e8aad547-96a7-40a4-a05d-710cf536f3a7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
         "name": "ggshield-lqX7PlwI", "description": "description", "created_at": "2024-08-05T09:21:26.211228Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b144b1fd-dc5f-4a36-abc7-a95d05331245",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b144b1fd-dc5f-4a36-abc7-a95d05331245",
         "name": "ggshield-uZr6LNDv", "description": "description", "created_at": "2024-08-27T07:44:46.267249Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b144b1fd-dc5f-4a36-abc7-a95d05331245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "903bf588-2a03-4318-be6c-b9e3198d1fd6",
-        "name": "ggshield-5Ty2Hu4r", "description": "description", "created_at": "2024-08-27T07:44:46.871854Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "903bf588-2a03-4318-be6c-b9e3198d1fd6", "name": "ggshield-5Ty2Hu4r",
+        "description": "description", "created_at": "2024-08-27T07:44:46.871854Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/903bf588-2a03-4318-be6c-b9e3198d1fd6",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "11222b98-7705-4180-99d1-6e719d8a05a9",
-        "name": "ggshield-qnLief7n", "description": "description", "created_at": "2024-08-27T08:20:15.846360Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "11222b98-7705-4180-99d1-6e719d8a05a9", "name": "ggshield-qnLief7n",
+        "description": "description", "created_at": "2024-08-27T08:20:15.846360Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/11222b98-7705-4180-99d1-6e719d8a05a9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "707b35fb-685b-4577-88b9-94cccc10e165",
-        "name": "ggshield-wqYwwgeK", "description": "description", "created_at": "2024-08-27T08:20:16.467770Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "707b35fb-685b-4577-88b9-94cccc10e165", "name": "ggshield-wqYwwgeK",
+        "description": "description", "created_at": "2024-08-27T08:20:16.467770Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/707b35fb-685b-4577-88b9-94cccc10e165",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "01c7668d-1467-4cac-a395-4b50fc278407",
-        "name": "ggshield-QkzL5Vyb", "description": "description", "created_at": "2024-09-24T08:50:15.865165Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "01c7668d-1467-4cac-a395-4b50fc278407", "name": "ggshield-QkzL5Vyb",
+        "description": "description", "created_at": "2024-09-24T08:50:15.865165Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/01c7668d-1467-4cac-a395-4b50fc278407",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
         "name": "ggshield-kkpkfk1s", "description": "description", "created_at": "2024-09-24T08:50:16.667172Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "730bdd87-31b2-4b42-a32a-5750bc595c9c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "730bdd87-31b2-4b42-a32a-5750bc595c9c",
         "name": "ggshield-dtxlZtWH", "description": "description", "created_at": "2024-10-01T13:18:29.918337Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/730bdd87-31b2-4b42-a32a-5750bc595c9c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b42c6945-05fc-4c5b-af83-e60478cd9db5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b42c6945-05fc-4c5b-af83-e60478cd9db5",
         "name": "ggshield-WPIELIcW", "description": "description", "created_at": "2024-10-01T13:18:30.820570Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b42c6945-05fc-4c5b-af83-e60478cd9db5",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
         "name": "ggshield-B8LwcRR0", "description": "description", "created_at": "2024-10-16T13:47:50.239094Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "81d30531-a54e-4f67-a46b-a7bac5783995",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "81d30531-a54e-4f67-a46b-a7bac5783995",
         "name": "ggshield-IjJFdqDS", "description": "description", "created_at": "2024-10-16T13:47:51.425195Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/81d30531-a54e-4f67-a46b-a7bac5783995",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a0b24134-0cbc-4ca5-b110-18b3311aef73",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a0b24134-0cbc-4ca5-b110-18b3311aef73",
         "name": "DO-demo", "description": "Digital Ocean Demo", "created_at": "2024-10-23T17:55:40.621634Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a0b24134-0cbc-4ca5-b110-18b3311aef73",
         "status": "revoked", "triggered_at": "2024-10-23T18:03:40.135215Z", "revoked_at":
         "2024-10-23T18:33:47.488182Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "50e53ab6-4950-48e6-9350-b5aaa88fafea", "name": "Demo",
-        "description": "Dev team 1", "created_at": "2024-10-27T21:01:47.725365Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/50e53ab6-4950-48e6-9350-b5aaa88fafea",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "50e53ab6-4950-48e6-9350-b5aaa88fafea", "name": "Demo", "description":
+        "Dev team 1", "created_at": "2024-10-27T21:01:47.725365Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/50e53ab6-4950-48e6-9350-b5aaa88fafea",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582569, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}], "token": "[REDACTED]"},
         {"id": "795decd4-4703-4073-9b3c-3ec2157f6182", "name": "Demo token", "description":
         "Take a look", "created_at": "2024-10-28T00:34:48.214122Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/795decd4-4703-4073-9b3c-3ec2157f6182",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582569, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
-        "name": "ggshield-c6YSc2Ie", "description": "description", "created_at": "2024-10-29T14:36:27.096968Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "c43ee48d-4646-40e8-bd12-3dfa30a6b3db", "name": "ggshield-c6YSc2Ie",
+        "description": "description", "created_at": "2024-10-29T14:36:27.096968Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
         "name": "ggshield-E6IPnu0f", "description": "description", "created_at": "2024-10-29T14:36:28.513178Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a454c002-679b-4250-aacf-28b5207543a4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a454c002-679b-4250-aacf-28b5207543a4",
         "name": "ggshield-HjwRkUAT", "description": "description", "created_at": "2024-11-27T12:32:44.877048Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a454c002-679b-4250-aacf-28b5207543a4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5af2ae0-f3f6-4301-82bc-b49108bd782b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5af2ae0-f3f6-4301-82bc-b49108bd782b",
         "name": "ggshield-hIlrbyRm", "description": "description", "created_at": "2024-11-27T12:32:45.728067Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c5af2ae0-f3f6-4301-82bc-b49108bd782b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "aed37b34-4721-43c2-99e2-2f2e78592f63",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "aed37b34-4721-43c2-99e2-2f2e78592f63",
         "name": "ggshield/setup.cfg", "description": "", "created_at": "2024-12-17T10:10:25.895137Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/aed37b34-4721-43c2-99e2-2f2e78592f63",
         "status": "triggered", "triggered_at": "2024-12-17T10:19:35.167833Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 309802, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476", "name": "pierredethoisy/dockerfile",
-        "description": "", "created_at": "2024-12-17T10:30:41.655876Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
+        "name": "pierredethoisy/dockerfile", "description": "", "created_at": "2024-12-17T10:30:41.655876Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
         "status": "triggered", "triggered_at": "2024-12-17T10:32:09.594850Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 309802, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "4b814f00-0897-479f-8a2d-a9593c5f18fa", "name": "WrongSecrets", "description":
-        "Honeytoken for the wrongsecrets repositort", "created_at": "2025-02-06T13:10:31.569094Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4b814f00-0897-479f-8a2d-a9593c5f18fa",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4b814f00-0897-479f-8a2d-a9593c5f18fa",
+        "name": "WrongSecrets", "description": "Honeytoken for the wrongsecrets repositort",
+        "created_at": "2025-02-06T13:10:31.569094Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4b814f00-0897-479f-8a2d-a9593c5f18fa",
         "status": "triggered", "triggered_at": "2025-02-06T13:16:26.325168Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "7dfdb8ee-56fc-486e-9b7a-e6ff248107fa", "name": "ggshield-AAcFXCwl",
-        "description": "description", "created_at": "2025-02-27T10:23:31.621722Z",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
+        "name": "ggshield-AAcFXCwl", "description": "description", "created_at": "2025-02-27T10:23:31.621722Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "97877334-808d-48c7-8802-2c54e9f43661",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "97877334-808d-48c7-8802-2c54e9f43661",
         "name": "ggshield-srahH0o3", "description": "description", "created_at": "2025-02-27T10:23:32.385844Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/97877334-808d-48c7-8802-2c54e9f43661",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ca642fe-2ce4-42b2-9097-5904093935c1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ca642fe-2ce4-42b2-9097-5904093935c1",
         "name": "ggshield-5Vx0aaQd", "description": "description", "created_at": "2025-02-27T10:31:34.080183Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ca642fe-2ce4-42b2-9097-5904093935c1",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d8590557-764f-4618-9b2e-277d536bd111",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d8590557-764f-4618-9b2e-277d536bd111",
         "name": "ggshield-QYqCVZ4i", "description": "description", "created_at": "2025-02-27T10:31:34.798380Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d8590557-764f-4618-9b2e-277d536bd111",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84b08c90-12f5-48ef-baee-ab8d8b15588c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84b08c90-12f5-48ef-baee-ab8d8b15588c",
         "name": "ggshield-4sJy2SkE", "description": "description", "created_at": "2025-02-27T10:53:01.890617Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84b08c90-12f5-48ef-baee-ab8d8b15588c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72204c1e-12c1-445f-b106-09488214d610",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72204c1e-12c1-445f-b106-09488214d610",
         "name": "ggshield-eqoLjiAS", "description": "description", "created_at": "2025-02-27T10:53:02.563136Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72204c1e-12c1-445f-b106-09488214d610",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
         "name": "ggshield-yaqMNJFA", "description": "description", "created_at": "2025-02-27T11:24:20.630794Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a5d5ca0-000f-4011-aaf2-b4f627c19649",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a5d5ca0-000f-4011-aaf2-b4f627c19649",
         "name": "ggshield-x12c7zPc", "description": "description", "created_at": "2025-02-27T11:24:21.465056Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8a5d5ca0-000f-4011-aaf2-b4f627c19649",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c823f31a-73a8-46cc-be4a-029d6d081793",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c823f31a-73a8-46cc-be4a-029d6d081793",
         "name": "ggshield-9Mq5rTUV", "description": "description", "created_at": "2025-02-27T16:44:10.862683Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c823f31a-73a8-46cc-be4a-029d6d081793",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49f1055b-b505-402b-8b79-e4b2c6cf2041",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49f1055b-b505-402b-8b79-e4b2c6cf2041",
         "name": "ggshield-4MmSKBvx", "description": "description", "created_at": "2025-02-27T16:44:11.663957Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/49f1055b-b505-402b-8b79-e4b2c6cf2041",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be8e40e8-b204-40de-8d37-247ac6ef7077",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be8e40e8-b204-40de-8d37-247ac6ef7077",
         "name": "ggshield-DBuxWn0n", "description": "description", "created_at": "2025-02-27T16:57:21.290157Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be8e40e8-b204-40de-8d37-247ac6ef7077",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d10551f8-36f0-4966-a684-d5f9eca89e8d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d10551f8-36f0-4966-a684-d5f9eca89e8d",
         "name": "ggshield-bukJ4Md2", "description": "description", "created_at": "2025-02-27T16:57:22.079317Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d10551f8-36f0-4966-a684-d5f9eca89e8d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d5385824-6a93-47cb-81f3-e818e64371d7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d5385824-6a93-47cb-81f3-e818e64371d7",
         "name": "ggshield-vI1CTIm2", "description": "description", "created_at": "2025-02-27T17:24:28.533666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d5385824-6a93-47cb-81f3-e818e64371d7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
         "name": "ggshield-C519GYI9", "description": "description", "created_at": "2025-02-27T17:24:29.231126Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
         "name": "ggshield-i8zN7WRH", "description": "description", "created_at": "2025-02-27T17:27:14.478281Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "661dae4d-5944-4a20-b7f7-f74913356479",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "661dae4d-5944-4a20-b7f7-f74913356479",
         "name": "ggshield-IX7GxSIs", "description": "description", "created_at": "2025-02-27T17:27:15.226298Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/661dae4d-5944-4a20-b7f7-f74913356479",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "adaea919-086f-4e37-b4e5-dc8208d0e4f5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "adaea919-086f-4e37-b4e5-dc8208d0e4f5",
         "name": "ggshield-rWApiuse", "description": "description", "created_at": "2025-03-03T09:15:26.314595Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/adaea919-086f-4e37-b4e5-dc8208d0e4f5",
         "status": "triggered", "triggered_at": "2026-02-18T14:51:12.198393Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
-        "key": "env", "value": "staging"}], "custom_tags": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
+        null, "tags": [], "custom_tags": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
         "key": "env", "value": "staging"}], "token": "[REDACTED]"}, {"id": "da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
         "name": "ggshield-jdbeH3gE", "description": "description", "created_at": "2025-03-03T09:15:27.049176Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22", "key": "env",
-        "value": "production"}], "custom_tags": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22",
-        "key": "env", "value": "production"}], "token": "[REDACTED]"}, {"id": "1f4708b2-0e51-458c-abca-c03e502b4a5a",
+        [], "custom_tags": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22", "key":
+        "env", "value": "production"}], "token": "[REDACTED]"}, {"id": "1f4708b2-0e51-458c-abca-c03e502b4a5a",
         "name": "ggshield-QgwFEPjx", "description": "description", "created_at": "2025-03-27T15:12:18.744612Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1f4708b2-0e51-458c-abca-c03e502b4a5a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "a4ced9be-6ad5-4d8a-b188-65a117bc0eba",
-        "name": "ggshield-44tVmSvF", "description": "description", "created_at": "2025-03-27T15:12:19.507492Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "a4ced9be-6ad5-4d8a-b188-65a117bc0eba", "name": "ggshield-44tVmSvF",
+        "description": "description", "created_at": "2025-03-27T15:12:19.507492Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a4ced9be-6ad5-4d8a-b188-65a117bc0eba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5710ee7d-6428-4074-a9ff-09399782242d",
-        "name": "ggshield-bF87lDBl", "description": "description", "created_at": "2025-03-27T15:21:17.135616Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5710ee7d-6428-4074-a9ff-09399782242d", "name": "ggshield-bF87lDBl",
+        "description": "description", "created_at": "2025-03-27T15:21:17.135616Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5710ee7d-6428-4074-a9ff-09399782242d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
-        "name": "ggshield-LbIDqGyA", "description": "description", "created_at": "2025-03-27T15:21:17.953340Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "4cbf7af9-9989-4185-8ef8-0f39e6f3d145", "name": "ggshield-LbIDqGyA",
+        "description": "description", "created_at": "2025-03-27T15:21:17.953340Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2dfa1936-f53f-4d0c-8a69-ae9bab297021",
-        "name": "ggshield-qz84En8W", "description": "description", "created_at": "2025-03-27T15:24:16.907610Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2dfa1936-f53f-4d0c-8a69-ae9bab297021", "name": "ggshield-qz84En8W",
+        "description": "description", "created_at": "2025-03-27T15:24:16.907610Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2dfa1936-f53f-4d0c-8a69-ae9bab297021",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "11213dc7-118d-4997-a96b-714640c3ad0b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "11213dc7-118d-4997-a96b-714640c3ad0b",
         "name": "ggshield-CSF39jm8", "description": "description", "created_at": "2025-03-27T15:24:17.721006Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/11213dc7-118d-4997-a96b-714640c3ad0b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "899dd0b0-20b2-45d2-b779-0331cc448935",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "899dd0b0-20b2-45d2-b779-0331cc448935",
         "name": "toto", "description": "tata", "created_at": "2025-05-12T09:58:35.161641Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/899dd0b0-20b2-45d2-b779-0331cc448935",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "62d71685-2eba-4b88-8edd-cc73e698cfa5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "62d71685-2eba-4b88-8edd-cc73e698cfa5",
         "name": "test-greg", "description": "test greg", "created_at": "2025-05-12T10:06:19.826522Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/62d71685-2eba-4b88-8edd-cc73e698cfa5",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:59.739856Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "e948f77d-5353-413e-b37d-8beba84890ff", "name": "test-greg-2", "description":
-        "test greg", "created_at": "2025-05-12T10:08:11.667578Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e948f77d-5353-413e-b37d-8beba84890ff",
+        "name": "test-greg-2", "description": "test greg", "created_at": "2025-05-12T10:08:11.667578Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:54.809724Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb", "name": "test-greg-3", "description":
-        "test greg", "created_at": "2025-05-12T10:08:58.561160Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        "name": "test-greg-3", "description": "test greg", "created_at": "2025-05-12T10:08:58.561160Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:50.784137Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6", "name": "test-greg-4", "description":
-        "test", "created_at": "2025-05-12T10:10:12.927058Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6",
+        "name": "test-greg-4", "description": "test", "created_at": "2025-05-12T10:10:12.927058Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:46.594085Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a", "name": "test-greg-5", "description":
-        "test", "created_at": "2025-05-12T10:12:50.615700Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
+        "name": "test-greg-5", "description": "test", "created_at": "2025-05-12T10:12:50.615700Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:41.387978Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "9fcf0732-6b8d-41d3-ae98-727bd5dde585", "name": "achille-hackathon",
-        "description": "achille hackathon", "created_at": "2025-05-12T12:01:23.542568Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9fcf0732-6b8d-41d3-ae98-727bd5dde585",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9fcf0732-6b8d-41d3-ae98-727bd5dde585",
+        "name": "achille-hackathon", "description": "achille hackathon", "created_at":
+        "2025-05-12T12:01:23.542568Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9fcf0732-6b8d-41d3-ae98-727bd5dde585",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38",
         "name": "TestHoneytoken", "description": "Testing GitGuardian API connectivity",
         "created_at": "2025-05-12T12:19:05.294638Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b0ddbd44-4054-4127-aa00-cd6727e70d38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
         "name": "AWS Credentials", "description": "Honeytoken for testing, to be injected
         as requested by the user.", "created_at": "2025-05-12T12:38:25.640506Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
         "status": "triggered", "triggered_at": "2026-02-18T13:45:03.781945Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 269050, "revoker_id":
+        null, "type": "AWS", "open_events_count": 9, "creator_id": 269050, "revoker_id":
         null, "creator_api_token_id": "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec", "name": "test-greg-7", "description":
-        "test", "created_at": "2025-05-12T12:54:37.703725Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ab824e92-6068-4a9d-ae36-86a94516f2ec",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec",
+        "name": "test-greg-7", "description": "test", "created_at": "2025-05-12T12:54:37.703725Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ab824e92-6068-4a9d-ae36-86a94516f2ec",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:34.521470Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b65d42a4-587f-4701-a595-8429cbcda70b", "name": "gg-mcp-server-honeytoken",
-        "description": "Honeytoken for security monitoring in the gg-mcp-server project.",
-        "created_at": "2025-05-12T12:54:44.402023Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b65d42a4-587f-4701-a595-8429cbcda70b",
-        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
-        "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
-        "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3fe4aa4f-49f6-42ad-a34a-0c108b544215",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b65d42a4-587f-4701-a595-8429cbcda70b",
+        "name": "gg-mcp-server-honeytoken", "description": "Honeytoken for security
+        monitoring in the gg-mcp-server project.", "created_at": "2025-05-12T12:54:44.402023Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b65d42a4-587f-4701-a595-8429cbcda70b",
+        "status": "triggered", "triggered_at": "2026-06-04T13:16:15.961464Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 4, "creator_id": 269050, "revoker_id":
+        null, "creator_api_token_id": "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id":
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3fe4aa4f-49f6-42ad-a34a-0c108b544215",
         "name": "default-honeytoken", "description": "General purpose honeytoken for
         security monitoring", "created_at": "2025-05-12T13:07:52.676810Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/3fe4aa4f-49f6-42ad-a34a-0c108b544215",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
         "name": "test", "description": "test", "created_at": "2025-05-12T13:09:38.965752Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9844e55d-982c-4458-b65b-592ad99ce77a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1026550, "revoker_id": null, "creator_api_token_id":
         "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
         "name": "Test Honeytoken", "description": "Testing honeytoken generation",
         "created_at": "2025-05-12T14:35:34.295363Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b2a7e759-81ab-465d-a578-e3ce42c18741",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
         "name": "test-greg-9", "description": "", "created_at": "2025-05-12T14:50:23.123299Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6d185a-6f59-4b7c-9248-dd05616090db",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:27.366114Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
+        null, "tags": [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
         "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "fbb93094-9778-4b8b-97d8-de99954a758a",
         "name": "AWS_Honeytoken", "description": "Honeytoken generated via MCP", "created_at":
@@ -1432,17 +1343,15 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "34e08af4-59a7-4a3b-b799-65acb8a2019d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "34e08af4-59a7-4a3b-b799-65acb8a2019d",
         "name": "AWS-MCP-Honeytoken", "description": "Honeytoken for monitoring potential
         AWS credential leaks", "created_at": "2025-05-12T15:07:16.157981Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/34e08af4-59a7-4a3b-b799-65acb8a2019d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "16805984-70d6-4049-844a-79bac3054f6f",
         "name": "AwsTestHoneytoken", "description": "Test honeytoken for development
         and monitoring", "created_at": "2025-05-12T15:09:00.390236Z", "gitguardian_url":
@@ -1450,10 +1359,8 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "d476c118-b210-403d-b685-3d7f0a514950",
         "name": "aws-development-access-key", "description": "Development environment
         AWS access key for monitoring credential leaks", "created_at": "2025-05-12T15:12:56.525944Z",
@@ -1461,9 +1368,7 @@ interactions:
         "status": "triggered", "triggered_at": "2026-02-18T14:50:57.626529Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 2, "creator_id": 270722, "revoker_id":
         null, "creator_api_token_id": "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
+        null, "tags": [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
         "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "0a112323-6906-4bd0-a660-1b45a0fc59ca",
         "name": "NHI-Explorer-Secret", "description": "AWS access key for NHI Explorer
@@ -1472,232 +1377,412 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "69dbbe3c-2dfc-4c93-916c-f70c42f4e2af",
         "name": "ggshield-Leb9CGys", "description": "description", "created_at": "2025-05-27T08:18:31.020533Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/69dbbe3c-2dfc-4c93-916c-f70c42f4e2af",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "029e2aba-796c-47d8-8d52-e14f9868acfc",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "029e2aba-796c-47d8-8d52-e14f9868acfc",
         "name": "ggshield-Fhjl6QxB", "description": "description", "created_at": "2025-05-27T08:18:31.873128Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/029e2aba-796c-47d8-8d52-e14f9868acfc",
         "status": "triggered", "triggered_at": "2025-06-17T09:30:39.728240Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "c77d47b6-8d61-46a7-b6a1-1715fc47c7eb", "name": "ggshield-U8JeiAjO",
-        "description": "description", "created_at": "2025-06-24T13:04:20.196705Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
+        "name": "ggshield-U8JeiAjO", "description": "description", "created_at": "2025-06-24T13:04:20.196705Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab",
-        "name": "ggshield-NiJSM24s", "description": "description", "created_at": "2025-06-24T13:04:21.255669Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab", "name": "ggshield-NiJSM24s",
+        "description": "description", "created_at": "2025-06-24T13:04:21.255669Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5692a982-6603-443e-bdb4-5ea1a5de6f64",
-        "name": "ggshield-JKhVuHaW", "description": "description", "created_at": "2025-06-24T13:06:56.046343Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5692a982-6603-443e-bdb4-5ea1a5de6f64", "name": "ggshield-JKhVuHaW",
+        "description": "description", "created_at": "2025-06-24T13:06:56.046343Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5692a982-6603-443e-bdb4-5ea1a5de6f64",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "17925c95-1df7-4e86-9c42-aabb5dbdea69",
-        "name": "ggshield-vfjAXCfY", "description": "description", "created_at": "2025-06-24T13:06:57.033247Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "17925c95-1df7-4e86-9c42-aabb5dbdea69", "name": "ggshield-vfjAXCfY",
+        "description": "description", "created_at": "2025-06-24T13:06:57.033247Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/17925c95-1df7-4e86-9c42-aabb5dbdea69",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "631ef101-122f-4592-9de1-2d6cb5becafa",
-        "name": "ggshield-dbhOtleP", "description": "description", "created_at": "2025-06-24T13:13:01.219899Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "631ef101-122f-4592-9de1-2d6cb5becafa", "name": "ggshield-dbhOtleP",
+        "description": "description", "created_at": "2025-06-24T13:13:01.219899Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/631ef101-122f-4592-9de1-2d6cb5becafa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "bebc1ca8-933d-45ca-b201-fbabc4eab464",
-        "name": "ggshield-7pQLMJYV", "description": "description", "created_at": "2025-06-24T13:13:01.978212Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "bebc1ca8-933d-45ca-b201-fbabc4eab464", "name": "ggshield-7pQLMJYV",
+        "description": "description", "created_at": "2025-06-24T13:13:01.978212Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bebc1ca8-933d-45ca-b201-fbabc4eab464",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "3983e8ff-7fd6-4fde-9117-9612d4258052",
-        "name": "ggshield-phDsJ9wy", "description": "description", "created_at": "2025-06-24T13:29:15.096198Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "3983e8ff-7fd6-4fde-9117-9612d4258052", "name": "ggshield-phDsJ9wy",
+        "description": "description", "created_at": "2025-06-24T13:29:15.096198Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3983e8ff-7fd6-4fde-9117-9612d4258052",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "9340e7fe-f79c-467e-9dcd-43ddaa77dc0c",
-        "name": "ggshield-Md0MBV0B", "description": "description", "created_at": "2025-06-24T13:29:16.049584Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "9340e7fe-f79c-467e-9dcd-43ddaa77dc0c", "name": "ggshield-Md0MBV0B",
+        "description": "description", "created_at": "2025-06-24T13:29:16.049584Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9340e7fe-f79c-467e-9dcd-43ddaa77dc0c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "08b51a6e-dd6c-4a4b-93f9-b955663c6524",
-        "name": "ggshield-ZoWflf5b", "description": "description", "created_at": "2025-06-24T13:31:49.045062Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "08b51a6e-dd6c-4a4b-93f9-b955663c6524", "name": "ggshield-ZoWflf5b",
+        "description": "description", "created_at": "2025-06-24T13:31:49.045062Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/08b51a6e-dd6c-4a4b-93f9-b955663c6524",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "96da938d-d6fa-4e44-9254-c568a27be484",
-        "name": "ggshield-PirK5h1Q", "description": "description", "created_at": "2025-06-24T13:31:49.827284Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "96da938d-d6fa-4e44-9254-c568a27be484", "name": "ggshield-PirK5h1Q",
+        "description": "description", "created_at": "2025-06-24T13:31:49.827284Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/96da938d-d6fa-4e44-9254-c568a27be484",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f2c61b85-e11d-4db0-a8af-7fc327310b39",
-        "name": "ggshield-ZQ4jUtQr", "description": "description", "created_at": "2025-06-24T13:45:17.477850Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f2c61b85-e11d-4db0-a8af-7fc327310b39", "name": "ggshield-ZQ4jUtQr",
+        "description": "description", "created_at": "2025-06-24T13:45:17.477850Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f2c61b85-e11d-4db0-a8af-7fc327310b39",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f99173ff-9ffe-492c-b8ae-54157df89bac",
-        "name": "ggshield-5uK6KYFh", "description": "description", "created_at": "2025-06-24T13:45:18.309642Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f99173ff-9ffe-492c-b8ae-54157df89bac", "name": "ggshield-5uK6KYFh",
+        "description": "description", "created_at": "2025-06-24T13:45:18.309642Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f99173ff-9ffe-492c-b8ae-54157df89bac",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768",
-        "name": "ggshield-MGXkbqc7", "description": "description", "created_at": "2025-06-24T13:50:43.295521Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768", "name": "ggshield-MGXkbqc7",
+        "description": "description", "created_at": "2025-06-24T13:50:43.295521Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f3252f2c-16a9-45e4-97e8-bed4b5752415",
-        "name": "ggshield-YJd3rq9q", "description": "description", "created_at": "2025-06-24T13:50:44.165951Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f3252f2c-16a9-45e4-97e8-bed4b5752415", "name": "ggshield-YJd3rq9q",
+        "description": "description", "created_at": "2025-06-24T13:50:44.165951Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f3252f2c-16a9-45e4-97e8-bed4b5752415",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "e22705f1-5497-449b-9614-3c2d89e3b705",
-        "name": "ggshield-l4abwnpa", "description": null, "created_at": "2025-06-26T12:32:05.993896Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e22705f1-5497-449b-9614-3c2d89e3b705",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "e22705f1-5497-449b-9614-3c2d89e3b705", "name": "ggshield-l4abwnpa",
+        "description": null, "created_at": "2025-06-26T12:32:05.993896Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e22705f1-5497-449b-9614-3c2d89e3b705",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
         "4ff03654-f280-4c31-8eef-5295d2b75a50", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7691445a-2cb0-4093-94ca-f2c5de877075",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7691445a-2cb0-4093-94ca-f2c5de877075",
         "name": "ggshield-Lwhu1Nax", "description": "description", "created_at": "2025-07-29T10:34:41.534666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7691445a-2cb0-4093-94ca-f2c5de877075",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "951e1f19-5804-444a-b275-b51dc5bf68ee",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "951e1f19-5804-444a-b275-b51dc5bf68ee",
         "name": "ggshield-u9ltlEmT", "description": "description", "created_at": "2025-07-29T10:34:42.385215Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/951e1f19-5804-444a-b275-b51dc5bf68ee",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
         "name": "ggshield-CC0Lj0vS", "description": "description", "created_at": "2025-07-29T10:40:27.317817Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
         "name": "ggshield-0k2Xha2i", "description": "description", "created_at": "2025-07-29T10:40:28.088246Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
         "status": "triggered", "triggered_at": "2025-08-22T16:59:58.315774Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "49e4fce7-aa48-42b0-9fc4-e16105ae08e5", "name": "ggshield-ncOpkfP8",
-        "description": "description", "created_at": "2025-08-27T11:43:11.666517Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
+        "name": "ggshield-ncOpkfP8", "description": "description", "created_at": "2025-08-27T11:43:11.666517Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2b15518b-3100-4736-bee6-b47fe8d26fc1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2b15518b-3100-4736-bee6-b47fe8d26fc1",
         "name": "ggshield-H2eDvilF", "description": "description", "created_at": "2025-08-27T11:43:12.618589Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2b15518b-3100-4736-bee6-b47fe8d26fc1",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "368a90bf-269b-4a60-95c2-1c77c86f7fd4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "368a90bf-269b-4a60-95c2-1c77c86f7fd4",
         "name": "ggshield-V6RzZJGL", "description": "description", "created_at": "2025-11-14T16:54:30.227288Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/368a90bf-269b-4a60-95c2-1c77c86f7fd4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "eae1aaaf-d700-475d-b65a-ffd79f84806d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "eae1aaaf-d700-475d-b65a-ffd79f84806d",
         "name": "ggshield-Pya2g1xF", "description": "description", "created_at": "2025-11-14T16:54:30.933576Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/eae1aaaf-d700-475d-b65a-ffd79f84806d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
         "name": "ggshield-Z2Ji3PxX", "description": "description", "created_at": "2026-03-31T13:26:20.710346Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
         "name": "ggshield-FsL9dCzu", "description": "description", "created_at": "2026-03-31T13:26:21.681383Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7daed77-1fa4-416d-88e2-473200b810aa",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7daed77-1fa4-416d-88e2-473200b810aa",
         "name": "ggshield-dqv39cn2", "description": "description", "created_at": "2026-03-31T13:32:28.824725Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e7daed77-1fa4-416d-88e2-473200b810aa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "601c59d9-7579-402e-90c4-59da055a8d3b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "601c59d9-7579-402e-90c4-59da055a8d3b",
         "name": "ggshield-YpbVgsRl", "description": "description", "created_at": "2026-03-31T13:32:29.820990Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/601c59d9-7579-402e-90c4-59da055a8d3b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "54e52712-a036-4e80-899b-c1a200610339",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "54e52712-a036-4e80-899b-c1a200610339",
         "name": "ggshield-DZ5zVj1p", "description": "description", "created_at": "2026-03-31T13:37:32.513332Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/54e52712-a036-4e80-899b-c1a200610339",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51dc5671-8053-4b87-8174-975ccf7f249c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51dc5671-8053-4b87-8174-975ccf7f249c",
         "name": "ggshield-DXGKK2gC", "description": "description", "created_at": "2026-03-31T13:37:33.559937Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/51dc5671-8053-4b87-8174-975ccf7f249c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}]'
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "name": "test Pierre", "description": "", "created_at": "2026-04-07T18:38:38.199572Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "ae435f66-1ea9-4dfe-b73f-49f451fc00ab", "name": "Demo
+        Romain", "description": "", "created_at": "2026-04-24T12:48:19.654369Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/ae435f66-1ea9-4dfe-b73f-49f451fc00ab",
+        "status": "triggered", "triggered_at": "2026-04-29T12:54:19.464710Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 6, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [{"id": "7a2469eb-2b6b-4248-8103-2b0f6b4fac9b", "key":
+        "romain", "value": null}], "token": "[REDACTED]"}, {"id": "10f6e20b-12ae-4591-aa09-7e1ff00ef408",
+        "name": "qa / xyz-e732d912", "description": "", "created_at": "2026-04-24T16:05:46.508625Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/10f6e20b-12ae-4591-aa09-7e1ff00ef408",
+        "status": "triggered", "triggered_at": "2026-04-24T16:13:17.276672Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9266c0f4-f0e0-41d2-a8c8-c164ccb84e47",
+        "name": "qa / test-nriv-e732d912", "description": "", "created_at": "2026-04-24T16:05:50.013606Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9266c0f4-f0e0-41d2-a8c8-c164ccb84e47",
+        "status": "triggered", "triggered_at": "2026-04-24T16:15:44.494587Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "name": "dev / Salome Test-e732d912", "description": "", "created_at": "2026-04-24T16:05:53.158978Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "status": "triggered", "triggered_at": "2026-04-24T16:16:21.895694Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "name": "qa / test-r8327r-e732d912", "description": "", "created_at": "2026-04-24T16:05:56.586568Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "status": "triggered", "triggered_at": "2026-04-24T16:18:31.419829Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2314a2ef-cec4-4e3d-834a-09b0c40c99d2",
+        "name": "qa / abc-e732d912", "description": "", "created_at": "2026-04-24T16:05:59.728317Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2314a2ef-cec4-4e3d-834a-09b0c40c99d2",
+        "status": "triggered", "triggered_at": "2026-04-24T16:25:50.024911Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "fe96d213-a002-4161-a7c9-cb3be4ad88f8",
+        "name": "qa / Handcrafted Metal Bike-e732d912", "description": "", "created_at":
+        "2026-04-24T16:06:02.936659Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fe96d213-a002-4161-a7c9-cb3be4ad88f8",
+        "status": "triggered", "triggered_at": "2026-04-24T16:35:48.958630Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a72f662-2357-4b93-b48a-00028e36cfff",
+        "name": "test1", "description": "tEST 2", "created_at": "2026-04-30T09:12:55.584248Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a72f662-2357-4b93-b48a-00028e36cfff",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "963fbabe-3d2c-4154-8281-2f13be7c06f7", "name": "test121",
+        "description": "testing 12", "created_at": "2026-04-30T11:31:57.689130Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/963fbabe-3d2c-4154-8281-2f13be7c06f7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "1acff09e-02c1-4a24-8869-568dfab124c9", "name": "test-pierredt",
+        "description": "hello", "created_at": "2026-05-06T19:57:39.689471Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/1acff09e-02c1-4a24-8869-568dfab124c9",
+        "status": "triggered", "triggered_at": "2026-05-06T19:59:18.645288Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 6, "creator_id": 309802, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "name": "qa / test-nriv-d2363bd5", "description": "", "created_at": "2026-05-19T08:29:37.247067Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "status": "triggered", "triggered_at": "2026-05-19T08:33:36.289678Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 1754656, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "03e7e668-6fbf-493a-8d1c-ac9d0c6c1b97",
+        "name": "qa / xyz-d2363bd5", "description": "", "created_at": "2026-05-19T08:29:41.396307Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/03e7e668-6fbf-493a-8d1c-ac9d0c6c1b97",
+        "status": "triggered", "triggered_at": "2026-05-19T08:34:30.001210Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 1754656, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "bb1adf06-28ea-4daf-b338-59d5ef094f67",
+        "name": "TheBigHoney", "description": "Big Honey Pot for our core secrets",
+        "created_at": "2026-05-19T11:51:12.957707Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bb1adf06-28ea-4daf-b338-59d5ef094f67",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "93abaf01-cac6-48f4-bfa1-735cfb7fde7d", "name": "ttoprjog",
+        "description": "Henri", "created_at": "2026-05-20T12:22:37.974250Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/93abaf01-cac6-48f4-bfa1-735cfb7fde7d",
+        "status": "revoked", "triggered_at": null, "revoked_at": "2026-05-20T12:23:19.883989Z",
+        "type": "AWS", "open_events_count": 0, "creator_id": 113168, "revoker_id":
+        113168, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be3d1024-d9df-466c-9e75-afc1ed88b8f5",
+        "name": "test-plc", "description": "", "created_at": "2026-05-26T07:26:21.052034Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be3d1024-d9df-466c-9e75-afc1ed88b8f5",
+        "status": "revoked", "triggered_at": "2026-05-26T08:44:57.678480Z", "revoked_at":
+        "2026-05-26T12:19:01.401494Z", "type": "AWS", "open_events_count": 0, "creator_id":
+        701514, "revoker_id": 701514, "creator_api_token_id": null, "revoker_api_token_id":
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "8409c955-f217-47c9-9cf1-3a6b557c65c9", "name": "Test", "description": "",
+        "created_at": "2026-05-26T14:12:05.347374Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8409c955-f217-47c9-9cf1-3a6b557c65c9",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754650, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "82f00514-d9d3-442c-b575-c40ff77db387", "name": "test-plc2",
+        "description": "", "created_at": "2026-05-27T13:13:33.943814Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/82f00514-d9d3-442c-b575-c40ff77db387",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 701514, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "2fb03282-9878-481c-be5b-eda6036f909d", "name": "ahah-plc", "description":
+        "", "created_at": "2026-06-01T12:43:48.383287Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2fb03282-9878-481c-be5b-eda6036f909d",
+        "status": "triggered", "triggered_at": "2026-06-04T21:49:55.543841Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 701514, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86344c0b-c360-4709-bb6b-fce628ace1d7",
+        "name": "honeytoken-toot-991c4137", "description": "", "created_at": "2026-06-05T17:59:07.240726Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86344c0b-c360-4709-bb6b-fce628ace1d7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
+        "97c1b533-d768-4054-94de-ae3d967a5128", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "949d59d0-c3c2-4d5e-ae3c-4f365b9b8456",
+        "name": "honeytoken-toot-0fefb095", "description": "", "created_at": "2026-06-05T17:59:07.748651Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/949d59d0-c3c2-4d5e-ae3c-4f365b9b8456",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
+        "97c1b533-d768-4054-94de-ae3d967a5128", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ab5965c-8f7e-44ec-b64e-1111e140586f",
+        "name": "ggshield-WOmcC4wM", "description": "description", "created_at": "2026-06-15T15:05:19.990102Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ab5965c-8f7e-44ec-b64e-1111e140586f",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "95786b03-4165-4245-8aef-fac41ff6a1de",
+        "name": "ggshield-E2HxYogl", "description": "description", "created_at": "2026-06-15T15:05:20.446208Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/95786b03-4165-4245-8aef-fac41ff6a1de",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "98271cf2-3025-4e7d-b120-afd29fe20c8f",
+        "name": "ggshield-32Xli2ct", "description": "description", "created_at": "2026-06-15T15:13:44.456933Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/98271cf2-3025-4e7d-b120-afd29fe20c8f",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "68f09d33-1cab-4b93-84a5-2861a7a01fbc",
+        "name": "ggshield-o2ocvFQZ", "description": "description", "created_at": "2026-06-15T15:13:45.228488Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/68f09d33-1cab-4b93-84a5-2861a7a01fbc",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ee69dfd0-fa9c-451d-947e-261c2edd4355",
+        "name": "ggshield-rGxN1k4I", "description": "description", "created_at": "2026-06-15T15:46:58.088837Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ee69dfd0-fa9c-451d-947e-261c2edd4355",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f91525c-02bd-4a0f-9c5d-c9949f7196f4",
+        "name": "ggshield-bZoVll0H", "description": "description", "created_at": "2026-06-15T15:46:58.839510Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f91525c-02bd-4a0f-9c5d-c9949f7196f4",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4a3a3699-fb2e-4e0f-ae02-4905fe8228ec",
+        "name": "ggshield-VuSeELel", "description": "description", "created_at": "2026-06-17T13:23:52.166183Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4a3a3699-fb2e-4e0f-ae02-4905fe8228ec",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "dd2d3e47-d804-41c5-b8b8-f640e6292096", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d82dc520-9ea5-4a38-a9d8-84bf2f94975b",
+        "name": "ggshield-yQlAvTpn", "description": "description", "created_at": "2026-06-17T13:23:52.682610Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d82dc520-9ea5-4a38-a9d8-84bf2f94975b",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "dd2d3e47-d804-41c5-b8b8-f640e6292096", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}]'
     headers:
+      CF-RAY:
+      - a1039503ef3fa876-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:06 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, POST, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '139756'
+      - '145842'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:21 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '741'
+      - '778'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -1729,43 +1814,50 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/411d33c0-7fad-4fc1-b94e-bb440c8f9c49",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:11.250010Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}'
+        "token": "[REDACTED]"}'
     headers:
+      CF-RAY:
+      - a103950e396ceba9-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:06 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, PUT, PATCH, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '747'
+      - '657'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:22 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '34'
+      - '33'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_get_honeytoken_without_token.yaml
+++ b/tests/cassettes/client/vcr/test_get_honeytoken_without_token.yaml
@@ -25,33 +25,29 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/411d33c0-7fad-4fc1-b94e-bb440c8f9c49",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:11.250010Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}, {"id": "858a3a76-f6f2-4c2e-b0bc-323d9a575413",
-        "name": "test_honey_token", "description": "description", "created_at": "2023-05-15T14:09:09.210845Z",
+        "token": "[REDACTED]"}, {"id": "858a3a76-f6f2-4c2e-b0bc-323d9a575413", "name":
+        "test_honey_token", "description": "description", "created_at": "2023-05-15T14:09:09.210845Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/858a3a76-f6f2-4c2e-b0bc-323d9a575413",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:17.165934Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}, {"id": "72a52279-8e9f-40de-a1d4-bc5fcc48795d",
-        "name": "passwordscon", "description": "", "created_at": "2023-05-16T10:03:49.677782Z",
+        "token": "[REDACTED]"}, {"id": "72a52279-8e9f-40de-a1d4-bc5fcc48795d", "name":
+        "passwordscon", "description": "", "created_at": "2023-05-16T10:03:49.677782Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72a52279-8e9f-40de-a1d4-bc5fcc48795d",
         "status": "triggered", "triggered_at": "2023-05-16T10:04:10.262805Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 222, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
-        "key": "location", "value": "test"}], "custom_tags": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
+        ["publicly_exposed"], "custom_tags": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
         "key": "location", "value": "test"}], "token": "[REDACTED]"}, {"id": "8bf5f99a-538d-4cfe-8e74-61cd7081ae25",
         "name": "PasswordsCon2", "description": "For presentation", "created_at":
         "2023-05-16T11:30:36.210395Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8bf5f99a-538d-4cfe-8e74-61cd7081ae25",
         "status": "triggered", "triggered_at": "2023-05-16T12:29:45.638074Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 344, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "45182b59-b659-41ef-9bb8-44a78740fade", "name": "solid-octo-repo", "description":
         "Placed in solid-octo repo, file ... on 16May2023", "created_at": "2023-05-16T11:51:06.384073Z",
@@ -59,47 +55,41 @@ interactions:
         "status": "triggered", "triggered_at": "2026-02-18T14:51:12.499369Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432", "key": "place",
-        "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
+        [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432", "key":
+        "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
         "name": "jira-OPS-124", "description": "honeytoken deployed in jira ticket
         OPS-124", "created_at": "2023-05-16T11:58:57.713307Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "63bbd74e-bb5f-4910-8e63-eed358af3bc8",
         "name": "improved-carnival repo", "description": "", "created_at": "2023-05-16T14:45:09.811724Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/63bbd74e-bb5f-4910-8e63-eed358af3bc8",
         "status": "revoked", "triggered_at": "2023-05-16T14:49:44.284195Z", "revoked_at":
         "2024-06-19T10:46:44.282148Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "72fcdb5c-e128-4ca5-8970-f1f52f95a78a",
         "name": "slack-chan-website", "description": "", "created_at": "2023-05-16T15:35:26.129025Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72fcdb5c-e128-4ca5-8970-f1f52f95a78a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
-        "key": "place", "value": "website"}], "custom_tags": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
         "key": "place", "value": "website"}], "token": "[REDACTED]"}, {"id": "84d43c23-6d4d-47f8-bf62-e7c1b0ae1625",
         "name": "analytic-repo", "description": "", "created_at": "2023-05-16T16:17:11.435058Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84d43c23-6d4d-47f8-bf62-e7c1b0ae1625",
         "status": "revoked", "triggered_at": "2023-05-16T16:27:55.091410Z", "revoked_at":
         "2023-12-11T14:01:44.427581Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "ef11a80c-6d8e-4fb5-8ee2-4556bae695c3",
         "name": "test ht public", "description": "", "created_at": "2023-05-17T17:00:24.966335Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef11a80c-6d8e-4fb5-8ee2-4556bae695c3",
         "status": "triggered", "triggered_at": "2023-05-17T17:02:33.386529Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 5012, "creator_id": 166199, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
-        "key": "location", "value": "slack"}], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
+        ["publicly_exposed"], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
         "key": "location", "value": "slack"}], "token": "[REDACTED]"}, {"id": "db7bf6ea-57cb-4d13-8ed9-dc59b2620e00",
         "name": "Honeytoken demo 17 may", "description": "This is a token for the
         live demo", "created_at": "2023-05-17T17:15:04.921233Z", "gitguardian_url":
@@ -107,173 +97,161 @@ interactions:
         "status": "triggered", "triggered_at": "2023-05-17T17:16:48.960267Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 5018, "creator_id": 166199, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "79db31fc-ffd1-4bc9-b6e4-3ef37a94712a", "name": "QubitConfrence", "description":
         "", "created_at": "2023-05-18T07:58:37.174577Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/79db31fc-ffd1-4bc9-b6e4-3ef37a94712a",
         "status": "triggered", "triggered_at": "2023-05-18T09:30:01.025933Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 215, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263", "name": "NDC-OSLO Demo", "description":
-        "Demo key for NDC Oslo confrence", "created_at": "2023-05-25T07:59:05.651290Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
+        "name": "NDC-OSLO Demo", "description": "Demo key for NDC Oslo confrence",
+        "created_at": "2023-05-25T07:59:05.651290Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
         "status": "triggered", "triggered_at": "2023-05-25T08:38:27.471330Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 221, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b6f2b765-a8e5-458f-b68a-4b5ef934bcc8", "name": "Pycon Italia", "description":
-        "", "created_at": "2023-05-28T09:34:01.581495Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
+        "name": "Pycon Italia", "description": "", "created_at": "2023-05-28T09:34:01.581495Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
         "status": "revoked", "triggered_at": "2023-05-28T09:45:30.255118Z", "revoked_at":
         "2024-12-10T12:17:08.199275Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "bb494eed-6ba4-4b98-b949-ad5f54d929dd", "name": "ggshield-uORy0any",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "bb494eed-6ba4-4b98-b949-ad5f54d929dd", "name": "ggshield-uORy0any",
         "description": "description", "created_at": "2023-05-30T10:30:39.803353Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bb494eed-6ba4-4b98-b949-ad5f54d929dd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1266b395-a545-42c1-b700-24dbae36447c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1266b395-a545-42c1-b700-24dbae36447c",
         "name": "test_honey_token_previous", "description": "description", "created_at":
         "2023-05-30T10:30:40.547255Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1266b395-a545-42c1-b700-24dbae36447c",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:41:43.173510Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "f60db759-7041-4dfe-80fa-91012d97fdd3",
         "name": "ggshield-tsCPoUcx", "description": "description", "created_at": "2023-05-30T10:37:14.527124Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f60db759-7041-4dfe-80fa-91012d97fdd3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
         "name": "ggshield-BA0VsBh3", "description": "description", "created_at": "2023-05-30T10:39:09.968782Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e7f275d-e115-44d3-8854-5c6472494951",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e7f275d-e115-44d3-8854-5c6472494951",
         "name": "ggshield-UXgNYVXL", "description": "description", "created_at": "2023-05-30T10:42:36.847031Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6e7f275d-e115-44d3-8854-5c6472494951",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7494298b-75c5-44e4-898c-77b3b9017113",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7494298b-75c5-44e4-898c-77b3b9017113",
         "name": "test_honey_token_abc", "description": "description", "created_at":
         "2023-05-30T10:42:37.520767Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7494298b-75c5-44e4-898c-77b3b9017113",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:45:41.905071Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "092dba62-9d82-41bd-84aa-95430d540edc", "name": "ggshield-224Lwv95",
-        "description": "description", "created_at": "2023-05-30T10:46:10.997022Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "092dba62-9d82-41bd-84aa-95430d540edc",
+        "name": "ggshield-224Lwv95", "description": "description", "created_at": "2023-05-30T10:46:10.997022Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/092dba62-9d82-41bd-84aa-95430d540edc",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
         "name": "test_honey_token_previous", "description": "description", "created_at":
         "2023-05-30T10:46:11.714531Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:07.762156Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "13f6dbf3-ae1a-4757-95f6-e0fbc830fc55", "name": "ggshield-agateau",
-        "description": null, "created_at": "2023-05-30T13:32:31.845201Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
+        "name": "ggshield-agateau", "description": null, "created_at": "2023-05-30T13:32:31.845201Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T13:33:03.363563Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 160089, "revoker_id":
         160089, "creator_api_token_id": "425e1a78-209e-4cd5-b08f-8450a0026ac0", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "f17302cd-850b-4b54-9054-60d26a76cf38", "name": "test demo 31may",
-        "description": "", "created_at": "2023-05-31T08:10:36.754144Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f17302cd-850b-4b54-9054-60d26a76cf38",
+        "name": "test demo 31may", "description": "", "created_at": "2023-05-31T08:10:36.754144Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "41d76272-ee3d-4639-93e8-29222b662b93",
         "name": "demo31may-public", "description": "", "created_at": "2023-05-31T08:13:48.373887Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/41d76272-ee3d-4639-93e8-29222b662b93",
         "status": "revoked", "triggered_at": "2023-05-31T08:15:09.926931Z", "revoked_at":
         "2024-12-10T12:16:03.693045Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "63728091-d083-47cc-9898-73c2636f2c7f", "name": "ggshield-ZIU1V3Bv", "description":
         null, "created_at": "2023-05-31T08:17:12.607879Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/63728091-d083-47cc-9898-73c2636f2c7f",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-31T08:17:38.021142Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "001c53df-b63c-4b81-a4fb-35e5b38bf328", "name": "DevOxx Poland", "description":
-        "", "created_at": "2023-05-31T12:28:39.713989Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/001c53df-b63c-4b81-a4fb-35e5b38bf328",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "001c53df-b63c-4b81-a4fb-35e5b38bf328",
+        "name": "DevOxx Poland", "description": "", "created_at": "2023-05-31T12:28:39.713989Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/001c53df-b63c-4b81-a4fb-35e5b38bf328",
         "status": "triggered", "triggered_at": "2023-05-31T14:09:21.767459Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 225, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05", "name": "ggshield-cptptJHt",
-        "description": "ggshield test", "created_at": "2023-06-02T08:47:41.149126Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05",
+        "name": "ggshield-cptptJHt", "description": "ggshield test", "created_at":
+        "2023-06-02T08:47:41.149126Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
-        "name": "ggshield-TtJwtxNE", "description": "ggshield test", "created_at":
-        "2023-06-02T08:48:20.148216Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72", "name": "ggshield-TtJwtxNE",
+        "description": "ggshield test", "created_at": "2023-06-02T08:48:20.148216Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "27379093-c6a4-4732-a64a-715c94e74fd7",
-        "name": "ggshield-TvFzKVed", "description": null, "created_at": "2023-06-09T08:01:57.360210Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/27379093-c6a4-4732-a64a-715c94e74fd7",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "27379093-c6a4-4732-a64a-715c94e74fd7", "name": "ggshield-TvFzKVed",
+        "description": null, "created_at": "2023-06-09T08:01:57.360210Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/27379093-c6a4-4732-a64a-715c94e74fd7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "62cb7048-4302-4b52-9163-e2ceff775b39", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc7214d0-c97a-44b3-b576-664f0a81c4f7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc7214d0-c97a-44b3-b576-664f0a81c4f7",
         "name": "repo analytics 19jun", "description": "", "created_at": "2023-06-19T09:11:21.788070Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc7214d0-c97a-44b3-b576-664f0a81c4f7",
         "status": "revoked", "triggered_at": "2023-06-20T17:24:35.145047Z", "revoked_at":
         "2023-12-11T14:50:27.627289Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb", "name": "ggshield-0etjSvZJ",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb", "name": "ggshield-0etjSvZJ",
         "description": "description", "created_at": "2023-07-05T08:27:14.048162Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-05T08:27:15.756813Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0e4f0dbd-b288-4990-9565-3cc7b0171a79",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:53.240550Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 160089, "revoker_id":
         296618, "creator_api_token_id": "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "14566c1f-0b52-4770-ab68-000704242633", "name": "ggshield-Rv2mUej7",
-        "description": "description", "created_at": "2023-07-05T08:55:23.864812Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "14566c1f-0b52-4770-ab68-000704242633",
+        "name": "ggshield-Rv2mUej7", "description": "description", "created_at": "2023-07-05T08:55:23.864812Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/14566c1f-0b52-4770-ab68-000704242633",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c8c94ffa-c0af-48c6-976a-6502a41811af",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c8c94ffa-c0af-48c6-976a-6502a41811af",
         "name": "honeytoken demo eric", "description": "demo here", "created_at":
         "2023-07-05T14:48:53.893911Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c8c94ffa-c0af-48c6-976a-6502a41811af",
         "status": "triggered", "triggered_at": "2023-07-05T14:49:33.528178Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
         "name": "Example TOken ", "description": "ubvcub", "created_at": "2023-07-12T13:16:10.775681Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
-        "key": "file", "value": ".env"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "0c3f182e-98f5-4a64-aadb-664fd7c9de88", "name": "ggshield-ewIAL7lq", "description":
@@ -282,58 +260,55 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
         "name": "ggshield-w1P1Ggsz", "description": "description", "created_at": "2023-07-27T08:56:55.435203Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a20a718-7b9e-4582-abdf-772053bffd72",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a20a718-7b9e-4582-abdf-772053bffd72",
         "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T08:56:56.138738Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a20a718-7b9e-4582-abdf-772053bffd72",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:58.657957Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "51f41814-f029-4ab4-b863-c0fecba025b3", "name": "ggshield-v3LhZCz8",
-        "description": "description", "created_at": "2023-07-27T09:01:36.117217Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51f41814-f029-4ab4-b863-c0fecba025b3",
+        "name": "ggshield-v3LhZCz8", "description": "description", "created_at": "2023-07-27T09:01:36.117217Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/51f41814-f029-4ab4-b863-c0fecba025b3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T09:01:36.764795Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-27T09:01:37.417151Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e842a635-eb7e-4617-8984-ac57fe909ef7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
         "name": "ggshield-5voYnhhy", "description": null, "created_at": "2023-07-27T13:50:51.332176Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T13:52:58.300149Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "521efd01-bbcc-4380-b548-ed7242c017ea",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "521efd01-bbcc-4380-b548-ed7242c017ea",
         "name": "ggshield-HLZpiznn", "description": null, "created_at": "2023-07-27T14:54:03.198466Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/521efd01-bbcc-4380-b548-ed7242c017ea",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0d81797a-6fc0-4a6e-a211-af16828c0c39",
-        "name": "Webinar Public ", "description": "from webinar ", "created_at": "2023-07-27T15:33:07.472730Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0d81797a-6fc0-4a6e-a211-af16828c0c39", "name": "Webinar
+        Public ", "description": "from webinar ", "created_at": "2023-07-27T15:33:07.472730Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0d81797a-6fc0-4a6e-a211-af16828c0c39",
         "status": "triggered", "triggered_at": "2023-07-27T15:34:48.902462Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 204, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "27e9ba01-4bb6-46ed-84c8-ff14366a3bde", "name": "Private network", "description":
@@ -342,60 +317,55 @@ interactions:
         "status": "triggered", "triggered_at": "2023-07-27T16:23:35.804271Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5670c657-618f-41d7-984b-d59656d905e4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5670c657-618f-41d7-984b-d59656d905e4",
         "name": "ggshield-3KTmbo8u", "description": null, "created_at": "2023-07-27T15:44:43.238742Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5670c657-618f-41d7-984b-d59656d905e4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5d3ad22c-e422-48d2-b7f5-6d52801599aa",
-        "name": "demo 31jul", "description": "", "created_at": "2023-07-31T15:27:18.323098Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d3ad22c-e422-48d2-b7f5-6d52801599aa",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5d3ad22c-e422-48d2-b7f5-6d52801599aa", "name": "demo
+        31jul", "description": "", "created_at": "2023-07-31T15:27:18.323098Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d3ad22c-e422-48d2-b7f5-6d52801599aa",
         "status": "revoked", "triggered_at": "2023-07-31T15:33:49.570793Z", "revoked_at":
         "2023-12-11T14:01:40.706751Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a", "name": "test
-        Antonin 1", "description": "", "created_at": "2023-08-03T08:42:25.251504Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fa63d76d-4297-4d41-8e77-b47d1a97a41a",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a", "name": "test Antonin 1", "description":
+        "", "created_at": "2023-08-03T08:42:25.251504Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fa63d76d-4297-4d41-8e77-b47d1a97a41a",
         "status": "revoked", "triggered_at": "2023-08-03T08:59:58.717709Z", "revoked_at":
         "2023-08-03T09:00:05.809852Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "a11570c6-f472-4fda-a493-30d65fd8e651", "name": "test Antonin 2", "description":
-        "", "created_at": "2023-08-03T14:09:46.046004Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a11570c6-f472-4fda-a493-30d65fd8e651",
+        "name": "test Antonin 2", "description": "", "created_at": "2023-08-03T14:09:46.046004Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40",
-        "name": "vBOY test segment", "description": "sdqsdqsdqsdqsd", "created_at":
-        "2023-08-07T12:45:52.890085Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40", "name": "vBOY
+        test segment", "description": "sdqsdqsdqsdqsd", "created_at": "2023-08-07T12:45:52.890085Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-08-07T12:46:45.470113Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "name": "vBOY test segment 2", "description": "sdqsdqsd", "created_at": "2023-08-07T12:47:49.515448Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "86670f84-e117-4f96-aa16-e399a0bb2cf2",
-        "name": "juuj", "description": "", "created_at": "2023-08-08T15:53:23.097840Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86670f84-e117-4f96-aa16-e399a0bb2cf2",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "86670f84-e117-4f96-aa16-e399a0bb2cf2", "name": "juuj",
+        "description": "", "created_at": "2023-08-08T15:53:23.097840Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/86670f84-e117-4f96-aa16-e399a0bb2cf2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
-        "name": "BSidesLV", "description": "Key leaked publically by leakymcgee again",
-        "created_at": "2023-08-10T00:11:42.132386Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "978bf5aa-1f8e-425b-ac4b-b617ddbc178e", "name": "BSidesLV",
+        "description": "Key leaked publically by leakymcgee again", "created_at":
+        "2023-08-10T00:11:42.132386Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
         "status": "triggered", "triggered_at": "2023-08-10T00:13:19.948280Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
-        "key": "date leaked", "value": "08/09/2023"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
-        "key": "format", "value": "public"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
+        ["publicly_exposed"], "custom_tags": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
         "key": "date leaked", "value": "08/09/2023"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
         "key": "format", "value": "public"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
@@ -405,9 +375,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-08-11T18:55:35.503991Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 61, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
+        ["publicly_exposed"], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "90d4c2b6-ecae-4ef9-a754-4561929b9e38",
         "name": "ggshield-mpkTH5jF", "description": "description", "created_at": "2023-08-16T08:28:18.684517Z",
@@ -415,34 +383,31 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
         "name": "ggshield-mzO8qHEz", "description": "description", "created_at": "2023-08-22T08:19:03.821471Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
         "name": "testket ", "description": "eew", "created_at": "2023-08-29T10:21:29.956291Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "46776cb3-6b11-41fc-b431-07609992f0cb",
-        "name": "HoneyTokenaLARTest", "description": "Testworkshop", "created_at":
-        "2023-08-29T12:07:20.692993Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/46776cb3-6b11-41fc-b431-07609992f0cb",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "46776cb3-6b11-41fc-b431-07609992f0cb", "name": "HoneyTokenaLARTest",
+        "description": "Testworkshop", "created_at": "2023-08-29T12:07:20.692993Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/46776cb3-6b11-41fc-b431-07609992f0cb",
         "status": "revoked", "triggered_at": "2023-08-29T12:09:16.581232Z", "revoked_at":
         "2023-08-29T12:42:37.841866Z", "type": "AWS", "open_events_count": 0, "creator_id":
         37699, "revoker_id": 37699, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "edd96a3b-5c71-4346-b5e2-2150e454dc91", "name": "Bsides Krakow", "description":
-        "Demo for leaking a key on GitHub", "created_at": "2023-09-02T13:20:53.501588Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/edd96a3b-5c71-4346-b5e2-2150e454dc91",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "edd96a3b-5c71-4346-b5e2-2150e454dc91",
+        "name": "Bsides Krakow", "description": "Demo for leaking a key on GitHub",
+        "created_at": "2023-09-02T13:20:53.501588Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/edd96a3b-5c71-4346-b5e2-2150e454dc91",
         "status": "triggered", "triggered_at": "2023-09-02T13:22:51.142717Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "de145bd4-b424-49ab-b95b-80126914bf2e",
         "name": "ctf-demo-test-honeytoken-django-app", "description": "", "created_at":
@@ -450,68 +415,59 @@ interactions:
         "status": "revoked", "triggered_at": "2023-09-06T07:42:55.177580Z", "revoked_at":
         "2023-09-06T10:03:30.948628Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "5564ed3c-3eec-4375-9fc8-e0ada71dce02", "name": "ctf-demo-test-honeytoken-micro-api",
-        "description": "", "created_at": "2023-09-05T19:18:08.504776Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/5564ed3c-3eec-4375-9fc8-e0ada71dce02",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5564ed3c-3eec-4375-9fc8-e0ada71dce02",
+        "name": "ctf-demo-test-honeytoken-micro-api", "description": "", "created_at":
+        "2023-09-05T19:18:08.504776Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5564ed3c-3eec-4375-9fc8-e0ada71dce02",
         "status": "revoked", "triggered_at": "2023-09-06T07:44:18.074891Z", "revoked_at":
         "2023-09-06T10:03:48.581110Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "f246c64a-3494-43ae-9d81-500df2f950c3", "name": "demo-honeytoken-ctf-personal-",
-        "description": "", "created_at": "2023-09-06T11:29:57.547211Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/f246c64a-3494-43ae-9d81-500df2f950c3",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f246c64a-3494-43ae-9d81-500df2f950c3",
+        "name": "demo-honeytoken-ctf-personal-", "description": "", "created_at":
+        "2023-09-06T11:29:57.547211Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f246c64a-3494-43ae-9d81-500df2f950c3",
         "status": "revoked", "triggered_at": "2023-09-06T12:18:14.949044Z", "revoked_at":
         "2024-12-10T12:15:49.265110Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
         "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "ff623703-9ca1-4fba-99dc-c20110894ed3",
         "name": "-demo-honeytoken-ctf-django-app-", "description": "", "created_at":
         "2023-09-06T11:33:27.376222Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff623703-9ca1-4fba-99dc-c20110894ed3",
         "status": "triggered", "triggered_at": "2023-09-06T14:19:10.580142Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 4, "creator_id": null, "revoker_id":
+        null, "type": "AWS", "open_events_count": 9, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "a58154f6-e66f-4079-82b7-aabec70c73ff",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "a58154f6-e66f-4079-82b7-aabec70c73ff",
         "name": "demo-honeytoken-ctf-micro-api", "description": "", "created_at":
         "2023-09-06T11:33:37.828240Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a58154f6-e66f-4079-82b7-aabec70c73ff",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-09-06T14:17:20.708816Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b01db549-a2fa-4527-913d-0715a1119530",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "b01db549-a2fa-4527-913d-0715a1119530",
         "name": "demo-honeytoken-ctf-internal-share-", "description": "", "created_at":
         "2023-09-06T11:33:48.881275Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b01db549-a2fa-4527-913d-0715a1119530",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-09-06T14:21:42.509905Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "89a1745a-f796-4ece-99f7-106671aea57c",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "89a1745a-f796-4ece-99f7-106671aea57c",
         "name": "-demo-honeytoken-ctf-micro-api-", "description": "", "created_at":
         "2023-09-06T14:19:32.695323Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/89a1745a-f796-4ece-99f7-106671aea57c",
         "status": "triggered", "triggered_at": "2023-09-06T14:24:18.462424Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "095d655f-a273-400f-ba01-eff8951242ed",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "095d655f-a273-400f-ba01-eff8951242ed",
         "name": "-demo-honeytoken-ctf-internal-share-", "description": "", "created_at":
         "2023-09-06T14:21:55.062468Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/095d655f-a273-400f-ba01-eff8951242ed",
         "status": "triggered", "triggered_at": "2023-09-08T16:58:49.455578Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 6, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "3664c283-d479-41ac-9ad9-30283731ee25",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "3664c283-d479-41ac-9ad9-30283731ee25",
         "name": "Balccon Demo", "description": "Demo key for Balccon ", "created_at":
         "2023-09-08T14:55:02.417580Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3664c283-d479-41ac-9ad9-30283731ee25",
         "status": "triggered", "triggered_at": "2023-09-08T14:56:49.516889Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
-        "key": "location", "value": "sourcecode"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
-        "key": "visability", "value": "public"}], "custom_tags": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
+        ["publicly_exposed"], "custom_tags": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
         "key": "location", "value": "sourcecode"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
         "key": "visability", "value": "public"}], "token": "[REDACTED]"}, {"id": "7ca5ca92-a0a1-48bf-9618-d7194beaa039",
@@ -520,9 +476,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-09-29T16:11:40.077048Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 344, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
-        "key": "confrence", "value": "grrcon"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}], "custom_tags": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
+        ["publicly_exposed"], "custom_tags": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
         "key": "confrence", "value": "grrcon"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}], "token": "[REDACTED]"}, {"id": "2544b3e6-57b2-48e2-a1a5-c4b6551987bb",
         "name": "SBB demo", "description": "Leaking key on GitHub", "created_at":
@@ -530,11 +484,8 @@ interactions:
         "status": "triggered", "triggered_at": "2024-08-17T15:36:55.810693Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key": "commiter",
-        "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca", "key":
-        "file", "value": ".env"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327", "key":
-        "vcs", "value": "github"}], "custom_tags": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda",
-        "key": "commiter", "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
+        [], "custom_tags": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key":
+        "commiter", "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "7d80793b-c702-441e-837e-b1d3da94d576",
         "name": "Hacktivity Key", "description": "Test Key Leak for Hacktivity", "created_at":
@@ -542,9 +493,7 @@ interactions:
         "status": "revoked", "triggered_at": "2023-10-05T14:42:57.752365Z", "revoked_at":
         "2024-12-10T12:17:33.875750Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "576dc1ce-ab72-4604-934f-526cff5a667e", "name": "BsidesCyprus", "description":
@@ -553,8 +502,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-10-07T11:35:53.017981Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 249, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "22fdf53a-e348-464a-a87f-5bcecb1a4e62", "name": "Slack test", "description":
         "blablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablabla
@@ -567,21 +515,20 @@ interactions:
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-06-03T09:50:06.667490Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 363707, "revoker_id":
         353920, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "137c9fee-4b3c-4231-92fd-98debf6557c2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "137c9fee-4b3c-4231-92fd-98debf6557c2",
         "name": "BSides ATL demo for session", "description": "This one will be triggered
         from 2 different spots online", "created_at": "2023-10-14T12:28:51.206659Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/137c9fee-4b3c-4231-92fd-98debf6557c2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 354585, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "cdaea884-25fb-49db-90ec-a18879be36c4",
-        "name": "Demo Honeytoken", "description": "Leaking on Public Demo", "created_at":
-        "2023-10-16T15:13:10.845487Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cdaea884-25fb-49db-90ec-a18879be36c4",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "cdaea884-25fb-49db-90ec-a18879be36c4", "name": "Demo
+        Honeytoken", "description": "Leaking on Public Demo", "created_at": "2023-10-16T15:13:10.845487Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cdaea884-25fb-49db-90ec-a18879be36c4",
         "status": "revoked", "triggered_at": "2023-10-16T15:14:25.574559Z", "revoked_at":
         "2023-10-27T15:01:19.053629Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "48f7c567-93d1-4925-9f77-d3919f120b88", "name": "ggshield-KlAkKRtE", "description":
         "description", "created_at": "2023-10-16T19:49:08.588391Z", "gitguardian_url":
@@ -589,52 +536,50 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
         "name": "Jason test", "description": "Token for Test ", "created_at": "2023-10-24T13:45:31.371710Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f8e0968-664a-49f3-af85-9cc468b960ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "fe392ff1-b3d7-462f-a26f-d094326f40ed",
-        "name": "Jason and team", "description": "akljdlaj", "created_at": "2023-10-24T14:23:20.991107Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fe392ff1-b3d7-462f-a26f-d094326f40ed", "name": "Jason
+        and team", "description": "akljdlaj", "created_at": "2023-10-24T14:23:20.991107Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fe392ff1-b3d7-462f-a26f-d094326f40ed",
         "status": "triggered", "triggered_at": "2024-05-10T22:15:09.224357Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29",
         "name": "Eric Demo Test 01", "description": "", "created_at": "2023-10-31T12:51:44.535200Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d69a098c-8b61-4102-bb2b-9a82958a3e29",
         "status": "revoked", "triggered_at": "2023-10-31T12:52:49.851916Z", "revoked_at":
         "2024-12-10T12:16:28.115539Z", "type": "AWS", "open_events_count": 0, "creator_id":
         136170, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb", "name": "test
-        eric dd 02", "description": "", "created_at": "2023-10-31T14:33:35.801324Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4affa602-902b-47ff-a1f4-721dc3e671bb",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb", "name": "test eric dd 02",
+        "description": "", "created_at": "2023-10-31T14:33:35.801324Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/4affa602-902b-47ff-a1f4-721dc3e671bb",
         "status": "triggered", "triggered_at": "2023-10-31T14:35:33.676298Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 2897, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "8df388e2-aeb5-42ca-b6d5-221a54a40339", "name": "ggshield-P47kTh7j",
-        "description": null, "created_at": "2023-11-09T15:44:33.671666Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/8df388e2-aeb5-42ca-b6d5-221a54a40339",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8df388e2-aeb5-42ca-b6d5-221a54a40339",
+        "name": "ggshield-P47kTh7j", "description": null, "created_at": "2023-11-09T15:44:33.671666Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8df388e2-aeb5-42ca-b6d5-221a54a40339",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "bd51c3d9-0943-43d5-8f87-359ecee03903",
-        "name": "ggshield-73VAsjsO", "description": null, "created_at": "2023-11-14T08:27:44.885242Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bd51c3d9-0943-43d5-8f87-359ecee03903",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "bd51c3d9-0943-43d5-8f87-359ecee03903", "name": "ggshield-73VAsjsO",
+        "description": null, "created_at": "2023-11-14T08:27:44.885242Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/bd51c3d9-0943-43d5-8f87-359ecee03903",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-11-14T08:28:08.188201Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
         "name": "DeepSec Demo", "description": "Demo for DeepSec Confrence ", "created_at":
         "2023-11-16T16:01:21.723176Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
         "status": "triggered", "triggered_at": "2023-11-16T16:01:58.603599Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "ae448808-3865-4797-a008-9eef6344f9da", "name": "Bsides Berlin", "description":
         "test key for a demo", "created_at": "2023-11-18T16:19:36.463172Z", "gitguardian_url":
@@ -642,9 +587,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-11-18T16:20:14.365596Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 105, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
-        "key": "repo", "value": "mackenziejj"}], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
+        ["publicly_exposed"], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
         "key": "repo", "value": "mackenziejj"}], "token": "[REDACTED]"}, {"id": "ecb3d61d-bdab-4636-a436-bef8079a005d",
         "name": "ggshield-ObfCUUCA", "description": "description", "created_at": "2023-11-28T08:50:32.130230Z",
@@ -652,48 +595,41 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d6d5d79d-08fa-4c8a-bd54-c34851866cde",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d6d5d79d-08fa-4c8a-bd54-c34851866cde",
         "name": "test1112", "description": "test publicly exposed honeytoken", "created_at":
         "2023-12-11T16:24:56.253683Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d6d5d79d-08fa-4c8a-bd54-c34851866cde",
         "status": "triggered", "triggered_at": "2023-12-11T16:26:07.733443Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "4046ccf5-7821-47f4-be7d-8240be69631b",
         "name": "ideal-journey-lena", "description": "", "created_at": "2023-12-11T16:29:20.759489Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4046ccf5-7821-47f4-be7d-8240be69631b",
-        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
-        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
+        "status": "triggered", "triggered_at": "2026-05-28T07:56:58.047592Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 5, "creator_id": 319222, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
         "name": "analytics-repo", "description": "", "created_at": "2023-12-11T17:37:24.471286Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
         "status": "triggered", "triggered_at": "2023-12-11T17:46:48.024345Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "b7daf77c-e3e0-4747-a7e2-485a1a6f05e2",
-        "key": "team", "value": "dev"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "b7daf77c-e3e0-4747-a7e2-485a1a6f05e2",
         "key": "team", "value": "dev"}], "token": "[REDACTED]"}, {"id": "52903632-f6ff-460e-8a68-80a942349979",
         "name": "Network Honeytoken", "description": "Aws Honeytoken on Network",
         "created_at": "2023-12-18T13:47:39.151311Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/52903632-f6ff-460e-8a68-80a942349979",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
-        "key": "network", "value": "directory"}], "custom_tags": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
         "key": "network", "value": "directory"}], "token": "[REDACTED]"}, {"id": "6c5d9856-835e-468c-9448-7bf0e77f1e53",
         "name": "improved carnival", "description": "", "created_at": "2023-12-21T13:43:01.544215Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6c5d9856-835e-468c-9448-7bf0e77f1e53",
         "status": "revoked", "triggered_at": "2023-12-21T13:57:59.435706Z", "revoked_at":
         "2023-12-22T09:33:18.668820Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "4dd77510-fc74-411f-9dbe-77619fa920dd",
         "name": "My Postman Public Collection", "description": "Will it ring?", "created_at":
@@ -701,242 +637,231 @@ interactions:
         "status": "triggered", "triggered_at": "2024-01-04T17:52:01.203498Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 811, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
         "name": "ggshield-JZV5XT71", "description": "description", "created_at": "2024-01-09T09:39:34.421404Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "name": "sss", "description": "test", "created_at": "2024-01-09T14:24:10.741214Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
-        "name": "AWS key honeytoken for Slack", "description": "Honeytoken on Slack
-        channel", "created_at": "2024-01-15T16:13:53.656688Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "123ecd19-e66f-4e5c-ad73-12f0a51eda5a", "name": "AWS
+        key honeytoken for Slack", "description": "Honeytoken on Slack channel", "created_at":
+        "2024-01-15T16:13:53.656688Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
         "status": "triggered", "triggered_at": "2024-01-15T16:14:14.960066Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 104, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "23ca2658-aecf-471c-abf0-add09962e320", "key": "ods",
-        "value": "slack"}], "custom_tags": [{"id": "23ca2658-aecf-471c-abf0-add09962e320",
-        "key": "ods", "value": "slack"}], "token": "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a",
+        [], "custom_tags": [{"id": "23ca2658-aecf-471c-abf0-add09962e320", "key":
+        "ods", "value": "slack"}], "token": "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a",
         "name": "BK Test Paris", "description": "Brandon while in Paris office", "created_at":
         "2024-01-17T11:12:14.759334Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/34d5205b-accd-429c-9efa-eda48989c83a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
-        "name": "Lauren Testing", "description": "Lauren wuz here", "created_at":
-        "2024-01-29T17:37:45.379096Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4", "name": "Lauren
+        Testing", "description": "Lauren wuz here", "created_at": "2024-01-29T17:37:45.379096Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 637596, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "07fb5f6f-23f1-42e8-bdb2-c95864412a16",
         "name": "My Little Honeytoken", "description": "for testing", "created_at":
         "2024-02-02T22:18:06.038874Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/07fb5f6f-23f1-42e8-bdb2-c95864412a16",
         "status": "triggered", "triggered_at": "2024-02-09T20:50:13.173911Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b00bfddb-98c2-48e4-ad38-0cb9bc79cad6", "name": "orga_083643/solid-octo",
-        "description": "", "created_at": "2024-02-09T14:45:12.139727Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
+        "name": "orga_083643/solid-octo", "description": "", "created_at": "2024-02-09T14:45:12.139727Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
         "status": "revoked", "triggered_at": "2024-02-09T14:52:11.339548Z", "revoked_at":
         "2024-05-29T13:09:29.773300Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 2508, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "cf0806c4-093d-4165-9ad3-7e7ded211d3f", "name": "DemoKey", "description":
-        "sss", "created_at": "2024-02-15T12:39:23.633481Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cf0806c4-093d-4165-9ad3-7e7ded211d3f",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cf0806c4-093d-4165-9ad3-7e7ded211d3f",
+        "name": "DemoKey", "description": "sss", "created_at": "2024-02-15T12:39:23.633481Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cf0806c4-093d-4165-9ad3-7e7ded211d3f",
         "status": "triggered", "triggered_at": "2024-02-15T12:45:44.649197Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "638f6f82-6679-4399-a336-dd7996f4beae", "name": "demo-2024-02-16dm",
-        "description": "demo", "created_at": "2024-02-16T19:39:33.970811Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/638f6f82-6679-4399-a336-dd7996f4beae",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "638f6f82-6679-4399-a336-dd7996f4beae",
+        "name": "demo-2024-02-16dm", "description": "demo", "created_at": "2024-02-16T19:39:33.970811Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/638f6f82-6679-4399-a336-dd7996f4beae",
         "status": "revoked", "triggered_at": "2024-02-16T19:40:02.759791Z", "revoked_at":
         "2024-02-16T20:10:11.153368Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "6fcc5cf2-4b47-497d-9a80-c2d794b96ebc", "name": "solid-octo",
-        "description": "", "created_at": "2024-02-19T13:06:26.880374Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "6fcc5cf2-4b47-497d-9a80-c2d794b96ebc", "name": "solid-octo", "description":
+        "", "created_at": "2024-02-19T13:06:26.880374Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
-        "key": "team", "value": "octo"}], "custom_tags": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
         "key": "team", "value": "octo"}], "token": "[REDACTED]"}, {"id": "1592023a-2f39-4ba6-a503-4c07132f1eb0",
         "name": "GGnikalston/rock-paper-scissors-f4c01375", "description": "", "created_at":
         "2024-02-20T13:32:45.163630Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1592023a-2f39-4ba6-a503-4c07132f1eb0",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d024b464-cd1e-4daf-9b1d-863dcf517a7a",
-        "name": "Demo -2024-02-22", "description": "", "created_at": "2024-02-22T18:53:26.142516Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d024b464-cd1e-4daf-9b1d-863dcf517a7a", "name": "Demo
+        -2024-02-22", "description": "", "created_at": "2024-02-22T18:53:26.142516Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d024b464-cd1e-4daf-9b1d-863dcf517a7a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 354585, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0a94480f-5361-47f8-bc23-45a331624e9d",
-        "name": "demo ", "description": "demo ", "created_at": "2024-02-22T19:02:29.338420Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0a94480f-5361-47f8-bc23-45a331624e9d",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0a94480f-5361-47f8-bc23-45a331624e9d", "name": "demo
+        ", "description": "demo ", "created_at": "2024-02-22T19:02:29.338420Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/0a94480f-5361-47f8-bc23-45a331624e9d",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T17:03:31.533534Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86136984-d415-41c2-bfc4-59da8f9584fd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86136984-d415-41c2-bfc4-59da8f9584fd",
         "name": "demo-2024-02-23-dm", "description": "", "created_at": "2024-02-23T15:38:04.895275Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86136984-d415-41c2-bfc4-59da8f9584fd",
         "status": "revoked", "triggered_at": "2024-02-23T15:49:03.613445Z", "revoked_at":
         "2024-02-23T15:59:54.768989Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "b38455f9-822c-4f21-8525-0d4f2fa63850", "name": "demo-dwayne-2024-02-23",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "b38455f9-822c-4f21-8525-0d4f2fa63850", "name": "demo-dwayne-2024-02-23",
         "description": "dfnijsbuisbfids", "created_at": "2024-02-23T15:45:47.636481Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b38455f9-822c-4f21-8525-0d4f2fa63850",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T16:28:23.939971Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "612055eb-7fb5-4ba3-ab10-aa481f3d9962",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "612055eb-7fb5-4ba3-ab10-aa481f3d9962",
         "name": "demo-dwayne-2024-02-23-v2", "description": "Demo for video", "created_at":
         "2024-02-23T16:28:49.949332Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/612055eb-7fb5-4ba3-ab10-aa481f3d9962",
         "status": "revoked", "triggered_at": "2024-02-23T16:31:01.657151Z", "revoked_at":
         "2024-02-23T16:52:50.712289Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e", "name": "myname-dwayneptoday",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e", "name": "myname-dwayneptoday",
         "description": "dfsdfsdf", "created_at": "2024-02-23T16:38:14.323313Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T17:03:21.653827Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1bba091c-fc4c-48b5-b558-46c191f67103",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1bba091c-fc4c-48b5-b558-46c191f67103",
         "name": "ggshield-ldC5hqqo", "description": "description", "created_at": "2024-02-27T13:42:36.686028Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1bba091c-fc4c-48b5-b558-46c191f67103",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d7764013-fdd5-4b08-b195-dff5a338906d",
-        "name": "ggshield-LRYYnjOa", "description": "description", "created_at": "2024-02-27T13:42:37.569678Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d7764013-fdd5-4b08-b195-dff5a338906d", "name": "ggshield-LRYYnjOa",
+        "description": "description", "created_at": "2024-02-27T13:42:37.569678Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d7764013-fdd5-4b08-b195-dff5a338906d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "def4a23d-3d12-4fe1-b8e0-02250e74e47a",
-        "name": "ggshield-itglxnie", "description": "description", "created_at": "2024-02-27T13:58:30.205444Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "def4a23d-3d12-4fe1-b8e0-02250e74e47a", "name": "ggshield-itglxnie",
+        "description": "description", "created_at": "2024-02-27T13:58:30.205444Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/def4a23d-3d12-4fe1-b8e0-02250e74e47a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "33d149f1-68f4-4446-ae4f-def0ce962724",
-        "name": "ggshield-2Mf02eVA", "description": "description", "created_at": "2024-02-27T13:58:31.125075Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "33d149f1-68f4-4446-ae4f-def0ce962724", "name": "ggshield-2Mf02eVA",
+        "description": "description", "created_at": "2024-02-27T13:58:31.125075Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/33d149f1-68f4-4446-ae4f-def0ce962724",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5ff5eee1-fc18-4474-86fa-c46321c903c8",
-        "name": "ggshield-rmnfzrW2", "description": "description", "created_at": "2024-02-27T14:02:45.009113Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5ff5eee1-fc18-4474-86fa-c46321c903c8", "name": "ggshield-rmnfzrW2",
+        "description": "description", "created_at": "2024-02-27T14:02:45.009113Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5ff5eee1-fc18-4474-86fa-c46321c903c8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "4dd6c06e-e2c0-4593-9be0-b0418ba7a370",
-        "name": "ggshield-5YTKZZTB", "description": "description", "created_at": "2024-02-27T14:02:45.717261Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "4dd6c06e-e2c0-4593-9be0-b0418ba7a370", "name": "ggshield-5YTKZZTB",
+        "description": "description", "created_at": "2024-02-27T14:02:45.717261Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4dd6c06e-e2c0-4593-9be0-b0418ba7a370",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "eba79796-4f46-4e10-b876-280f75138cc9",
-        "name": "ggshield-z3Y6zgih", "description": "description", "created_at": "2024-02-27T14:06:02.196977Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "eba79796-4f46-4e10-b876-280f75138cc9", "name": "ggshield-z3Y6zgih",
+        "description": "description", "created_at": "2024-02-27T14:06:02.196977Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/eba79796-4f46-4e10-b876-280f75138cc9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0ebc8091-454b-461e-a6f8-fd17bf412c76",
-        "name": "ggshield-jqk54PrI", "description": "description", "created_at": "2024-02-27T14:06:03.018091Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0ebc8091-454b-461e-a6f8-fd17bf412c76", "name": "ggshield-jqk54PrI",
+        "description": "description", "created_at": "2024-02-27T14:06:03.018091Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ebc8091-454b-461e-a6f8-fd17bf412c76",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "664af568-cfc7-4726-9fb4-0b61606b7386",
-        "name": "ggshield-horgQNnR", "description": "description", "created_at": "2024-02-27T14:19:39.357690Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "664af568-cfc7-4726-9fb4-0b61606b7386", "name": "ggshield-horgQNnR",
+        "description": "description", "created_at": "2024-02-27T14:19:39.357690Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/664af568-cfc7-4726-9fb4-0b61606b7386",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5d915aca-6f6f-4b4e-a996-2c1f53016114",
-        "name": "ggshield-LNgN8R1S", "description": "description", "created_at": "2024-02-27T14:19:40.283320Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5d915aca-6f6f-4b4e-a996-2c1f53016114", "name": "ggshield-LNgN8R1S",
+        "description": "description", "created_at": "2024-02-27T14:19:40.283320Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d915aca-6f6f-4b4e-a996-2c1f53016114",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245",
-        "name": "Test key ", "description": "ss", "created_at": "2024-02-29T13:49:52.467489Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245", "name": "Test
+        key ", "description": "ss", "created_at": "2024-02-29T13:49:52.467489Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e",
-        "name": "test-lena-1903", "description": "", "created_at": "2024-03-19T09:13:00.819618Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/443045cc-7fa4-441d-a161-b060bd7fbb3e",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e", "name": "test-lena-1903",
+        "description": "", "created_at": "2024-03-19T09:13:00.819618Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/443045cc-7fa4-441d-a161-b060bd7fbb3e",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-05-29T09:51:31.597203Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 319222, "revoker_id":
         319222, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
         "name": "ggshield-Psfrcoxl", "description": "description", "created_at": "2024-03-27T08:48:20.857237Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5a01f826-4f8f-4235-8867-ce58ac88ce1c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5a01f826-4f8f-4235-8867-ce58ac88ce1c",
         "name": "ggshield-inUFY47O", "description": "description", "created_at": "2024-03-27T08:48:21.791104Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5a01f826-4f8f-4235-8867-ce58ac88ce1c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d72113d0-c346-42c7-bd88-fd5fe0e716f3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d72113d0-c346-42c7-bd88-fd5fe0e716f3",
         "name": "ggshield-eY0ZOlXS", "description": "description", "created_at": "2024-04-30T09:25:38.689800Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d72113d0-c346-42c7-bd88-fd5fe0e716f3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "7f2873cd-3759-4727-a683-31cac57fe5d8",
-        "name": "ggshield-TvlX76OG", "description": "description", "created_at": "2024-04-30T09:25:39.573115Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "7f2873cd-3759-4727-a683-31cac57fe5d8", "name": "ggshield-TvlX76OG",
+        "description": "description", "created_at": "2024-04-30T09:25:39.573115Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7f2873cd-3759-4727-a683-31cac57fe5d8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "72e98633-9179-4a3e-8908-ea2319d19b3b",
-        "name": "ggshield-XYKDhLUY", "description": "description", "created_at": "2024-04-30T10:19:12.369644Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "72e98633-9179-4a3e-8908-ea2319d19b3b", "name": "ggshield-XYKDhLUY",
+        "description": "description", "created_at": "2024-04-30T10:19:12.369644Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72e98633-9179-4a3e-8908-ea2319d19b3b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
         "name": "ggshield-HRoZzrBq", "description": "description", "created_at": "2024-04-30T10:19:13.126568Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
         "name": "Test key", "description": "Access key", "created_at": "2024-05-22T12:16:55.833940Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c7101eaa-ea38-495d-b3b4-c016db23e859",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "a67f962c-9dde-40c2-b404-e7cd4449cc82",
         "name": "pouet", "description": "", "created_at": "2024-05-22T12:19:03.143437Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a67f962c-9dde-40c2-b404-e7cd4449cc82",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
-        "key": "visability", "value": "public"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
         "key": "visability", "value": "public"}], "token": "[REDACTED]"}, {"id": "9cca01c5-535f-4f89-a214-6c4c5579fd07",
@@ -944,487 +869,473 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9cca01c5-535f-4f89-a214-6c4c5579fd07",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
-        "name": "test lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
-        "status": "triggered", "triggered_at": "2024-06-06T08:19:18.422045Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 319222, "revoker_id":
-        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca", "key": "machine",
-        "value": "ggprdgim01"}], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99", "name": "test
+        lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
         "key": "machine", "value": "ggprdgim01"}], "token": "[REDACTED]"}, {"id":
         "a411fa2c-a465-4099-8353-3c42365aca50", "name": "test MINT", "description":
         "test MINT", "created_at": "2024-06-10T14:40:08.522247Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/a411fa2c-a465-4099-8353-3c42365aca50",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "12c4562e-deb8-4d14-bb23-e344e79b6f04",
-        "name": "ggshield-Wq4EyTMI", "description": "description", "created_at": "2024-06-25T08:36:52.179380Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "12c4562e-deb8-4d14-bb23-e344e79b6f04", "name": "ggshield-Wq4EyTMI",
+        "description": "description", "created_at": "2024-06-25T08:36:52.179380Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/12c4562e-deb8-4d14-bb23-e344e79b6f04",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3407738b-2095-47bb-9cbd-dd16de158d67",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3407738b-2095-47bb-9cbd-dd16de158d67",
         "name": "ggshield-65KCwJls", "description": "description", "created_at": "2024-06-25T08:36:52.873146Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3407738b-2095-47bb-9cbd-dd16de158d67",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
         "name": "ggshield-fb77weow", "description": "description", "created_at": "2024-06-26T09:27:38.724573Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9223e352-43b6-4e06-8d12-682d669cedd7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9223e352-43b6-4e06-8d12-682d669cedd7",
         "name": "ggshield-TRO3H56N", "description": "description", "created_at": "2024-06-26T09:27:39.479744Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9223e352-43b6-4e06-8d12-682d669cedd7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "17e088b8-2463-48f8-957b-41d017f1dc83",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "17e088b8-2463-48f8-957b-41d017f1dc83",
         "name": "ggshield-s7IOqS0q", "description": "description", "created_at": "2024-06-26T09:42:26.454643Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/17e088b8-2463-48f8-957b-41d017f1dc83",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e332d717-641d-4ea4-81fc-e98115178454",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e332d717-641d-4ea4-81fc-e98115178454",
         "name": "ggshield-JaAf9b0W", "description": "description", "created_at": "2024-06-26T09:42:27.174527Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e332d717-641d-4ea4-81fc-e98115178454",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26514e1f-4237-474b-b907-037b88427f29",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26514e1f-4237-474b-b907-037b88427f29",
         "name": "ggshield-Uuc8EiUn", "description": "description", "created_at": "2024-06-26T11:51:19.747630Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/26514e1f-4237-474b-b907-037b88427f29",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
         "name": "ggshield-GL7wc5WW", "description": "description", "created_at": "2024-06-26T11:51:20.402145Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
         "name": "test ericf", "description": "", "created_at": "2024-07-09T09:34:04.089955Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
         "status": "triggered", "triggered_at": "2024-07-09T09:34:57.541777Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "a507d04c-bb61-4f2a-93ea-601b8aa27940",
         "name": "ggshield-w1cOSspy", "description": "description", "created_at": "2024-07-31T15:31:09.349255Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a507d04c-bb61-4f2a-93ea-601b8aa27940",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dafa04c5-299a-4a13-9c35-c523e51763f3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dafa04c5-299a-4a13-9c35-c523e51763f3",
         "name": "ggshield-b7VHMqbK", "description": "description", "created_at": "2024-07-31T15:31:10.071786Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dafa04c5-299a-4a13-9c35-c523e51763f3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
         "name": "ggshield-Fu1nGsc9", "description": "description", "created_at": "2024-08-05T09:03:52.745860Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "83888e42-dc57-471c-9a08-f023e3dc2949",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "83888e42-dc57-471c-9a08-f023e3dc2949",
         "name": "ggshield-5suF2vRt", "description": "description", "created_at": "2024-08-05T09:03:53.434873Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/83888e42-dc57-471c-9a08-f023e3dc2949",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e8aad547-96a7-40a4-a05d-710cf536f3a7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e8aad547-96a7-40a4-a05d-710cf536f3a7",
         "name": "ggshield-Vqz4LULC", "description": "description", "created_at": "2024-08-05T09:21:25.593516Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e8aad547-96a7-40a4-a05d-710cf536f3a7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
         "name": "ggshield-lqX7PlwI", "description": "description", "created_at": "2024-08-05T09:21:26.211228Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b144b1fd-dc5f-4a36-abc7-a95d05331245",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b144b1fd-dc5f-4a36-abc7-a95d05331245",
         "name": "ggshield-uZr6LNDv", "description": "description", "created_at": "2024-08-27T07:44:46.267249Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b144b1fd-dc5f-4a36-abc7-a95d05331245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "903bf588-2a03-4318-be6c-b9e3198d1fd6",
-        "name": "ggshield-5Ty2Hu4r", "description": "description", "created_at": "2024-08-27T07:44:46.871854Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "903bf588-2a03-4318-be6c-b9e3198d1fd6", "name": "ggshield-5Ty2Hu4r",
+        "description": "description", "created_at": "2024-08-27T07:44:46.871854Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/903bf588-2a03-4318-be6c-b9e3198d1fd6",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "11222b98-7705-4180-99d1-6e719d8a05a9",
-        "name": "ggshield-qnLief7n", "description": "description", "created_at": "2024-08-27T08:20:15.846360Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "11222b98-7705-4180-99d1-6e719d8a05a9", "name": "ggshield-qnLief7n",
+        "description": "description", "created_at": "2024-08-27T08:20:15.846360Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/11222b98-7705-4180-99d1-6e719d8a05a9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "707b35fb-685b-4577-88b9-94cccc10e165",
-        "name": "ggshield-wqYwwgeK", "description": "description", "created_at": "2024-08-27T08:20:16.467770Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "707b35fb-685b-4577-88b9-94cccc10e165", "name": "ggshield-wqYwwgeK",
+        "description": "description", "created_at": "2024-08-27T08:20:16.467770Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/707b35fb-685b-4577-88b9-94cccc10e165",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "01c7668d-1467-4cac-a395-4b50fc278407",
-        "name": "ggshield-QkzL5Vyb", "description": "description", "created_at": "2024-09-24T08:50:15.865165Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "01c7668d-1467-4cac-a395-4b50fc278407", "name": "ggshield-QkzL5Vyb",
+        "description": "description", "created_at": "2024-09-24T08:50:15.865165Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/01c7668d-1467-4cac-a395-4b50fc278407",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
         "name": "ggshield-kkpkfk1s", "description": "description", "created_at": "2024-09-24T08:50:16.667172Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "730bdd87-31b2-4b42-a32a-5750bc595c9c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "730bdd87-31b2-4b42-a32a-5750bc595c9c",
         "name": "ggshield-dtxlZtWH", "description": "description", "created_at": "2024-10-01T13:18:29.918337Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/730bdd87-31b2-4b42-a32a-5750bc595c9c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b42c6945-05fc-4c5b-af83-e60478cd9db5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b42c6945-05fc-4c5b-af83-e60478cd9db5",
         "name": "ggshield-WPIELIcW", "description": "description", "created_at": "2024-10-01T13:18:30.820570Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b42c6945-05fc-4c5b-af83-e60478cd9db5",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
         "name": "ggshield-B8LwcRR0", "description": "description", "created_at": "2024-10-16T13:47:50.239094Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "81d30531-a54e-4f67-a46b-a7bac5783995",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "81d30531-a54e-4f67-a46b-a7bac5783995",
         "name": "ggshield-IjJFdqDS", "description": "description", "created_at": "2024-10-16T13:47:51.425195Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/81d30531-a54e-4f67-a46b-a7bac5783995",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a0b24134-0cbc-4ca5-b110-18b3311aef73",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a0b24134-0cbc-4ca5-b110-18b3311aef73",
         "name": "DO-demo", "description": "Digital Ocean Demo", "created_at": "2024-10-23T17:55:40.621634Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a0b24134-0cbc-4ca5-b110-18b3311aef73",
         "status": "revoked", "triggered_at": "2024-10-23T18:03:40.135215Z", "revoked_at":
         "2024-10-23T18:33:47.488182Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "50e53ab6-4950-48e6-9350-b5aaa88fafea", "name": "Demo",
-        "description": "Dev team 1", "created_at": "2024-10-27T21:01:47.725365Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/50e53ab6-4950-48e6-9350-b5aaa88fafea",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "50e53ab6-4950-48e6-9350-b5aaa88fafea", "name": "Demo", "description":
+        "Dev team 1", "created_at": "2024-10-27T21:01:47.725365Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/50e53ab6-4950-48e6-9350-b5aaa88fafea",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582569, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}], "token": "[REDACTED]"},
         {"id": "795decd4-4703-4073-9b3c-3ec2157f6182", "name": "Demo token", "description":
         "Take a look", "created_at": "2024-10-28T00:34:48.214122Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/795decd4-4703-4073-9b3c-3ec2157f6182",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582569, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
-        "name": "ggshield-c6YSc2Ie", "description": "description", "created_at": "2024-10-29T14:36:27.096968Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "c43ee48d-4646-40e8-bd12-3dfa30a6b3db", "name": "ggshield-c6YSc2Ie",
+        "description": "description", "created_at": "2024-10-29T14:36:27.096968Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
         "name": "ggshield-E6IPnu0f", "description": "description", "created_at": "2024-10-29T14:36:28.513178Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a454c002-679b-4250-aacf-28b5207543a4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a454c002-679b-4250-aacf-28b5207543a4",
         "name": "ggshield-HjwRkUAT", "description": "description", "created_at": "2024-11-27T12:32:44.877048Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a454c002-679b-4250-aacf-28b5207543a4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5af2ae0-f3f6-4301-82bc-b49108bd782b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5af2ae0-f3f6-4301-82bc-b49108bd782b",
         "name": "ggshield-hIlrbyRm", "description": "description", "created_at": "2024-11-27T12:32:45.728067Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c5af2ae0-f3f6-4301-82bc-b49108bd782b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "aed37b34-4721-43c2-99e2-2f2e78592f63",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "aed37b34-4721-43c2-99e2-2f2e78592f63",
         "name": "ggshield/setup.cfg", "description": "", "created_at": "2024-12-17T10:10:25.895137Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/aed37b34-4721-43c2-99e2-2f2e78592f63",
         "status": "triggered", "triggered_at": "2024-12-17T10:19:35.167833Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 309802, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476", "name": "pierredethoisy/dockerfile",
-        "description": "", "created_at": "2024-12-17T10:30:41.655876Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
+        "name": "pierredethoisy/dockerfile", "description": "", "created_at": "2024-12-17T10:30:41.655876Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
         "status": "triggered", "triggered_at": "2024-12-17T10:32:09.594850Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 309802, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "4b814f00-0897-479f-8a2d-a9593c5f18fa", "name": "WrongSecrets", "description":
-        "Honeytoken for the wrongsecrets repositort", "created_at": "2025-02-06T13:10:31.569094Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4b814f00-0897-479f-8a2d-a9593c5f18fa",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4b814f00-0897-479f-8a2d-a9593c5f18fa",
+        "name": "WrongSecrets", "description": "Honeytoken for the wrongsecrets repositort",
+        "created_at": "2025-02-06T13:10:31.569094Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4b814f00-0897-479f-8a2d-a9593c5f18fa",
         "status": "triggered", "triggered_at": "2025-02-06T13:16:26.325168Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "7dfdb8ee-56fc-486e-9b7a-e6ff248107fa", "name": "ggshield-AAcFXCwl",
-        "description": "description", "created_at": "2025-02-27T10:23:31.621722Z",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
+        "name": "ggshield-AAcFXCwl", "description": "description", "created_at": "2025-02-27T10:23:31.621722Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "97877334-808d-48c7-8802-2c54e9f43661",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "97877334-808d-48c7-8802-2c54e9f43661",
         "name": "ggshield-srahH0o3", "description": "description", "created_at": "2025-02-27T10:23:32.385844Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/97877334-808d-48c7-8802-2c54e9f43661",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ca642fe-2ce4-42b2-9097-5904093935c1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ca642fe-2ce4-42b2-9097-5904093935c1",
         "name": "ggshield-5Vx0aaQd", "description": "description", "created_at": "2025-02-27T10:31:34.080183Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ca642fe-2ce4-42b2-9097-5904093935c1",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d8590557-764f-4618-9b2e-277d536bd111",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d8590557-764f-4618-9b2e-277d536bd111",
         "name": "ggshield-QYqCVZ4i", "description": "description", "created_at": "2025-02-27T10:31:34.798380Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d8590557-764f-4618-9b2e-277d536bd111",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84b08c90-12f5-48ef-baee-ab8d8b15588c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84b08c90-12f5-48ef-baee-ab8d8b15588c",
         "name": "ggshield-4sJy2SkE", "description": "description", "created_at": "2025-02-27T10:53:01.890617Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84b08c90-12f5-48ef-baee-ab8d8b15588c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72204c1e-12c1-445f-b106-09488214d610",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72204c1e-12c1-445f-b106-09488214d610",
         "name": "ggshield-eqoLjiAS", "description": "description", "created_at": "2025-02-27T10:53:02.563136Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72204c1e-12c1-445f-b106-09488214d610",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
         "name": "ggshield-yaqMNJFA", "description": "description", "created_at": "2025-02-27T11:24:20.630794Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a5d5ca0-000f-4011-aaf2-b4f627c19649",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a5d5ca0-000f-4011-aaf2-b4f627c19649",
         "name": "ggshield-x12c7zPc", "description": "description", "created_at": "2025-02-27T11:24:21.465056Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8a5d5ca0-000f-4011-aaf2-b4f627c19649",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c823f31a-73a8-46cc-be4a-029d6d081793",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c823f31a-73a8-46cc-be4a-029d6d081793",
         "name": "ggshield-9Mq5rTUV", "description": "description", "created_at": "2025-02-27T16:44:10.862683Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c823f31a-73a8-46cc-be4a-029d6d081793",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49f1055b-b505-402b-8b79-e4b2c6cf2041",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49f1055b-b505-402b-8b79-e4b2c6cf2041",
         "name": "ggshield-4MmSKBvx", "description": "description", "created_at": "2025-02-27T16:44:11.663957Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/49f1055b-b505-402b-8b79-e4b2c6cf2041",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be8e40e8-b204-40de-8d37-247ac6ef7077",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be8e40e8-b204-40de-8d37-247ac6ef7077",
         "name": "ggshield-DBuxWn0n", "description": "description", "created_at": "2025-02-27T16:57:21.290157Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be8e40e8-b204-40de-8d37-247ac6ef7077",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d10551f8-36f0-4966-a684-d5f9eca89e8d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d10551f8-36f0-4966-a684-d5f9eca89e8d",
         "name": "ggshield-bukJ4Md2", "description": "description", "created_at": "2025-02-27T16:57:22.079317Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d10551f8-36f0-4966-a684-d5f9eca89e8d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d5385824-6a93-47cb-81f3-e818e64371d7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d5385824-6a93-47cb-81f3-e818e64371d7",
         "name": "ggshield-vI1CTIm2", "description": "description", "created_at": "2025-02-27T17:24:28.533666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d5385824-6a93-47cb-81f3-e818e64371d7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
         "name": "ggshield-C519GYI9", "description": "description", "created_at": "2025-02-27T17:24:29.231126Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
         "name": "ggshield-i8zN7WRH", "description": "description", "created_at": "2025-02-27T17:27:14.478281Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "661dae4d-5944-4a20-b7f7-f74913356479",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "661dae4d-5944-4a20-b7f7-f74913356479",
         "name": "ggshield-IX7GxSIs", "description": "description", "created_at": "2025-02-27T17:27:15.226298Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/661dae4d-5944-4a20-b7f7-f74913356479",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "adaea919-086f-4e37-b4e5-dc8208d0e4f5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "adaea919-086f-4e37-b4e5-dc8208d0e4f5",
         "name": "ggshield-rWApiuse", "description": "description", "created_at": "2025-03-03T09:15:26.314595Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/adaea919-086f-4e37-b4e5-dc8208d0e4f5",
         "status": "triggered", "triggered_at": "2026-02-18T14:51:12.198393Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
-        "key": "env", "value": "staging"}], "custom_tags": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
+        null, "tags": [], "custom_tags": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
         "key": "env", "value": "staging"}], "token": "[REDACTED]"}, {"id": "da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
         "name": "ggshield-jdbeH3gE", "description": "description", "created_at": "2025-03-03T09:15:27.049176Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22", "key": "env",
-        "value": "production"}], "custom_tags": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22",
-        "key": "env", "value": "production"}], "token": "[REDACTED]"}, {"id": "1f4708b2-0e51-458c-abca-c03e502b4a5a",
+        [], "custom_tags": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22", "key":
+        "env", "value": "production"}], "token": "[REDACTED]"}, {"id": "1f4708b2-0e51-458c-abca-c03e502b4a5a",
         "name": "ggshield-QgwFEPjx", "description": "description", "created_at": "2025-03-27T15:12:18.744612Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1f4708b2-0e51-458c-abca-c03e502b4a5a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "a4ced9be-6ad5-4d8a-b188-65a117bc0eba",
-        "name": "ggshield-44tVmSvF", "description": "description", "created_at": "2025-03-27T15:12:19.507492Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "a4ced9be-6ad5-4d8a-b188-65a117bc0eba", "name": "ggshield-44tVmSvF",
+        "description": "description", "created_at": "2025-03-27T15:12:19.507492Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a4ced9be-6ad5-4d8a-b188-65a117bc0eba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5710ee7d-6428-4074-a9ff-09399782242d",
-        "name": "ggshield-bF87lDBl", "description": "description", "created_at": "2025-03-27T15:21:17.135616Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5710ee7d-6428-4074-a9ff-09399782242d", "name": "ggshield-bF87lDBl",
+        "description": "description", "created_at": "2025-03-27T15:21:17.135616Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5710ee7d-6428-4074-a9ff-09399782242d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
-        "name": "ggshield-LbIDqGyA", "description": "description", "created_at": "2025-03-27T15:21:17.953340Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "4cbf7af9-9989-4185-8ef8-0f39e6f3d145", "name": "ggshield-LbIDqGyA",
+        "description": "description", "created_at": "2025-03-27T15:21:17.953340Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2dfa1936-f53f-4d0c-8a69-ae9bab297021",
-        "name": "ggshield-qz84En8W", "description": "description", "created_at": "2025-03-27T15:24:16.907610Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2dfa1936-f53f-4d0c-8a69-ae9bab297021", "name": "ggshield-qz84En8W",
+        "description": "description", "created_at": "2025-03-27T15:24:16.907610Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2dfa1936-f53f-4d0c-8a69-ae9bab297021",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "11213dc7-118d-4997-a96b-714640c3ad0b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "11213dc7-118d-4997-a96b-714640c3ad0b",
         "name": "ggshield-CSF39jm8", "description": "description", "created_at": "2025-03-27T15:24:17.721006Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/11213dc7-118d-4997-a96b-714640c3ad0b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "899dd0b0-20b2-45d2-b779-0331cc448935",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "899dd0b0-20b2-45d2-b779-0331cc448935",
         "name": "toto", "description": "tata", "created_at": "2025-05-12T09:58:35.161641Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/899dd0b0-20b2-45d2-b779-0331cc448935",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "62d71685-2eba-4b88-8edd-cc73e698cfa5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "62d71685-2eba-4b88-8edd-cc73e698cfa5",
         "name": "test-greg", "description": "test greg", "created_at": "2025-05-12T10:06:19.826522Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/62d71685-2eba-4b88-8edd-cc73e698cfa5",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:59.739856Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "e948f77d-5353-413e-b37d-8beba84890ff", "name": "test-greg-2", "description":
-        "test greg", "created_at": "2025-05-12T10:08:11.667578Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e948f77d-5353-413e-b37d-8beba84890ff",
+        "name": "test-greg-2", "description": "test greg", "created_at": "2025-05-12T10:08:11.667578Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:54.809724Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb", "name": "test-greg-3", "description":
-        "test greg", "created_at": "2025-05-12T10:08:58.561160Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        "name": "test-greg-3", "description": "test greg", "created_at": "2025-05-12T10:08:58.561160Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:50.784137Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6", "name": "test-greg-4", "description":
-        "test", "created_at": "2025-05-12T10:10:12.927058Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6",
+        "name": "test-greg-4", "description": "test", "created_at": "2025-05-12T10:10:12.927058Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:46.594085Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a", "name": "test-greg-5", "description":
-        "test", "created_at": "2025-05-12T10:12:50.615700Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
+        "name": "test-greg-5", "description": "test", "created_at": "2025-05-12T10:12:50.615700Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:41.387978Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "9fcf0732-6b8d-41d3-ae98-727bd5dde585", "name": "achille-hackathon",
-        "description": "achille hackathon", "created_at": "2025-05-12T12:01:23.542568Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9fcf0732-6b8d-41d3-ae98-727bd5dde585",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9fcf0732-6b8d-41d3-ae98-727bd5dde585",
+        "name": "achille-hackathon", "description": "achille hackathon", "created_at":
+        "2025-05-12T12:01:23.542568Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9fcf0732-6b8d-41d3-ae98-727bd5dde585",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38",
         "name": "TestHoneytoken", "description": "Testing GitGuardian API connectivity",
         "created_at": "2025-05-12T12:19:05.294638Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b0ddbd44-4054-4127-aa00-cd6727e70d38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
         "name": "AWS Credentials", "description": "Honeytoken for testing, to be injected
         as requested by the user.", "created_at": "2025-05-12T12:38:25.640506Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
         "status": "triggered", "triggered_at": "2026-02-18T13:45:03.781945Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 269050, "revoker_id":
+        null, "type": "AWS", "open_events_count": 9, "creator_id": 269050, "revoker_id":
         null, "creator_api_token_id": "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec", "name": "test-greg-7", "description":
-        "test", "created_at": "2025-05-12T12:54:37.703725Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ab824e92-6068-4a9d-ae36-86a94516f2ec",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec",
+        "name": "test-greg-7", "description": "test", "created_at": "2025-05-12T12:54:37.703725Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ab824e92-6068-4a9d-ae36-86a94516f2ec",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:34.521470Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b65d42a4-587f-4701-a595-8429cbcda70b", "name": "gg-mcp-server-honeytoken",
-        "description": "Honeytoken for security monitoring in the gg-mcp-server project.",
-        "created_at": "2025-05-12T12:54:44.402023Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b65d42a4-587f-4701-a595-8429cbcda70b",
-        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
-        "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
-        "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3fe4aa4f-49f6-42ad-a34a-0c108b544215",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b65d42a4-587f-4701-a595-8429cbcda70b",
+        "name": "gg-mcp-server-honeytoken", "description": "Honeytoken for security
+        monitoring in the gg-mcp-server project.", "created_at": "2025-05-12T12:54:44.402023Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b65d42a4-587f-4701-a595-8429cbcda70b",
+        "status": "triggered", "triggered_at": "2026-06-04T13:16:15.961464Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 4, "creator_id": 269050, "revoker_id":
+        null, "creator_api_token_id": "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id":
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3fe4aa4f-49f6-42ad-a34a-0c108b544215",
         "name": "default-honeytoken", "description": "General purpose honeytoken for
         security monitoring", "created_at": "2025-05-12T13:07:52.676810Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/3fe4aa4f-49f6-42ad-a34a-0c108b544215",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
         "name": "test", "description": "test", "created_at": "2025-05-12T13:09:38.965752Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9844e55d-982c-4458-b65b-592ad99ce77a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1026550, "revoker_id": null, "creator_api_token_id":
         "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
         "name": "Test Honeytoken", "description": "Testing honeytoken generation",
         "created_at": "2025-05-12T14:35:34.295363Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b2a7e759-81ab-465d-a578-e3ce42c18741",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
         "name": "test-greg-9", "description": "", "created_at": "2025-05-12T14:50:23.123299Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6d185a-6f59-4b7c-9248-dd05616090db",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:27.366114Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
+        null, "tags": [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
         "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "fbb93094-9778-4b8b-97d8-de99954a758a",
         "name": "AWS_Honeytoken", "description": "Honeytoken generated via MCP", "created_at":
@@ -1432,17 +1343,15 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "34e08af4-59a7-4a3b-b799-65acb8a2019d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "34e08af4-59a7-4a3b-b799-65acb8a2019d",
         "name": "AWS-MCP-Honeytoken", "description": "Honeytoken for monitoring potential
         AWS credential leaks", "created_at": "2025-05-12T15:07:16.157981Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/34e08af4-59a7-4a3b-b799-65acb8a2019d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "16805984-70d6-4049-844a-79bac3054f6f",
         "name": "AwsTestHoneytoken", "description": "Test honeytoken for development
         and monitoring", "created_at": "2025-05-12T15:09:00.390236Z", "gitguardian_url":
@@ -1450,10 +1359,8 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "d476c118-b210-403d-b685-3d7f0a514950",
         "name": "aws-development-access-key", "description": "Development environment
         AWS access key for monitoring credential leaks", "created_at": "2025-05-12T15:12:56.525944Z",
@@ -1461,9 +1368,7 @@ interactions:
         "status": "triggered", "triggered_at": "2026-02-18T14:50:57.626529Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 2, "creator_id": 270722, "revoker_id":
         null, "creator_api_token_id": "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
+        null, "tags": [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
         "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "0a112323-6906-4bd0-a660-1b45a0fc59ca",
         "name": "NHI-Explorer-Secret", "description": "AWS access key for NHI Explorer
@@ -1472,232 +1377,412 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "69dbbe3c-2dfc-4c93-916c-f70c42f4e2af",
         "name": "ggshield-Leb9CGys", "description": "description", "created_at": "2025-05-27T08:18:31.020533Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/69dbbe3c-2dfc-4c93-916c-f70c42f4e2af",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "029e2aba-796c-47d8-8d52-e14f9868acfc",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "029e2aba-796c-47d8-8d52-e14f9868acfc",
         "name": "ggshield-Fhjl6QxB", "description": "description", "created_at": "2025-05-27T08:18:31.873128Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/029e2aba-796c-47d8-8d52-e14f9868acfc",
         "status": "triggered", "triggered_at": "2025-06-17T09:30:39.728240Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "c77d47b6-8d61-46a7-b6a1-1715fc47c7eb", "name": "ggshield-U8JeiAjO",
-        "description": "description", "created_at": "2025-06-24T13:04:20.196705Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
+        "name": "ggshield-U8JeiAjO", "description": "description", "created_at": "2025-06-24T13:04:20.196705Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab",
-        "name": "ggshield-NiJSM24s", "description": "description", "created_at": "2025-06-24T13:04:21.255669Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab", "name": "ggshield-NiJSM24s",
+        "description": "description", "created_at": "2025-06-24T13:04:21.255669Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5692a982-6603-443e-bdb4-5ea1a5de6f64",
-        "name": "ggshield-JKhVuHaW", "description": "description", "created_at": "2025-06-24T13:06:56.046343Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5692a982-6603-443e-bdb4-5ea1a5de6f64", "name": "ggshield-JKhVuHaW",
+        "description": "description", "created_at": "2025-06-24T13:06:56.046343Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5692a982-6603-443e-bdb4-5ea1a5de6f64",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "17925c95-1df7-4e86-9c42-aabb5dbdea69",
-        "name": "ggshield-vfjAXCfY", "description": "description", "created_at": "2025-06-24T13:06:57.033247Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "17925c95-1df7-4e86-9c42-aabb5dbdea69", "name": "ggshield-vfjAXCfY",
+        "description": "description", "created_at": "2025-06-24T13:06:57.033247Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/17925c95-1df7-4e86-9c42-aabb5dbdea69",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "631ef101-122f-4592-9de1-2d6cb5becafa",
-        "name": "ggshield-dbhOtleP", "description": "description", "created_at": "2025-06-24T13:13:01.219899Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "631ef101-122f-4592-9de1-2d6cb5becafa", "name": "ggshield-dbhOtleP",
+        "description": "description", "created_at": "2025-06-24T13:13:01.219899Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/631ef101-122f-4592-9de1-2d6cb5becafa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "bebc1ca8-933d-45ca-b201-fbabc4eab464",
-        "name": "ggshield-7pQLMJYV", "description": "description", "created_at": "2025-06-24T13:13:01.978212Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "bebc1ca8-933d-45ca-b201-fbabc4eab464", "name": "ggshield-7pQLMJYV",
+        "description": "description", "created_at": "2025-06-24T13:13:01.978212Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bebc1ca8-933d-45ca-b201-fbabc4eab464",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "3983e8ff-7fd6-4fde-9117-9612d4258052",
-        "name": "ggshield-phDsJ9wy", "description": "description", "created_at": "2025-06-24T13:29:15.096198Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "3983e8ff-7fd6-4fde-9117-9612d4258052", "name": "ggshield-phDsJ9wy",
+        "description": "description", "created_at": "2025-06-24T13:29:15.096198Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3983e8ff-7fd6-4fde-9117-9612d4258052",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "9340e7fe-f79c-467e-9dcd-43ddaa77dc0c",
-        "name": "ggshield-Md0MBV0B", "description": "description", "created_at": "2025-06-24T13:29:16.049584Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "9340e7fe-f79c-467e-9dcd-43ddaa77dc0c", "name": "ggshield-Md0MBV0B",
+        "description": "description", "created_at": "2025-06-24T13:29:16.049584Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9340e7fe-f79c-467e-9dcd-43ddaa77dc0c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "08b51a6e-dd6c-4a4b-93f9-b955663c6524",
-        "name": "ggshield-ZoWflf5b", "description": "description", "created_at": "2025-06-24T13:31:49.045062Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "08b51a6e-dd6c-4a4b-93f9-b955663c6524", "name": "ggshield-ZoWflf5b",
+        "description": "description", "created_at": "2025-06-24T13:31:49.045062Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/08b51a6e-dd6c-4a4b-93f9-b955663c6524",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "96da938d-d6fa-4e44-9254-c568a27be484",
-        "name": "ggshield-PirK5h1Q", "description": "description", "created_at": "2025-06-24T13:31:49.827284Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "96da938d-d6fa-4e44-9254-c568a27be484", "name": "ggshield-PirK5h1Q",
+        "description": "description", "created_at": "2025-06-24T13:31:49.827284Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/96da938d-d6fa-4e44-9254-c568a27be484",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f2c61b85-e11d-4db0-a8af-7fc327310b39",
-        "name": "ggshield-ZQ4jUtQr", "description": "description", "created_at": "2025-06-24T13:45:17.477850Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f2c61b85-e11d-4db0-a8af-7fc327310b39", "name": "ggshield-ZQ4jUtQr",
+        "description": "description", "created_at": "2025-06-24T13:45:17.477850Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f2c61b85-e11d-4db0-a8af-7fc327310b39",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f99173ff-9ffe-492c-b8ae-54157df89bac",
-        "name": "ggshield-5uK6KYFh", "description": "description", "created_at": "2025-06-24T13:45:18.309642Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f99173ff-9ffe-492c-b8ae-54157df89bac", "name": "ggshield-5uK6KYFh",
+        "description": "description", "created_at": "2025-06-24T13:45:18.309642Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f99173ff-9ffe-492c-b8ae-54157df89bac",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768",
-        "name": "ggshield-MGXkbqc7", "description": "description", "created_at": "2025-06-24T13:50:43.295521Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768", "name": "ggshield-MGXkbqc7",
+        "description": "description", "created_at": "2025-06-24T13:50:43.295521Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f3252f2c-16a9-45e4-97e8-bed4b5752415",
-        "name": "ggshield-YJd3rq9q", "description": "description", "created_at": "2025-06-24T13:50:44.165951Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f3252f2c-16a9-45e4-97e8-bed4b5752415", "name": "ggshield-YJd3rq9q",
+        "description": "description", "created_at": "2025-06-24T13:50:44.165951Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f3252f2c-16a9-45e4-97e8-bed4b5752415",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "e22705f1-5497-449b-9614-3c2d89e3b705",
-        "name": "ggshield-l4abwnpa", "description": null, "created_at": "2025-06-26T12:32:05.993896Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e22705f1-5497-449b-9614-3c2d89e3b705",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "e22705f1-5497-449b-9614-3c2d89e3b705", "name": "ggshield-l4abwnpa",
+        "description": null, "created_at": "2025-06-26T12:32:05.993896Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e22705f1-5497-449b-9614-3c2d89e3b705",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
         "4ff03654-f280-4c31-8eef-5295d2b75a50", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7691445a-2cb0-4093-94ca-f2c5de877075",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7691445a-2cb0-4093-94ca-f2c5de877075",
         "name": "ggshield-Lwhu1Nax", "description": "description", "created_at": "2025-07-29T10:34:41.534666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7691445a-2cb0-4093-94ca-f2c5de877075",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "951e1f19-5804-444a-b275-b51dc5bf68ee",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "951e1f19-5804-444a-b275-b51dc5bf68ee",
         "name": "ggshield-u9ltlEmT", "description": "description", "created_at": "2025-07-29T10:34:42.385215Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/951e1f19-5804-444a-b275-b51dc5bf68ee",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
         "name": "ggshield-CC0Lj0vS", "description": "description", "created_at": "2025-07-29T10:40:27.317817Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
         "name": "ggshield-0k2Xha2i", "description": "description", "created_at": "2025-07-29T10:40:28.088246Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
         "status": "triggered", "triggered_at": "2025-08-22T16:59:58.315774Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "49e4fce7-aa48-42b0-9fc4-e16105ae08e5", "name": "ggshield-ncOpkfP8",
-        "description": "description", "created_at": "2025-08-27T11:43:11.666517Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
+        "name": "ggshield-ncOpkfP8", "description": "description", "created_at": "2025-08-27T11:43:11.666517Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2b15518b-3100-4736-bee6-b47fe8d26fc1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2b15518b-3100-4736-bee6-b47fe8d26fc1",
         "name": "ggshield-H2eDvilF", "description": "description", "created_at": "2025-08-27T11:43:12.618589Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2b15518b-3100-4736-bee6-b47fe8d26fc1",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "368a90bf-269b-4a60-95c2-1c77c86f7fd4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "368a90bf-269b-4a60-95c2-1c77c86f7fd4",
         "name": "ggshield-V6RzZJGL", "description": "description", "created_at": "2025-11-14T16:54:30.227288Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/368a90bf-269b-4a60-95c2-1c77c86f7fd4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "eae1aaaf-d700-475d-b65a-ffd79f84806d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "eae1aaaf-d700-475d-b65a-ffd79f84806d",
         "name": "ggshield-Pya2g1xF", "description": "description", "created_at": "2025-11-14T16:54:30.933576Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/eae1aaaf-d700-475d-b65a-ffd79f84806d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
         "name": "ggshield-Z2Ji3PxX", "description": "description", "created_at": "2026-03-31T13:26:20.710346Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
         "name": "ggshield-FsL9dCzu", "description": "description", "created_at": "2026-03-31T13:26:21.681383Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7daed77-1fa4-416d-88e2-473200b810aa",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7daed77-1fa4-416d-88e2-473200b810aa",
         "name": "ggshield-dqv39cn2", "description": "description", "created_at": "2026-03-31T13:32:28.824725Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e7daed77-1fa4-416d-88e2-473200b810aa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "601c59d9-7579-402e-90c4-59da055a8d3b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "601c59d9-7579-402e-90c4-59da055a8d3b",
         "name": "ggshield-YpbVgsRl", "description": "description", "created_at": "2026-03-31T13:32:29.820990Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/601c59d9-7579-402e-90c4-59da055a8d3b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "54e52712-a036-4e80-899b-c1a200610339",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "54e52712-a036-4e80-899b-c1a200610339",
         "name": "ggshield-DZ5zVj1p", "description": "description", "created_at": "2026-03-31T13:37:32.513332Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/54e52712-a036-4e80-899b-c1a200610339",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51dc5671-8053-4b87-8174-975ccf7f249c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51dc5671-8053-4b87-8174-975ccf7f249c",
         "name": "ggshield-DXGKK2gC", "description": "description", "created_at": "2026-03-31T13:37:33.559937Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/51dc5671-8053-4b87-8174-975ccf7f249c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}]'
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "name": "test Pierre", "description": "", "created_at": "2026-04-07T18:38:38.199572Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "ae435f66-1ea9-4dfe-b73f-49f451fc00ab", "name": "Demo
+        Romain", "description": "", "created_at": "2026-04-24T12:48:19.654369Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/ae435f66-1ea9-4dfe-b73f-49f451fc00ab",
+        "status": "triggered", "triggered_at": "2026-04-29T12:54:19.464710Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 6, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [{"id": "7a2469eb-2b6b-4248-8103-2b0f6b4fac9b", "key":
+        "romain", "value": null}], "token": "[REDACTED]"}, {"id": "10f6e20b-12ae-4591-aa09-7e1ff00ef408",
+        "name": "qa / xyz-e732d912", "description": "", "created_at": "2026-04-24T16:05:46.508625Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/10f6e20b-12ae-4591-aa09-7e1ff00ef408",
+        "status": "triggered", "triggered_at": "2026-04-24T16:13:17.276672Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9266c0f4-f0e0-41d2-a8c8-c164ccb84e47",
+        "name": "qa / test-nriv-e732d912", "description": "", "created_at": "2026-04-24T16:05:50.013606Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9266c0f4-f0e0-41d2-a8c8-c164ccb84e47",
+        "status": "triggered", "triggered_at": "2026-04-24T16:15:44.494587Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "name": "dev / Salome Test-e732d912", "description": "", "created_at": "2026-04-24T16:05:53.158978Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "status": "triggered", "triggered_at": "2026-04-24T16:16:21.895694Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "name": "qa / test-r8327r-e732d912", "description": "", "created_at": "2026-04-24T16:05:56.586568Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "status": "triggered", "triggered_at": "2026-04-24T16:18:31.419829Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2314a2ef-cec4-4e3d-834a-09b0c40c99d2",
+        "name": "qa / abc-e732d912", "description": "", "created_at": "2026-04-24T16:05:59.728317Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2314a2ef-cec4-4e3d-834a-09b0c40c99d2",
+        "status": "triggered", "triggered_at": "2026-04-24T16:25:50.024911Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "fe96d213-a002-4161-a7c9-cb3be4ad88f8",
+        "name": "qa / Handcrafted Metal Bike-e732d912", "description": "", "created_at":
+        "2026-04-24T16:06:02.936659Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fe96d213-a002-4161-a7c9-cb3be4ad88f8",
+        "status": "triggered", "triggered_at": "2026-04-24T16:35:48.958630Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a72f662-2357-4b93-b48a-00028e36cfff",
+        "name": "test1", "description": "tEST 2", "created_at": "2026-04-30T09:12:55.584248Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a72f662-2357-4b93-b48a-00028e36cfff",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "963fbabe-3d2c-4154-8281-2f13be7c06f7", "name": "test121",
+        "description": "testing 12", "created_at": "2026-04-30T11:31:57.689130Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/963fbabe-3d2c-4154-8281-2f13be7c06f7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "1acff09e-02c1-4a24-8869-568dfab124c9", "name": "test-pierredt",
+        "description": "hello", "created_at": "2026-05-06T19:57:39.689471Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/1acff09e-02c1-4a24-8869-568dfab124c9",
+        "status": "triggered", "triggered_at": "2026-05-06T19:59:18.645288Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 6, "creator_id": 309802, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "name": "qa / test-nriv-d2363bd5", "description": "", "created_at": "2026-05-19T08:29:37.247067Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "status": "triggered", "triggered_at": "2026-05-19T08:33:36.289678Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 1754656, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "03e7e668-6fbf-493a-8d1c-ac9d0c6c1b97",
+        "name": "qa / xyz-d2363bd5", "description": "", "created_at": "2026-05-19T08:29:41.396307Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/03e7e668-6fbf-493a-8d1c-ac9d0c6c1b97",
+        "status": "triggered", "triggered_at": "2026-05-19T08:34:30.001210Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 1754656, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "bb1adf06-28ea-4daf-b338-59d5ef094f67",
+        "name": "TheBigHoney", "description": "Big Honey Pot for our core secrets",
+        "created_at": "2026-05-19T11:51:12.957707Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bb1adf06-28ea-4daf-b338-59d5ef094f67",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "93abaf01-cac6-48f4-bfa1-735cfb7fde7d", "name": "ttoprjog",
+        "description": "Henri", "created_at": "2026-05-20T12:22:37.974250Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/93abaf01-cac6-48f4-bfa1-735cfb7fde7d",
+        "status": "revoked", "triggered_at": null, "revoked_at": "2026-05-20T12:23:19.883989Z",
+        "type": "AWS", "open_events_count": 0, "creator_id": 113168, "revoker_id":
+        113168, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be3d1024-d9df-466c-9e75-afc1ed88b8f5",
+        "name": "test-plc", "description": "", "created_at": "2026-05-26T07:26:21.052034Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be3d1024-d9df-466c-9e75-afc1ed88b8f5",
+        "status": "revoked", "triggered_at": "2026-05-26T08:44:57.678480Z", "revoked_at":
+        "2026-05-26T12:19:01.401494Z", "type": "AWS", "open_events_count": 0, "creator_id":
+        701514, "revoker_id": 701514, "creator_api_token_id": null, "revoker_api_token_id":
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "8409c955-f217-47c9-9cf1-3a6b557c65c9", "name": "Test", "description": "",
+        "created_at": "2026-05-26T14:12:05.347374Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8409c955-f217-47c9-9cf1-3a6b557c65c9",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754650, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "82f00514-d9d3-442c-b575-c40ff77db387", "name": "test-plc2",
+        "description": "", "created_at": "2026-05-27T13:13:33.943814Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/82f00514-d9d3-442c-b575-c40ff77db387",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 701514, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "2fb03282-9878-481c-be5b-eda6036f909d", "name": "ahah-plc", "description":
+        "", "created_at": "2026-06-01T12:43:48.383287Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2fb03282-9878-481c-be5b-eda6036f909d",
+        "status": "triggered", "triggered_at": "2026-06-04T21:49:55.543841Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 701514, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86344c0b-c360-4709-bb6b-fce628ace1d7",
+        "name": "honeytoken-toot-991c4137", "description": "", "created_at": "2026-06-05T17:59:07.240726Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86344c0b-c360-4709-bb6b-fce628ace1d7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
+        "97c1b533-d768-4054-94de-ae3d967a5128", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "949d59d0-c3c2-4d5e-ae3c-4f365b9b8456",
+        "name": "honeytoken-toot-0fefb095", "description": "", "created_at": "2026-06-05T17:59:07.748651Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/949d59d0-c3c2-4d5e-ae3c-4f365b9b8456",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
+        "97c1b533-d768-4054-94de-ae3d967a5128", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ab5965c-8f7e-44ec-b64e-1111e140586f",
+        "name": "ggshield-WOmcC4wM", "description": "description", "created_at": "2026-06-15T15:05:19.990102Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ab5965c-8f7e-44ec-b64e-1111e140586f",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "95786b03-4165-4245-8aef-fac41ff6a1de",
+        "name": "ggshield-E2HxYogl", "description": "description", "created_at": "2026-06-15T15:05:20.446208Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/95786b03-4165-4245-8aef-fac41ff6a1de",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "98271cf2-3025-4e7d-b120-afd29fe20c8f",
+        "name": "ggshield-32Xli2ct", "description": "description", "created_at": "2026-06-15T15:13:44.456933Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/98271cf2-3025-4e7d-b120-afd29fe20c8f",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "68f09d33-1cab-4b93-84a5-2861a7a01fbc",
+        "name": "ggshield-o2ocvFQZ", "description": "description", "created_at": "2026-06-15T15:13:45.228488Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/68f09d33-1cab-4b93-84a5-2861a7a01fbc",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ee69dfd0-fa9c-451d-947e-261c2edd4355",
+        "name": "ggshield-rGxN1k4I", "description": "description", "created_at": "2026-06-15T15:46:58.088837Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ee69dfd0-fa9c-451d-947e-261c2edd4355",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f91525c-02bd-4a0f-9c5d-c9949f7196f4",
+        "name": "ggshield-bZoVll0H", "description": "description", "created_at": "2026-06-15T15:46:58.839510Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f91525c-02bd-4a0f-9c5d-c9949f7196f4",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4a3a3699-fb2e-4e0f-ae02-4905fe8228ec",
+        "name": "ggshield-VuSeELel", "description": "description", "created_at": "2026-06-17T13:23:52.166183Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4a3a3699-fb2e-4e0f-ae02-4905fe8228ec",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "dd2d3e47-d804-41c5-b8b8-f640e6292096", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d82dc520-9ea5-4a38-a9d8-84bf2f94975b",
+        "name": "ggshield-yQlAvTpn", "description": "description", "created_at": "2026-06-17T13:23:52.682610Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d82dc520-9ea5-4a38-a9d8-84bf2f94975b",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "dd2d3e47-d804-41c5-b8b8-f640e6292096", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}]'
     headers:
+      CF-RAY:
+      - a10395107982565a-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:08 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, POST, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '139756'
+      - '145842'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:23 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '730'
+      - '781'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -1729,43 +1814,50 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/411d33c0-7fad-4fc1-b94e-bb440c8f9c49",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:11.250010Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}'
+        "token": "[REDACTED]"}'
     headers:
+      CF-RAY:
+      - a103951abef8e989-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:08 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, PUT, PATCH, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '673'
+      - '583'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:24 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '38'
+      - '45'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_get_incident.yaml
+++ b/tests/cassettes/client/vcr/test_get_incident.yaml
@@ -21,71 +21,80 @@ interactions:
   response:
     body:
       string: '[{"id": 21460, "detector": {"name": "aws_iam", "display_name": "AWS
-        IAM Keys", "nature": "specific", "family": "credentials", "detector_group_name":
-        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2020-10-29T13:19:59.005564Z",
-        "secret_id": 70588, "secret_hash": "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG",
-        "hmsl_hash": "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2026-03-11T22:41:04.525493Z", "resolver_id": 492181, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "invalid", "severity": "medium",
-        "assignee_id": null, "assignee_email": "vincent.boyer@gitguardian.com", "share_url":
-        "[REDACTED]", "feedback_list": [{"created_at": "2022-07-20T13:22:52.756189Z",
-        "updated_at": "2022-07-20T13:22:52.756207Z", "email": "stanislas.crepin@gitguardian.com",
-        "member_id": null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
-        "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
-        "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
-        give or has given access to any sensitive information or services?", "boolean":
-        true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
-        this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
-        "remarks_text", "field_label": "Additional remarks", "text": "Hasn''t been
-        revoked yet because X"}]}], "risk_score": 100, "is_vaulted": false, "ignore_reason":
-        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        IAM Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2020-10-29T13:19:59.005564Z", "secret_id": 70588, "secret_hash":
+        "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG", "hmsl_hash":
+        "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
+        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
+        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
+        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
+        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
+        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
+        given access to any sensitive information or services?", "boolean": true},
+        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
+        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
+        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
+        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
+        "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
         0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
         0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["PUBLICLY_LEAKED"],
-        "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["REVOCABLE_BY_GG",
+        "PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
         "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}]'
     headers:
+      CF-RAY:
+      - a103953c5c8f4fe6-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:14 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '2149'
+      - '2219'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:29 GMT
       link:
       - <https://api.gitguardian.com/v1/incidents/secrets?cursor=cD0yMTQ2MA%3D%3D&per_page=1>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '82'
+      - '87'
       x-frame-options:
       - DENY
       x-per-page:
       - '1'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -113,32 +122,34 @@ interactions:
   response:
     body:
       string: '{"id": 21460, "detector": {"name": "aws_iam", "display_name": "AWS
-        IAM Keys", "nature": "specific", "family": "credentials", "detector_group_name":
-        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2020-10-29T13:19:59.005564Z",
-        "secret_id": 70588, "secret_hash": "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG",
-        "hmsl_hash": "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2026-03-11T22:41:04.525493Z", "resolver_id": 492181, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "invalid", "severity": "medium",
-        "assignee_id": null, "assignee_email": "vincent.boyer@gitguardian.com", "share_url":
-        "[REDACTED]", "feedback_list": [{"created_at": "2022-07-20T13:22:52.756189Z",
-        "updated_at": "2022-07-20T13:22:52.756207Z", "email": "stanislas.crepin@gitguardian.com",
-        "member_id": null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
-        "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
-        "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
-        give or has given access to any sensitive information or services?", "boolean":
-        true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
-        this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
-        "remarks_text", "field_label": "Additional remarks", "text": "Hasn''t been
-        revoked yet because X"}]}], "risk_score": 100, "is_vaulted": false, "ignore_reason":
-        null, "occurrences": [{"id": 78197, "incident_id": 21460, "date": "2020-10-29T13:20:05.797462Z",
-        "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
-        [{"name": "client_id", "indice_start": 49, "indice_end": 69, "pre_line_start":
-        3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}, {"name":
-        "client_secret", "indice_start": 85, "indice_end": 125, "pre_line_start":
-        4, "pre_line_end": 4, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        IAM Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2020-10-29T13:19:59.005564Z", "secret_id": 70588, "secret_hash":
+        "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG", "hmsl_hash":
+        "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
+        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
+        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
+        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
+        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
+        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
+        given access to any sensitive information or services?", "boolean": true},
+        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
+        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
+        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
+        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
+        "ignore_reason": null, "occurrences": [{"id": 78197, "incident_id": 21460,
+        "date": "2020-10-29T13:20:05.797462Z", "filepath": "app.py", "kind": "realtime",
+        "presence": "removed", "matches": [{"name": "client_id", "indice_start": 49,
+        "indice_end": 69, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
+        null, "post_line_end": null}, {"name": "client_secret", "indice_start": 85,
+        "indice_end": 125, "pre_line_start": 4, "pre_line_end": 4, "post_line_start":
+        null, "post_line_end": null}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"], "url":
+        "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion",
         "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
@@ -146,20 +157,20 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "304477822", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "provider_metadata": {"archived": false}, "deleted": true}}, {"id": 78198,
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "304477822", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78198,
         "incident_id": 21460, "date": "2020-10-29T13:19:59.005564Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
         "indice_start": 92, "indice_end": 112, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 3}, {"name": "client_secret",
         "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
+        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition",
         "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
@@ -167,54 +178,62 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "304477822", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "provider_metadata": {"archived": false}, "deleted": true}}], "secret_presence":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "304477822", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}], "secret_presence":
         {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
         "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
         2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21460",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link":
-        "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}], "custom_tags":
-        []}'
+        "tags": ["PUBLICLY_LEAKED", "REVOCABLE_BY_GG"], "incident_name": "AWS IAM
+        Keys", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "destination_tickets": [{"id":
+        "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
+        "custom_tags": []}'
     headers:
+      CF-RAY:
+      - a103953f1944228e-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:14 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, PUT, PATCH, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '5516'
+      - '5666'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:30 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '147'
+      - '80'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_get_incidents_batch.yaml
+++ b/tests/cassettes/client/vcr/test_get_incidents_batch.yaml
@@ -21,36 +21,37 @@ interactions:
   response:
     body:
       string: '[{"id": 21460, "detector": {"name": "aws_iam", "display_name": "AWS
-        IAM Keys", "nature": "specific", "family": "credentials", "detector_group_name":
-        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2020-10-29T13:19:59.005564Z",
-        "secret_id": 70588, "secret_hash": "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG",
-        "hmsl_hash": "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2026-03-11T22:41:04.525493Z", "resolver_id": 492181, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "invalid", "severity": "medium",
-        "assignee_id": null, "assignee_email": "vincent.boyer@gitguardian.com", "share_url":
-        "[REDACTED]", "feedback_list": [{"created_at": "2022-07-20T13:22:52.756189Z",
-        "updated_at": "2022-07-20T13:22:52.756207Z", "email": "stanislas.crepin@gitguardian.com",
-        "member_id": null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
-        "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
-        "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
-        give or has given access to any sensitive information or services?", "boolean":
-        true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
-        this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
-        "remarks_text", "field_label": "Additional remarks", "text": "Hasn''t been
-        revoked yet because X"}]}], "risk_score": 100, "is_vaulted": false, "ignore_reason":
-        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        IAM Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2020-10-29T13:19:59.005564Z", "secret_id": 70588, "secret_hash":
+        "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG", "hmsl_hash":
+        "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
+        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
+        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
+        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
+        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
+        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
+        given access to any sensitive information or services?", "boolean": true},
+        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
+        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
+        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
+        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
+        "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
         0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
         0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["PUBLICLY_LEAKED"],
-        "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["REVOCABLE_BY_GG",
+        "PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
         "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}, {"id": 21461, "detector": {"name": "private_key_dsa",
         "display_name": "DSA Private Key", "nature": "specific", "family": "cryptographic_key",
-        "detector_group_name": "private_key_dsa", "detector_group_display_name": "DSA
-        Private Key"}, "date": "2020-10-29T09:19:54.249454Z", "secret_id": 70589,
+        "category": "private_key", "detector_group_name": "private_key_dsa", "detector_group_display_name":
+        "DSA Private Key"}, "date": "2020-10-29T09:19:54.249454Z", "secret_id": 70589,
         "secret_hash": "FNJbfEKG/ZXHjBfeEDa+45ryvtA8AC1egwR+QsSqIDlRVNh2Z/McHLTpLI6+WVL/",
         "hmsl_hash": "ae092263bbe1c8bbcc5e8e4dd785681b62e9d48226d66cb28f5d305fa5ef8e68",
         "occurrences_count": 2, "status": "ASSIGNED", "triggered_at": "2021-02-11T14:23:22.947605Z",
@@ -67,201 +68,80 @@ interactions:
         true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
         this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
         "remarks_text", "field_label": "Additional remarks", "text": "important info."}]}],
-        "risk_score": 72, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21461",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "DSA Private Key", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link":
-        "https://sandboxgitguardian.atlassian.net/browse/JB-15"}, {"id": "JB-14",
-        "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-14"}],
+        "risk_score": 72, "severity_rule_id": 11883, "is_vaulted": false, "ignore_reason":
+        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21461", "tags": ["PUBLICLY_LEAKED"],
+        "incident_name": "DSA Private Key", "public_exposure": {"source_publicly_visible":
+        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-15"},
+        {"id": "JB-14", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-14"}],
         "custom_tags": []}, {"id": 21462, "detector": {"name": "salesforce_oauth2",
         "display_name": "Salesforce Oauth2 Keys", "nature": "specific", "family":
-        "credentials", "detector_group_name": "salesforce_oauth2_keys", "detector_group_display_name":
-        "Salesforce Oauth2 Keys"}, "date": "2020-10-29T07:19:30.598398Z", "secret_id":
-        70590, "secret_hash": "c7Kwkwc1D3iO0XnbILGE93uD0GJXOV0CL1t/0icvVnmQUzR2LCAWyy4SR5jhsuGk",
+        "credentials", "category": "crm", "detector_group_name": "salesforce_oauth2_keys",
+        "detector_group_display_name": "Salesforce Oauth2 Keys"}, "date": "2020-10-29T07:19:30.598398Z",
+        "secret_id": 70590, "secret_hash": "c7Kwkwc1D3iO0XnbILGE93uD0GJXOV0CL1t/0icvVnmQUzR2LCAWyy4SR5jhsuGk",
         "hmsl_hash": "e2671771c77564e0f9b6dea27d7b71faa3e9566445b52e7ed403fc8f5e100390",
         "occurrences_count": 2, "status": "IGNORED", "triggered_at": "2021-02-11T14:23:22.947632Z",
         "ignored_at": "2025-07-28T09:27:09.871747Z", "ignorer_id": 492181, "ignorer_api_token_id":
         null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
         "secret_revoked": false, "validity": "invalid", "severity": "high", "assignee_id":
         10, "assignee_email": "bruce-wayne-gg@protonmail.com", "share_url": "[REDACTED]",
-        "feedback_list": [], "risk_score": 23, "is_vaulted": false, "ignore_reason":
-        "invalid", "occurrences": null, "secret_presence": {"files_requiring_code_fix":
-        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
-        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21462", "tags": ["PUBLICLY_LEAKED"],
-        "incident_name": "Salesforce Oauth2 Keys", "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [], "custom_tags": []}]'
+        "feedback_list": [], "risk_score": 23, "severity_rule_id": 31, "is_vaulted":
+        false, "ignore_reason": "invalid", "occurrences": null, "secret_presence":
+        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
+        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
+        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21462",
+        "tags": ["PUBLICLY_LEAKED"], "incident_name": "Salesforce Oauth2 Keys", "public_exposure":
+        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "destination_tickets": [], "custom_tags": []}]'
     headers:
+      CF-RAY:
+      - a10395447a2b5d26-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:15 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '5802'
+      - '5961'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:31 GMT
       link:
       - <https://api.gitguardian.com/v1/incidents/secrets?cursor=cD0yMTQ2Mg%3D%3D&per_page=3>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '108'
+      - '97'
       x-frame-options:
       - DENY
       x-per-page:
       - '3'
       x-secrets-engine-version:
-      - 2.159.0
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: ''
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Host:
-      - api.gitguardian.com
-      User-Agent:
-      - GitGuardian-MCP-Server/0.5.0
-      X-Privacy-Mode:
-      - 'true'
-    method: GET
-    uri: https://api.gitguardian.com/v1/incidents/secrets/21460
-  response:
-    body:
-      string: '{"id": 21460, "detector": {"name": "aws_iam", "display_name": "AWS
-        IAM Keys", "nature": "specific", "family": "credentials", "detector_group_name":
-        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2020-10-29T13:19:59.005564Z",
-        "secret_id": 70588, "secret_hash": "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG",
-        "hmsl_hash": "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2026-03-11T22:41:04.525493Z", "resolver_id": 492181, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "invalid", "severity": "medium",
-        "assignee_id": null, "assignee_email": "vincent.boyer@gitguardian.com", "share_url":
-        "[REDACTED]", "feedback_list": [{"created_at": "2022-07-20T13:22:52.756189Z",
-        "updated_at": "2022-07-20T13:22:52.756207Z", "email": "stanislas.crepin@gitguardian.com",
-        "member_id": null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
-        "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
-        "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
-        give or has given access to any sensitive information or services?", "boolean":
-        true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
-        this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
-        "remarks_text", "field_label": "Additional remarks", "text": "Hasn''t been
-        revoked yet because X"}]}], "risk_score": 100, "is_vaulted": false, "ignore_reason":
-        null, "occurrences": [{"id": 78197, "incident_id": 21460, "date": "2020-10-29T13:20:05.797462Z",
-        "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
-        [{"name": "client_id", "indice_start": 49, "indice_end": 69, "pre_line_start":
-        3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}, {"name":
-        "client_secret", "indice_start": 85, "indice_end": 125, "pre_line_start":
-        4, "pre_line_end": 4, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
-        11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "304477822", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "provider_metadata": {"archived": false}, "deleted": true}}, {"id": 78198,
-        "incident_id": 21460, "date": "2020-10-29T13:19:59.005564Z", "filepath": "app.py",
-        "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
-        "indice_start": 92, "indice_end": 112, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 3, "post_line_end": 3}, {"name": "client_secret",
-        "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
-        11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "304477822", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "provider_metadata": {"archived": false}, "deleted": true}}], "secret_presence":
-        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
-        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
-        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21460",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link":
-        "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}], "custom_tags":
-        []}'
-    headers:
-      access-control-expose-headers:
-      - X-App-Version
-      allow:
-      - GET, PUT, PATCH, HEAD, OPTIONS
-      content-length:
-      - '5516'
-      content-security-policy:
-      - frame-ancestors 'none'
-      content-type:
-      - application/json
-      cross-origin-opener-policy:
-      - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:31 GMT
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Cookie
-      x-app-version:
-      - v2.426.0
-      x-content-type-options:
-      - nosniff
-      x-envoy-upstream-service-time:
-      - '88'
-      x-frame-options:
-      - DENY
-      x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -289,9 +169,10 @@ interactions:
   response:
     body:
       string: '{"id": 21461, "detector": {"name": "private_key_dsa", "display_name":
-        "DSA Private Key", "nature": "specific", "family": "cryptographic_key", "detector_group_name":
-        "private_key_dsa", "detector_group_display_name": "DSA Private Key"}, "date":
-        "2020-10-29T09:19:54.249454Z", "secret_id": 70589, "secret_hash": "FNJbfEKG/ZXHjBfeEDa+45ryvtA8AC1egwR+QsSqIDlRVNh2Z/McHLTpLI6+WVL/",
+        "DSA Private Key", "nature": "specific", "family": "cryptographic_key", "category":
+        "private_key", "detector_group_name": "private_key_dsa", "detector_group_display_name":
+        "DSA Private Key"}, "date": "2020-10-29T09:19:54.249454Z", "secret_id": 70589,
+        "secret_hash": "FNJbfEKG/ZXHjBfeEDa+45ryvtA8AC1egwR+QsSqIDlRVNh2Z/McHLTpLI6+WVL/",
         "hmsl_hash": "ae092263bbe1c8bbcc5e8e4dd785681b62e9d48226d66cb28f5d305fa5ef8e68",
         "occurrences_count": 2, "status": "ASSIGNED", "triggered_at": "2021-02-11T14:23:22.947605Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
@@ -307,8 +188,8 @@ interactions:
         true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
         this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
         "remarks_text", "field_label": "Additional remarks", "text": "important info."}]}],
-        "risk_score": 72, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        [{"id": 78199, "incident_id": 21461, "date": "2020-10-29T10:19:39.723768Z",
+        "risk_score": 72, "severity_rule_id": 11883, "is_vaulted": false, "ignore_reason":
+        null, "occurrences": [{"id": 78199, "incident_id": 21461, "date": "2020-10-29T10:19:39.723768Z",
         "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
         [{"name": "apikey", "indice_start": 48, "indice_end": 726, "pre_line_start":
         3, "pre_line_end": 14, "post_line_start": null, "post_line_end": null}], "tags":
@@ -320,17 +201,18 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 1524, "duration": "4.818047", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "295879950", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        2, "severity_breakdown": {"critical": 2, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 13, "severity_breakdown":
-        {"critical": 1, "high": 12, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09", "provider_metadata":
-        {"archived": false}, "deleted": true}}, {"id": 78200, "incident_id": 21461,
-        "date": "2020-10-29T09:19:54.249454Z", "filepath": "app.py", "kind": "realtime",
-        "presence": "removed", "matches": [{"name": "apikey", "indice_start": 91,
-        "indice_end": 769, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        3, "post_line_end": 14}], "tags": ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "295879950", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78200,
+        "incident_id": 21461, "date": "2020-10-29T09:19:54.249454Z", "filepath": "app.py",
+        "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
+        "indice_start": 91, "indice_end": 769, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 14}], "tags": ["PUBLICLY_EXPOSED",
+        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "76dd4f31a31c78a151723031bfebff4d076751b2", "change_type": "addition",
         "source": {"id": 12320, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-09",
@@ -338,54 +220,202 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 1524, "duration": "4.818047", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "295879950", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        2, "severity_breakdown": {"critical": 2, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 13, "severity_breakdown":
-        {"critical": 1, "high": 12, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09", "provider_metadata":
-        {"archived": false}, "deleted": true}}], "secret_presence": {"files_requiring_code_fix":
-        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
-        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21461", "tags": ["PUBLICLY_LEAKED"],
-        "incident_name": "DSA Private Key", "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-15"},
-        {"id": "JB-14", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-14"}],
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "295879950", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        "provider_metadata": {"archived": false}, "deleted": false}}], "secret_presence":
+        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
+        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
+        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21461",
+        "tags": ["PUBLICLY_LEAKED"], "incident_name": "DSA Private Key", "public_exposure":
+        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link":
+        "https://sandboxgitguardian.atlassian.net/browse/JB-15"}, {"id": "JB-14",
+        "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-14"}],
         "custom_tags": []}'
     headers:
+      CF-RAY:
+      - a10395469958d104-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:16 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, PUT, PATCH, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '5295'
+      - '5427'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:31 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '89'
+      - '80'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/incidents/secrets/21460
+  response:
+    body:
+      string: '{"id": 21460, "detector": {"name": "aws_iam", "display_name": "AWS
+        IAM Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2020-10-29T13:19:59.005564Z", "secret_id": 70588, "secret_hash":
+        "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG", "hmsl_hash":
+        "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
+        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
+        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
+        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
+        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
+        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
+        given access to any sensitive information or services?", "boolean": true},
+        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
+        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
+        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
+        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
+        "ignore_reason": null, "occurrences": [{"id": 78197, "incident_id": 21460,
+        "date": "2020-10-29T13:20:05.797462Z", "filepath": "app.py", "kind": "realtime",
+        "presence": "removed", "matches": [{"name": "client_id", "indice_start": 49,
+        "indice_end": 69, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
+        null, "post_line_end": null}, {"name": "client_secret", "indice_start": 85,
+        "indice_end": 125, "pre_line_start": 4, "pre_line_end": 4, "post_line_start":
+        null, "post_line_end": null}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"], "url":
+        "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
+        "sha": "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion",
+        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
+        11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "304477822", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78198,
+        "incident_id": 21460, "date": "2020-10-29T13:19:59.005564Z", "filepath": "app.py",
+        "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
+        "indice_start": 92, "indice_end": 112, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}, {"name": "client_secret",
+        "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
+        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
+        "sha": "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition",
+        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
+        11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "304477822", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}], "secret_presence":
+        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
+        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
+        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21460",
+        "tags": ["REVOCABLE_BY_GG", "PUBLICLY_LEAKED"], "incident_name": "AWS IAM
+        Keys", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "destination_tickets": [{"id":
+        "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
+        "custom_tags": []}'
+    headers:
+      CF-RAY:
+      - a1039546896e3ce3-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:16 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, PUT, PATCH, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '5666'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '94'
+      x-frame-options:
+      - DENY
+      x-secrets-engine-version:
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_get_member_by_id.yaml
+++ b/tests/cassettes/client/vcr/test_get_member_by_id.yaml
@@ -20,47 +20,58 @@ interactions:
     uri: https://api.gitguardian.com/v1/api_tokens/self
   response:
     body:
-      string: '{"id": "8a262c6a-832d-49e5-8744-23c743ff25ac", "name": "ggmcp CI",
-        "type": "personal_access_token", "scopes": ["scan", "incidents:read", "members:read",
-        "audit_logs:read", "teams:read", "honeytokens:read", "honeytokens:write",
-        "api_tokens:read", "sources:read", "nhi:send-inventory", "nhi:write-vault",
-        "custom_tags:read", "custom_tags:write", "secrets:read", "secrets:write",
-        "scan:create-incidents", "public-perimeter:read"], "member_id": 480870, "workspace_id":
-        8, "created_at": "2025-12-07T14:13:08.044416Z", "last_used_at": "2026-04-03T08:43:00Z",
-        "expire_at": null, "revoked_at": null, "status": "active", "creator_id": 480870}'
+      string: '{"id": "d0ca9877-641f-4c37-8857-c08e0ae148c4", "name": "ggmcp CI (April)",
+        "type": "personal_access_token", "scopes": ["scan", "incidents:read", "incidents:write",
+        "incidents:share", "members:read", "members:write", "audit_logs:read", "teams:read",
+        "teams:write", "honeytokens:read", "honeytokens:write", "api_tokens:read",
+        "api_tokens:write", "ip_allowlist:read", "ip_allowlist:write", "sources:read",
+        "sources:write", "nhi:send-inventory", "nhi:write-vault", "custom_tags:read",
+        "custom_tags:write", "secrets:read", "secrets:write", "scan:create-incidents",
+        "public-perimeter:read", "nhi:ownership:read", "nhi:ownership:write", "sources:scan"],
+        "member_id": 480870, "workspace_id": 8, "created_at": "2026-04-20T13:31:42.422943Z",
+        "last_used_at": "2026-06-23T12:45:00Z", "expire_at": null, "revoked_at": null,
+        "status": "active", "creator_id": 480870}'
     headers:
+      CF-RAY:
+      - a103973d9bfdef43-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:36 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '594'
+      - '802'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:26 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '22'
+      - '20'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -89,41 +100,49 @@ interactions:
     body:
       string: '{"id": 480870, "role": "manager", "access_level": "manager", "email":
         "timothe.delion@gitguardian.com", "name": "Timoth\u00e9 DELION", "created_at":
-        "2023-06-26T12:41:18.599497Z", "last_login": "2026-04-02T13:15:43.810850Z",
+        "2023-06-26T12:41:18.599497Z", "last_login": "2026-06-23T12:20:54.639679Z",
         "active": true}'
     headers:
+      CF-RAY:
+      - a103973f3dd2c627-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:36 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '221'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:27 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '40'
+      - '26'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -152,41 +171,49 @@ interactions:
     body:
       string: '{"id": 480870, "role": "manager", "access_level": "manager", "email":
         "timothe.delion@gitguardian.com", "name": "Timoth\u00e9 DELION", "created_at":
-        "2023-06-26T12:41:18.599497Z", "last_login": "2026-04-02T13:15:43.810850Z",
+        "2023-06-26T12:41:18.599497Z", "last_login": "2026-06-23T12:20:54.639679Z",
         "active": true}'
     headers:
+      CF-RAY:
+      - a1039740eb816f8e-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:36 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '221'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:27 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '27'
+      - '38'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_get_public_incident_returns_same_id.yaml
+++ b/tests/cassettes/client/vcr/test_get_public_incident_returns_same_id.yaml
@@ -37,13 +37,13 @@ interactions:
         "destination_tickets": [], "incident_name": "Stripe Keys"}]'
     headers:
       CF-RAY:
-      - 9efb894d0c5c9f0a-CDG
+      - a103960c49d16f94-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:59:30 GMT
+      - Tue, 23 Jun 2026 12:44:47 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -70,17 +70,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '79'
+      - '90'
       x-frame-options:
       - DENY
       x-per-page:
       - '1'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -124,13 +124,13 @@ interactions:
         "destination_tickets": [], "incident_name": "Stripe Keys"}'
     headers:
       CF-RAY:
-      - 9efb894f3cf7d15d-CDG
+      - a103960e4cebd08f-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:59:30 GMT
+      - Tue, 23 Jun 2026 12:44:47 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -154,15 +154,15 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '81'
+      - '86'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_get_source_by_name.yaml
+++ b/tests/cassettes/client/vcr/test_get_source_by_name.yaml
@@ -20,56 +20,62 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?per_page=1
   response:
     body:
-      string: '[{"id": 12338, "type": "github", "full_name": "wayne-enterprises-gg/shared-app",
-        "health": "safe", "source_criticality": "low", "default_branch": "master",
-        "default_branch_head": "a219c18ff8e913427c38fc7d90756d6bb1bb5b43", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2026-02-02T10:49:30.905195Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 544, "duration":
-        "0.0", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "218964926", "secret_incidents_breakdown": {"open_secret_incidents":
+      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/shared-app",
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a10397123e600b18-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:29 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '882'
+      - '709'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:17 GMT
       link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjMzOA%3D%3D&per_page=1>;
+      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjI1OQ%3D%3D&per_page=1>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '225'
+      - '473'
       x-frame-options:
       - DENY
       x-per-page:
       - '1'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -93,58 +99,64 @@ interactions:
       X-Privacy-Mode:
       - 'true'
     method: GET
-    uri: https://api.gitguardian.com/v1/sources?search=wayne-enterprises-gg%2Fshared-app&per_page=50
+    uri: https://api.gitguardian.com/v1/sources?search=lonely%2Fcowboy&per_page=50
   response:
     body:
-      string: '[{"id": 12338, "type": "github", "full_name": "wayne-enterprises-gg/shared-app",
-        "health": "safe", "source_criticality": "low", "default_branch": "master",
-        "default_branch_head": "a219c18ff8e913427c38fc7d90756d6bb1bb5b43", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2026-02-02T10:49:30.905195Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 544, "duration":
-        "0.0", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "218964926", "secret_incidents_breakdown": {"open_secret_incidents":
+      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/shared-app",
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a10397169b2bd50e-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:30 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '882'
+      - '709'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:18 GMT
       link:
       - ''
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '262'
+      - '352'
       x-frame-options:
       - DENY
       x-per-page:
       - '50'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_get_source_by_name_no_match.yaml
+++ b/tests/cassettes/client/vcr/test_get_source_by_name_no_match.yaml
@@ -22,42 +22,48 @@ interactions:
     body:
       string: '[]'
     headers:
+      CF-RAY:
+      - a103971a5d738634-CDG
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:31 GMT
+      Server:
+      - cloudflare
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
-      content-length:
-      - '2'
+      cf-cache-status:
+      - DYNAMIC
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:19 GMT
       link:
       - ''
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '231'
+      - '536'
       x-frame-options:
       - DENY
       x-per-page:
       - '50'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_get_source_by_name_return_all_on_no_match.yaml
+++ b/tests/cassettes/client/vcr/test_get_source_by_name_return_all_on_no_match.yaml
@@ -20,611 +20,561 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?search=test&per_page=50
   response:
     body:
-      string: '[{"id": 9123882, "type": "github", "full_name": "orga-083643/analytics-test",
-        "health": "safe", "source_criticality": "unknown", "default_branch": "main",
-        "default_branch_head": "f19d79466ce40e0bb69c9ee0ea08787ead9b5845", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:45:43.352186Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 7, "duration":
-        "0.942938", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "private", "external_id": "630536182", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/analytics-test",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11363204,
-        "type": "github", "full_name": "amascia-gg/ftn-test-circleci", "health": "at_risk",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 2, "closed_incidents_count": 1, "last_scan":
-        {"date": "2025-10-09T16:45:43.354963Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 3121, "duration": "95.292729", "branches_scanned":
-        2, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "704004504", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        2, "severity_breakdown": {"critical": 1, "high": 1, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/amascia-gg/ftn-test-circleci", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 11677085, "type": "github",
-        "full_name": "peterringball/test", "health": "unknown", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": false, "visibility":
-        "private", "external_id": "673461264", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/peterringball/test",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11678252,
-        "type": "github", "full_name": "tuches/Test", "health": "safe", "source_criticality":
-        "low", "default_branch": "master", "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 1, "last_scan": {"date": "2025-10-09T16:45:43.352050Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 5, "duration":
-        "0.68205", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "291043633", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        1, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/tuches/Test", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 11756704, "type": "github",
-        "full_name": "peterringball/test4", "health": "safe", "source_criticality":
-        "low", "default_branch": "main", "default_branch_head": "d7d00895483d9e6fd62acf72594199ee5cabf7c7",
-        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
-        "2025-10-09T16:45:43.353873Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 32, "duration": "3.878778", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "684649378",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/peterringball/test4",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12322614,
-        "type": "slack", "full_name": "Demo Slack Integration / #test-timothe-delion",
+      string: '[{"id": 12263, "type": "github", "full_name": "my-testing-org/christian_dior",
         "health": "safe", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": {"date": "2025-10-09T16:44:19.449065Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 0, "duration": "0.233054", "branches_scanned":
-        0, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "C06D386SZC0", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://demoslackinte-0vf1761.slack.com/archives/C06D386SZC0", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 12470998, "type": "slack",
-        "full_name": "Demo Slack Integration / #test-channel-creation", "health":
-        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:44:19.444580Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.23533", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "C06EGV15G8Z",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://demoslackinte-0vf1761.slack.com/archives/C06EGV15G8Z",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12482445,
-        "type": "slack", "full_name": "Demo Slack Integration / #test", "health":
-        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:44:19.440496Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.26622", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "C06EYF11U0G",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://demoslackinte-0vf1761.slack.com/archives/C06EYF11U0G",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12662970,
-        "type": "github", "full_name": "aymericGG/sample_secrets_Codacytest", "health":
-        "at_risk", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 1, "closed_incidents_count": 2, "last_scan":
-        {"date": "2025-10-09T16:45:43.354102Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 7, "duration": "2.949598", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "750268193",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 1, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
-        0, "high": 1, "medium": 1, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/sample_secrets_Codacytest",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12663154,
-        "type": "github", "full_name": "aymericGG/juice-shop-Codacytest", "health":
-        "at_risk", "source_criticality": "unknown", "default_branch": "master", "default_branch_head":
-        null, "open_incidents_count": 52, "closed_incidents_count": 33, "last_scan":
-        {"date": "2026-01-15T16:49:11.671959Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 19830, "duration": "82.392816", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "750273107", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        52, "severity_breakdown": {"critical": 27, "high": 25, "medium": 0, "low":
-        0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 33, "severity_breakdown":
-        {"critical": 2, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 30}}},
-        "url": "https://github.com/aymericGG/juice-shop-Codacytest", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 13056005, "type": "github",
-        "full_name": "amascia-gg/test_sca_scan", "health": "safe", "source_criticality":
-        "unknown", "default_branch": "modified_def", "default_branch_head": "80331d9b7d90ccc8e97f24a5712346b18712d016",
-        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
-        "2025-10-09T16:45:43.351336Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 283, "duration": "0.993776", "branches_scanned": 3, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "608577245",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/amascia-gg/test_sca_scan",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 13926516,
-        "type": "github", "full_name": "ferdi05/test_keys", "health": "at_risk", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": null, "open_incidents_count":
-        2, "closed_incidents_count": 1, "last_scan": {"date": "2025-10-09T16:45:43.353532Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 6, "duration":
-        "0.732485", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "791829364", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 2, "severity_breakdown": {"critical": 2, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        1, "severity_breakdown": {"critical": 1, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/ferdi05/test_keys",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218896,
-        "type": "gitlab", "full_name": "qa / test-nriv", "health": "at_risk", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": "1dee221c6baeb2677e1463ce1446b334fb5f007f",
-        "open_incidents_count": 4, "closed_incidents_count": 9, "last_scan": {"date":
-        "2026-02-18T22:22:32.238978Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 16, "duration": "6.19076", "branches_scanned": 4, "progress":
-        100}, "monitored": true, "visibility": "internal", "external_id": "255", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
-        0, "high": 3, "medium": 0, "low": 0, "info": 0, "unknown": 1}}, "closed_secret_incidents":
-        {"total": 9, "severity_breakdown": {"critical": 1, "high": 3, "medium": 0,
-        "low": 0, "info": 0, "unknown": 5}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa1/test-nriv",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218897,
-        "type": "gitlab", "full_name": "dev / Salome Test", "health": "at_risk", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": null, "open_incidents_count":
-        5, "closed_incidents_count": 0, "last_scan": {"date": "2026-02-18T22:22:33.652100Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 10, "duration":
-        "4.211253", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "private", "external_id": "254", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 5, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 5}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/dev/salome-test",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218898,
-        "type": "gitlab", "full_name": "qa / test-r8327r", "health": "at_risk", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": null, "open_incidents_count":
-        5, "closed_incidents_count": 5, "last_scan": {"date": "2026-02-18T22:22:35.009680Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 11, "duration":
-        "5.2262", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "internal", "external_id": "253", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 5, "severity_breakdown": {"critical": 0, "high": 2, "medium": 0,
-        "low": 0, "info": 0, "unknown": 3}}, "closed_secret_incidents": {"total":
-        5, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0, "low": 0,
-        "info": 0, "unknown": 4}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa/test-r8327r",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218901,
-        "type": "gitlab", "full_name": "QATeam / test-renovate-npm", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2026-02-18T22:22:39.531659Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 5, "duration": "1.013955", "branches_scanned": 2, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "250", "secret_incidents_breakdown":
+        0, "last_scan": {"date": "2020-09-24T09:06:39.211442Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1, "duration": "1.218169", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "12", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/QATeam/test-renovate-npm",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218902,
-        "type": "gitlab", "full_name": "QATeam / test-renovate", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2026-02-18T22:22:41.194813Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 13, "duration": "1.340437", "branches_scanned": 11,
-        "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "249", "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0,
-        "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0, "info":
-        0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://gitlab-01.aws-qa-gitguardian.com/QATeam/test-renovate", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 16218904, "type": "gitlab",
-        "full_name": "qa-sca-iac / test_scan_ci", "health": "at_risk", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": null, "open_incidents_count":
-        1, "closed_incidents_count": 0, "last_scan": {"date": "2026-02-18T22:22:44.456605Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 28, "duration":
-        "1.839371", "branches_scanned": 3, "progress": 100}, "monitored": true, "visibility":
-        "internal", "external_id": "247", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 1, "severity_breakdown": {"critical": 1, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa-sca-iac/test_scan_ci",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218905,
-        "type": "gitlab", "full_name": "qa / test-adrien-4", "health": "safe", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2026-02-18T22:22:45.881202Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 1, "duration":
-        "2.691519", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "private", "external_id": "246", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa/test-adrien-4",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218906,
-        "type": "gitlab", "full_name": "sguillaume-test-group / remediation-example",
-        "health": "safe", "source_criticality": "unknown", "default_branch": "main",
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        2, "last_scan": {"date": "2026-02-18T22:22:47.300341Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 2, "duration": "2.18343", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "245", "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0,
-        "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0, "info":
-        0, "unknown": 0}}, "closed_secret_incidents": {"total": 2, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 2}}},
-        "url": "https://gitlab-01.aws-qa-gitguardian.com/sguillaume-test-group/remediation-example",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218908,
-        "type": "gitlab", "full_name": "qa / mdeclercq-test", "health": "at_risk",
-        "source_criticality": "unknown", "default_branch": "master", "default_branch_head":
-        null, "open_incidents_count": 12, "closed_incidents_count": 1, "last_scan":
-        {"date": "2026-02-18T22:22:50.344636Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 16, "duration": "3.738315", "branches_scanned": 3,
-        "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "243", "secret_incidents_breakdown": {"open_secret_incidents": {"total": 12,
-        "severity_breakdown": {"critical": 1, "high": 3, "medium": 0, "low": 0, "info":
-        0, "unknown": 8}}, "closed_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://gitlab-01.aws-qa-gitguardian.com/qa/mdeclercq-test", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 16218910, "type": "gitlab",
-        "full_name": "sylvain-test-grp / test-private-project", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2026-02-18T22:22:54.387619Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 9, "duration": "2.593891", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "241", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/sylvain-test-grp/test-private-project",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218911,
-        "type": "gitlab", "full_name": "Achille / sca-on-prem-test", "health": "at_risk",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 3, "closed_incidents_count": 1, "last_scan":
-        {"date": "2026-02-18T22:22:55.744591Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 13, "duration": "2.883655", "branches_scanned": 6,
-        "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "240", "secret_incidents_breakdown": {"open_secret_incidents": {"total": 3,
-        "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0, "info":
-        0, "unknown": 3}}, "closed_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 1}}},
-        "url": "https://gitlab-01.aws-qa-gitguardian.com/amascia/sca-on-prem-test",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218913,
-        "type": "gitlab", "full_name": "qa / test", "health": "safe", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2026-02-18T22:22:57.069116Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 2, "duration":
-        "1.144702", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "internal", "external_id": "238", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa/test",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218914,
-        "type": "gitlab", "full_name": "gg-tools / Henritest", "health": "at_risk",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 2, "closed_incidents_count": 0, "last_scan":
-        {"date": "2026-02-18T22:22:58.438189Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 4, "duration": "2.43681", "branches_scanned": 2, "progress":
-        100}, "monitored": true, "visibility": "internal", "external_id": "236", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 2}}, "closed_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/gg-tools/Henritest",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218917,
-        "type": "gitlab", "full_name": "test group / dc comics / test subsubgroup
-        / batman", "health": "safe", "source_criticality": "unknown", "default_branch":
-        "main", "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        1, "last_scan": {"date": "2026-02-18T22:23:02.618235Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 2, "duration": "1.149728", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "230", "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0,
-        "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0, "info":
-        0, "unknown": 0}}, "closed_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 1}}},
-        "url": "https://gitlab-01.aws-qa-gitguardian.com/test-group/dc-comics/test-subsubgroup/batman",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218920,
-        "type": "gitlab", "full_name": "qa / nathan realtime test", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2026-02-18T22:23:06.993061Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 1, "duration": "1.038476", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "227", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa/nathan-realtime-test",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218921,
-        "type": "gitlab", "full_name": "Alina Tuholukova / testNewProject", "health":
-        "at_risk", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 1, "closed_incidents_count": 0, "last_scan":
-        {"date": "2026-02-18T22:23:08.474151Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 5, "duration": "3.825191", "branches_scanned": 2, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "226", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
-        1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/atuholukova/testnewproject",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218922,
-        "type": "gitlab", "full_name": "cgarcia / TestNewProject", "health": "at_risk",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 3, "closed_incidents_count": 1, "last_scan":
-        {"date": "2026-02-18T22:23:09.792745Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 5, "duration": "8.89352", "branches_scanned": 2, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "225", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
-        0, "high": 3, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 1, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/cgarcia/TestNewProject",
-        "provider_metadata": {"archived": true}, "deleted": false}, {"id": 16218929,
-        "type": "gitlab", "full_name": "dev / pierre-test-repo", "health": "at_risk",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 3, "closed_incidents_count": 3, "last_scan":
-        {"date": "2026-02-18T22:23:19.802234Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 10, "duration": "2.393559", "branches_scanned": 2,
-        "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "218", "secret_incidents_breakdown": {"open_secret_incidents": {"total": 3,
-        "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0, "info":
-        0, "unknown": 3}}, "closed_secret_incidents": {"total": 3, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 3}}},
-        "url": "https://gitlab-01.aws-qa-gitguardian.com/dev/pierre-test-repo", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 16218932, "type": "gitlab",
-        "full_name": "SE-test-group-access / new-project-test-group-access", "health":
-        "at_risk", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 1, "closed_incidents_count": 1, "last_scan":
-        {"date": "2026-02-18T22:23:23.975277Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 3, "duration": "1.470983", "branches_scanned": 2, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "214", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 1, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 1,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/se-test-group-access/new-project-test-group-access",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218938,
-        "type": "gitlab", "full_name": "dev / xblanchot-test-sca", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2026-02-18T22:23:30.978999Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 1, "duration": "2.543753", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "internal", "external_id": "208", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/dev/xblanchot-test-sca",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218940,
-        "type": "gitlab", "full_name": "gim-qa-gitlabSandbox-auto / gim-qa-gitlabSandbox-Test-Longname-Repository",
-        "health": "safe", "source_criticality": "unknown", "default_branch": "main",
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        1, "last_scan": {"date": "2026-02-18T22:23:33.853539Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 3, "duration": "1.665081", "branches_scanned":
-        2, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "203", "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0,
-        "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0, "info":
-        0, "unknown": 0}}, "closed_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-test-longname-repository",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218942,
-        "type": "gitlab", "full_name": "cgarcia / TestHoneytoken", "health": "at_risk",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 7, "closed_incidents_count": 10, "last_scan":
-        {"date": "2026-02-18T22:23:37.127441Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 24, "duration": "3.716215", "branches_scanned": 6,
-        "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "200", "secret_incidents_breakdown": {"open_secret_incidents": {"total": 7,
-        "severity_breakdown": {"critical": 0, "high": 5, "medium": 0, "low": 0, "info":
-        0, "unknown": 2}}, "closed_secret_incidents": {"total": 10, "severity_breakdown":
-        {"critical": 0, "high": 9, "medium": 0, "low": 0, "info": 0, "unknown": 1}}},
-        "url": "https://gitlab-01.aws-qa-gitguardian.com/cgarcia/testhoneytoken",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218943,
-        "type": "gitlab", "full_name": "dev / Test New Integration", "health": "at_risk",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 1, "closed_incidents_count": 1, "last_scan":
-        {"date": "2026-02-18T22:23:38.579980Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 3, "duration": "1.6112", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "198", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 1}}, "closed_secret_incidents":
-        {"total": 1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/dev/test_new_integration",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218945,
-        "type": "gitlab", "full_name": "sguillaume-test-group / pysimplesoap", "health":
-        "at_risk", "source_criticality": "unknown", "default_branch": "master", "default_branch_head":
-        null, "open_incidents_count": 11, "closed_incidents_count": 1, "last_scan":
-        {"date": "2026-02-18T22:23:39.885259Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 547, "duration": "2.789674", "branches_scanned": 1,
-        "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "196", "secret_incidents_breakdown": {"open_secret_incidents": {"total": 11,
-        "severity_breakdown": {"critical": 8, "high": 0, "medium": 0, "low": 0, "info":
-        0, "unknown": 3}}, "closed_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://gitlab-01.aws-qa-gitguardian.com/sguillaume-test-group/pysimplesoap",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218946,
-        "type": "gitlab", "full_name": "Alina Tuholukova / test_new_project", "health":
-        "at_risk", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 1, "closed_incidents_count": 2, "last_scan":
-        {"date": "2026-02-18T22:23:41.342033Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 5, "duration": "1.58631", "branches_scanned": 4, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "195", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 1}}, "closed_secret_incidents":
-        {"total": 2, "severity_breakdown": {"critical": 0, "high": 2, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/atuholukova/test_new_project",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218947,
-        "type": "gitlab", "full_name": "fperucki2 / fperucki-test", "health": "at_risk",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "425f36647e5a5eb4db7b6ae6db8b9cf28ed55d2b", "open_incidents_count": 7, "closed_incidents_count":
-        0, "last_scan": {"date": "2026-02-18T22:23:42.881801Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 38, "duration": "2.070126", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "194", "secret_incidents_breakdown": {"open_secret_incidents": {"total": 7,
-        "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0, "info":
-        0, "unknown": 7}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://gitlab-01.aws-qa-gitguardian.com/fperucki2/test", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 16218948, "type": "gitlab",
-        "full_name": "amascia / test-sca-iac-repo-scanner", "health": "safe", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 3, "last_scan": {"date": "2026-02-18T22:23:44.288065Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 4, "duration":
-        "0.0", "branches_scanned": 4, "progress": 100}, "monitored": true, "visibility":
-        "private", "external_id": "193", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        3, "severity_breakdown": {"critical": 0, "high": 3, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/amascia1/test-sca-iac-repo-scanner",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218949,
-        "type": "gitlab", "full_name": "amascia / test_sca_scan_repo_scanner", "health":
-        "safe", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12264,
+        "type": "github", "full_name": "my-testing-org/armani_code", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 1, "last_scan":
-        {"date": "2026-02-18T22:23:45.694811Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 17, "duration": "0.0", "branches_scanned": 3, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "192", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 1, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/amascia1/test_sca_scan_repo_scanner",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218950,
-        "type": "gitlab", "full_name": "dev / test_davequin", "health": "at_risk",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "dfb493889c0f1c450926bcc61227da4347159a86", "open_incidents_count": 3, "closed_incidents_count":
-        23, "last_scan": {"date": "2026-02-18T22:23:47.006587Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 38, "duration": "7.517583", "branches_scanned":
-        2, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "191", "secret_incidents_breakdown": {"open_secret_incidents": {"total": 3,
-        "severity_breakdown": {"critical": 3, "high": 0, "medium": 0, "low": 0, "info":
-        0, "unknown": 0}}, "closed_secret_incidents": {"total": 23, "severity_breakdown":
-        {"critical": 1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 22}}},
-        "url": "https://gitlab-01.aws-qa-gitguardian.com/dev/test_davequin", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 16218953, "type": "gitlab",
-        "full_name": "L\u00e9na Cuissard / lena-swift-test", "health": "at_risk",
-        "source_criticality": "unknown", "default_branch": "master", "default_branch_head":
-        "8a0153b9a7a9604f8a69b22857a8176fc23f3662", "open_incidents_count": 3, "closed_incidents_count":
-        19, "last_scan": {"date": "2026-02-18T22:23:51.223394Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 30, "duration": "5.430756", "branches_scanned":
-        15, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "188", "secret_incidents_breakdown": {"open_secret_incidents": {"total": 3,
-        "severity_breakdown": {"critical": 3, "high": 0, "medium": 0, "low": 0, "info":
-        0, "unknown": 0}}, "closed_secret_incidents": {"total": 19, "severity_breakdown":
-        {"critical": 1, "high": 15, "medium": 0, "low": 0, "info": 0, "unknown": 3}}},
-        "url": "https://gitlab-01.aws-qa-gitguardian.com/lcuissard/lena-swift-test",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218954,
-        "type": "gitlab", "full_name": "gg-tools / Paulin Test", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 1, "last_scan":
-        {"date": "2026-02-18T22:23:53.263745Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 12, "duration": "1.456493", "branches_scanned": 4,
-        "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "187", "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0,
-        "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0, "info":
-        0, "unknown": 0}}, "closed_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://gitlab-01.aws-qa-gitguardian.com/gg-tools/paulin-test", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 16218955, "type": "gitlab",
-        "full_name": "qa / Adrien-testQA-4", "health": "safe", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2026-02-18T22:23:53.960022Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 1, "duration":
-        "0.898988", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "185", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"date": "2020-06-04T09:06:33.833273Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 2, "duration": "2.830578", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "30", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa/adrien-testqa-4",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218957,
-        "type": "gitlab", "full_name": "Valentin Murat / test-project", "health":
-        "at_risk", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "e9841d32614c7ad22d40ff6a4154dd3129504813", "open_incidents_count": 2, "closed_incidents_count":
-        3, "last_scan": {"date": "2026-02-18T22:23:56.884117Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 9, "duration": "4.189152", "branches_scanned":
-        2, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "183", "secret_incidents_breakdown": {"open_secret_incidents": {"total": 2,
-        "severity_breakdown": {"critical": 1, "high": 0, "medium": 0, "low": 0, "info":
-        0, "unknown": 1}}, "closed_secret_incidents": {"total": 3, "severity_breakdown":
-        {"critical": 1, "high": 1, "medium": 0, "low": 0, "info": 1, "unknown": 0}}},
-        "url": "https://gitlab-01.aws-qa-gitguardian.com/vmurat/test-project", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 16218959, "type": "gitlab",
-        "full_name": "cgarcia / TestLanguages", "health": "at_risk", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": "2f97737024395e59e7c7f1baa2b09a313c8beaf9",
-        "open_incidents_count": 2, "closed_incidents_count": 15, "last_scan": {"date":
-        "2026-02-18T22:24:01.792999Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 30, "duration": "6.124585", "branches_scanned": 12, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "181", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
-        0, "high": 2, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 15, "severity_breakdown": {"critical": 1, "high": 10, "medium":
-        0, "low": 0, "info": 0, "unknown": 4}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/cgarcia/test-languages",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218964,
-        "type": "gitlab", "full_name": "gim-qa-gitlabSandbox-auto / testSCA", "health":
-        "safe", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2026-02-18T22:24:06.513901Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 2, "duration": "1.059793", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "175", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/testsca",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218966,
-        "type": "gitlab", "full_name": "gim-qa-gitlabSandbox-auto / teamtestgitlab",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": "main",
-        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
-        0, "last_scan": {"date": "2026-02-18T22:24:07.822623Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 3, "duration": "1.395084", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "172", "secret_incidents_breakdown": {"open_secret_incidents": {"total": 2,
-        "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0, "info":
-        0, "unknown": 2}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/teamtestgitlab",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218967,
-        "type": "gitlab", "full_name": "qa / test-nathan", "health": "at_risk", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": null, "open_incidents_count":
-        11, "closed_incidents_count": 1, "last_scan": {"date": "2026-02-18T22:24:09.434190Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 13, "duration":
-        "2.670679", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "private", "external_id": "168", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 11, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0,
-        "low": 0, "info": 0, "unknown": 10}}, "closed_secret_incidents": {"total":
         1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 1}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa/test-nathan",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 16218968,
-        "type": "gitlab", "full_name": "qa / Adrien-testQA-3", "health": "at_risk",
-        "source_criticality": "unknown", "default_branch": "trunk", "default_branch_head":
-        null, "open_incidents_count": 2, "closed_incidents_count": 2, "last_scan":
-        {"date": "2026-02-18T22:24:11.419809Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 8, "duration": "4.365037", "branches_scanned": 2, "progress":
-        100}, "monitored": true, "visibility": "internal", "external_id": "167", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
-        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 2, "severity_breakdown": {"critical": 0, "high": 2, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa/adrien-testqa-3",
+        "info": 0, "unknown": 1}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/armani_code",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12265,
+        "type": "github", "full_name": "my-testing-org/louis_vuitton", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:32.770273Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 0, "duration": "1.141495", "branches_scanned": 0, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "13", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/louis_vuitton",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12266,
+        "type": "github", "full_name": "my-testing-org/lagarfeld", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:33.598712Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1, "duration": "1.253906", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "29", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/lagarfeld",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12267,
+        "type": "github", "full_name": "my-testing-org/saint_laurent", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-10-09T12:55:14.542227Z", "status": "canceled", "failing_reason":
+        "", "commits_scanned": 0, "duration": "1.684644", "branches_scanned": 0, "progress":
+        0}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "28", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/saint_laurent",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 3342391,
+        "type": "github", "full_name": "github-app-test-eugene/test", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": "master", "default_branch_head":
+        "739d8fc531ae1130672b694ef20d445be095266c", "open_incidents_count": 0, "closed_incidents_count":
+        6, "last_scan": null, "monitored": false, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "157555465", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 6, "severity_breakdown": {"critical": 0, "high": 6, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/github-app-test-eugene/test",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 3342392,
+        "type": "github", "full_name": "github-app-test-eugene/test_preprod", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
+        "59ad17cf384bb8abdb3fd21bdc557382b8f85fbf", "open_incidents_count": 0, "closed_incidents_count":
+        4, "last_scan": null, "monitored": false, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "327924619", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 4, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 4}}}, "url": "https://github.com/github-app-test-eugene/test_preprod",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6088722,
+        "type": "github", "full_name": "github-app-test-eugene/test_local_1", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
+        "529672f724fe0cb58ec7db5753f1ba8c26e62b1f", "open_incidents_count": 13, "closed_incidents_count":
+        8, "last_scan": null, "monitored": false, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "515202288", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 13, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 13}}, "closed_secret_incidents":
+        {"total": 8, "severity_breakdown": {"critical": 0, "high": 4, "medium": 0,
+        "low": 0, "info": 0, "unknown": 4}}}, "url": "https://github.com/github-app-test-eugene/test_local_1",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6088740,
+        "type": "github", "full_name": "github-app-test-eugene/test_local_2", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
+        "5f014343520d1baefd1dc34a9fca19ae210b052a", "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": false, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "515203110", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/github-app-test-eugene/test_local_2",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6088766,
+        "type": "github", "full_name": "github-app-test-eugene/test_local_3", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
+        "587f67ce9635b955452eb56a69ddae46e8bcbae6", "open_incidents_count": 0, "closed_incidents_count":
+        1, "last_scan": null, "monitored": false, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "515204240", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://github.com/github-app-test-eugene/test_local_3",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863732,
+        "type": "gitlab", "full_name": "gmalle-test / gmalle-test-project", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14127", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/gmalle1/gmalle-test-project",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863734,
+        "type": "gitlab", "full_name": "My Own Group nRIV 89FE7Z98F7E / test-98FEZF898",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14124", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/my-own-group-nriv-89fe7z98f7e/test-98fezf898",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863736,
+        "type": "gitlab", "full_name": "Stanislas Cr\u00e9pin / TestPrereceive", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14122", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/stanislas.crepin/testprereceive",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863737,
+        "type": "gitlab", "full_name": "gim-qa-gitlabDoSandbox-auto  / gim-qa-gitlabDoSandbox-onpremise
+        ", "health": "unknown", "source_criticality": "unknown", "default_branch":
+        null, "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14121", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qatesting/qatesting_onprem",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863738,
+        "type": "gitlab", "full_name": "gim-qa-gitlabDoSandbox-auto  / gim-qa-gitlabDoSandbox-preprod",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14120", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qatesting/qatesting_preprod",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863739,
+        "type": "gitlab", "full_name": "gim-qa-gitlabDoSandbox-auto  / gim-qa-gitlabDoSandbox-staging",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14119", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qatesting/qatesting_staging",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863742,
+        "type": "gitlab", "full_name": "QAGroupTest / Agitlabpresence", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "internal", "external_id": "14115", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qagrouptest/agitlabpresence",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863745,
+        "type": "gitlab", "full_name": "Aur\u00e9lien G\u00e2teau / prereceive-test",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "internal", "external_id": "14112", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/agateau/prereceive-test",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863747,
+        "type": "gitlab", "full_name": "QAgroupGitlabEntr / QASubGroupRepo / QATesting
+        / onprem_QATesting", "health": "unknown", "source_criticality": "unknown",
+        "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "private", "external_id": "14110", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qagroupgitlabentr/qasubgrouprepo/qatesting/onprem_qatesting",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863748,
+        "type": "gitlab", "full_name": "QAgroupGitlabEntr / QASubGroupRepo / QATesting
+        / preprod_QATesting", "health": "unknown", "source_criticality": "unknown",
+        "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "private", "external_id": "14109", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qagroupgitlabentr/qasubgrouprepo/qatesting/preprod_qatesting",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863749,
+        "type": "gitlab", "full_name": "QAgroupGitlabEntr / QASubGroupRepo / QATesting
+        / staging_QA", "health": "unknown", "source_criticality": "unknown", "default_branch":
+        null, "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14108", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qagroupgitlabentr/qasubgrouprepo/qatesting/staging_qa",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863751,
+        "type": "gitlab", "full_name": "QAGroupTest / 1SubGroup / 1SubSubGroup / 1subsubsubGroup
+        / 1subsubsubsubgroup / 1subgroupLastRepo", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "14106", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qagrouptest/1subgroup/1subsubgroup/1subsubsubgroup/1subsubsubsubgroup/1subgrouplastrepo",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863752,
+        "type": "gitlab", "full_name": "QAGroupTest / 1SubGroup / 1SubSubGroup / 1subsubsubGroup
+        / 1subsubsubgroupFirstRepo", "health": "unknown", "source_criticality": "unknown",
+        "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "14105", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qagrouptest/1subgroup/1subsubgroup/1subsubsubgroup/1subsubsubgroupfirstrepo",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863753,
+        "type": "gitlab", "full_name": "QAGroupTest / 1SubGroup / 1SubSubGroup / 1subsubGroupSecondRepo
+        ", "health": "unknown", "source_criticality": "unknown", "default_branch":
+        null, "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "14104", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qagrouptest/1subgroup/1subsubgroup/1subsubgroupsecondrepo",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863754,
+        "type": "gitlab", "full_name": "QAGroupTest / 1SubGroup / 1SubSubGroup / 1subsubGroupFirstRepo",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "14103", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qagrouptest/1subgroup/1subsubgroup/1subsubgroupfirstrepo",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863755,
+        "type": "gitlab", "full_name": "QATest_GitLabEnterRepos / QATest_Staging",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14102", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qatest_preprod/qatest_staging",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863756,
+        "type": "gitlab", "full_name": "QATest_GitLabEnterRepos / QATest_Preprod",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14101", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qatest_preprod/qa_preprod",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863772,
+        "type": "gitlab", "full_name": "test / test_local", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "private", "external_id": "14081", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/test/test_local",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863773,
+        "type": "gitlab", "full_name": "eugene_group / test_local", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14080", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/eugene_group/test_local",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863774,
+        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-go-cty-funcs",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14079", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-go-cty-funcs",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863775,
+        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-hashicat-gcp",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14078", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-hashicat-gcp",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863776,
+        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-workshop-puzzles",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14077", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-workshop-puzzles",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863777,
+        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-boundary",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14076", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-boundary",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863778,
+        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-terraform-cdk",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14075", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-terraform-cdk",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863779,
+        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-hyparview-example",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14074", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-hyparview-example",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863780,
+        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-tfc-workshops-sentinel",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14073", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-tfc-workshops-sentinel",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863781,
+        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-micron-vault-workshop",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14072", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-micron-vault-workshop",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863782,
+        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-learn-terraform-modules",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14071", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-learn-terraform-modules",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863783,
+        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-terraform-helm",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14070", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-terraform-helm",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863784,
+        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-structure",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14069", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-structure",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863785,
+        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-terraform-k8s",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14068", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-terraform-k8s",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863786,
+        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-packer-builder-vsphere",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14067", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-packer-builder-vsphere",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863787,
+        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-gokrb5",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14066", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-gokrb5",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863788,
+        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-cloud-consul-ama-api-spec",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14065", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-cloud-consul-ama-api-spec",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863789,
+        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-azure-sdk-for-go",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14064", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-azure-sdk-for-go",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863790,
+        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-kitchen-sync",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14063", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-kitchen-sync",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863791,
+        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-hyparview",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14062", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-hyparview",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863792,
+        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-vault-plugin-secrets-mongodbatlas",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14061", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-vault-plugin-secrets-mongodbatlas",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863793,
+        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-vault-plugin-database-mongodbatlas",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14060", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-vault-plugin-database-mongodbatlas",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863794,
+        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-nomad-skeleton-device-plugin",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14059", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-nomad-skeleton-device-plugin",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a103971f3b5d9dae-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:32 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '43119'
+      - '40772'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:20 GMT
       link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD0xNjIxODk2OA%3D%3D&per_page=50&search=test>;
+      - <https://api.gitguardian.com/v1/sources?cursor=cD02ODYzNzk0&per_page=50&search=test>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '188'
+      - '807'
       x-frame-options:
       - DENY
       x-per-page:
       - '50'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_ignore_public_incident_with_test_credential.yaml
+++ b/tests/cassettes/client/vcr/test_ignore_public_incident_with_test_credential.yaml
@@ -20,16 +20,70 @@ interactions:
     uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=1&status=TRIGGERED
   response:
     body:
-      string: '[{"id": 3759, "detector": {"name": "slack_bot_token", "display_name":
-        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
-        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
-        Bot Token"}, "date": "2024-08-22T14:15:22Z", "occurrences_count": 4, "status":
-        "TRIGGERED", "validity": "valid", "severity": "high", "assignee_id": null,
-        "assignee_email": null, "tags": ["FROM_HISTORICAL_SCAN"], "risk_score": 80,
-        "share_url": "[REDACTED]", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/3759"}]'
+      string: '[{"id": 3, "detector": {"name": "gitguardian_test_token", "display_name":
+        "GitGuardian Development Secret", "nature": "specific", "family": "token",
+        "category": "internal", "detector_group_name": "gitguardian_test_token", "detector_group_display_name":
+        "GitGuardian Development Secret"}, "date": "2019-11-19T14:11:01Z", "secret_id":
+        14592836, "secret_hash": "UkaGM2d1NaALSIkUqCBkEgY+xnpQYM3vPZeWQp9v/O680MxYd9tR0/CjGaYu0TLp",
+        "hmsl_hash": "2cc5873afae5ee7747e26e2d73f7b8abe0ac63e7971442ceb50be7c4bf5c77c9",
+        "occurrences_count": 13, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/3", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Development Secret"}]'
     headers:
-      content-type:
+      CF-RAY:
+      - a10396796a90c0a4-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
       - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:05 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1195'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0z&per_page=1&status=TRIGGERED>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '53'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '1'
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
@@ -43,7 +97,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '36'
+      - '35'
       Content-Type:
       - application/json
       Host:
@@ -53,21 +107,68 @@ interactions:
       X-Privacy-Mode:
       - 'true'
     method: POST
-    uri: https://api.gitguardian.com/v1/public-incidents/secrets/3759/ignore
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/3/ignore
   response:
     body:
-      string: '{"id": 3759, "detector": {"name": "slack_bot_token", "display_name":
-        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
-        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
-        Bot Token"}, "date": "2024-08-22T14:15:22Z", "occurrences_count": 4, "status":
-        "IGNORED", "validity": "valid", "severity": "high", "assignee_id": 480870,
-        "assignee_email": "ci@gitguardian.com", "ignored_at": "2026-04-28T12:00:00Z",
-        "ignorer_id": 480870, "ignorer_api_token_id": "8a262c6a-832d-49e5-8744-23c743ff25ac",
-        "ignore_reason": "test_credential", "tags": ["FROM_HISTORICAL_SCAN"], "risk_score":
-        80, "share_url": "[REDACTED]", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/3759"}'
+      string: '{"id": 3, "detector": {"name": "gitguardian_test_token", "display_name":
+        "GitGuardian Development Secret", "nature": "specific", "family": "token",
+        "category": "internal", "detector_group_name": "gitguardian_test_token", "detector_group_display_name":
+        "GitGuardian Development Secret"}, "date": "2019-11-19T14:11:01Z", "secret_id":
+        14592836, "secret_hash": "UkaGM2d1NaALSIkUqCBkEgY+xnpQYM3vPZeWQp9v/O680MxYd9tR0/CjGaYu0TLp",
+        "hmsl_hash": "2cc5873afae5ee7747e26e2d73f7b8abe0ac63e7971442ceb50be7c4bf5c77c9",
+        "occurrences_count": 13, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": "2026-06-23T12:45:05.272899Z", "ignorer_id": 480870, "ignorer_api_token_id":
+        "d0ca9877-641f-4c37-8857-c08e0ae148c4", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "no_checker", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 44, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "test_cred", "resolve_reason":
+        null, "ignore_reason": "test_credential", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/3",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "GitGuardian Development Secret"}'
     headers:
-      content-type:
+      CF-RAY:
+      - a103967b4ccf9efc-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
       - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:05 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - POST, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1268'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '95'
+      x-frame-options:
+      - DENY
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK

--- a/tests/cassettes/client/vcr/test_list_api_tokens.yaml
+++ b/tests/cassettes/client/vcr/test_list_api_tokens.yaml
@@ -20,18 +20,7 @@ interactions:
     uri: https://api.gitguardian.com/v1/api_tokens
   response:
     body:
-      string: '[{"id": "002a13bb-3db7-4f66-930c-85294ca61c00", "name": "-", "type":
-        "personal_access_token", "scopes": ["scan", "incidents:read", "incidents:write",
-        "incidents:share", "members:read", "members:write", "audit_logs:read", "teams:read",
-        "teams:write", "honeytokens:read", "honeytokens:write", "api_tokens:read",
-        "api_tokens:write", "ip_allowlist:read", "ip_allowlist:write", "sources:read",
-        "sources:write", "nhi:send-inventory", "nhi:write-vault", "custom_tags:read",
-        "custom_tags:write", "secrets:read", "secrets:write", "scan:create-incidents",
-        "public-perimeter:read", "nhi:ownership:read", "nhi:ownership:write", "health_checks:read",
-        "health_checks:write"], "member_id": 309802, "workspace_id": 8, "created_at":
-        "2026-03-19T13:37:17.662856Z", "last_used_at": "2026-03-19T13:37:00Z", "expire_at":
-        "2026-03-29T13:37:17.635970Z", "revoked_at": null, "status": "expired", "creator_id":
-        309802}, {"id": "004bc4f5-7f44-427f-97e7-517e9292f82b", "name": "-", "type":
+      string: '[{"id": "004bc4f5-7f44-427f-97e7-517e9292f82b", "name": "-", "type":
         "personal_access_token", "scopes": ["secrets:read"], "member_id": 1094434,
         "workspace_id": 8, "created_at": "2025-10-08T12:29:22.250242Z", "last_used_at":
         "2025-10-08T13:22:00Z", "expire_at": null, "revoked_at": "2025-10-08T13:23:04.839231Z",
@@ -47,39 +36,33 @@ interactions:
         {"id": "015d6ea5-2e02-45b8-a726-10d4b720169a", "name": "-", "type": "personal_access_token",
         "scopes": ["scan"], "member_id": 270722, "workspace_id": 8, "created_at":
         "2025-05-28T13:20:20.737076Z", "last_used_at": "2025-10-10T07:40:00Z", "expire_at":
-        null, "revoked_at": null, "status": "active", "creator_id": 270722}, {"id":
-        "01632444-8789-4796-9cdc-4d29c626cb14", "name": "-", "type": "personal_access_token",
-        "scopes": ["scan"], "member_id": 104544, "workspace_id": 8, "created_at":
-        "2022-11-10T17:15:03.225307Z", "last_used_at": "2022-11-10T17:15:00Z", "expire_at":
-        null, "revoked_at": "2022-11-17T14:57:59.179727Z", "status": "revoked", "creator_id":
-        104544}, {"id": "0198b4bd-038b-40f5-a7f0-1129bf27948c", "name": "-", "type":
-        "personal_access_token", "scopes": ["scan", "incidents:read", "incidents:write",
-        "incidents:share", "members:read", "members:write", "audit_logs:read", "teams:read",
-        "teams:write", "honeytokens:read", "honeytokens:write", "api_tokens:read",
-        "api_tokens:write", "ip_allowlist:read", "ip_allowlist:write", "sources:read",
-        "sources:write", "nhi:send-inventory", "nhi:write-vault", "custom_tags:read",
-        "custom_tags:write", "secrets:read", "secrets:write", "scan:create-incidents",
-        "public-perimeter:read", "nhi:ownership:read", "nhi:ownership:write", "health_checks:read",
-        "health_checks:write"], "member_id": 104544, "workspace_id": 8, "created_at":
-        "2026-03-24T14:34:37.992013Z", "last_used_at": "2026-04-02T15:41:00Z", "expire_at":
-        "2026-04-03T14:34:37.963444Z", "revoked_at": null, "status": "active", "creator_id":
-        104544}, {"id": "027631b1-f9fe-44db-973e-8cc2db7be4b1", "name": "-", "type":
-        "personal_access_token", "scopes": ["scan"], "member_id": 203333, "workspace_id":
-        8, "created_at": "2025-03-17T18:54:10.945004Z", "last_used_at": "2025-03-17T19:05:00Z",
-        "expire_at": "2025-03-24T18:54:10.942325Z", "revoked_at": "2025-03-17T19:07:15.496197Z",
-        "status": "revoked", "creator_id": 203333}, {"id": "02891016-0627-4430-ba9a-a090cbb38ec7",
-        "name": "Tets", "type": "service_account", "scopes": ["scan"], "member_id":
-        null, "workspace_id": 8, "created_at": "2021-01-20T16:43:17.087778Z", "last_used_at":
-        "2021-02-09T11:29:11.230118Z", "expire_at": null, "revoked_at": "2021-03-04T13:19:24.644171Z",
-        "status": "revoked", "creator_id": 13}, {"id": "034239f3-1914-44b9-9924-fad14b972ac6",
+        null, "revoked_at": "2026-04-20T12:35:15.922178Z", "status": "revoked", "creator_id":
+        270722}, {"id": "01632444-8789-4796-9cdc-4d29c626cb14", "name": "-", "type":
+        "personal_access_token", "scopes": ["scan"], "member_id": 104544, "workspace_id":
+        8, "created_at": "2022-11-10T17:15:03.225307Z", "last_used_at": "2022-11-10T17:15:00Z",
+        "expire_at": null, "revoked_at": "2022-11-17T14:57:59.179727Z", "status":
+        "revoked", "creator_id": 104544}, {"id": "027631b1-f9fe-44db-973e-8cc2db7be4b1",
         "name": "-", "type": "personal_access_token", "scopes": ["scan"], "member_id":
-        160089, "workspace_id": 8, "created_at": "2022-10-13T10:55:06.198702Z", "last_used_at":
-        "2022-10-13T10:55:00Z", "expire_at": "2022-10-17T10:55:06Z", "revoked_at":
-        null, "status": "expired", "creator_id": 160089}, {"id": "03d6898b-53e8-452d-b0f3-2962d84448f1",
+        203333, "workspace_id": 8, "created_at": "2025-03-17T18:54:10.945004Z", "last_used_at":
+        "2025-03-17T19:05:00Z", "expire_at": "2025-03-24T18:54:10.942325Z", "revoked_at":
+        "2025-03-17T19:07:15.496197Z", "status": "revoked", "creator_id": 203333},
+        {"id": "02891016-0627-4430-ba9a-a090cbb38ec7", "name": "Tets", "type": "service_account",
+        "scopes": ["scan"], "member_id": null, "workspace_id": 8, "created_at": "2021-01-20T16:43:17.087778Z",
+        "last_used_at": "2021-02-09T11:29:11.230118Z", "expire_at": null, "revoked_at":
+        "2021-03-04T13:19:24.644171Z", "status": "revoked", "creator_id": 13}, {"id":
+        "034239f3-1914-44b9-9924-fad14b972ac6", "name": "-", "type": "personal_access_token",
+        "scopes": ["scan"], "member_id": 160089, "workspace_id": 8, "created_at":
+        "2022-10-13T10:55:06.198702Z", "last_used_at": "2022-10-13T10:55:00Z", "expire_at":
+        "2022-10-17T10:55:06Z", "revoked_at": null, "status": "expired", "creator_id":
+        160089}, {"id": "03d6898b-53e8-452d-b0f3-2962d84448f1", "name": "-", "type":
+        "personal_access_token", "scopes": ["scan"], "member_id": 786511, "workspace_id":
+        8, "created_at": "2024-09-25T13:53:51.886879Z", "last_used_at": "2024-09-25T13:54:00Z",
+        "expire_at": null, "revoked_at": "2024-09-25T13:54:42.205728Z", "status":
+        "revoked", "creator_id": 786511}, {"id": "043cfca1-f854-4478-bffd-fb991ad39ca8",
         "name": "-", "type": "personal_access_token", "scopes": ["scan"], "member_id":
-        786511, "workspace_id": 8, "created_at": "2024-09-25T13:53:51.886879Z", "last_used_at":
-        "2024-09-25T13:54:00Z", "expire_at": null, "revoked_at": "2024-09-25T13:54:42.205728Z",
-        "status": "revoked", "creator_id": 786511}, {"id": "044a698d-2afd-443a-9784-2153a4d0f24a",
+        113168, "workspace_id": 8, "created_at": "2026-05-25T13:57:53.164294Z", "last_used_at":
+        "2026-05-25T14:56:00Z", "expire_at": null, "revoked_at": "2026-06-10T20:31:08.330248Z",
+        "status": "revoked", "creator_id": 113168}, {"id": "044a698d-2afd-443a-9784-2153a4d0f24a",
         "name": "MCP Token", "type": "personal_access_token", "scopes": ["scan", "incidents:read",
         "honeytokens:read", "honeytokens:write", "sources:read"], "member_id": 480870,
         "workspace_id": 8, "created_at": "2025-10-23T12:24:55.112665Z", "last_used_at":
@@ -92,19 +75,9 @@ interactions:
         "name": "Jake-GH-Action", "type": "service_account", "scopes": ["scan"], "member_id":
         null, "workspace_id": 8, "created_at": "2025-04-29T18:47:41.714793Z", "last_used_at":
         "2025-04-29T21:07:00Z", "expire_at": null, "revoked_at": null, "status": "active",
-        "creator_id": 1144062}, {"id": "05c37cbb-38a6-4965-ac85-e5df2519d9a6", "name":
-        "-", "type": "personal_access_token", "scopes": ["scan", "incidents:read",
-        "incidents:write", "incidents:share", "members:read", "members:write", "audit_logs:read",
-        "teams:read", "teams:write", "honeytokens:read", "honeytokens:write", "api_tokens:read",
-        "api_tokens:write", "ip_allowlist:read", "ip_allowlist:write", "sources:read",
-        "sources:write", "nhi:send-inventory", "nhi:write-vault", "custom_tags:read",
-        "custom_tags:write", "secrets:read", "secrets:write", "scan:create-incidents",
-        "public-perimeter:read", "nhi:ownership:read", "nhi:ownership:write"], "member_id":
-        313030, "workspace_id": 8, "created_at": "2026-02-10T14:56:48.514832Z", "last_used_at":
-        "2026-02-10T14:56:00Z", "expire_at": "2026-02-20T14:56:48.474063Z", "revoked_at":
-        null, "status": "expired", "creator_id": 313030}, {"id": "05eb85ee-e424-4bfe-a7a0-f44230995be0",
-        "name": "-", "type": "personal_access_token", "scopes": ["scan"], "member_id":
-        786511, "workspace_id": 8, "created_at": "2024-09-27T08:22:42.071973Z", "last_used_at":
+        "creator_id": 1144062}, {"id": "05eb85ee-e424-4bfe-a7a0-f44230995be0", "name":
+        "-", "type": "personal_access_token", "scopes": ["scan"], "member_id": 786511,
+        "workspace_id": 8, "created_at": "2024-09-27T08:22:42.071973Z", "last_used_at":
         "2024-09-27T09:20:00Z", "expire_at": null, "revoked_at": "2024-09-27T09:20:05.340431Z",
         "status": "revoked", "creator_id": 786511}, {"id": "066cbd4b-195a-4835-99b1-b95d9fbb59df",
         "name": "-", "type": "personal_access_token", "scopes": ["scan"], "member_id":
@@ -114,59 +87,69 @@ interactions:
         "name": "ggshield token 2024-07-19", "type": "personal_access_token", "scopes":
         ["scan"], "member_id": 480870, "workspace_id": 8, "created_at": "2024-07-19T13:49:57.819902Z",
         "last_used_at": "2025-12-09T16:02:00Z", "expire_at": null, "revoked_at": "2026-02-10T13:10:32.105054Z",
-        "status": "revoked", "creator_id": 480870}, {"id": "06be620c-121d-4fe7-a4d4-768f694c5463",
-        "name": "-", "type": "personal_access_token", "scopes": ["scan", "incidents:read",
-        "incidents:write", "incidents:share", "members:read", "members:write", "audit_logs:read",
-        "teams:read", "teams:write", "honeytokens:read", "honeytokens:write", "api_tokens:read",
-        "api_tokens:write", "ip_allowlist:read", "ip_allowlist:write", "sources:read",
-        "sources:write", "nhi:send-inventory", "nhi:write-vault", "custom_tags:read",
-        "custom_tags:write", "secrets:read", "secrets:write", "scan:create-incidents",
-        "public-perimeter:read", "nhi:ownership:read", "nhi:ownership:write"], "member_id":
-        1078297, "workspace_id": 8, "created_at": "2026-03-02T14:16:03.241579Z", "last_used_at":
-        "2026-03-02T14:16:00Z", "expire_at": "2026-03-12T14:16:03.208147Z", "revoked_at":
-        null, "status": "expired", "creator_id": 1078297}, {"id": "070a5ec1-bed1-418f-a837-905af598d744",
+        "status": "revoked", "creator_id": 480870}, {"id": "070a5ec1-bed1-418f-a837-905af598d744",
         "name": "-", "type": "personal_access_token", "scopes": ["scan"], "member_id":
         104544, "workspace_id": 8, "created_at": "2023-08-31T11:50:47.371009Z", "last_used_at":
         "2023-09-06T14:50:00Z", "expire_at": null, "revoked_at": "2023-09-06T14:50:25.607895Z",
-        "status": "revoked", "creator_id": 104544}]'
+        "status": "revoked", "creator_id": 104544}, {"id": "07407245-f877-4161-a2a8-df110b0e6479",
+        "name": "-", "type": "personal_access_token", "scopes": ["scan", "incidents:read"],
+        "member_id": 363707, "workspace_id": 8, "created_at": "2025-11-13T17:25:10.615284Z",
+        "last_used_at": "2025-11-13T17:25:00Z", "expire_at": null, "revoked_at": null,
+        "status": "active", "creator_id": 363707}, {"id": "075218cc-3624-4303-8efb-50117e9d7f6a",
+        "name": "-", "type": "personal_access_token", "scopes": ["scan"], "member_id":
+        269050, "workspace_id": 8, "created_at": "2022-06-17T09:58:51.896646Z", "last_used_at":
+        "2023-10-11T12:47:00Z", "expire_at": "2023-10-29T11:45:39.280782Z", "revoked_at":
+        null, "status": "expired", "creator_id": 269050}, {"id": "07769629-9d05-4ff6-af0b-19466cc95f5d",
+        "name": "-", "type": "personal_access_token", "scopes": ["scan"], "member_id":
+        270722, "workspace_id": 8, "created_at": "2025-04-28T14:15:11.389273Z", "last_used_at":
+        "2025-04-28T15:02:00Z", "expire_at": null, "revoked_at": "2025-05-12T12:13:09.823639Z",
+        "status": "revoked", "creator_id": 270722}]'
     headers:
+      CF-RAY:
+      - a1039735fb856f0a-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:35 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '8516'
+      - '6538'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:24 GMT
       link:
-      - <https://api.gitguardian.com/v1/api_tokens?cursor=cD0wNzBhNWVjMS1iZWQxLTQxOGYtYTgzNy05MDVhZjU5OGQ3NDQ%3D>;
+      - <https://api.gitguardian.com/v1/api_tokens?cursor=cD0wNzc2OTYyOS05ZDA1LTRmZjYtYWYwYi0xOTQ2NmNjOTVmNWQ%3D>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '46'
+      - '39'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_custom_tags.yaml
+++ b/tests/cassettes/client/vcr/test_list_custom_tags.yaml
@@ -21,10 +21,11 @@ interactions:
   response:
     body:
       string: '[{"id": "925fe3fa-8810-43a7-8652-8bb3130b671c", "key": "antoine", "value":
-        null}, {"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key": "commiter", "value":
-        "leaky mcgee"}, {"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037", "key": "confrence",
-        "value": "grrcon"}, {"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7", "key":
-        "confrence test", "value": "hacktivity"}, {"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
+        null}, {"id": "2b918aac-f9db-401c-b86e-69839a91ed6a", "key": "BU", "value":
+        "italia"}, {"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key": "commiter",
+        "value": "leaky mcgee"}, {"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037", "key":
+        "confrence", "value": "grrcon"}, {"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        "key": "confrence test", "value": "hacktivity"}, {"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
         "key": "date leaked", "value": "08/09/2023"}, {"id": "a5ad67ad-da66-4b5d-ac94-a079fe470d58",
         "key": "default", "value": "value"}, {"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22",
         "key": "env", "value": "production"}, {"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
@@ -32,53 +33,60 @@ interactions:
         "key": "event", "value": "cab"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
         "key": "format", "value": "public"}, {"id": "6925b698-1dba-4f0f-8c6c-87be4ce3493e",
-        "key": "Generic test", "value": null}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        "key": "Generic test", "value": null}, {"id": "a6772878-f860-4dc1-a45d-7e0b02161c65",
+        "key": "GG test", "value": null}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "e8d2acf7-efa2-4ee5-b2df-1bff3701af31",
         "key": "important_leak", "value": null}, {"id": "21c8f2fd-9a88-42ab-aa1d-16111e371c62",
         "key": "investigation", "value": null}, {"id": "54697103-1a85-4f35-8766-6cf16399f83e",
         "key": "linked incident", "value": null}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}, {"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
-        "key": "location", "value": "slack"}, {"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
-        "key": "location", "value": "sourcecode"}]'
+        "key": "location", "value": "publicrepo"}]'
     headers:
+      CF-RAY:
+      - a10394bfccd8d145-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:43:54 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, POST, PATCH, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '1614'
+      - '1600'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:09 GMT
       link:
-      - <https://api.gitguardian.com/v1/custom_tags?cursor=cD1sb2NhdGlvbiUzQXNvdXJjZWNvZGU%3D>;
+      - <https://api.gitguardian.com/v1/custom_tags?cursor=cD1sb2NhdGlvbiUzQXB1YmxpY3JlcG8%3D>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '28'
+      - '18'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_honeytokens_basic.yaml
+++ b/tests/cassettes/client/vcr/test_list_honeytokens_basic.yaml
@@ -25,33 +25,29 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/411d33c0-7fad-4fc1-b94e-bb440c8f9c49",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:11.250010Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}, {"id": "858a3a76-f6f2-4c2e-b0bc-323d9a575413",
-        "name": "test_honey_token", "description": "description", "created_at": "2023-05-15T14:09:09.210845Z",
+        "token": "[REDACTED]"}, {"id": "858a3a76-f6f2-4c2e-b0bc-323d9a575413", "name":
+        "test_honey_token", "description": "description", "created_at": "2023-05-15T14:09:09.210845Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/858a3a76-f6f2-4c2e-b0bc-323d9a575413",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:17.165934Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}, {"id": "72a52279-8e9f-40de-a1d4-bc5fcc48795d",
-        "name": "passwordscon", "description": "", "created_at": "2023-05-16T10:03:49.677782Z",
+        "token": "[REDACTED]"}, {"id": "72a52279-8e9f-40de-a1d4-bc5fcc48795d", "name":
+        "passwordscon", "description": "", "created_at": "2023-05-16T10:03:49.677782Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72a52279-8e9f-40de-a1d4-bc5fcc48795d",
         "status": "triggered", "triggered_at": "2023-05-16T10:04:10.262805Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 222, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
-        "key": "location", "value": "test"}], "custom_tags": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
+        ["publicly_exposed"], "custom_tags": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
         "key": "location", "value": "test"}], "token": "[REDACTED]"}, {"id": "8bf5f99a-538d-4cfe-8e74-61cd7081ae25",
         "name": "PasswordsCon2", "description": "For presentation", "created_at":
         "2023-05-16T11:30:36.210395Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8bf5f99a-538d-4cfe-8e74-61cd7081ae25",
         "status": "triggered", "triggered_at": "2023-05-16T12:29:45.638074Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 344, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "45182b59-b659-41ef-9bb8-44a78740fade", "name": "solid-octo-repo", "description":
         "Placed in solid-octo repo, file ... on 16May2023", "created_at": "2023-05-16T11:51:06.384073Z",
@@ -59,47 +55,41 @@ interactions:
         "status": "triggered", "triggered_at": "2026-02-18T14:51:12.499369Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432", "key": "place",
-        "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
+        [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432", "key":
+        "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
         "name": "jira-OPS-124", "description": "honeytoken deployed in jira ticket
         OPS-124", "created_at": "2023-05-16T11:58:57.713307Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "63bbd74e-bb5f-4910-8e63-eed358af3bc8",
         "name": "improved-carnival repo", "description": "", "created_at": "2023-05-16T14:45:09.811724Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/63bbd74e-bb5f-4910-8e63-eed358af3bc8",
         "status": "revoked", "triggered_at": "2023-05-16T14:49:44.284195Z", "revoked_at":
         "2024-06-19T10:46:44.282148Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "72fcdb5c-e128-4ca5-8970-f1f52f95a78a",
         "name": "slack-chan-website", "description": "", "created_at": "2023-05-16T15:35:26.129025Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72fcdb5c-e128-4ca5-8970-f1f52f95a78a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
-        "key": "place", "value": "website"}], "custom_tags": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
         "key": "place", "value": "website"}], "token": "[REDACTED]"}, {"id": "84d43c23-6d4d-47f8-bf62-e7c1b0ae1625",
         "name": "analytic-repo", "description": "", "created_at": "2023-05-16T16:17:11.435058Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84d43c23-6d4d-47f8-bf62-e7c1b0ae1625",
         "status": "revoked", "triggered_at": "2023-05-16T16:27:55.091410Z", "revoked_at":
         "2023-12-11T14:01:44.427581Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "ef11a80c-6d8e-4fb5-8ee2-4556bae695c3",
         "name": "test ht public", "description": "", "created_at": "2023-05-17T17:00:24.966335Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef11a80c-6d8e-4fb5-8ee2-4556bae695c3",
         "status": "triggered", "triggered_at": "2023-05-17T17:02:33.386529Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 5012, "creator_id": 166199, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
-        "key": "location", "value": "slack"}], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
+        ["publicly_exposed"], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
         "key": "location", "value": "slack"}], "token": "[REDACTED]"}, {"id": "db7bf6ea-57cb-4d13-8ed9-dc59b2620e00",
         "name": "Honeytoken demo 17 may", "description": "This is a token for the
         live demo", "created_at": "2023-05-17T17:15:04.921233Z", "gitguardian_url":
@@ -107,173 +97,161 @@ interactions:
         "status": "triggered", "triggered_at": "2023-05-17T17:16:48.960267Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 5018, "creator_id": 166199, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "79db31fc-ffd1-4bc9-b6e4-3ef37a94712a", "name": "QubitConfrence", "description":
         "", "created_at": "2023-05-18T07:58:37.174577Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/79db31fc-ffd1-4bc9-b6e4-3ef37a94712a",
         "status": "triggered", "triggered_at": "2023-05-18T09:30:01.025933Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 215, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263", "name": "NDC-OSLO Demo", "description":
-        "Demo key for NDC Oslo confrence", "created_at": "2023-05-25T07:59:05.651290Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
+        "name": "NDC-OSLO Demo", "description": "Demo key for NDC Oslo confrence",
+        "created_at": "2023-05-25T07:59:05.651290Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
         "status": "triggered", "triggered_at": "2023-05-25T08:38:27.471330Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 221, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b6f2b765-a8e5-458f-b68a-4b5ef934bcc8", "name": "Pycon Italia", "description":
-        "", "created_at": "2023-05-28T09:34:01.581495Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
+        "name": "Pycon Italia", "description": "", "created_at": "2023-05-28T09:34:01.581495Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
         "status": "revoked", "triggered_at": "2023-05-28T09:45:30.255118Z", "revoked_at":
         "2024-12-10T12:17:08.199275Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "bb494eed-6ba4-4b98-b949-ad5f54d929dd", "name": "ggshield-uORy0any",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "bb494eed-6ba4-4b98-b949-ad5f54d929dd", "name": "ggshield-uORy0any",
         "description": "description", "created_at": "2023-05-30T10:30:39.803353Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bb494eed-6ba4-4b98-b949-ad5f54d929dd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1266b395-a545-42c1-b700-24dbae36447c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1266b395-a545-42c1-b700-24dbae36447c",
         "name": "test_honey_token_previous", "description": "description", "created_at":
         "2023-05-30T10:30:40.547255Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1266b395-a545-42c1-b700-24dbae36447c",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:41:43.173510Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "f60db759-7041-4dfe-80fa-91012d97fdd3",
         "name": "ggshield-tsCPoUcx", "description": "description", "created_at": "2023-05-30T10:37:14.527124Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f60db759-7041-4dfe-80fa-91012d97fdd3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
         "name": "ggshield-BA0VsBh3", "description": "description", "created_at": "2023-05-30T10:39:09.968782Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e7f275d-e115-44d3-8854-5c6472494951",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e7f275d-e115-44d3-8854-5c6472494951",
         "name": "ggshield-UXgNYVXL", "description": "description", "created_at": "2023-05-30T10:42:36.847031Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6e7f275d-e115-44d3-8854-5c6472494951",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7494298b-75c5-44e4-898c-77b3b9017113",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7494298b-75c5-44e4-898c-77b3b9017113",
         "name": "test_honey_token_abc", "description": "description", "created_at":
         "2023-05-30T10:42:37.520767Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7494298b-75c5-44e4-898c-77b3b9017113",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:45:41.905071Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "092dba62-9d82-41bd-84aa-95430d540edc", "name": "ggshield-224Lwv95",
-        "description": "description", "created_at": "2023-05-30T10:46:10.997022Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "092dba62-9d82-41bd-84aa-95430d540edc",
+        "name": "ggshield-224Lwv95", "description": "description", "created_at": "2023-05-30T10:46:10.997022Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/092dba62-9d82-41bd-84aa-95430d540edc",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
         "name": "test_honey_token_previous", "description": "description", "created_at":
         "2023-05-30T10:46:11.714531Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:07.762156Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "13f6dbf3-ae1a-4757-95f6-e0fbc830fc55", "name": "ggshield-agateau",
-        "description": null, "created_at": "2023-05-30T13:32:31.845201Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
+        "name": "ggshield-agateau", "description": null, "created_at": "2023-05-30T13:32:31.845201Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T13:33:03.363563Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 160089, "revoker_id":
         160089, "creator_api_token_id": "425e1a78-209e-4cd5-b08f-8450a0026ac0", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "f17302cd-850b-4b54-9054-60d26a76cf38", "name": "test demo 31may",
-        "description": "", "created_at": "2023-05-31T08:10:36.754144Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f17302cd-850b-4b54-9054-60d26a76cf38",
+        "name": "test demo 31may", "description": "", "created_at": "2023-05-31T08:10:36.754144Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "41d76272-ee3d-4639-93e8-29222b662b93",
         "name": "demo31may-public", "description": "", "created_at": "2023-05-31T08:13:48.373887Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/41d76272-ee3d-4639-93e8-29222b662b93",
         "status": "revoked", "triggered_at": "2023-05-31T08:15:09.926931Z", "revoked_at":
         "2024-12-10T12:16:03.693045Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "63728091-d083-47cc-9898-73c2636f2c7f", "name": "ggshield-ZIU1V3Bv", "description":
         null, "created_at": "2023-05-31T08:17:12.607879Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/63728091-d083-47cc-9898-73c2636f2c7f",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-31T08:17:38.021142Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "001c53df-b63c-4b81-a4fb-35e5b38bf328", "name": "DevOxx Poland", "description":
-        "", "created_at": "2023-05-31T12:28:39.713989Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/001c53df-b63c-4b81-a4fb-35e5b38bf328",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "001c53df-b63c-4b81-a4fb-35e5b38bf328",
+        "name": "DevOxx Poland", "description": "", "created_at": "2023-05-31T12:28:39.713989Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/001c53df-b63c-4b81-a4fb-35e5b38bf328",
         "status": "triggered", "triggered_at": "2023-05-31T14:09:21.767459Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 225, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05", "name": "ggshield-cptptJHt",
-        "description": "ggshield test", "created_at": "2023-06-02T08:47:41.149126Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05",
+        "name": "ggshield-cptptJHt", "description": "ggshield test", "created_at":
+        "2023-06-02T08:47:41.149126Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
-        "name": "ggshield-TtJwtxNE", "description": "ggshield test", "created_at":
-        "2023-06-02T08:48:20.148216Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72", "name": "ggshield-TtJwtxNE",
+        "description": "ggshield test", "created_at": "2023-06-02T08:48:20.148216Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "27379093-c6a4-4732-a64a-715c94e74fd7",
-        "name": "ggshield-TvFzKVed", "description": null, "created_at": "2023-06-09T08:01:57.360210Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/27379093-c6a4-4732-a64a-715c94e74fd7",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "27379093-c6a4-4732-a64a-715c94e74fd7", "name": "ggshield-TvFzKVed",
+        "description": null, "created_at": "2023-06-09T08:01:57.360210Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/27379093-c6a4-4732-a64a-715c94e74fd7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "62cb7048-4302-4b52-9163-e2ceff775b39", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc7214d0-c97a-44b3-b576-664f0a81c4f7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc7214d0-c97a-44b3-b576-664f0a81c4f7",
         "name": "repo analytics 19jun", "description": "", "created_at": "2023-06-19T09:11:21.788070Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc7214d0-c97a-44b3-b576-664f0a81c4f7",
         "status": "revoked", "triggered_at": "2023-06-20T17:24:35.145047Z", "revoked_at":
         "2023-12-11T14:50:27.627289Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb", "name": "ggshield-0etjSvZJ",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb", "name": "ggshield-0etjSvZJ",
         "description": "description", "created_at": "2023-07-05T08:27:14.048162Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-05T08:27:15.756813Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0e4f0dbd-b288-4990-9565-3cc7b0171a79",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:53.240550Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 160089, "revoker_id":
         296618, "creator_api_token_id": "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "14566c1f-0b52-4770-ab68-000704242633", "name": "ggshield-Rv2mUej7",
-        "description": "description", "created_at": "2023-07-05T08:55:23.864812Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "14566c1f-0b52-4770-ab68-000704242633",
+        "name": "ggshield-Rv2mUej7", "description": "description", "created_at": "2023-07-05T08:55:23.864812Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/14566c1f-0b52-4770-ab68-000704242633",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c8c94ffa-c0af-48c6-976a-6502a41811af",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c8c94ffa-c0af-48c6-976a-6502a41811af",
         "name": "honeytoken demo eric", "description": "demo here", "created_at":
         "2023-07-05T14:48:53.893911Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c8c94ffa-c0af-48c6-976a-6502a41811af",
         "status": "triggered", "triggered_at": "2023-07-05T14:49:33.528178Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
         "name": "Example TOken ", "description": "ubvcub", "created_at": "2023-07-12T13:16:10.775681Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
-        "key": "file", "value": ".env"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "0c3f182e-98f5-4a64-aadb-664fd7c9de88", "name": "ggshield-ewIAL7lq", "description":
@@ -282,58 +260,55 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
         "name": "ggshield-w1P1Ggsz", "description": "description", "created_at": "2023-07-27T08:56:55.435203Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a20a718-7b9e-4582-abdf-772053bffd72",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a20a718-7b9e-4582-abdf-772053bffd72",
         "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T08:56:56.138738Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a20a718-7b9e-4582-abdf-772053bffd72",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:58.657957Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "51f41814-f029-4ab4-b863-c0fecba025b3", "name": "ggshield-v3LhZCz8",
-        "description": "description", "created_at": "2023-07-27T09:01:36.117217Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51f41814-f029-4ab4-b863-c0fecba025b3",
+        "name": "ggshield-v3LhZCz8", "description": "description", "created_at": "2023-07-27T09:01:36.117217Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/51f41814-f029-4ab4-b863-c0fecba025b3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T09:01:36.764795Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-27T09:01:37.417151Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e842a635-eb7e-4617-8984-ac57fe909ef7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
         "name": "ggshield-5voYnhhy", "description": null, "created_at": "2023-07-27T13:50:51.332176Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T13:52:58.300149Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "521efd01-bbcc-4380-b548-ed7242c017ea",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "521efd01-bbcc-4380-b548-ed7242c017ea",
         "name": "ggshield-HLZpiznn", "description": null, "created_at": "2023-07-27T14:54:03.198466Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/521efd01-bbcc-4380-b548-ed7242c017ea",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0d81797a-6fc0-4a6e-a211-af16828c0c39",
-        "name": "Webinar Public ", "description": "from webinar ", "created_at": "2023-07-27T15:33:07.472730Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0d81797a-6fc0-4a6e-a211-af16828c0c39", "name": "Webinar
+        Public ", "description": "from webinar ", "created_at": "2023-07-27T15:33:07.472730Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0d81797a-6fc0-4a6e-a211-af16828c0c39",
         "status": "triggered", "triggered_at": "2023-07-27T15:34:48.902462Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 204, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "27e9ba01-4bb6-46ed-84c8-ff14366a3bde", "name": "Private network", "description":
@@ -342,60 +317,55 @@ interactions:
         "status": "triggered", "triggered_at": "2023-07-27T16:23:35.804271Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5670c657-618f-41d7-984b-d59656d905e4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5670c657-618f-41d7-984b-d59656d905e4",
         "name": "ggshield-3KTmbo8u", "description": null, "created_at": "2023-07-27T15:44:43.238742Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5670c657-618f-41d7-984b-d59656d905e4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5d3ad22c-e422-48d2-b7f5-6d52801599aa",
-        "name": "demo 31jul", "description": "", "created_at": "2023-07-31T15:27:18.323098Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d3ad22c-e422-48d2-b7f5-6d52801599aa",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5d3ad22c-e422-48d2-b7f5-6d52801599aa", "name": "demo
+        31jul", "description": "", "created_at": "2023-07-31T15:27:18.323098Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d3ad22c-e422-48d2-b7f5-6d52801599aa",
         "status": "revoked", "triggered_at": "2023-07-31T15:33:49.570793Z", "revoked_at":
         "2023-12-11T14:01:40.706751Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a", "name": "test
-        Antonin 1", "description": "", "created_at": "2023-08-03T08:42:25.251504Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fa63d76d-4297-4d41-8e77-b47d1a97a41a",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a", "name": "test Antonin 1", "description":
+        "", "created_at": "2023-08-03T08:42:25.251504Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fa63d76d-4297-4d41-8e77-b47d1a97a41a",
         "status": "revoked", "triggered_at": "2023-08-03T08:59:58.717709Z", "revoked_at":
         "2023-08-03T09:00:05.809852Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "a11570c6-f472-4fda-a493-30d65fd8e651", "name": "test Antonin 2", "description":
-        "", "created_at": "2023-08-03T14:09:46.046004Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a11570c6-f472-4fda-a493-30d65fd8e651",
+        "name": "test Antonin 2", "description": "", "created_at": "2023-08-03T14:09:46.046004Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40",
-        "name": "vBOY test segment", "description": "sdqsdqsdqsdqsd", "created_at":
-        "2023-08-07T12:45:52.890085Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40", "name": "vBOY
+        test segment", "description": "sdqsdqsdqsdqsd", "created_at": "2023-08-07T12:45:52.890085Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-08-07T12:46:45.470113Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "name": "vBOY test segment 2", "description": "sdqsdqsd", "created_at": "2023-08-07T12:47:49.515448Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "86670f84-e117-4f96-aa16-e399a0bb2cf2",
-        "name": "juuj", "description": "", "created_at": "2023-08-08T15:53:23.097840Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86670f84-e117-4f96-aa16-e399a0bb2cf2",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "86670f84-e117-4f96-aa16-e399a0bb2cf2", "name": "juuj",
+        "description": "", "created_at": "2023-08-08T15:53:23.097840Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/86670f84-e117-4f96-aa16-e399a0bb2cf2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
-        "name": "BSidesLV", "description": "Key leaked publically by leakymcgee again",
-        "created_at": "2023-08-10T00:11:42.132386Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "978bf5aa-1f8e-425b-ac4b-b617ddbc178e", "name": "BSidesLV",
+        "description": "Key leaked publically by leakymcgee again", "created_at":
+        "2023-08-10T00:11:42.132386Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
         "status": "triggered", "triggered_at": "2023-08-10T00:13:19.948280Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
-        "key": "date leaked", "value": "08/09/2023"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
-        "key": "format", "value": "public"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
+        ["publicly_exposed"], "custom_tags": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
         "key": "date leaked", "value": "08/09/2023"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
         "key": "format", "value": "public"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
@@ -405,9 +375,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-08-11T18:55:35.503991Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 61, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
+        ["publicly_exposed"], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "90d4c2b6-ecae-4ef9-a754-4561929b9e38",
         "name": "ggshield-mpkTH5jF", "description": "description", "created_at": "2023-08-16T08:28:18.684517Z",
@@ -415,34 +383,31 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
         "name": "ggshield-mzO8qHEz", "description": "description", "created_at": "2023-08-22T08:19:03.821471Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
         "name": "testket ", "description": "eew", "created_at": "2023-08-29T10:21:29.956291Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "46776cb3-6b11-41fc-b431-07609992f0cb",
-        "name": "HoneyTokenaLARTest", "description": "Testworkshop", "created_at":
-        "2023-08-29T12:07:20.692993Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/46776cb3-6b11-41fc-b431-07609992f0cb",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "46776cb3-6b11-41fc-b431-07609992f0cb", "name": "HoneyTokenaLARTest",
+        "description": "Testworkshop", "created_at": "2023-08-29T12:07:20.692993Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/46776cb3-6b11-41fc-b431-07609992f0cb",
         "status": "revoked", "triggered_at": "2023-08-29T12:09:16.581232Z", "revoked_at":
         "2023-08-29T12:42:37.841866Z", "type": "AWS", "open_events_count": 0, "creator_id":
         37699, "revoker_id": 37699, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "edd96a3b-5c71-4346-b5e2-2150e454dc91", "name": "Bsides Krakow", "description":
-        "Demo for leaking a key on GitHub", "created_at": "2023-09-02T13:20:53.501588Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/edd96a3b-5c71-4346-b5e2-2150e454dc91",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "edd96a3b-5c71-4346-b5e2-2150e454dc91",
+        "name": "Bsides Krakow", "description": "Demo for leaking a key on GitHub",
+        "created_at": "2023-09-02T13:20:53.501588Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/edd96a3b-5c71-4346-b5e2-2150e454dc91",
         "status": "triggered", "triggered_at": "2023-09-02T13:22:51.142717Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "de145bd4-b424-49ab-b95b-80126914bf2e",
         "name": "ctf-demo-test-honeytoken-django-app", "description": "", "created_at":
@@ -450,68 +415,59 @@ interactions:
         "status": "revoked", "triggered_at": "2023-09-06T07:42:55.177580Z", "revoked_at":
         "2023-09-06T10:03:30.948628Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "5564ed3c-3eec-4375-9fc8-e0ada71dce02", "name": "ctf-demo-test-honeytoken-micro-api",
-        "description": "", "created_at": "2023-09-05T19:18:08.504776Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/5564ed3c-3eec-4375-9fc8-e0ada71dce02",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5564ed3c-3eec-4375-9fc8-e0ada71dce02",
+        "name": "ctf-demo-test-honeytoken-micro-api", "description": "", "created_at":
+        "2023-09-05T19:18:08.504776Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5564ed3c-3eec-4375-9fc8-e0ada71dce02",
         "status": "revoked", "triggered_at": "2023-09-06T07:44:18.074891Z", "revoked_at":
         "2023-09-06T10:03:48.581110Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "f246c64a-3494-43ae-9d81-500df2f950c3", "name": "demo-honeytoken-ctf-personal-",
-        "description": "", "created_at": "2023-09-06T11:29:57.547211Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/f246c64a-3494-43ae-9d81-500df2f950c3",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f246c64a-3494-43ae-9d81-500df2f950c3",
+        "name": "demo-honeytoken-ctf-personal-", "description": "", "created_at":
+        "2023-09-06T11:29:57.547211Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f246c64a-3494-43ae-9d81-500df2f950c3",
         "status": "revoked", "triggered_at": "2023-09-06T12:18:14.949044Z", "revoked_at":
         "2024-12-10T12:15:49.265110Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
         "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "ff623703-9ca1-4fba-99dc-c20110894ed3",
         "name": "-demo-honeytoken-ctf-django-app-", "description": "", "created_at":
         "2023-09-06T11:33:27.376222Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff623703-9ca1-4fba-99dc-c20110894ed3",
         "status": "triggered", "triggered_at": "2023-09-06T14:19:10.580142Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 4, "creator_id": null, "revoker_id":
+        null, "type": "AWS", "open_events_count": 9, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "a58154f6-e66f-4079-82b7-aabec70c73ff",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "a58154f6-e66f-4079-82b7-aabec70c73ff",
         "name": "demo-honeytoken-ctf-micro-api", "description": "", "created_at":
         "2023-09-06T11:33:37.828240Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a58154f6-e66f-4079-82b7-aabec70c73ff",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-09-06T14:17:20.708816Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b01db549-a2fa-4527-913d-0715a1119530",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "b01db549-a2fa-4527-913d-0715a1119530",
         "name": "demo-honeytoken-ctf-internal-share-", "description": "", "created_at":
         "2023-09-06T11:33:48.881275Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b01db549-a2fa-4527-913d-0715a1119530",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-09-06T14:21:42.509905Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "89a1745a-f796-4ece-99f7-106671aea57c",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "89a1745a-f796-4ece-99f7-106671aea57c",
         "name": "-demo-honeytoken-ctf-micro-api-", "description": "", "created_at":
         "2023-09-06T14:19:32.695323Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/89a1745a-f796-4ece-99f7-106671aea57c",
         "status": "triggered", "triggered_at": "2023-09-06T14:24:18.462424Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "095d655f-a273-400f-ba01-eff8951242ed",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "095d655f-a273-400f-ba01-eff8951242ed",
         "name": "-demo-honeytoken-ctf-internal-share-", "description": "", "created_at":
         "2023-09-06T14:21:55.062468Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/095d655f-a273-400f-ba01-eff8951242ed",
         "status": "triggered", "triggered_at": "2023-09-08T16:58:49.455578Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 6, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "3664c283-d479-41ac-9ad9-30283731ee25",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "3664c283-d479-41ac-9ad9-30283731ee25",
         "name": "Balccon Demo", "description": "Demo key for Balccon ", "created_at":
         "2023-09-08T14:55:02.417580Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3664c283-d479-41ac-9ad9-30283731ee25",
         "status": "triggered", "triggered_at": "2023-09-08T14:56:49.516889Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
-        "key": "location", "value": "sourcecode"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
-        "key": "visability", "value": "public"}], "custom_tags": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
+        ["publicly_exposed"], "custom_tags": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
         "key": "location", "value": "sourcecode"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
         "key": "visability", "value": "public"}], "token": "[REDACTED]"}, {"id": "7ca5ca92-a0a1-48bf-9618-d7194beaa039",
@@ -520,9 +476,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-09-29T16:11:40.077048Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 344, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
-        "key": "confrence", "value": "grrcon"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}], "custom_tags": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
+        ["publicly_exposed"], "custom_tags": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
         "key": "confrence", "value": "grrcon"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}], "token": "[REDACTED]"}, {"id": "2544b3e6-57b2-48e2-a1a5-c4b6551987bb",
         "name": "SBB demo", "description": "Leaking key on GitHub", "created_at":
@@ -530,11 +484,8 @@ interactions:
         "status": "triggered", "triggered_at": "2024-08-17T15:36:55.810693Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key": "commiter",
-        "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca", "key":
-        "file", "value": ".env"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327", "key":
-        "vcs", "value": "github"}], "custom_tags": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda",
-        "key": "commiter", "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
+        [], "custom_tags": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key":
+        "commiter", "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "7d80793b-c702-441e-837e-b1d3da94d576",
         "name": "Hacktivity Key", "description": "Test Key Leak for Hacktivity", "created_at":
@@ -542,9 +493,7 @@ interactions:
         "status": "revoked", "triggered_at": "2023-10-05T14:42:57.752365Z", "revoked_at":
         "2024-12-10T12:17:33.875750Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "576dc1ce-ab72-4604-934f-526cff5a667e", "name": "BsidesCyprus", "description":
@@ -553,8 +502,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-10-07T11:35:53.017981Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 249, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "22fdf53a-e348-464a-a87f-5bcecb1a4e62", "name": "Slack test", "description":
         "blablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablabla
@@ -567,21 +515,20 @@ interactions:
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-06-03T09:50:06.667490Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 363707, "revoker_id":
         353920, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "137c9fee-4b3c-4231-92fd-98debf6557c2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "137c9fee-4b3c-4231-92fd-98debf6557c2",
         "name": "BSides ATL demo for session", "description": "This one will be triggered
         from 2 different spots online", "created_at": "2023-10-14T12:28:51.206659Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/137c9fee-4b3c-4231-92fd-98debf6557c2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 354585, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "cdaea884-25fb-49db-90ec-a18879be36c4",
-        "name": "Demo Honeytoken", "description": "Leaking on Public Demo", "created_at":
-        "2023-10-16T15:13:10.845487Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cdaea884-25fb-49db-90ec-a18879be36c4",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "cdaea884-25fb-49db-90ec-a18879be36c4", "name": "Demo
+        Honeytoken", "description": "Leaking on Public Demo", "created_at": "2023-10-16T15:13:10.845487Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cdaea884-25fb-49db-90ec-a18879be36c4",
         "status": "revoked", "triggered_at": "2023-10-16T15:14:25.574559Z", "revoked_at":
         "2023-10-27T15:01:19.053629Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "48f7c567-93d1-4925-9f77-d3919f120b88", "name": "ggshield-KlAkKRtE", "description":
         "description", "created_at": "2023-10-16T19:49:08.588391Z", "gitguardian_url":
@@ -589,52 +536,50 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
         "name": "Jason test", "description": "Token for Test ", "created_at": "2023-10-24T13:45:31.371710Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f8e0968-664a-49f3-af85-9cc468b960ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "fe392ff1-b3d7-462f-a26f-d094326f40ed",
-        "name": "Jason and team", "description": "akljdlaj", "created_at": "2023-10-24T14:23:20.991107Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fe392ff1-b3d7-462f-a26f-d094326f40ed", "name": "Jason
+        and team", "description": "akljdlaj", "created_at": "2023-10-24T14:23:20.991107Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fe392ff1-b3d7-462f-a26f-d094326f40ed",
         "status": "triggered", "triggered_at": "2024-05-10T22:15:09.224357Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29",
         "name": "Eric Demo Test 01", "description": "", "created_at": "2023-10-31T12:51:44.535200Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d69a098c-8b61-4102-bb2b-9a82958a3e29",
         "status": "revoked", "triggered_at": "2023-10-31T12:52:49.851916Z", "revoked_at":
         "2024-12-10T12:16:28.115539Z", "type": "AWS", "open_events_count": 0, "creator_id":
         136170, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb", "name": "test
-        eric dd 02", "description": "", "created_at": "2023-10-31T14:33:35.801324Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4affa602-902b-47ff-a1f4-721dc3e671bb",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb", "name": "test eric dd 02",
+        "description": "", "created_at": "2023-10-31T14:33:35.801324Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/4affa602-902b-47ff-a1f4-721dc3e671bb",
         "status": "triggered", "triggered_at": "2023-10-31T14:35:33.676298Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 2897, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "8df388e2-aeb5-42ca-b6d5-221a54a40339", "name": "ggshield-P47kTh7j",
-        "description": null, "created_at": "2023-11-09T15:44:33.671666Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/8df388e2-aeb5-42ca-b6d5-221a54a40339",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8df388e2-aeb5-42ca-b6d5-221a54a40339",
+        "name": "ggshield-P47kTh7j", "description": null, "created_at": "2023-11-09T15:44:33.671666Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8df388e2-aeb5-42ca-b6d5-221a54a40339",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "bd51c3d9-0943-43d5-8f87-359ecee03903",
-        "name": "ggshield-73VAsjsO", "description": null, "created_at": "2023-11-14T08:27:44.885242Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bd51c3d9-0943-43d5-8f87-359ecee03903",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "bd51c3d9-0943-43d5-8f87-359ecee03903", "name": "ggshield-73VAsjsO",
+        "description": null, "created_at": "2023-11-14T08:27:44.885242Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/bd51c3d9-0943-43d5-8f87-359ecee03903",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-11-14T08:28:08.188201Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
         "name": "DeepSec Demo", "description": "Demo for DeepSec Confrence ", "created_at":
         "2023-11-16T16:01:21.723176Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
         "status": "triggered", "triggered_at": "2023-11-16T16:01:58.603599Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "ae448808-3865-4797-a008-9eef6344f9da", "name": "Bsides Berlin", "description":
         "test key for a demo", "created_at": "2023-11-18T16:19:36.463172Z", "gitguardian_url":
@@ -642,9 +587,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-11-18T16:20:14.365596Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 105, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
-        "key": "repo", "value": "mackenziejj"}], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
+        ["publicly_exposed"], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
         "key": "repo", "value": "mackenziejj"}], "token": "[REDACTED]"}, {"id": "ecb3d61d-bdab-4636-a436-bef8079a005d",
         "name": "ggshield-ObfCUUCA", "description": "description", "created_at": "2023-11-28T08:50:32.130230Z",
@@ -652,48 +595,41 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d6d5d79d-08fa-4c8a-bd54-c34851866cde",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d6d5d79d-08fa-4c8a-bd54-c34851866cde",
         "name": "test1112", "description": "test publicly exposed honeytoken", "created_at":
         "2023-12-11T16:24:56.253683Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d6d5d79d-08fa-4c8a-bd54-c34851866cde",
         "status": "triggered", "triggered_at": "2023-12-11T16:26:07.733443Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "4046ccf5-7821-47f4-be7d-8240be69631b",
         "name": "ideal-journey-lena", "description": "", "created_at": "2023-12-11T16:29:20.759489Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4046ccf5-7821-47f4-be7d-8240be69631b",
-        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
-        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
+        "status": "triggered", "triggered_at": "2026-05-28T07:56:58.047592Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 5, "creator_id": 319222, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
         "name": "analytics-repo", "description": "", "created_at": "2023-12-11T17:37:24.471286Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
         "status": "triggered", "triggered_at": "2023-12-11T17:46:48.024345Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "b7daf77c-e3e0-4747-a7e2-485a1a6f05e2",
-        "key": "team", "value": "dev"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "b7daf77c-e3e0-4747-a7e2-485a1a6f05e2",
         "key": "team", "value": "dev"}], "token": "[REDACTED]"}, {"id": "52903632-f6ff-460e-8a68-80a942349979",
         "name": "Network Honeytoken", "description": "Aws Honeytoken on Network",
         "created_at": "2023-12-18T13:47:39.151311Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/52903632-f6ff-460e-8a68-80a942349979",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
-        "key": "network", "value": "directory"}], "custom_tags": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
         "key": "network", "value": "directory"}], "token": "[REDACTED]"}, {"id": "6c5d9856-835e-468c-9448-7bf0e77f1e53",
         "name": "improved carnival", "description": "", "created_at": "2023-12-21T13:43:01.544215Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6c5d9856-835e-468c-9448-7bf0e77f1e53",
         "status": "revoked", "triggered_at": "2023-12-21T13:57:59.435706Z", "revoked_at":
         "2023-12-22T09:33:18.668820Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "4dd77510-fc74-411f-9dbe-77619fa920dd",
         "name": "My Postman Public Collection", "description": "Will it ring?", "created_at":
@@ -701,242 +637,231 @@ interactions:
         "status": "triggered", "triggered_at": "2024-01-04T17:52:01.203498Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 811, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
         "name": "ggshield-JZV5XT71", "description": "description", "created_at": "2024-01-09T09:39:34.421404Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "name": "sss", "description": "test", "created_at": "2024-01-09T14:24:10.741214Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
-        "name": "AWS key honeytoken for Slack", "description": "Honeytoken on Slack
-        channel", "created_at": "2024-01-15T16:13:53.656688Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "123ecd19-e66f-4e5c-ad73-12f0a51eda5a", "name": "AWS
+        key honeytoken for Slack", "description": "Honeytoken on Slack channel", "created_at":
+        "2024-01-15T16:13:53.656688Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
         "status": "triggered", "triggered_at": "2024-01-15T16:14:14.960066Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 104, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "23ca2658-aecf-471c-abf0-add09962e320", "key": "ods",
-        "value": "slack"}], "custom_tags": [{"id": "23ca2658-aecf-471c-abf0-add09962e320",
-        "key": "ods", "value": "slack"}], "token": "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a",
+        [], "custom_tags": [{"id": "23ca2658-aecf-471c-abf0-add09962e320", "key":
+        "ods", "value": "slack"}], "token": "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a",
         "name": "BK Test Paris", "description": "Brandon while in Paris office", "created_at":
         "2024-01-17T11:12:14.759334Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/34d5205b-accd-429c-9efa-eda48989c83a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
-        "name": "Lauren Testing", "description": "Lauren wuz here", "created_at":
-        "2024-01-29T17:37:45.379096Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4", "name": "Lauren
+        Testing", "description": "Lauren wuz here", "created_at": "2024-01-29T17:37:45.379096Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 637596, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "07fb5f6f-23f1-42e8-bdb2-c95864412a16",
         "name": "My Little Honeytoken", "description": "for testing", "created_at":
         "2024-02-02T22:18:06.038874Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/07fb5f6f-23f1-42e8-bdb2-c95864412a16",
         "status": "triggered", "triggered_at": "2024-02-09T20:50:13.173911Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b00bfddb-98c2-48e4-ad38-0cb9bc79cad6", "name": "orga_083643/solid-octo",
-        "description": "", "created_at": "2024-02-09T14:45:12.139727Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
+        "name": "orga_083643/solid-octo", "description": "", "created_at": "2024-02-09T14:45:12.139727Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
         "status": "revoked", "triggered_at": "2024-02-09T14:52:11.339548Z", "revoked_at":
         "2024-05-29T13:09:29.773300Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 2508, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "cf0806c4-093d-4165-9ad3-7e7ded211d3f", "name": "DemoKey", "description":
-        "sss", "created_at": "2024-02-15T12:39:23.633481Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cf0806c4-093d-4165-9ad3-7e7ded211d3f",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cf0806c4-093d-4165-9ad3-7e7ded211d3f",
+        "name": "DemoKey", "description": "sss", "created_at": "2024-02-15T12:39:23.633481Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cf0806c4-093d-4165-9ad3-7e7ded211d3f",
         "status": "triggered", "triggered_at": "2024-02-15T12:45:44.649197Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "638f6f82-6679-4399-a336-dd7996f4beae", "name": "demo-2024-02-16dm",
-        "description": "demo", "created_at": "2024-02-16T19:39:33.970811Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/638f6f82-6679-4399-a336-dd7996f4beae",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "638f6f82-6679-4399-a336-dd7996f4beae",
+        "name": "demo-2024-02-16dm", "description": "demo", "created_at": "2024-02-16T19:39:33.970811Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/638f6f82-6679-4399-a336-dd7996f4beae",
         "status": "revoked", "triggered_at": "2024-02-16T19:40:02.759791Z", "revoked_at":
         "2024-02-16T20:10:11.153368Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "6fcc5cf2-4b47-497d-9a80-c2d794b96ebc", "name": "solid-octo",
-        "description": "", "created_at": "2024-02-19T13:06:26.880374Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "6fcc5cf2-4b47-497d-9a80-c2d794b96ebc", "name": "solid-octo", "description":
+        "", "created_at": "2024-02-19T13:06:26.880374Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
-        "key": "team", "value": "octo"}], "custom_tags": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
         "key": "team", "value": "octo"}], "token": "[REDACTED]"}, {"id": "1592023a-2f39-4ba6-a503-4c07132f1eb0",
         "name": "GGnikalston/rock-paper-scissors-f4c01375", "description": "", "created_at":
         "2024-02-20T13:32:45.163630Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1592023a-2f39-4ba6-a503-4c07132f1eb0",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d024b464-cd1e-4daf-9b1d-863dcf517a7a",
-        "name": "Demo -2024-02-22", "description": "", "created_at": "2024-02-22T18:53:26.142516Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d024b464-cd1e-4daf-9b1d-863dcf517a7a", "name": "Demo
+        -2024-02-22", "description": "", "created_at": "2024-02-22T18:53:26.142516Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d024b464-cd1e-4daf-9b1d-863dcf517a7a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 354585, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0a94480f-5361-47f8-bc23-45a331624e9d",
-        "name": "demo ", "description": "demo ", "created_at": "2024-02-22T19:02:29.338420Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0a94480f-5361-47f8-bc23-45a331624e9d",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0a94480f-5361-47f8-bc23-45a331624e9d", "name": "demo
+        ", "description": "demo ", "created_at": "2024-02-22T19:02:29.338420Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/0a94480f-5361-47f8-bc23-45a331624e9d",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T17:03:31.533534Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86136984-d415-41c2-bfc4-59da8f9584fd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86136984-d415-41c2-bfc4-59da8f9584fd",
         "name": "demo-2024-02-23-dm", "description": "", "created_at": "2024-02-23T15:38:04.895275Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86136984-d415-41c2-bfc4-59da8f9584fd",
         "status": "revoked", "triggered_at": "2024-02-23T15:49:03.613445Z", "revoked_at":
         "2024-02-23T15:59:54.768989Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "b38455f9-822c-4f21-8525-0d4f2fa63850", "name": "demo-dwayne-2024-02-23",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "b38455f9-822c-4f21-8525-0d4f2fa63850", "name": "demo-dwayne-2024-02-23",
         "description": "dfnijsbuisbfids", "created_at": "2024-02-23T15:45:47.636481Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b38455f9-822c-4f21-8525-0d4f2fa63850",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T16:28:23.939971Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "612055eb-7fb5-4ba3-ab10-aa481f3d9962",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "612055eb-7fb5-4ba3-ab10-aa481f3d9962",
         "name": "demo-dwayne-2024-02-23-v2", "description": "Demo for video", "created_at":
         "2024-02-23T16:28:49.949332Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/612055eb-7fb5-4ba3-ab10-aa481f3d9962",
         "status": "revoked", "triggered_at": "2024-02-23T16:31:01.657151Z", "revoked_at":
         "2024-02-23T16:52:50.712289Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e", "name": "myname-dwayneptoday",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e", "name": "myname-dwayneptoday",
         "description": "dfsdfsdf", "created_at": "2024-02-23T16:38:14.323313Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T17:03:21.653827Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1bba091c-fc4c-48b5-b558-46c191f67103",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1bba091c-fc4c-48b5-b558-46c191f67103",
         "name": "ggshield-ldC5hqqo", "description": "description", "created_at": "2024-02-27T13:42:36.686028Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1bba091c-fc4c-48b5-b558-46c191f67103",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d7764013-fdd5-4b08-b195-dff5a338906d",
-        "name": "ggshield-LRYYnjOa", "description": "description", "created_at": "2024-02-27T13:42:37.569678Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d7764013-fdd5-4b08-b195-dff5a338906d", "name": "ggshield-LRYYnjOa",
+        "description": "description", "created_at": "2024-02-27T13:42:37.569678Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d7764013-fdd5-4b08-b195-dff5a338906d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "def4a23d-3d12-4fe1-b8e0-02250e74e47a",
-        "name": "ggshield-itglxnie", "description": "description", "created_at": "2024-02-27T13:58:30.205444Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "def4a23d-3d12-4fe1-b8e0-02250e74e47a", "name": "ggshield-itglxnie",
+        "description": "description", "created_at": "2024-02-27T13:58:30.205444Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/def4a23d-3d12-4fe1-b8e0-02250e74e47a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "33d149f1-68f4-4446-ae4f-def0ce962724",
-        "name": "ggshield-2Mf02eVA", "description": "description", "created_at": "2024-02-27T13:58:31.125075Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "33d149f1-68f4-4446-ae4f-def0ce962724", "name": "ggshield-2Mf02eVA",
+        "description": "description", "created_at": "2024-02-27T13:58:31.125075Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/33d149f1-68f4-4446-ae4f-def0ce962724",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5ff5eee1-fc18-4474-86fa-c46321c903c8",
-        "name": "ggshield-rmnfzrW2", "description": "description", "created_at": "2024-02-27T14:02:45.009113Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5ff5eee1-fc18-4474-86fa-c46321c903c8", "name": "ggshield-rmnfzrW2",
+        "description": "description", "created_at": "2024-02-27T14:02:45.009113Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5ff5eee1-fc18-4474-86fa-c46321c903c8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "4dd6c06e-e2c0-4593-9be0-b0418ba7a370",
-        "name": "ggshield-5YTKZZTB", "description": "description", "created_at": "2024-02-27T14:02:45.717261Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "4dd6c06e-e2c0-4593-9be0-b0418ba7a370", "name": "ggshield-5YTKZZTB",
+        "description": "description", "created_at": "2024-02-27T14:02:45.717261Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4dd6c06e-e2c0-4593-9be0-b0418ba7a370",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "eba79796-4f46-4e10-b876-280f75138cc9",
-        "name": "ggshield-z3Y6zgih", "description": "description", "created_at": "2024-02-27T14:06:02.196977Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "eba79796-4f46-4e10-b876-280f75138cc9", "name": "ggshield-z3Y6zgih",
+        "description": "description", "created_at": "2024-02-27T14:06:02.196977Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/eba79796-4f46-4e10-b876-280f75138cc9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0ebc8091-454b-461e-a6f8-fd17bf412c76",
-        "name": "ggshield-jqk54PrI", "description": "description", "created_at": "2024-02-27T14:06:03.018091Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0ebc8091-454b-461e-a6f8-fd17bf412c76", "name": "ggshield-jqk54PrI",
+        "description": "description", "created_at": "2024-02-27T14:06:03.018091Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ebc8091-454b-461e-a6f8-fd17bf412c76",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "664af568-cfc7-4726-9fb4-0b61606b7386",
-        "name": "ggshield-horgQNnR", "description": "description", "created_at": "2024-02-27T14:19:39.357690Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "664af568-cfc7-4726-9fb4-0b61606b7386", "name": "ggshield-horgQNnR",
+        "description": "description", "created_at": "2024-02-27T14:19:39.357690Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/664af568-cfc7-4726-9fb4-0b61606b7386",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5d915aca-6f6f-4b4e-a996-2c1f53016114",
-        "name": "ggshield-LNgN8R1S", "description": "description", "created_at": "2024-02-27T14:19:40.283320Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5d915aca-6f6f-4b4e-a996-2c1f53016114", "name": "ggshield-LNgN8R1S",
+        "description": "description", "created_at": "2024-02-27T14:19:40.283320Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d915aca-6f6f-4b4e-a996-2c1f53016114",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245",
-        "name": "Test key ", "description": "ss", "created_at": "2024-02-29T13:49:52.467489Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245", "name": "Test
+        key ", "description": "ss", "created_at": "2024-02-29T13:49:52.467489Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e",
-        "name": "test-lena-1903", "description": "", "created_at": "2024-03-19T09:13:00.819618Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/443045cc-7fa4-441d-a161-b060bd7fbb3e",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e", "name": "test-lena-1903",
+        "description": "", "created_at": "2024-03-19T09:13:00.819618Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/443045cc-7fa4-441d-a161-b060bd7fbb3e",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-05-29T09:51:31.597203Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 319222, "revoker_id":
         319222, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
         "name": "ggshield-Psfrcoxl", "description": "description", "created_at": "2024-03-27T08:48:20.857237Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5a01f826-4f8f-4235-8867-ce58ac88ce1c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5a01f826-4f8f-4235-8867-ce58ac88ce1c",
         "name": "ggshield-inUFY47O", "description": "description", "created_at": "2024-03-27T08:48:21.791104Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5a01f826-4f8f-4235-8867-ce58ac88ce1c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d72113d0-c346-42c7-bd88-fd5fe0e716f3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d72113d0-c346-42c7-bd88-fd5fe0e716f3",
         "name": "ggshield-eY0ZOlXS", "description": "description", "created_at": "2024-04-30T09:25:38.689800Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d72113d0-c346-42c7-bd88-fd5fe0e716f3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "7f2873cd-3759-4727-a683-31cac57fe5d8",
-        "name": "ggshield-TvlX76OG", "description": "description", "created_at": "2024-04-30T09:25:39.573115Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "7f2873cd-3759-4727-a683-31cac57fe5d8", "name": "ggshield-TvlX76OG",
+        "description": "description", "created_at": "2024-04-30T09:25:39.573115Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7f2873cd-3759-4727-a683-31cac57fe5d8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "72e98633-9179-4a3e-8908-ea2319d19b3b",
-        "name": "ggshield-XYKDhLUY", "description": "description", "created_at": "2024-04-30T10:19:12.369644Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "72e98633-9179-4a3e-8908-ea2319d19b3b", "name": "ggshield-XYKDhLUY",
+        "description": "description", "created_at": "2024-04-30T10:19:12.369644Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72e98633-9179-4a3e-8908-ea2319d19b3b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
         "name": "ggshield-HRoZzrBq", "description": "description", "created_at": "2024-04-30T10:19:13.126568Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
         "name": "Test key", "description": "Access key", "created_at": "2024-05-22T12:16:55.833940Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c7101eaa-ea38-495d-b3b4-c016db23e859",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "a67f962c-9dde-40c2-b404-e7cd4449cc82",
         "name": "pouet", "description": "", "created_at": "2024-05-22T12:19:03.143437Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a67f962c-9dde-40c2-b404-e7cd4449cc82",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
-        "key": "visability", "value": "public"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
         "key": "visability", "value": "public"}], "token": "[REDACTED]"}, {"id": "9cca01c5-535f-4f89-a214-6c4c5579fd07",
@@ -944,487 +869,473 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9cca01c5-535f-4f89-a214-6c4c5579fd07",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
-        "name": "test lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
-        "status": "triggered", "triggered_at": "2024-06-06T08:19:18.422045Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 319222, "revoker_id":
-        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca", "key": "machine",
-        "value": "ggprdgim01"}], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99", "name": "test
+        lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
         "key": "machine", "value": "ggprdgim01"}], "token": "[REDACTED]"}, {"id":
         "a411fa2c-a465-4099-8353-3c42365aca50", "name": "test MINT", "description":
         "test MINT", "created_at": "2024-06-10T14:40:08.522247Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/a411fa2c-a465-4099-8353-3c42365aca50",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "12c4562e-deb8-4d14-bb23-e344e79b6f04",
-        "name": "ggshield-Wq4EyTMI", "description": "description", "created_at": "2024-06-25T08:36:52.179380Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "12c4562e-deb8-4d14-bb23-e344e79b6f04", "name": "ggshield-Wq4EyTMI",
+        "description": "description", "created_at": "2024-06-25T08:36:52.179380Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/12c4562e-deb8-4d14-bb23-e344e79b6f04",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3407738b-2095-47bb-9cbd-dd16de158d67",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3407738b-2095-47bb-9cbd-dd16de158d67",
         "name": "ggshield-65KCwJls", "description": "description", "created_at": "2024-06-25T08:36:52.873146Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3407738b-2095-47bb-9cbd-dd16de158d67",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
         "name": "ggshield-fb77weow", "description": "description", "created_at": "2024-06-26T09:27:38.724573Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9223e352-43b6-4e06-8d12-682d669cedd7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9223e352-43b6-4e06-8d12-682d669cedd7",
         "name": "ggshield-TRO3H56N", "description": "description", "created_at": "2024-06-26T09:27:39.479744Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9223e352-43b6-4e06-8d12-682d669cedd7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "17e088b8-2463-48f8-957b-41d017f1dc83",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "17e088b8-2463-48f8-957b-41d017f1dc83",
         "name": "ggshield-s7IOqS0q", "description": "description", "created_at": "2024-06-26T09:42:26.454643Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/17e088b8-2463-48f8-957b-41d017f1dc83",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e332d717-641d-4ea4-81fc-e98115178454",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e332d717-641d-4ea4-81fc-e98115178454",
         "name": "ggshield-JaAf9b0W", "description": "description", "created_at": "2024-06-26T09:42:27.174527Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e332d717-641d-4ea4-81fc-e98115178454",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26514e1f-4237-474b-b907-037b88427f29",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26514e1f-4237-474b-b907-037b88427f29",
         "name": "ggshield-Uuc8EiUn", "description": "description", "created_at": "2024-06-26T11:51:19.747630Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/26514e1f-4237-474b-b907-037b88427f29",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
         "name": "ggshield-GL7wc5WW", "description": "description", "created_at": "2024-06-26T11:51:20.402145Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
         "name": "test ericf", "description": "", "created_at": "2024-07-09T09:34:04.089955Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
         "status": "triggered", "triggered_at": "2024-07-09T09:34:57.541777Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "a507d04c-bb61-4f2a-93ea-601b8aa27940",
         "name": "ggshield-w1cOSspy", "description": "description", "created_at": "2024-07-31T15:31:09.349255Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a507d04c-bb61-4f2a-93ea-601b8aa27940",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dafa04c5-299a-4a13-9c35-c523e51763f3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dafa04c5-299a-4a13-9c35-c523e51763f3",
         "name": "ggshield-b7VHMqbK", "description": "description", "created_at": "2024-07-31T15:31:10.071786Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dafa04c5-299a-4a13-9c35-c523e51763f3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
         "name": "ggshield-Fu1nGsc9", "description": "description", "created_at": "2024-08-05T09:03:52.745860Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "83888e42-dc57-471c-9a08-f023e3dc2949",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "83888e42-dc57-471c-9a08-f023e3dc2949",
         "name": "ggshield-5suF2vRt", "description": "description", "created_at": "2024-08-05T09:03:53.434873Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/83888e42-dc57-471c-9a08-f023e3dc2949",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e8aad547-96a7-40a4-a05d-710cf536f3a7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e8aad547-96a7-40a4-a05d-710cf536f3a7",
         "name": "ggshield-Vqz4LULC", "description": "description", "created_at": "2024-08-05T09:21:25.593516Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e8aad547-96a7-40a4-a05d-710cf536f3a7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
         "name": "ggshield-lqX7PlwI", "description": "description", "created_at": "2024-08-05T09:21:26.211228Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b144b1fd-dc5f-4a36-abc7-a95d05331245",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b144b1fd-dc5f-4a36-abc7-a95d05331245",
         "name": "ggshield-uZr6LNDv", "description": "description", "created_at": "2024-08-27T07:44:46.267249Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b144b1fd-dc5f-4a36-abc7-a95d05331245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "903bf588-2a03-4318-be6c-b9e3198d1fd6",
-        "name": "ggshield-5Ty2Hu4r", "description": "description", "created_at": "2024-08-27T07:44:46.871854Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "903bf588-2a03-4318-be6c-b9e3198d1fd6", "name": "ggshield-5Ty2Hu4r",
+        "description": "description", "created_at": "2024-08-27T07:44:46.871854Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/903bf588-2a03-4318-be6c-b9e3198d1fd6",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "11222b98-7705-4180-99d1-6e719d8a05a9",
-        "name": "ggshield-qnLief7n", "description": "description", "created_at": "2024-08-27T08:20:15.846360Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "11222b98-7705-4180-99d1-6e719d8a05a9", "name": "ggshield-qnLief7n",
+        "description": "description", "created_at": "2024-08-27T08:20:15.846360Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/11222b98-7705-4180-99d1-6e719d8a05a9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "707b35fb-685b-4577-88b9-94cccc10e165",
-        "name": "ggshield-wqYwwgeK", "description": "description", "created_at": "2024-08-27T08:20:16.467770Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "707b35fb-685b-4577-88b9-94cccc10e165", "name": "ggshield-wqYwwgeK",
+        "description": "description", "created_at": "2024-08-27T08:20:16.467770Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/707b35fb-685b-4577-88b9-94cccc10e165",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "01c7668d-1467-4cac-a395-4b50fc278407",
-        "name": "ggshield-QkzL5Vyb", "description": "description", "created_at": "2024-09-24T08:50:15.865165Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "01c7668d-1467-4cac-a395-4b50fc278407", "name": "ggshield-QkzL5Vyb",
+        "description": "description", "created_at": "2024-09-24T08:50:15.865165Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/01c7668d-1467-4cac-a395-4b50fc278407",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
         "name": "ggshield-kkpkfk1s", "description": "description", "created_at": "2024-09-24T08:50:16.667172Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "730bdd87-31b2-4b42-a32a-5750bc595c9c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "730bdd87-31b2-4b42-a32a-5750bc595c9c",
         "name": "ggshield-dtxlZtWH", "description": "description", "created_at": "2024-10-01T13:18:29.918337Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/730bdd87-31b2-4b42-a32a-5750bc595c9c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b42c6945-05fc-4c5b-af83-e60478cd9db5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b42c6945-05fc-4c5b-af83-e60478cd9db5",
         "name": "ggshield-WPIELIcW", "description": "description", "created_at": "2024-10-01T13:18:30.820570Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b42c6945-05fc-4c5b-af83-e60478cd9db5",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
         "name": "ggshield-B8LwcRR0", "description": "description", "created_at": "2024-10-16T13:47:50.239094Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "81d30531-a54e-4f67-a46b-a7bac5783995",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "81d30531-a54e-4f67-a46b-a7bac5783995",
         "name": "ggshield-IjJFdqDS", "description": "description", "created_at": "2024-10-16T13:47:51.425195Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/81d30531-a54e-4f67-a46b-a7bac5783995",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a0b24134-0cbc-4ca5-b110-18b3311aef73",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a0b24134-0cbc-4ca5-b110-18b3311aef73",
         "name": "DO-demo", "description": "Digital Ocean Demo", "created_at": "2024-10-23T17:55:40.621634Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a0b24134-0cbc-4ca5-b110-18b3311aef73",
         "status": "revoked", "triggered_at": "2024-10-23T18:03:40.135215Z", "revoked_at":
         "2024-10-23T18:33:47.488182Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "50e53ab6-4950-48e6-9350-b5aaa88fafea", "name": "Demo",
-        "description": "Dev team 1", "created_at": "2024-10-27T21:01:47.725365Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/50e53ab6-4950-48e6-9350-b5aaa88fafea",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "50e53ab6-4950-48e6-9350-b5aaa88fafea", "name": "Demo", "description":
+        "Dev team 1", "created_at": "2024-10-27T21:01:47.725365Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/50e53ab6-4950-48e6-9350-b5aaa88fafea",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582569, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}], "token": "[REDACTED]"},
         {"id": "795decd4-4703-4073-9b3c-3ec2157f6182", "name": "Demo token", "description":
         "Take a look", "created_at": "2024-10-28T00:34:48.214122Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/795decd4-4703-4073-9b3c-3ec2157f6182",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582569, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
-        "name": "ggshield-c6YSc2Ie", "description": "description", "created_at": "2024-10-29T14:36:27.096968Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "c43ee48d-4646-40e8-bd12-3dfa30a6b3db", "name": "ggshield-c6YSc2Ie",
+        "description": "description", "created_at": "2024-10-29T14:36:27.096968Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
         "name": "ggshield-E6IPnu0f", "description": "description", "created_at": "2024-10-29T14:36:28.513178Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a454c002-679b-4250-aacf-28b5207543a4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a454c002-679b-4250-aacf-28b5207543a4",
         "name": "ggshield-HjwRkUAT", "description": "description", "created_at": "2024-11-27T12:32:44.877048Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a454c002-679b-4250-aacf-28b5207543a4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5af2ae0-f3f6-4301-82bc-b49108bd782b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5af2ae0-f3f6-4301-82bc-b49108bd782b",
         "name": "ggshield-hIlrbyRm", "description": "description", "created_at": "2024-11-27T12:32:45.728067Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c5af2ae0-f3f6-4301-82bc-b49108bd782b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "aed37b34-4721-43c2-99e2-2f2e78592f63",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "aed37b34-4721-43c2-99e2-2f2e78592f63",
         "name": "ggshield/setup.cfg", "description": "", "created_at": "2024-12-17T10:10:25.895137Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/aed37b34-4721-43c2-99e2-2f2e78592f63",
         "status": "triggered", "triggered_at": "2024-12-17T10:19:35.167833Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 309802, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476", "name": "pierredethoisy/dockerfile",
-        "description": "", "created_at": "2024-12-17T10:30:41.655876Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
+        "name": "pierredethoisy/dockerfile", "description": "", "created_at": "2024-12-17T10:30:41.655876Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
         "status": "triggered", "triggered_at": "2024-12-17T10:32:09.594850Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 309802, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "4b814f00-0897-479f-8a2d-a9593c5f18fa", "name": "WrongSecrets", "description":
-        "Honeytoken for the wrongsecrets repositort", "created_at": "2025-02-06T13:10:31.569094Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4b814f00-0897-479f-8a2d-a9593c5f18fa",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4b814f00-0897-479f-8a2d-a9593c5f18fa",
+        "name": "WrongSecrets", "description": "Honeytoken for the wrongsecrets repositort",
+        "created_at": "2025-02-06T13:10:31.569094Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4b814f00-0897-479f-8a2d-a9593c5f18fa",
         "status": "triggered", "triggered_at": "2025-02-06T13:16:26.325168Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "7dfdb8ee-56fc-486e-9b7a-e6ff248107fa", "name": "ggshield-AAcFXCwl",
-        "description": "description", "created_at": "2025-02-27T10:23:31.621722Z",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
+        "name": "ggshield-AAcFXCwl", "description": "description", "created_at": "2025-02-27T10:23:31.621722Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "97877334-808d-48c7-8802-2c54e9f43661",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "97877334-808d-48c7-8802-2c54e9f43661",
         "name": "ggshield-srahH0o3", "description": "description", "created_at": "2025-02-27T10:23:32.385844Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/97877334-808d-48c7-8802-2c54e9f43661",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ca642fe-2ce4-42b2-9097-5904093935c1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ca642fe-2ce4-42b2-9097-5904093935c1",
         "name": "ggshield-5Vx0aaQd", "description": "description", "created_at": "2025-02-27T10:31:34.080183Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ca642fe-2ce4-42b2-9097-5904093935c1",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d8590557-764f-4618-9b2e-277d536bd111",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d8590557-764f-4618-9b2e-277d536bd111",
         "name": "ggshield-QYqCVZ4i", "description": "description", "created_at": "2025-02-27T10:31:34.798380Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d8590557-764f-4618-9b2e-277d536bd111",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84b08c90-12f5-48ef-baee-ab8d8b15588c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84b08c90-12f5-48ef-baee-ab8d8b15588c",
         "name": "ggshield-4sJy2SkE", "description": "description", "created_at": "2025-02-27T10:53:01.890617Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84b08c90-12f5-48ef-baee-ab8d8b15588c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72204c1e-12c1-445f-b106-09488214d610",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72204c1e-12c1-445f-b106-09488214d610",
         "name": "ggshield-eqoLjiAS", "description": "description", "created_at": "2025-02-27T10:53:02.563136Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72204c1e-12c1-445f-b106-09488214d610",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
         "name": "ggshield-yaqMNJFA", "description": "description", "created_at": "2025-02-27T11:24:20.630794Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a5d5ca0-000f-4011-aaf2-b4f627c19649",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a5d5ca0-000f-4011-aaf2-b4f627c19649",
         "name": "ggshield-x12c7zPc", "description": "description", "created_at": "2025-02-27T11:24:21.465056Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8a5d5ca0-000f-4011-aaf2-b4f627c19649",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c823f31a-73a8-46cc-be4a-029d6d081793",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c823f31a-73a8-46cc-be4a-029d6d081793",
         "name": "ggshield-9Mq5rTUV", "description": "description", "created_at": "2025-02-27T16:44:10.862683Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c823f31a-73a8-46cc-be4a-029d6d081793",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49f1055b-b505-402b-8b79-e4b2c6cf2041",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49f1055b-b505-402b-8b79-e4b2c6cf2041",
         "name": "ggshield-4MmSKBvx", "description": "description", "created_at": "2025-02-27T16:44:11.663957Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/49f1055b-b505-402b-8b79-e4b2c6cf2041",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be8e40e8-b204-40de-8d37-247ac6ef7077",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be8e40e8-b204-40de-8d37-247ac6ef7077",
         "name": "ggshield-DBuxWn0n", "description": "description", "created_at": "2025-02-27T16:57:21.290157Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be8e40e8-b204-40de-8d37-247ac6ef7077",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d10551f8-36f0-4966-a684-d5f9eca89e8d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d10551f8-36f0-4966-a684-d5f9eca89e8d",
         "name": "ggshield-bukJ4Md2", "description": "description", "created_at": "2025-02-27T16:57:22.079317Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d10551f8-36f0-4966-a684-d5f9eca89e8d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d5385824-6a93-47cb-81f3-e818e64371d7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d5385824-6a93-47cb-81f3-e818e64371d7",
         "name": "ggshield-vI1CTIm2", "description": "description", "created_at": "2025-02-27T17:24:28.533666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d5385824-6a93-47cb-81f3-e818e64371d7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
         "name": "ggshield-C519GYI9", "description": "description", "created_at": "2025-02-27T17:24:29.231126Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
         "name": "ggshield-i8zN7WRH", "description": "description", "created_at": "2025-02-27T17:27:14.478281Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "661dae4d-5944-4a20-b7f7-f74913356479",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "661dae4d-5944-4a20-b7f7-f74913356479",
         "name": "ggshield-IX7GxSIs", "description": "description", "created_at": "2025-02-27T17:27:15.226298Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/661dae4d-5944-4a20-b7f7-f74913356479",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "adaea919-086f-4e37-b4e5-dc8208d0e4f5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "adaea919-086f-4e37-b4e5-dc8208d0e4f5",
         "name": "ggshield-rWApiuse", "description": "description", "created_at": "2025-03-03T09:15:26.314595Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/adaea919-086f-4e37-b4e5-dc8208d0e4f5",
         "status": "triggered", "triggered_at": "2026-02-18T14:51:12.198393Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
-        "key": "env", "value": "staging"}], "custom_tags": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
+        null, "tags": [], "custom_tags": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
         "key": "env", "value": "staging"}], "token": "[REDACTED]"}, {"id": "da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
         "name": "ggshield-jdbeH3gE", "description": "description", "created_at": "2025-03-03T09:15:27.049176Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22", "key": "env",
-        "value": "production"}], "custom_tags": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22",
-        "key": "env", "value": "production"}], "token": "[REDACTED]"}, {"id": "1f4708b2-0e51-458c-abca-c03e502b4a5a",
+        [], "custom_tags": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22", "key":
+        "env", "value": "production"}], "token": "[REDACTED]"}, {"id": "1f4708b2-0e51-458c-abca-c03e502b4a5a",
         "name": "ggshield-QgwFEPjx", "description": "description", "created_at": "2025-03-27T15:12:18.744612Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1f4708b2-0e51-458c-abca-c03e502b4a5a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "a4ced9be-6ad5-4d8a-b188-65a117bc0eba",
-        "name": "ggshield-44tVmSvF", "description": "description", "created_at": "2025-03-27T15:12:19.507492Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "a4ced9be-6ad5-4d8a-b188-65a117bc0eba", "name": "ggshield-44tVmSvF",
+        "description": "description", "created_at": "2025-03-27T15:12:19.507492Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a4ced9be-6ad5-4d8a-b188-65a117bc0eba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5710ee7d-6428-4074-a9ff-09399782242d",
-        "name": "ggshield-bF87lDBl", "description": "description", "created_at": "2025-03-27T15:21:17.135616Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5710ee7d-6428-4074-a9ff-09399782242d", "name": "ggshield-bF87lDBl",
+        "description": "description", "created_at": "2025-03-27T15:21:17.135616Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5710ee7d-6428-4074-a9ff-09399782242d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
-        "name": "ggshield-LbIDqGyA", "description": "description", "created_at": "2025-03-27T15:21:17.953340Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "4cbf7af9-9989-4185-8ef8-0f39e6f3d145", "name": "ggshield-LbIDqGyA",
+        "description": "description", "created_at": "2025-03-27T15:21:17.953340Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2dfa1936-f53f-4d0c-8a69-ae9bab297021",
-        "name": "ggshield-qz84En8W", "description": "description", "created_at": "2025-03-27T15:24:16.907610Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2dfa1936-f53f-4d0c-8a69-ae9bab297021", "name": "ggshield-qz84En8W",
+        "description": "description", "created_at": "2025-03-27T15:24:16.907610Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2dfa1936-f53f-4d0c-8a69-ae9bab297021",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "11213dc7-118d-4997-a96b-714640c3ad0b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "11213dc7-118d-4997-a96b-714640c3ad0b",
         "name": "ggshield-CSF39jm8", "description": "description", "created_at": "2025-03-27T15:24:17.721006Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/11213dc7-118d-4997-a96b-714640c3ad0b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "899dd0b0-20b2-45d2-b779-0331cc448935",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "899dd0b0-20b2-45d2-b779-0331cc448935",
         "name": "toto", "description": "tata", "created_at": "2025-05-12T09:58:35.161641Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/899dd0b0-20b2-45d2-b779-0331cc448935",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "62d71685-2eba-4b88-8edd-cc73e698cfa5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "62d71685-2eba-4b88-8edd-cc73e698cfa5",
         "name": "test-greg", "description": "test greg", "created_at": "2025-05-12T10:06:19.826522Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/62d71685-2eba-4b88-8edd-cc73e698cfa5",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:59.739856Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "e948f77d-5353-413e-b37d-8beba84890ff", "name": "test-greg-2", "description":
-        "test greg", "created_at": "2025-05-12T10:08:11.667578Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e948f77d-5353-413e-b37d-8beba84890ff",
+        "name": "test-greg-2", "description": "test greg", "created_at": "2025-05-12T10:08:11.667578Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:54.809724Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb", "name": "test-greg-3", "description":
-        "test greg", "created_at": "2025-05-12T10:08:58.561160Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        "name": "test-greg-3", "description": "test greg", "created_at": "2025-05-12T10:08:58.561160Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:50.784137Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6", "name": "test-greg-4", "description":
-        "test", "created_at": "2025-05-12T10:10:12.927058Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6",
+        "name": "test-greg-4", "description": "test", "created_at": "2025-05-12T10:10:12.927058Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:46.594085Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a", "name": "test-greg-5", "description":
-        "test", "created_at": "2025-05-12T10:12:50.615700Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
+        "name": "test-greg-5", "description": "test", "created_at": "2025-05-12T10:12:50.615700Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:41.387978Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "9fcf0732-6b8d-41d3-ae98-727bd5dde585", "name": "achille-hackathon",
-        "description": "achille hackathon", "created_at": "2025-05-12T12:01:23.542568Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9fcf0732-6b8d-41d3-ae98-727bd5dde585",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9fcf0732-6b8d-41d3-ae98-727bd5dde585",
+        "name": "achille-hackathon", "description": "achille hackathon", "created_at":
+        "2025-05-12T12:01:23.542568Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9fcf0732-6b8d-41d3-ae98-727bd5dde585",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38",
         "name": "TestHoneytoken", "description": "Testing GitGuardian API connectivity",
         "created_at": "2025-05-12T12:19:05.294638Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b0ddbd44-4054-4127-aa00-cd6727e70d38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
         "name": "AWS Credentials", "description": "Honeytoken for testing, to be injected
         as requested by the user.", "created_at": "2025-05-12T12:38:25.640506Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
         "status": "triggered", "triggered_at": "2026-02-18T13:45:03.781945Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 269050, "revoker_id":
+        null, "type": "AWS", "open_events_count": 9, "creator_id": 269050, "revoker_id":
         null, "creator_api_token_id": "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec", "name": "test-greg-7", "description":
-        "test", "created_at": "2025-05-12T12:54:37.703725Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ab824e92-6068-4a9d-ae36-86a94516f2ec",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec",
+        "name": "test-greg-7", "description": "test", "created_at": "2025-05-12T12:54:37.703725Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ab824e92-6068-4a9d-ae36-86a94516f2ec",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:34.521470Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b65d42a4-587f-4701-a595-8429cbcda70b", "name": "gg-mcp-server-honeytoken",
-        "description": "Honeytoken for security monitoring in the gg-mcp-server project.",
-        "created_at": "2025-05-12T12:54:44.402023Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b65d42a4-587f-4701-a595-8429cbcda70b",
-        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
-        "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
-        "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3fe4aa4f-49f6-42ad-a34a-0c108b544215",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b65d42a4-587f-4701-a595-8429cbcda70b",
+        "name": "gg-mcp-server-honeytoken", "description": "Honeytoken for security
+        monitoring in the gg-mcp-server project.", "created_at": "2025-05-12T12:54:44.402023Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b65d42a4-587f-4701-a595-8429cbcda70b",
+        "status": "triggered", "triggered_at": "2026-06-04T13:16:15.961464Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 4, "creator_id": 269050, "revoker_id":
+        null, "creator_api_token_id": "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id":
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3fe4aa4f-49f6-42ad-a34a-0c108b544215",
         "name": "default-honeytoken", "description": "General purpose honeytoken for
         security monitoring", "created_at": "2025-05-12T13:07:52.676810Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/3fe4aa4f-49f6-42ad-a34a-0c108b544215",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
         "name": "test", "description": "test", "created_at": "2025-05-12T13:09:38.965752Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9844e55d-982c-4458-b65b-592ad99ce77a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1026550, "revoker_id": null, "creator_api_token_id":
         "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
         "name": "Test Honeytoken", "description": "Testing honeytoken generation",
         "created_at": "2025-05-12T14:35:34.295363Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b2a7e759-81ab-465d-a578-e3ce42c18741",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
         "name": "test-greg-9", "description": "", "created_at": "2025-05-12T14:50:23.123299Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6d185a-6f59-4b7c-9248-dd05616090db",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:27.366114Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
+        null, "tags": [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
         "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "fbb93094-9778-4b8b-97d8-de99954a758a",
         "name": "AWS_Honeytoken", "description": "Honeytoken generated via MCP", "created_at":
@@ -1432,17 +1343,15 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "34e08af4-59a7-4a3b-b799-65acb8a2019d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "34e08af4-59a7-4a3b-b799-65acb8a2019d",
         "name": "AWS-MCP-Honeytoken", "description": "Honeytoken for monitoring potential
         AWS credential leaks", "created_at": "2025-05-12T15:07:16.157981Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/34e08af4-59a7-4a3b-b799-65acb8a2019d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "16805984-70d6-4049-844a-79bac3054f6f",
         "name": "AwsTestHoneytoken", "description": "Test honeytoken for development
         and monitoring", "created_at": "2025-05-12T15:09:00.390236Z", "gitguardian_url":
@@ -1450,10 +1359,8 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "d476c118-b210-403d-b685-3d7f0a514950",
         "name": "aws-development-access-key", "description": "Development environment
         AWS access key for monitoring credential leaks", "created_at": "2025-05-12T15:12:56.525944Z",
@@ -1461,9 +1368,7 @@ interactions:
         "status": "triggered", "triggered_at": "2026-02-18T14:50:57.626529Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 2, "creator_id": 270722, "revoker_id":
         null, "creator_api_token_id": "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
+        null, "tags": [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
         "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "0a112323-6906-4bd0-a660-1b45a0fc59ca",
         "name": "NHI-Explorer-Secret", "description": "AWS access key for NHI Explorer
@@ -1472,232 +1377,412 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "69dbbe3c-2dfc-4c93-916c-f70c42f4e2af",
         "name": "ggshield-Leb9CGys", "description": "description", "created_at": "2025-05-27T08:18:31.020533Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/69dbbe3c-2dfc-4c93-916c-f70c42f4e2af",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "029e2aba-796c-47d8-8d52-e14f9868acfc",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "029e2aba-796c-47d8-8d52-e14f9868acfc",
         "name": "ggshield-Fhjl6QxB", "description": "description", "created_at": "2025-05-27T08:18:31.873128Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/029e2aba-796c-47d8-8d52-e14f9868acfc",
         "status": "triggered", "triggered_at": "2025-06-17T09:30:39.728240Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "c77d47b6-8d61-46a7-b6a1-1715fc47c7eb", "name": "ggshield-U8JeiAjO",
-        "description": "description", "created_at": "2025-06-24T13:04:20.196705Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
+        "name": "ggshield-U8JeiAjO", "description": "description", "created_at": "2025-06-24T13:04:20.196705Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab",
-        "name": "ggshield-NiJSM24s", "description": "description", "created_at": "2025-06-24T13:04:21.255669Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab", "name": "ggshield-NiJSM24s",
+        "description": "description", "created_at": "2025-06-24T13:04:21.255669Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5692a982-6603-443e-bdb4-5ea1a5de6f64",
-        "name": "ggshield-JKhVuHaW", "description": "description", "created_at": "2025-06-24T13:06:56.046343Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5692a982-6603-443e-bdb4-5ea1a5de6f64", "name": "ggshield-JKhVuHaW",
+        "description": "description", "created_at": "2025-06-24T13:06:56.046343Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5692a982-6603-443e-bdb4-5ea1a5de6f64",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "17925c95-1df7-4e86-9c42-aabb5dbdea69",
-        "name": "ggshield-vfjAXCfY", "description": "description", "created_at": "2025-06-24T13:06:57.033247Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "17925c95-1df7-4e86-9c42-aabb5dbdea69", "name": "ggshield-vfjAXCfY",
+        "description": "description", "created_at": "2025-06-24T13:06:57.033247Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/17925c95-1df7-4e86-9c42-aabb5dbdea69",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "631ef101-122f-4592-9de1-2d6cb5becafa",
-        "name": "ggshield-dbhOtleP", "description": "description", "created_at": "2025-06-24T13:13:01.219899Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "631ef101-122f-4592-9de1-2d6cb5becafa", "name": "ggshield-dbhOtleP",
+        "description": "description", "created_at": "2025-06-24T13:13:01.219899Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/631ef101-122f-4592-9de1-2d6cb5becafa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "bebc1ca8-933d-45ca-b201-fbabc4eab464",
-        "name": "ggshield-7pQLMJYV", "description": "description", "created_at": "2025-06-24T13:13:01.978212Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "bebc1ca8-933d-45ca-b201-fbabc4eab464", "name": "ggshield-7pQLMJYV",
+        "description": "description", "created_at": "2025-06-24T13:13:01.978212Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bebc1ca8-933d-45ca-b201-fbabc4eab464",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "3983e8ff-7fd6-4fde-9117-9612d4258052",
-        "name": "ggshield-phDsJ9wy", "description": "description", "created_at": "2025-06-24T13:29:15.096198Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "3983e8ff-7fd6-4fde-9117-9612d4258052", "name": "ggshield-phDsJ9wy",
+        "description": "description", "created_at": "2025-06-24T13:29:15.096198Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3983e8ff-7fd6-4fde-9117-9612d4258052",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "9340e7fe-f79c-467e-9dcd-43ddaa77dc0c",
-        "name": "ggshield-Md0MBV0B", "description": "description", "created_at": "2025-06-24T13:29:16.049584Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "9340e7fe-f79c-467e-9dcd-43ddaa77dc0c", "name": "ggshield-Md0MBV0B",
+        "description": "description", "created_at": "2025-06-24T13:29:16.049584Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9340e7fe-f79c-467e-9dcd-43ddaa77dc0c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "08b51a6e-dd6c-4a4b-93f9-b955663c6524",
-        "name": "ggshield-ZoWflf5b", "description": "description", "created_at": "2025-06-24T13:31:49.045062Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "08b51a6e-dd6c-4a4b-93f9-b955663c6524", "name": "ggshield-ZoWflf5b",
+        "description": "description", "created_at": "2025-06-24T13:31:49.045062Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/08b51a6e-dd6c-4a4b-93f9-b955663c6524",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "96da938d-d6fa-4e44-9254-c568a27be484",
-        "name": "ggshield-PirK5h1Q", "description": "description", "created_at": "2025-06-24T13:31:49.827284Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "96da938d-d6fa-4e44-9254-c568a27be484", "name": "ggshield-PirK5h1Q",
+        "description": "description", "created_at": "2025-06-24T13:31:49.827284Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/96da938d-d6fa-4e44-9254-c568a27be484",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f2c61b85-e11d-4db0-a8af-7fc327310b39",
-        "name": "ggshield-ZQ4jUtQr", "description": "description", "created_at": "2025-06-24T13:45:17.477850Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f2c61b85-e11d-4db0-a8af-7fc327310b39", "name": "ggshield-ZQ4jUtQr",
+        "description": "description", "created_at": "2025-06-24T13:45:17.477850Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f2c61b85-e11d-4db0-a8af-7fc327310b39",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f99173ff-9ffe-492c-b8ae-54157df89bac",
-        "name": "ggshield-5uK6KYFh", "description": "description", "created_at": "2025-06-24T13:45:18.309642Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f99173ff-9ffe-492c-b8ae-54157df89bac", "name": "ggshield-5uK6KYFh",
+        "description": "description", "created_at": "2025-06-24T13:45:18.309642Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f99173ff-9ffe-492c-b8ae-54157df89bac",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768",
-        "name": "ggshield-MGXkbqc7", "description": "description", "created_at": "2025-06-24T13:50:43.295521Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768", "name": "ggshield-MGXkbqc7",
+        "description": "description", "created_at": "2025-06-24T13:50:43.295521Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f3252f2c-16a9-45e4-97e8-bed4b5752415",
-        "name": "ggshield-YJd3rq9q", "description": "description", "created_at": "2025-06-24T13:50:44.165951Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f3252f2c-16a9-45e4-97e8-bed4b5752415", "name": "ggshield-YJd3rq9q",
+        "description": "description", "created_at": "2025-06-24T13:50:44.165951Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f3252f2c-16a9-45e4-97e8-bed4b5752415",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "e22705f1-5497-449b-9614-3c2d89e3b705",
-        "name": "ggshield-l4abwnpa", "description": null, "created_at": "2025-06-26T12:32:05.993896Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e22705f1-5497-449b-9614-3c2d89e3b705",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "e22705f1-5497-449b-9614-3c2d89e3b705", "name": "ggshield-l4abwnpa",
+        "description": null, "created_at": "2025-06-26T12:32:05.993896Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e22705f1-5497-449b-9614-3c2d89e3b705",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
         "4ff03654-f280-4c31-8eef-5295d2b75a50", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7691445a-2cb0-4093-94ca-f2c5de877075",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7691445a-2cb0-4093-94ca-f2c5de877075",
         "name": "ggshield-Lwhu1Nax", "description": "description", "created_at": "2025-07-29T10:34:41.534666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7691445a-2cb0-4093-94ca-f2c5de877075",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "951e1f19-5804-444a-b275-b51dc5bf68ee",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "951e1f19-5804-444a-b275-b51dc5bf68ee",
         "name": "ggshield-u9ltlEmT", "description": "description", "created_at": "2025-07-29T10:34:42.385215Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/951e1f19-5804-444a-b275-b51dc5bf68ee",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
         "name": "ggshield-CC0Lj0vS", "description": "description", "created_at": "2025-07-29T10:40:27.317817Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
         "name": "ggshield-0k2Xha2i", "description": "description", "created_at": "2025-07-29T10:40:28.088246Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
         "status": "triggered", "triggered_at": "2025-08-22T16:59:58.315774Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "49e4fce7-aa48-42b0-9fc4-e16105ae08e5", "name": "ggshield-ncOpkfP8",
-        "description": "description", "created_at": "2025-08-27T11:43:11.666517Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
+        "name": "ggshield-ncOpkfP8", "description": "description", "created_at": "2025-08-27T11:43:11.666517Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2b15518b-3100-4736-bee6-b47fe8d26fc1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2b15518b-3100-4736-bee6-b47fe8d26fc1",
         "name": "ggshield-H2eDvilF", "description": "description", "created_at": "2025-08-27T11:43:12.618589Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2b15518b-3100-4736-bee6-b47fe8d26fc1",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "368a90bf-269b-4a60-95c2-1c77c86f7fd4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "368a90bf-269b-4a60-95c2-1c77c86f7fd4",
         "name": "ggshield-V6RzZJGL", "description": "description", "created_at": "2025-11-14T16:54:30.227288Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/368a90bf-269b-4a60-95c2-1c77c86f7fd4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "eae1aaaf-d700-475d-b65a-ffd79f84806d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "eae1aaaf-d700-475d-b65a-ffd79f84806d",
         "name": "ggshield-Pya2g1xF", "description": "description", "created_at": "2025-11-14T16:54:30.933576Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/eae1aaaf-d700-475d-b65a-ffd79f84806d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
         "name": "ggshield-Z2Ji3PxX", "description": "description", "created_at": "2026-03-31T13:26:20.710346Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
         "name": "ggshield-FsL9dCzu", "description": "description", "created_at": "2026-03-31T13:26:21.681383Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7daed77-1fa4-416d-88e2-473200b810aa",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7daed77-1fa4-416d-88e2-473200b810aa",
         "name": "ggshield-dqv39cn2", "description": "description", "created_at": "2026-03-31T13:32:28.824725Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e7daed77-1fa4-416d-88e2-473200b810aa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "601c59d9-7579-402e-90c4-59da055a8d3b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "601c59d9-7579-402e-90c4-59da055a8d3b",
         "name": "ggshield-YpbVgsRl", "description": "description", "created_at": "2026-03-31T13:32:29.820990Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/601c59d9-7579-402e-90c4-59da055a8d3b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "54e52712-a036-4e80-899b-c1a200610339",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "54e52712-a036-4e80-899b-c1a200610339",
         "name": "ggshield-DZ5zVj1p", "description": "description", "created_at": "2026-03-31T13:37:32.513332Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/54e52712-a036-4e80-899b-c1a200610339",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51dc5671-8053-4b87-8174-975ccf7f249c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51dc5671-8053-4b87-8174-975ccf7f249c",
         "name": "ggshield-DXGKK2gC", "description": "description", "created_at": "2026-03-31T13:37:33.559937Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/51dc5671-8053-4b87-8174-975ccf7f249c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}]'
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "name": "test Pierre", "description": "", "created_at": "2026-04-07T18:38:38.199572Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "ae435f66-1ea9-4dfe-b73f-49f451fc00ab", "name": "Demo
+        Romain", "description": "", "created_at": "2026-04-24T12:48:19.654369Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/ae435f66-1ea9-4dfe-b73f-49f451fc00ab",
+        "status": "triggered", "triggered_at": "2026-04-29T12:54:19.464710Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 6, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [{"id": "7a2469eb-2b6b-4248-8103-2b0f6b4fac9b", "key":
+        "romain", "value": null}], "token": "[REDACTED]"}, {"id": "10f6e20b-12ae-4591-aa09-7e1ff00ef408",
+        "name": "qa / xyz-e732d912", "description": "", "created_at": "2026-04-24T16:05:46.508625Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/10f6e20b-12ae-4591-aa09-7e1ff00ef408",
+        "status": "triggered", "triggered_at": "2026-04-24T16:13:17.276672Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9266c0f4-f0e0-41d2-a8c8-c164ccb84e47",
+        "name": "qa / test-nriv-e732d912", "description": "", "created_at": "2026-04-24T16:05:50.013606Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9266c0f4-f0e0-41d2-a8c8-c164ccb84e47",
+        "status": "triggered", "triggered_at": "2026-04-24T16:15:44.494587Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "name": "dev / Salome Test-e732d912", "description": "", "created_at": "2026-04-24T16:05:53.158978Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "status": "triggered", "triggered_at": "2026-04-24T16:16:21.895694Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "name": "qa / test-r8327r-e732d912", "description": "", "created_at": "2026-04-24T16:05:56.586568Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "status": "triggered", "triggered_at": "2026-04-24T16:18:31.419829Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2314a2ef-cec4-4e3d-834a-09b0c40c99d2",
+        "name": "qa / abc-e732d912", "description": "", "created_at": "2026-04-24T16:05:59.728317Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2314a2ef-cec4-4e3d-834a-09b0c40c99d2",
+        "status": "triggered", "triggered_at": "2026-04-24T16:25:50.024911Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "fe96d213-a002-4161-a7c9-cb3be4ad88f8",
+        "name": "qa / Handcrafted Metal Bike-e732d912", "description": "", "created_at":
+        "2026-04-24T16:06:02.936659Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fe96d213-a002-4161-a7c9-cb3be4ad88f8",
+        "status": "triggered", "triggered_at": "2026-04-24T16:35:48.958630Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a72f662-2357-4b93-b48a-00028e36cfff",
+        "name": "test1", "description": "tEST 2", "created_at": "2026-04-30T09:12:55.584248Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a72f662-2357-4b93-b48a-00028e36cfff",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "963fbabe-3d2c-4154-8281-2f13be7c06f7", "name": "test121",
+        "description": "testing 12", "created_at": "2026-04-30T11:31:57.689130Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/963fbabe-3d2c-4154-8281-2f13be7c06f7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "1acff09e-02c1-4a24-8869-568dfab124c9", "name": "test-pierredt",
+        "description": "hello", "created_at": "2026-05-06T19:57:39.689471Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/1acff09e-02c1-4a24-8869-568dfab124c9",
+        "status": "triggered", "triggered_at": "2026-05-06T19:59:18.645288Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 6, "creator_id": 309802, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "name": "qa / test-nriv-d2363bd5", "description": "", "created_at": "2026-05-19T08:29:37.247067Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "status": "triggered", "triggered_at": "2026-05-19T08:33:36.289678Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 1754656, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "03e7e668-6fbf-493a-8d1c-ac9d0c6c1b97",
+        "name": "qa / xyz-d2363bd5", "description": "", "created_at": "2026-05-19T08:29:41.396307Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/03e7e668-6fbf-493a-8d1c-ac9d0c6c1b97",
+        "status": "triggered", "triggered_at": "2026-05-19T08:34:30.001210Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 1754656, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "bb1adf06-28ea-4daf-b338-59d5ef094f67",
+        "name": "TheBigHoney", "description": "Big Honey Pot for our core secrets",
+        "created_at": "2026-05-19T11:51:12.957707Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bb1adf06-28ea-4daf-b338-59d5ef094f67",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "93abaf01-cac6-48f4-bfa1-735cfb7fde7d", "name": "ttoprjog",
+        "description": "Henri", "created_at": "2026-05-20T12:22:37.974250Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/93abaf01-cac6-48f4-bfa1-735cfb7fde7d",
+        "status": "revoked", "triggered_at": null, "revoked_at": "2026-05-20T12:23:19.883989Z",
+        "type": "AWS", "open_events_count": 0, "creator_id": 113168, "revoker_id":
+        113168, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be3d1024-d9df-466c-9e75-afc1ed88b8f5",
+        "name": "test-plc", "description": "", "created_at": "2026-05-26T07:26:21.052034Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be3d1024-d9df-466c-9e75-afc1ed88b8f5",
+        "status": "revoked", "triggered_at": "2026-05-26T08:44:57.678480Z", "revoked_at":
+        "2026-05-26T12:19:01.401494Z", "type": "AWS", "open_events_count": 0, "creator_id":
+        701514, "revoker_id": 701514, "creator_api_token_id": null, "revoker_api_token_id":
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "8409c955-f217-47c9-9cf1-3a6b557c65c9", "name": "Test", "description": "",
+        "created_at": "2026-05-26T14:12:05.347374Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8409c955-f217-47c9-9cf1-3a6b557c65c9",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754650, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "82f00514-d9d3-442c-b575-c40ff77db387", "name": "test-plc2",
+        "description": "", "created_at": "2026-05-27T13:13:33.943814Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/82f00514-d9d3-442c-b575-c40ff77db387",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 701514, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "2fb03282-9878-481c-be5b-eda6036f909d", "name": "ahah-plc", "description":
+        "", "created_at": "2026-06-01T12:43:48.383287Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2fb03282-9878-481c-be5b-eda6036f909d",
+        "status": "triggered", "triggered_at": "2026-06-04T21:49:55.543841Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 701514, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86344c0b-c360-4709-bb6b-fce628ace1d7",
+        "name": "honeytoken-toot-991c4137", "description": "", "created_at": "2026-06-05T17:59:07.240726Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86344c0b-c360-4709-bb6b-fce628ace1d7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
+        "97c1b533-d768-4054-94de-ae3d967a5128", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "949d59d0-c3c2-4d5e-ae3c-4f365b9b8456",
+        "name": "honeytoken-toot-0fefb095", "description": "", "created_at": "2026-06-05T17:59:07.748651Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/949d59d0-c3c2-4d5e-ae3c-4f365b9b8456",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
+        "97c1b533-d768-4054-94de-ae3d967a5128", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ab5965c-8f7e-44ec-b64e-1111e140586f",
+        "name": "ggshield-WOmcC4wM", "description": "description", "created_at": "2026-06-15T15:05:19.990102Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ab5965c-8f7e-44ec-b64e-1111e140586f",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "95786b03-4165-4245-8aef-fac41ff6a1de",
+        "name": "ggshield-E2HxYogl", "description": "description", "created_at": "2026-06-15T15:05:20.446208Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/95786b03-4165-4245-8aef-fac41ff6a1de",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "98271cf2-3025-4e7d-b120-afd29fe20c8f",
+        "name": "ggshield-32Xli2ct", "description": "description", "created_at": "2026-06-15T15:13:44.456933Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/98271cf2-3025-4e7d-b120-afd29fe20c8f",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "68f09d33-1cab-4b93-84a5-2861a7a01fbc",
+        "name": "ggshield-o2ocvFQZ", "description": "description", "created_at": "2026-06-15T15:13:45.228488Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/68f09d33-1cab-4b93-84a5-2861a7a01fbc",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ee69dfd0-fa9c-451d-947e-261c2edd4355",
+        "name": "ggshield-rGxN1k4I", "description": "description", "created_at": "2026-06-15T15:46:58.088837Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ee69dfd0-fa9c-451d-947e-261c2edd4355",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f91525c-02bd-4a0f-9c5d-c9949f7196f4",
+        "name": "ggshield-bZoVll0H", "description": "description", "created_at": "2026-06-15T15:46:58.839510Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f91525c-02bd-4a0f-9c5d-c9949f7196f4",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4a3a3699-fb2e-4e0f-ae02-4905fe8228ec",
+        "name": "ggshield-VuSeELel", "description": "description", "created_at": "2026-06-17T13:23:52.166183Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4a3a3699-fb2e-4e0f-ae02-4905fe8228ec",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "dd2d3e47-d804-41c5-b8b8-f640e6292096", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d82dc520-9ea5-4a38-a9d8-84bf2f94975b",
+        "name": "ggshield-yQlAvTpn", "description": "description", "created_at": "2026-06-17T13:23:52.682610Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d82dc520-9ea5-4a38-a9d8-84bf2f94975b",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "dd2d3e47-d804-41c5-b8b8-f640e6292096", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}]'
     headers:
+      CF-RAY:
+      - a10394cf1a4774cd-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:43:58 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, POST, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '139756'
+      - '145842'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:12 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '786'
+      - '1171'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_honeytokens_get_all.yaml
+++ b/tests/cassettes/client/vcr/test_list_honeytokens_get_all.yaml
@@ -25,33 +25,29 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/411d33c0-7fad-4fc1-b94e-bb440c8f9c49",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:11.250010Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}, {"id": "858a3a76-f6f2-4c2e-b0bc-323d9a575413",
-        "name": "test_honey_token", "description": "description", "created_at": "2023-05-15T14:09:09.210845Z",
+        "token": "[REDACTED]"}, {"id": "858a3a76-f6f2-4c2e-b0bc-323d9a575413", "name":
+        "test_honey_token", "description": "description", "created_at": "2023-05-15T14:09:09.210845Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/858a3a76-f6f2-4c2e-b0bc-323d9a575413",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:17.165934Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}, {"id": "72a52279-8e9f-40de-a1d4-bc5fcc48795d",
-        "name": "passwordscon", "description": "", "created_at": "2023-05-16T10:03:49.677782Z",
+        "token": "[REDACTED]"}, {"id": "72a52279-8e9f-40de-a1d4-bc5fcc48795d", "name":
+        "passwordscon", "description": "", "created_at": "2023-05-16T10:03:49.677782Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72a52279-8e9f-40de-a1d4-bc5fcc48795d",
         "status": "triggered", "triggered_at": "2023-05-16T10:04:10.262805Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 222, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
-        "key": "location", "value": "test"}], "custom_tags": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
+        ["publicly_exposed"], "custom_tags": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
         "key": "location", "value": "test"}], "token": "[REDACTED]"}, {"id": "8bf5f99a-538d-4cfe-8e74-61cd7081ae25",
         "name": "PasswordsCon2", "description": "For presentation", "created_at":
         "2023-05-16T11:30:36.210395Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8bf5f99a-538d-4cfe-8e74-61cd7081ae25",
         "status": "triggered", "triggered_at": "2023-05-16T12:29:45.638074Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 344, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "45182b59-b659-41ef-9bb8-44a78740fade", "name": "solid-octo-repo", "description":
         "Placed in solid-octo repo, file ... on 16May2023", "created_at": "2023-05-16T11:51:06.384073Z",
@@ -59,47 +55,41 @@ interactions:
         "status": "triggered", "triggered_at": "2026-02-18T14:51:12.499369Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432", "key": "place",
-        "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
+        [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432", "key":
+        "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
         "name": "jira-OPS-124", "description": "honeytoken deployed in jira ticket
         OPS-124", "created_at": "2023-05-16T11:58:57.713307Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "63bbd74e-bb5f-4910-8e63-eed358af3bc8",
         "name": "improved-carnival repo", "description": "", "created_at": "2023-05-16T14:45:09.811724Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/63bbd74e-bb5f-4910-8e63-eed358af3bc8",
         "status": "revoked", "triggered_at": "2023-05-16T14:49:44.284195Z", "revoked_at":
         "2024-06-19T10:46:44.282148Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "72fcdb5c-e128-4ca5-8970-f1f52f95a78a",
         "name": "slack-chan-website", "description": "", "created_at": "2023-05-16T15:35:26.129025Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72fcdb5c-e128-4ca5-8970-f1f52f95a78a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
-        "key": "place", "value": "website"}], "custom_tags": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
         "key": "place", "value": "website"}], "token": "[REDACTED]"}, {"id": "84d43c23-6d4d-47f8-bf62-e7c1b0ae1625",
         "name": "analytic-repo", "description": "", "created_at": "2023-05-16T16:17:11.435058Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84d43c23-6d4d-47f8-bf62-e7c1b0ae1625",
         "status": "revoked", "triggered_at": "2023-05-16T16:27:55.091410Z", "revoked_at":
         "2023-12-11T14:01:44.427581Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "ef11a80c-6d8e-4fb5-8ee2-4556bae695c3",
         "name": "test ht public", "description": "", "created_at": "2023-05-17T17:00:24.966335Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef11a80c-6d8e-4fb5-8ee2-4556bae695c3",
         "status": "triggered", "triggered_at": "2023-05-17T17:02:33.386529Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 5012, "creator_id": 166199, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
-        "key": "location", "value": "slack"}], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
+        ["publicly_exposed"], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
         "key": "location", "value": "slack"}], "token": "[REDACTED]"}, {"id": "db7bf6ea-57cb-4d13-8ed9-dc59b2620e00",
         "name": "Honeytoken demo 17 may", "description": "This is a token for the
         live demo", "created_at": "2023-05-17T17:15:04.921233Z", "gitguardian_url":
@@ -107,173 +97,161 @@ interactions:
         "status": "triggered", "triggered_at": "2023-05-17T17:16:48.960267Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 5018, "creator_id": 166199, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "79db31fc-ffd1-4bc9-b6e4-3ef37a94712a", "name": "QubitConfrence", "description":
         "", "created_at": "2023-05-18T07:58:37.174577Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/79db31fc-ffd1-4bc9-b6e4-3ef37a94712a",
         "status": "triggered", "triggered_at": "2023-05-18T09:30:01.025933Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 215, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263", "name": "NDC-OSLO Demo", "description":
-        "Demo key for NDC Oslo confrence", "created_at": "2023-05-25T07:59:05.651290Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
+        "name": "NDC-OSLO Demo", "description": "Demo key for NDC Oslo confrence",
+        "created_at": "2023-05-25T07:59:05.651290Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
         "status": "triggered", "triggered_at": "2023-05-25T08:38:27.471330Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 221, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b6f2b765-a8e5-458f-b68a-4b5ef934bcc8", "name": "Pycon Italia", "description":
-        "", "created_at": "2023-05-28T09:34:01.581495Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
+        "name": "Pycon Italia", "description": "", "created_at": "2023-05-28T09:34:01.581495Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
         "status": "revoked", "triggered_at": "2023-05-28T09:45:30.255118Z", "revoked_at":
         "2024-12-10T12:17:08.199275Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "bb494eed-6ba4-4b98-b949-ad5f54d929dd", "name": "ggshield-uORy0any",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "bb494eed-6ba4-4b98-b949-ad5f54d929dd", "name": "ggshield-uORy0any",
         "description": "description", "created_at": "2023-05-30T10:30:39.803353Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bb494eed-6ba4-4b98-b949-ad5f54d929dd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1266b395-a545-42c1-b700-24dbae36447c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1266b395-a545-42c1-b700-24dbae36447c",
         "name": "test_honey_token_previous", "description": "description", "created_at":
         "2023-05-30T10:30:40.547255Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1266b395-a545-42c1-b700-24dbae36447c",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:41:43.173510Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "f60db759-7041-4dfe-80fa-91012d97fdd3",
         "name": "ggshield-tsCPoUcx", "description": "description", "created_at": "2023-05-30T10:37:14.527124Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f60db759-7041-4dfe-80fa-91012d97fdd3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
         "name": "ggshield-BA0VsBh3", "description": "description", "created_at": "2023-05-30T10:39:09.968782Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e7f275d-e115-44d3-8854-5c6472494951",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e7f275d-e115-44d3-8854-5c6472494951",
         "name": "ggshield-UXgNYVXL", "description": "description", "created_at": "2023-05-30T10:42:36.847031Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6e7f275d-e115-44d3-8854-5c6472494951",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7494298b-75c5-44e4-898c-77b3b9017113",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7494298b-75c5-44e4-898c-77b3b9017113",
         "name": "test_honey_token_abc", "description": "description", "created_at":
         "2023-05-30T10:42:37.520767Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7494298b-75c5-44e4-898c-77b3b9017113",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:45:41.905071Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "092dba62-9d82-41bd-84aa-95430d540edc", "name": "ggshield-224Lwv95",
-        "description": "description", "created_at": "2023-05-30T10:46:10.997022Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "092dba62-9d82-41bd-84aa-95430d540edc",
+        "name": "ggshield-224Lwv95", "description": "description", "created_at": "2023-05-30T10:46:10.997022Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/092dba62-9d82-41bd-84aa-95430d540edc",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
         "name": "test_honey_token_previous", "description": "description", "created_at":
         "2023-05-30T10:46:11.714531Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:07.762156Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "13f6dbf3-ae1a-4757-95f6-e0fbc830fc55", "name": "ggshield-agateau",
-        "description": null, "created_at": "2023-05-30T13:32:31.845201Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
+        "name": "ggshield-agateau", "description": null, "created_at": "2023-05-30T13:32:31.845201Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T13:33:03.363563Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 160089, "revoker_id":
         160089, "creator_api_token_id": "425e1a78-209e-4cd5-b08f-8450a0026ac0", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "f17302cd-850b-4b54-9054-60d26a76cf38", "name": "test demo 31may",
-        "description": "", "created_at": "2023-05-31T08:10:36.754144Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f17302cd-850b-4b54-9054-60d26a76cf38",
+        "name": "test demo 31may", "description": "", "created_at": "2023-05-31T08:10:36.754144Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "41d76272-ee3d-4639-93e8-29222b662b93",
         "name": "demo31may-public", "description": "", "created_at": "2023-05-31T08:13:48.373887Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/41d76272-ee3d-4639-93e8-29222b662b93",
         "status": "revoked", "triggered_at": "2023-05-31T08:15:09.926931Z", "revoked_at":
         "2024-12-10T12:16:03.693045Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "63728091-d083-47cc-9898-73c2636f2c7f", "name": "ggshield-ZIU1V3Bv", "description":
         null, "created_at": "2023-05-31T08:17:12.607879Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/63728091-d083-47cc-9898-73c2636f2c7f",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-31T08:17:38.021142Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "001c53df-b63c-4b81-a4fb-35e5b38bf328", "name": "DevOxx Poland", "description":
-        "", "created_at": "2023-05-31T12:28:39.713989Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/001c53df-b63c-4b81-a4fb-35e5b38bf328",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "001c53df-b63c-4b81-a4fb-35e5b38bf328",
+        "name": "DevOxx Poland", "description": "", "created_at": "2023-05-31T12:28:39.713989Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/001c53df-b63c-4b81-a4fb-35e5b38bf328",
         "status": "triggered", "triggered_at": "2023-05-31T14:09:21.767459Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 225, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05", "name": "ggshield-cptptJHt",
-        "description": "ggshield test", "created_at": "2023-06-02T08:47:41.149126Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05",
+        "name": "ggshield-cptptJHt", "description": "ggshield test", "created_at":
+        "2023-06-02T08:47:41.149126Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
-        "name": "ggshield-TtJwtxNE", "description": "ggshield test", "created_at":
-        "2023-06-02T08:48:20.148216Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72", "name": "ggshield-TtJwtxNE",
+        "description": "ggshield test", "created_at": "2023-06-02T08:48:20.148216Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "27379093-c6a4-4732-a64a-715c94e74fd7",
-        "name": "ggshield-TvFzKVed", "description": null, "created_at": "2023-06-09T08:01:57.360210Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/27379093-c6a4-4732-a64a-715c94e74fd7",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "27379093-c6a4-4732-a64a-715c94e74fd7", "name": "ggshield-TvFzKVed",
+        "description": null, "created_at": "2023-06-09T08:01:57.360210Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/27379093-c6a4-4732-a64a-715c94e74fd7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "62cb7048-4302-4b52-9163-e2ceff775b39", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc7214d0-c97a-44b3-b576-664f0a81c4f7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc7214d0-c97a-44b3-b576-664f0a81c4f7",
         "name": "repo analytics 19jun", "description": "", "created_at": "2023-06-19T09:11:21.788070Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc7214d0-c97a-44b3-b576-664f0a81c4f7",
         "status": "revoked", "triggered_at": "2023-06-20T17:24:35.145047Z", "revoked_at":
         "2023-12-11T14:50:27.627289Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb", "name": "ggshield-0etjSvZJ",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb", "name": "ggshield-0etjSvZJ",
         "description": "description", "created_at": "2023-07-05T08:27:14.048162Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-05T08:27:15.756813Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0e4f0dbd-b288-4990-9565-3cc7b0171a79",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:53.240550Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 160089, "revoker_id":
         296618, "creator_api_token_id": "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "14566c1f-0b52-4770-ab68-000704242633", "name": "ggshield-Rv2mUej7",
-        "description": "description", "created_at": "2023-07-05T08:55:23.864812Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "14566c1f-0b52-4770-ab68-000704242633",
+        "name": "ggshield-Rv2mUej7", "description": "description", "created_at": "2023-07-05T08:55:23.864812Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/14566c1f-0b52-4770-ab68-000704242633",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c8c94ffa-c0af-48c6-976a-6502a41811af",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c8c94ffa-c0af-48c6-976a-6502a41811af",
         "name": "honeytoken demo eric", "description": "demo here", "created_at":
         "2023-07-05T14:48:53.893911Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c8c94ffa-c0af-48c6-976a-6502a41811af",
         "status": "triggered", "triggered_at": "2023-07-05T14:49:33.528178Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
         "name": "Example TOken ", "description": "ubvcub", "created_at": "2023-07-12T13:16:10.775681Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
-        "key": "file", "value": ".env"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "0c3f182e-98f5-4a64-aadb-664fd7c9de88", "name": "ggshield-ewIAL7lq", "description":
@@ -282,58 +260,55 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
         "name": "ggshield-w1P1Ggsz", "description": "description", "created_at": "2023-07-27T08:56:55.435203Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a20a718-7b9e-4582-abdf-772053bffd72",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a20a718-7b9e-4582-abdf-772053bffd72",
         "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T08:56:56.138738Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a20a718-7b9e-4582-abdf-772053bffd72",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:58.657957Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "51f41814-f029-4ab4-b863-c0fecba025b3", "name": "ggshield-v3LhZCz8",
-        "description": "description", "created_at": "2023-07-27T09:01:36.117217Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51f41814-f029-4ab4-b863-c0fecba025b3",
+        "name": "ggshield-v3LhZCz8", "description": "description", "created_at": "2023-07-27T09:01:36.117217Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/51f41814-f029-4ab4-b863-c0fecba025b3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T09:01:36.764795Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-27T09:01:37.417151Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e842a635-eb7e-4617-8984-ac57fe909ef7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
         "name": "ggshield-5voYnhhy", "description": null, "created_at": "2023-07-27T13:50:51.332176Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T13:52:58.300149Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "521efd01-bbcc-4380-b548-ed7242c017ea",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "521efd01-bbcc-4380-b548-ed7242c017ea",
         "name": "ggshield-HLZpiznn", "description": null, "created_at": "2023-07-27T14:54:03.198466Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/521efd01-bbcc-4380-b548-ed7242c017ea",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0d81797a-6fc0-4a6e-a211-af16828c0c39",
-        "name": "Webinar Public ", "description": "from webinar ", "created_at": "2023-07-27T15:33:07.472730Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0d81797a-6fc0-4a6e-a211-af16828c0c39", "name": "Webinar
+        Public ", "description": "from webinar ", "created_at": "2023-07-27T15:33:07.472730Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0d81797a-6fc0-4a6e-a211-af16828c0c39",
         "status": "triggered", "triggered_at": "2023-07-27T15:34:48.902462Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 204, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "27e9ba01-4bb6-46ed-84c8-ff14366a3bde", "name": "Private network", "description":
@@ -342,60 +317,55 @@ interactions:
         "status": "triggered", "triggered_at": "2023-07-27T16:23:35.804271Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5670c657-618f-41d7-984b-d59656d905e4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5670c657-618f-41d7-984b-d59656d905e4",
         "name": "ggshield-3KTmbo8u", "description": null, "created_at": "2023-07-27T15:44:43.238742Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5670c657-618f-41d7-984b-d59656d905e4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5d3ad22c-e422-48d2-b7f5-6d52801599aa",
-        "name": "demo 31jul", "description": "", "created_at": "2023-07-31T15:27:18.323098Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d3ad22c-e422-48d2-b7f5-6d52801599aa",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5d3ad22c-e422-48d2-b7f5-6d52801599aa", "name": "demo
+        31jul", "description": "", "created_at": "2023-07-31T15:27:18.323098Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d3ad22c-e422-48d2-b7f5-6d52801599aa",
         "status": "revoked", "triggered_at": "2023-07-31T15:33:49.570793Z", "revoked_at":
         "2023-12-11T14:01:40.706751Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a", "name": "test
-        Antonin 1", "description": "", "created_at": "2023-08-03T08:42:25.251504Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fa63d76d-4297-4d41-8e77-b47d1a97a41a",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a", "name": "test Antonin 1", "description":
+        "", "created_at": "2023-08-03T08:42:25.251504Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fa63d76d-4297-4d41-8e77-b47d1a97a41a",
         "status": "revoked", "triggered_at": "2023-08-03T08:59:58.717709Z", "revoked_at":
         "2023-08-03T09:00:05.809852Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "a11570c6-f472-4fda-a493-30d65fd8e651", "name": "test Antonin 2", "description":
-        "", "created_at": "2023-08-03T14:09:46.046004Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a11570c6-f472-4fda-a493-30d65fd8e651",
+        "name": "test Antonin 2", "description": "", "created_at": "2023-08-03T14:09:46.046004Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40",
-        "name": "vBOY test segment", "description": "sdqsdqsdqsdqsd", "created_at":
-        "2023-08-07T12:45:52.890085Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40", "name": "vBOY
+        test segment", "description": "sdqsdqsdqsdqsd", "created_at": "2023-08-07T12:45:52.890085Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-08-07T12:46:45.470113Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "name": "vBOY test segment 2", "description": "sdqsdqsd", "created_at": "2023-08-07T12:47:49.515448Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "86670f84-e117-4f96-aa16-e399a0bb2cf2",
-        "name": "juuj", "description": "", "created_at": "2023-08-08T15:53:23.097840Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86670f84-e117-4f96-aa16-e399a0bb2cf2",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "86670f84-e117-4f96-aa16-e399a0bb2cf2", "name": "juuj",
+        "description": "", "created_at": "2023-08-08T15:53:23.097840Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/86670f84-e117-4f96-aa16-e399a0bb2cf2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
-        "name": "BSidesLV", "description": "Key leaked publically by leakymcgee again",
-        "created_at": "2023-08-10T00:11:42.132386Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "978bf5aa-1f8e-425b-ac4b-b617ddbc178e", "name": "BSidesLV",
+        "description": "Key leaked publically by leakymcgee again", "created_at":
+        "2023-08-10T00:11:42.132386Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
         "status": "triggered", "triggered_at": "2023-08-10T00:13:19.948280Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
-        "key": "date leaked", "value": "08/09/2023"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
-        "key": "format", "value": "public"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
+        ["publicly_exposed"], "custom_tags": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
         "key": "date leaked", "value": "08/09/2023"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
         "key": "format", "value": "public"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
@@ -405,9 +375,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-08-11T18:55:35.503991Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 61, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
+        ["publicly_exposed"], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "90d4c2b6-ecae-4ef9-a754-4561929b9e38",
         "name": "ggshield-mpkTH5jF", "description": "description", "created_at": "2023-08-16T08:28:18.684517Z",
@@ -415,34 +383,31 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
         "name": "ggshield-mzO8qHEz", "description": "description", "created_at": "2023-08-22T08:19:03.821471Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
         "name": "testket ", "description": "eew", "created_at": "2023-08-29T10:21:29.956291Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "46776cb3-6b11-41fc-b431-07609992f0cb",
-        "name": "HoneyTokenaLARTest", "description": "Testworkshop", "created_at":
-        "2023-08-29T12:07:20.692993Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/46776cb3-6b11-41fc-b431-07609992f0cb",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "46776cb3-6b11-41fc-b431-07609992f0cb", "name": "HoneyTokenaLARTest",
+        "description": "Testworkshop", "created_at": "2023-08-29T12:07:20.692993Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/46776cb3-6b11-41fc-b431-07609992f0cb",
         "status": "revoked", "triggered_at": "2023-08-29T12:09:16.581232Z", "revoked_at":
         "2023-08-29T12:42:37.841866Z", "type": "AWS", "open_events_count": 0, "creator_id":
         37699, "revoker_id": 37699, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "edd96a3b-5c71-4346-b5e2-2150e454dc91", "name": "Bsides Krakow", "description":
-        "Demo for leaking a key on GitHub", "created_at": "2023-09-02T13:20:53.501588Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/edd96a3b-5c71-4346-b5e2-2150e454dc91",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "edd96a3b-5c71-4346-b5e2-2150e454dc91",
+        "name": "Bsides Krakow", "description": "Demo for leaking a key on GitHub",
+        "created_at": "2023-09-02T13:20:53.501588Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/edd96a3b-5c71-4346-b5e2-2150e454dc91",
         "status": "triggered", "triggered_at": "2023-09-02T13:22:51.142717Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "de145bd4-b424-49ab-b95b-80126914bf2e",
         "name": "ctf-demo-test-honeytoken-django-app", "description": "", "created_at":
@@ -450,68 +415,59 @@ interactions:
         "status": "revoked", "triggered_at": "2023-09-06T07:42:55.177580Z", "revoked_at":
         "2023-09-06T10:03:30.948628Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "5564ed3c-3eec-4375-9fc8-e0ada71dce02", "name": "ctf-demo-test-honeytoken-micro-api",
-        "description": "", "created_at": "2023-09-05T19:18:08.504776Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/5564ed3c-3eec-4375-9fc8-e0ada71dce02",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5564ed3c-3eec-4375-9fc8-e0ada71dce02",
+        "name": "ctf-demo-test-honeytoken-micro-api", "description": "", "created_at":
+        "2023-09-05T19:18:08.504776Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5564ed3c-3eec-4375-9fc8-e0ada71dce02",
         "status": "revoked", "triggered_at": "2023-09-06T07:44:18.074891Z", "revoked_at":
         "2023-09-06T10:03:48.581110Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "f246c64a-3494-43ae-9d81-500df2f950c3", "name": "demo-honeytoken-ctf-personal-",
-        "description": "", "created_at": "2023-09-06T11:29:57.547211Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/f246c64a-3494-43ae-9d81-500df2f950c3",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f246c64a-3494-43ae-9d81-500df2f950c3",
+        "name": "demo-honeytoken-ctf-personal-", "description": "", "created_at":
+        "2023-09-06T11:29:57.547211Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f246c64a-3494-43ae-9d81-500df2f950c3",
         "status": "revoked", "triggered_at": "2023-09-06T12:18:14.949044Z", "revoked_at":
         "2024-12-10T12:15:49.265110Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
         "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "ff623703-9ca1-4fba-99dc-c20110894ed3",
         "name": "-demo-honeytoken-ctf-django-app-", "description": "", "created_at":
         "2023-09-06T11:33:27.376222Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff623703-9ca1-4fba-99dc-c20110894ed3",
         "status": "triggered", "triggered_at": "2023-09-06T14:19:10.580142Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 4, "creator_id": null, "revoker_id":
+        null, "type": "AWS", "open_events_count": 9, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "a58154f6-e66f-4079-82b7-aabec70c73ff",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "a58154f6-e66f-4079-82b7-aabec70c73ff",
         "name": "demo-honeytoken-ctf-micro-api", "description": "", "created_at":
         "2023-09-06T11:33:37.828240Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a58154f6-e66f-4079-82b7-aabec70c73ff",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-09-06T14:17:20.708816Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b01db549-a2fa-4527-913d-0715a1119530",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "b01db549-a2fa-4527-913d-0715a1119530",
         "name": "demo-honeytoken-ctf-internal-share-", "description": "", "created_at":
         "2023-09-06T11:33:48.881275Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b01db549-a2fa-4527-913d-0715a1119530",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-09-06T14:21:42.509905Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "89a1745a-f796-4ece-99f7-106671aea57c",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "89a1745a-f796-4ece-99f7-106671aea57c",
         "name": "-demo-honeytoken-ctf-micro-api-", "description": "", "created_at":
         "2023-09-06T14:19:32.695323Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/89a1745a-f796-4ece-99f7-106671aea57c",
         "status": "triggered", "triggered_at": "2023-09-06T14:24:18.462424Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "095d655f-a273-400f-ba01-eff8951242ed",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "095d655f-a273-400f-ba01-eff8951242ed",
         "name": "-demo-honeytoken-ctf-internal-share-", "description": "", "created_at":
         "2023-09-06T14:21:55.062468Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/095d655f-a273-400f-ba01-eff8951242ed",
         "status": "triggered", "triggered_at": "2023-09-08T16:58:49.455578Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 6, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "3664c283-d479-41ac-9ad9-30283731ee25",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "3664c283-d479-41ac-9ad9-30283731ee25",
         "name": "Balccon Demo", "description": "Demo key for Balccon ", "created_at":
         "2023-09-08T14:55:02.417580Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3664c283-d479-41ac-9ad9-30283731ee25",
         "status": "triggered", "triggered_at": "2023-09-08T14:56:49.516889Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
-        "key": "location", "value": "sourcecode"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
-        "key": "visability", "value": "public"}], "custom_tags": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
+        ["publicly_exposed"], "custom_tags": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
         "key": "location", "value": "sourcecode"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
         "key": "visability", "value": "public"}], "token": "[REDACTED]"}, {"id": "7ca5ca92-a0a1-48bf-9618-d7194beaa039",
@@ -520,9 +476,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-09-29T16:11:40.077048Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 344, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
-        "key": "confrence", "value": "grrcon"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}], "custom_tags": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
+        ["publicly_exposed"], "custom_tags": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
         "key": "confrence", "value": "grrcon"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}], "token": "[REDACTED]"}, {"id": "2544b3e6-57b2-48e2-a1a5-c4b6551987bb",
         "name": "SBB demo", "description": "Leaking key on GitHub", "created_at":
@@ -530,11 +484,8 @@ interactions:
         "status": "triggered", "triggered_at": "2024-08-17T15:36:55.810693Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key": "commiter",
-        "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca", "key":
-        "file", "value": ".env"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327", "key":
-        "vcs", "value": "github"}], "custom_tags": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda",
-        "key": "commiter", "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
+        [], "custom_tags": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key":
+        "commiter", "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "7d80793b-c702-441e-837e-b1d3da94d576",
         "name": "Hacktivity Key", "description": "Test Key Leak for Hacktivity", "created_at":
@@ -542,9 +493,7 @@ interactions:
         "status": "revoked", "triggered_at": "2023-10-05T14:42:57.752365Z", "revoked_at":
         "2024-12-10T12:17:33.875750Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "576dc1ce-ab72-4604-934f-526cff5a667e", "name": "BsidesCyprus", "description":
@@ -553,8 +502,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-10-07T11:35:53.017981Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 249, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "22fdf53a-e348-464a-a87f-5bcecb1a4e62", "name": "Slack test", "description":
         "blablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablabla
@@ -567,21 +515,20 @@ interactions:
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-06-03T09:50:06.667490Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 363707, "revoker_id":
         353920, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "137c9fee-4b3c-4231-92fd-98debf6557c2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "137c9fee-4b3c-4231-92fd-98debf6557c2",
         "name": "BSides ATL demo for session", "description": "This one will be triggered
         from 2 different spots online", "created_at": "2023-10-14T12:28:51.206659Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/137c9fee-4b3c-4231-92fd-98debf6557c2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 354585, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "cdaea884-25fb-49db-90ec-a18879be36c4",
-        "name": "Demo Honeytoken", "description": "Leaking on Public Demo", "created_at":
-        "2023-10-16T15:13:10.845487Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cdaea884-25fb-49db-90ec-a18879be36c4",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "cdaea884-25fb-49db-90ec-a18879be36c4", "name": "Demo
+        Honeytoken", "description": "Leaking on Public Demo", "created_at": "2023-10-16T15:13:10.845487Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cdaea884-25fb-49db-90ec-a18879be36c4",
         "status": "revoked", "triggered_at": "2023-10-16T15:14:25.574559Z", "revoked_at":
         "2023-10-27T15:01:19.053629Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "48f7c567-93d1-4925-9f77-d3919f120b88", "name": "ggshield-KlAkKRtE", "description":
         "description", "created_at": "2023-10-16T19:49:08.588391Z", "gitguardian_url":
@@ -589,52 +536,50 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
         "name": "Jason test", "description": "Token for Test ", "created_at": "2023-10-24T13:45:31.371710Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f8e0968-664a-49f3-af85-9cc468b960ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "fe392ff1-b3d7-462f-a26f-d094326f40ed",
-        "name": "Jason and team", "description": "akljdlaj", "created_at": "2023-10-24T14:23:20.991107Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fe392ff1-b3d7-462f-a26f-d094326f40ed", "name": "Jason
+        and team", "description": "akljdlaj", "created_at": "2023-10-24T14:23:20.991107Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fe392ff1-b3d7-462f-a26f-d094326f40ed",
         "status": "triggered", "triggered_at": "2024-05-10T22:15:09.224357Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29",
         "name": "Eric Demo Test 01", "description": "", "created_at": "2023-10-31T12:51:44.535200Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d69a098c-8b61-4102-bb2b-9a82958a3e29",
         "status": "revoked", "triggered_at": "2023-10-31T12:52:49.851916Z", "revoked_at":
         "2024-12-10T12:16:28.115539Z", "type": "AWS", "open_events_count": 0, "creator_id":
         136170, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb", "name": "test
-        eric dd 02", "description": "", "created_at": "2023-10-31T14:33:35.801324Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4affa602-902b-47ff-a1f4-721dc3e671bb",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb", "name": "test eric dd 02",
+        "description": "", "created_at": "2023-10-31T14:33:35.801324Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/4affa602-902b-47ff-a1f4-721dc3e671bb",
         "status": "triggered", "triggered_at": "2023-10-31T14:35:33.676298Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 2897, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "8df388e2-aeb5-42ca-b6d5-221a54a40339", "name": "ggshield-P47kTh7j",
-        "description": null, "created_at": "2023-11-09T15:44:33.671666Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/8df388e2-aeb5-42ca-b6d5-221a54a40339",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8df388e2-aeb5-42ca-b6d5-221a54a40339",
+        "name": "ggshield-P47kTh7j", "description": null, "created_at": "2023-11-09T15:44:33.671666Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8df388e2-aeb5-42ca-b6d5-221a54a40339",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "bd51c3d9-0943-43d5-8f87-359ecee03903",
-        "name": "ggshield-73VAsjsO", "description": null, "created_at": "2023-11-14T08:27:44.885242Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bd51c3d9-0943-43d5-8f87-359ecee03903",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "bd51c3d9-0943-43d5-8f87-359ecee03903", "name": "ggshield-73VAsjsO",
+        "description": null, "created_at": "2023-11-14T08:27:44.885242Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/bd51c3d9-0943-43d5-8f87-359ecee03903",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-11-14T08:28:08.188201Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
         "name": "DeepSec Demo", "description": "Demo for DeepSec Confrence ", "created_at":
         "2023-11-16T16:01:21.723176Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
         "status": "triggered", "triggered_at": "2023-11-16T16:01:58.603599Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "ae448808-3865-4797-a008-9eef6344f9da", "name": "Bsides Berlin", "description":
         "test key for a demo", "created_at": "2023-11-18T16:19:36.463172Z", "gitguardian_url":
@@ -642,9 +587,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-11-18T16:20:14.365596Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 105, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
-        "key": "repo", "value": "mackenziejj"}], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
+        ["publicly_exposed"], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
         "key": "repo", "value": "mackenziejj"}], "token": "[REDACTED]"}, {"id": "ecb3d61d-bdab-4636-a436-bef8079a005d",
         "name": "ggshield-ObfCUUCA", "description": "description", "created_at": "2023-11-28T08:50:32.130230Z",
@@ -652,48 +595,41 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d6d5d79d-08fa-4c8a-bd54-c34851866cde",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d6d5d79d-08fa-4c8a-bd54-c34851866cde",
         "name": "test1112", "description": "test publicly exposed honeytoken", "created_at":
         "2023-12-11T16:24:56.253683Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d6d5d79d-08fa-4c8a-bd54-c34851866cde",
         "status": "triggered", "triggered_at": "2023-12-11T16:26:07.733443Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "4046ccf5-7821-47f4-be7d-8240be69631b",
         "name": "ideal-journey-lena", "description": "", "created_at": "2023-12-11T16:29:20.759489Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4046ccf5-7821-47f4-be7d-8240be69631b",
-        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
-        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
+        "status": "triggered", "triggered_at": "2026-05-28T07:56:58.047592Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 5, "creator_id": 319222, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
         "name": "analytics-repo", "description": "", "created_at": "2023-12-11T17:37:24.471286Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
         "status": "triggered", "triggered_at": "2023-12-11T17:46:48.024345Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "b7daf77c-e3e0-4747-a7e2-485a1a6f05e2",
-        "key": "team", "value": "dev"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "b7daf77c-e3e0-4747-a7e2-485a1a6f05e2",
         "key": "team", "value": "dev"}], "token": "[REDACTED]"}, {"id": "52903632-f6ff-460e-8a68-80a942349979",
         "name": "Network Honeytoken", "description": "Aws Honeytoken on Network",
         "created_at": "2023-12-18T13:47:39.151311Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/52903632-f6ff-460e-8a68-80a942349979",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
-        "key": "network", "value": "directory"}], "custom_tags": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
         "key": "network", "value": "directory"}], "token": "[REDACTED]"}, {"id": "6c5d9856-835e-468c-9448-7bf0e77f1e53",
         "name": "improved carnival", "description": "", "created_at": "2023-12-21T13:43:01.544215Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6c5d9856-835e-468c-9448-7bf0e77f1e53",
         "status": "revoked", "triggered_at": "2023-12-21T13:57:59.435706Z", "revoked_at":
         "2023-12-22T09:33:18.668820Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "4dd77510-fc74-411f-9dbe-77619fa920dd",
         "name": "My Postman Public Collection", "description": "Will it ring?", "created_at":
@@ -701,242 +637,231 @@ interactions:
         "status": "triggered", "triggered_at": "2024-01-04T17:52:01.203498Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 811, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
         "name": "ggshield-JZV5XT71", "description": "description", "created_at": "2024-01-09T09:39:34.421404Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "name": "sss", "description": "test", "created_at": "2024-01-09T14:24:10.741214Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
-        "name": "AWS key honeytoken for Slack", "description": "Honeytoken on Slack
-        channel", "created_at": "2024-01-15T16:13:53.656688Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "123ecd19-e66f-4e5c-ad73-12f0a51eda5a", "name": "AWS
+        key honeytoken for Slack", "description": "Honeytoken on Slack channel", "created_at":
+        "2024-01-15T16:13:53.656688Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
         "status": "triggered", "triggered_at": "2024-01-15T16:14:14.960066Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 104, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "23ca2658-aecf-471c-abf0-add09962e320", "key": "ods",
-        "value": "slack"}], "custom_tags": [{"id": "23ca2658-aecf-471c-abf0-add09962e320",
-        "key": "ods", "value": "slack"}], "token": "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a",
+        [], "custom_tags": [{"id": "23ca2658-aecf-471c-abf0-add09962e320", "key":
+        "ods", "value": "slack"}], "token": "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a",
         "name": "BK Test Paris", "description": "Brandon while in Paris office", "created_at":
         "2024-01-17T11:12:14.759334Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/34d5205b-accd-429c-9efa-eda48989c83a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
-        "name": "Lauren Testing", "description": "Lauren wuz here", "created_at":
-        "2024-01-29T17:37:45.379096Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4", "name": "Lauren
+        Testing", "description": "Lauren wuz here", "created_at": "2024-01-29T17:37:45.379096Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 637596, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "07fb5f6f-23f1-42e8-bdb2-c95864412a16",
         "name": "My Little Honeytoken", "description": "for testing", "created_at":
         "2024-02-02T22:18:06.038874Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/07fb5f6f-23f1-42e8-bdb2-c95864412a16",
         "status": "triggered", "triggered_at": "2024-02-09T20:50:13.173911Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b00bfddb-98c2-48e4-ad38-0cb9bc79cad6", "name": "orga_083643/solid-octo",
-        "description": "", "created_at": "2024-02-09T14:45:12.139727Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
+        "name": "orga_083643/solid-octo", "description": "", "created_at": "2024-02-09T14:45:12.139727Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
         "status": "revoked", "triggered_at": "2024-02-09T14:52:11.339548Z", "revoked_at":
         "2024-05-29T13:09:29.773300Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 2508, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "cf0806c4-093d-4165-9ad3-7e7ded211d3f", "name": "DemoKey", "description":
-        "sss", "created_at": "2024-02-15T12:39:23.633481Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cf0806c4-093d-4165-9ad3-7e7ded211d3f",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cf0806c4-093d-4165-9ad3-7e7ded211d3f",
+        "name": "DemoKey", "description": "sss", "created_at": "2024-02-15T12:39:23.633481Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cf0806c4-093d-4165-9ad3-7e7ded211d3f",
         "status": "triggered", "triggered_at": "2024-02-15T12:45:44.649197Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "638f6f82-6679-4399-a336-dd7996f4beae", "name": "demo-2024-02-16dm",
-        "description": "demo", "created_at": "2024-02-16T19:39:33.970811Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/638f6f82-6679-4399-a336-dd7996f4beae",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "638f6f82-6679-4399-a336-dd7996f4beae",
+        "name": "demo-2024-02-16dm", "description": "demo", "created_at": "2024-02-16T19:39:33.970811Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/638f6f82-6679-4399-a336-dd7996f4beae",
         "status": "revoked", "triggered_at": "2024-02-16T19:40:02.759791Z", "revoked_at":
         "2024-02-16T20:10:11.153368Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "6fcc5cf2-4b47-497d-9a80-c2d794b96ebc", "name": "solid-octo",
-        "description": "", "created_at": "2024-02-19T13:06:26.880374Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "6fcc5cf2-4b47-497d-9a80-c2d794b96ebc", "name": "solid-octo", "description":
+        "", "created_at": "2024-02-19T13:06:26.880374Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
-        "key": "team", "value": "octo"}], "custom_tags": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
         "key": "team", "value": "octo"}], "token": "[REDACTED]"}, {"id": "1592023a-2f39-4ba6-a503-4c07132f1eb0",
         "name": "GGnikalston/rock-paper-scissors-f4c01375", "description": "", "created_at":
         "2024-02-20T13:32:45.163630Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1592023a-2f39-4ba6-a503-4c07132f1eb0",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d024b464-cd1e-4daf-9b1d-863dcf517a7a",
-        "name": "Demo -2024-02-22", "description": "", "created_at": "2024-02-22T18:53:26.142516Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d024b464-cd1e-4daf-9b1d-863dcf517a7a", "name": "Demo
+        -2024-02-22", "description": "", "created_at": "2024-02-22T18:53:26.142516Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d024b464-cd1e-4daf-9b1d-863dcf517a7a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 354585, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0a94480f-5361-47f8-bc23-45a331624e9d",
-        "name": "demo ", "description": "demo ", "created_at": "2024-02-22T19:02:29.338420Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0a94480f-5361-47f8-bc23-45a331624e9d",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0a94480f-5361-47f8-bc23-45a331624e9d", "name": "demo
+        ", "description": "demo ", "created_at": "2024-02-22T19:02:29.338420Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/0a94480f-5361-47f8-bc23-45a331624e9d",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T17:03:31.533534Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86136984-d415-41c2-bfc4-59da8f9584fd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86136984-d415-41c2-bfc4-59da8f9584fd",
         "name": "demo-2024-02-23-dm", "description": "", "created_at": "2024-02-23T15:38:04.895275Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86136984-d415-41c2-bfc4-59da8f9584fd",
         "status": "revoked", "triggered_at": "2024-02-23T15:49:03.613445Z", "revoked_at":
         "2024-02-23T15:59:54.768989Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "b38455f9-822c-4f21-8525-0d4f2fa63850", "name": "demo-dwayne-2024-02-23",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "b38455f9-822c-4f21-8525-0d4f2fa63850", "name": "demo-dwayne-2024-02-23",
         "description": "dfnijsbuisbfids", "created_at": "2024-02-23T15:45:47.636481Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b38455f9-822c-4f21-8525-0d4f2fa63850",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T16:28:23.939971Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "612055eb-7fb5-4ba3-ab10-aa481f3d9962",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "612055eb-7fb5-4ba3-ab10-aa481f3d9962",
         "name": "demo-dwayne-2024-02-23-v2", "description": "Demo for video", "created_at":
         "2024-02-23T16:28:49.949332Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/612055eb-7fb5-4ba3-ab10-aa481f3d9962",
         "status": "revoked", "triggered_at": "2024-02-23T16:31:01.657151Z", "revoked_at":
         "2024-02-23T16:52:50.712289Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e", "name": "myname-dwayneptoday",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e", "name": "myname-dwayneptoday",
         "description": "dfsdfsdf", "created_at": "2024-02-23T16:38:14.323313Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T17:03:21.653827Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1bba091c-fc4c-48b5-b558-46c191f67103",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1bba091c-fc4c-48b5-b558-46c191f67103",
         "name": "ggshield-ldC5hqqo", "description": "description", "created_at": "2024-02-27T13:42:36.686028Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1bba091c-fc4c-48b5-b558-46c191f67103",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d7764013-fdd5-4b08-b195-dff5a338906d",
-        "name": "ggshield-LRYYnjOa", "description": "description", "created_at": "2024-02-27T13:42:37.569678Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d7764013-fdd5-4b08-b195-dff5a338906d", "name": "ggshield-LRYYnjOa",
+        "description": "description", "created_at": "2024-02-27T13:42:37.569678Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d7764013-fdd5-4b08-b195-dff5a338906d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "def4a23d-3d12-4fe1-b8e0-02250e74e47a",
-        "name": "ggshield-itglxnie", "description": "description", "created_at": "2024-02-27T13:58:30.205444Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "def4a23d-3d12-4fe1-b8e0-02250e74e47a", "name": "ggshield-itglxnie",
+        "description": "description", "created_at": "2024-02-27T13:58:30.205444Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/def4a23d-3d12-4fe1-b8e0-02250e74e47a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "33d149f1-68f4-4446-ae4f-def0ce962724",
-        "name": "ggshield-2Mf02eVA", "description": "description", "created_at": "2024-02-27T13:58:31.125075Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "33d149f1-68f4-4446-ae4f-def0ce962724", "name": "ggshield-2Mf02eVA",
+        "description": "description", "created_at": "2024-02-27T13:58:31.125075Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/33d149f1-68f4-4446-ae4f-def0ce962724",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5ff5eee1-fc18-4474-86fa-c46321c903c8",
-        "name": "ggshield-rmnfzrW2", "description": "description", "created_at": "2024-02-27T14:02:45.009113Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5ff5eee1-fc18-4474-86fa-c46321c903c8", "name": "ggshield-rmnfzrW2",
+        "description": "description", "created_at": "2024-02-27T14:02:45.009113Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5ff5eee1-fc18-4474-86fa-c46321c903c8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "4dd6c06e-e2c0-4593-9be0-b0418ba7a370",
-        "name": "ggshield-5YTKZZTB", "description": "description", "created_at": "2024-02-27T14:02:45.717261Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "4dd6c06e-e2c0-4593-9be0-b0418ba7a370", "name": "ggshield-5YTKZZTB",
+        "description": "description", "created_at": "2024-02-27T14:02:45.717261Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4dd6c06e-e2c0-4593-9be0-b0418ba7a370",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "eba79796-4f46-4e10-b876-280f75138cc9",
-        "name": "ggshield-z3Y6zgih", "description": "description", "created_at": "2024-02-27T14:06:02.196977Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "eba79796-4f46-4e10-b876-280f75138cc9", "name": "ggshield-z3Y6zgih",
+        "description": "description", "created_at": "2024-02-27T14:06:02.196977Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/eba79796-4f46-4e10-b876-280f75138cc9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0ebc8091-454b-461e-a6f8-fd17bf412c76",
-        "name": "ggshield-jqk54PrI", "description": "description", "created_at": "2024-02-27T14:06:03.018091Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0ebc8091-454b-461e-a6f8-fd17bf412c76", "name": "ggshield-jqk54PrI",
+        "description": "description", "created_at": "2024-02-27T14:06:03.018091Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ebc8091-454b-461e-a6f8-fd17bf412c76",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "664af568-cfc7-4726-9fb4-0b61606b7386",
-        "name": "ggshield-horgQNnR", "description": "description", "created_at": "2024-02-27T14:19:39.357690Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "664af568-cfc7-4726-9fb4-0b61606b7386", "name": "ggshield-horgQNnR",
+        "description": "description", "created_at": "2024-02-27T14:19:39.357690Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/664af568-cfc7-4726-9fb4-0b61606b7386",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5d915aca-6f6f-4b4e-a996-2c1f53016114",
-        "name": "ggshield-LNgN8R1S", "description": "description", "created_at": "2024-02-27T14:19:40.283320Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5d915aca-6f6f-4b4e-a996-2c1f53016114", "name": "ggshield-LNgN8R1S",
+        "description": "description", "created_at": "2024-02-27T14:19:40.283320Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d915aca-6f6f-4b4e-a996-2c1f53016114",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245",
-        "name": "Test key ", "description": "ss", "created_at": "2024-02-29T13:49:52.467489Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245", "name": "Test
+        key ", "description": "ss", "created_at": "2024-02-29T13:49:52.467489Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e",
-        "name": "test-lena-1903", "description": "", "created_at": "2024-03-19T09:13:00.819618Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/443045cc-7fa4-441d-a161-b060bd7fbb3e",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e", "name": "test-lena-1903",
+        "description": "", "created_at": "2024-03-19T09:13:00.819618Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/443045cc-7fa4-441d-a161-b060bd7fbb3e",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-05-29T09:51:31.597203Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 319222, "revoker_id":
         319222, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
         "name": "ggshield-Psfrcoxl", "description": "description", "created_at": "2024-03-27T08:48:20.857237Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5a01f826-4f8f-4235-8867-ce58ac88ce1c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5a01f826-4f8f-4235-8867-ce58ac88ce1c",
         "name": "ggshield-inUFY47O", "description": "description", "created_at": "2024-03-27T08:48:21.791104Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5a01f826-4f8f-4235-8867-ce58ac88ce1c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d72113d0-c346-42c7-bd88-fd5fe0e716f3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d72113d0-c346-42c7-bd88-fd5fe0e716f3",
         "name": "ggshield-eY0ZOlXS", "description": "description", "created_at": "2024-04-30T09:25:38.689800Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d72113d0-c346-42c7-bd88-fd5fe0e716f3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "7f2873cd-3759-4727-a683-31cac57fe5d8",
-        "name": "ggshield-TvlX76OG", "description": "description", "created_at": "2024-04-30T09:25:39.573115Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "7f2873cd-3759-4727-a683-31cac57fe5d8", "name": "ggshield-TvlX76OG",
+        "description": "description", "created_at": "2024-04-30T09:25:39.573115Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7f2873cd-3759-4727-a683-31cac57fe5d8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "72e98633-9179-4a3e-8908-ea2319d19b3b",
-        "name": "ggshield-XYKDhLUY", "description": "description", "created_at": "2024-04-30T10:19:12.369644Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "72e98633-9179-4a3e-8908-ea2319d19b3b", "name": "ggshield-XYKDhLUY",
+        "description": "description", "created_at": "2024-04-30T10:19:12.369644Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72e98633-9179-4a3e-8908-ea2319d19b3b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
         "name": "ggshield-HRoZzrBq", "description": "description", "created_at": "2024-04-30T10:19:13.126568Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
         "name": "Test key", "description": "Access key", "created_at": "2024-05-22T12:16:55.833940Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c7101eaa-ea38-495d-b3b4-c016db23e859",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "a67f962c-9dde-40c2-b404-e7cd4449cc82",
         "name": "pouet", "description": "", "created_at": "2024-05-22T12:19:03.143437Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a67f962c-9dde-40c2-b404-e7cd4449cc82",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
-        "key": "visability", "value": "public"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
         "key": "visability", "value": "public"}], "token": "[REDACTED]"}, {"id": "9cca01c5-535f-4f89-a214-6c4c5579fd07",
@@ -944,487 +869,473 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9cca01c5-535f-4f89-a214-6c4c5579fd07",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
-        "name": "test lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
-        "status": "triggered", "triggered_at": "2024-06-06T08:19:18.422045Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 319222, "revoker_id":
-        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca", "key": "machine",
-        "value": "ggprdgim01"}], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99", "name": "test
+        lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
         "key": "machine", "value": "ggprdgim01"}], "token": "[REDACTED]"}, {"id":
         "a411fa2c-a465-4099-8353-3c42365aca50", "name": "test MINT", "description":
         "test MINT", "created_at": "2024-06-10T14:40:08.522247Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/a411fa2c-a465-4099-8353-3c42365aca50",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "12c4562e-deb8-4d14-bb23-e344e79b6f04",
-        "name": "ggshield-Wq4EyTMI", "description": "description", "created_at": "2024-06-25T08:36:52.179380Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "12c4562e-deb8-4d14-bb23-e344e79b6f04", "name": "ggshield-Wq4EyTMI",
+        "description": "description", "created_at": "2024-06-25T08:36:52.179380Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/12c4562e-deb8-4d14-bb23-e344e79b6f04",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3407738b-2095-47bb-9cbd-dd16de158d67",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3407738b-2095-47bb-9cbd-dd16de158d67",
         "name": "ggshield-65KCwJls", "description": "description", "created_at": "2024-06-25T08:36:52.873146Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3407738b-2095-47bb-9cbd-dd16de158d67",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
         "name": "ggshield-fb77weow", "description": "description", "created_at": "2024-06-26T09:27:38.724573Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9223e352-43b6-4e06-8d12-682d669cedd7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9223e352-43b6-4e06-8d12-682d669cedd7",
         "name": "ggshield-TRO3H56N", "description": "description", "created_at": "2024-06-26T09:27:39.479744Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9223e352-43b6-4e06-8d12-682d669cedd7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "17e088b8-2463-48f8-957b-41d017f1dc83",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "17e088b8-2463-48f8-957b-41d017f1dc83",
         "name": "ggshield-s7IOqS0q", "description": "description", "created_at": "2024-06-26T09:42:26.454643Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/17e088b8-2463-48f8-957b-41d017f1dc83",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e332d717-641d-4ea4-81fc-e98115178454",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e332d717-641d-4ea4-81fc-e98115178454",
         "name": "ggshield-JaAf9b0W", "description": "description", "created_at": "2024-06-26T09:42:27.174527Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e332d717-641d-4ea4-81fc-e98115178454",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26514e1f-4237-474b-b907-037b88427f29",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26514e1f-4237-474b-b907-037b88427f29",
         "name": "ggshield-Uuc8EiUn", "description": "description", "created_at": "2024-06-26T11:51:19.747630Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/26514e1f-4237-474b-b907-037b88427f29",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
         "name": "ggshield-GL7wc5WW", "description": "description", "created_at": "2024-06-26T11:51:20.402145Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
         "name": "test ericf", "description": "", "created_at": "2024-07-09T09:34:04.089955Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
         "status": "triggered", "triggered_at": "2024-07-09T09:34:57.541777Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "a507d04c-bb61-4f2a-93ea-601b8aa27940",
         "name": "ggshield-w1cOSspy", "description": "description", "created_at": "2024-07-31T15:31:09.349255Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a507d04c-bb61-4f2a-93ea-601b8aa27940",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dafa04c5-299a-4a13-9c35-c523e51763f3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dafa04c5-299a-4a13-9c35-c523e51763f3",
         "name": "ggshield-b7VHMqbK", "description": "description", "created_at": "2024-07-31T15:31:10.071786Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dafa04c5-299a-4a13-9c35-c523e51763f3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
         "name": "ggshield-Fu1nGsc9", "description": "description", "created_at": "2024-08-05T09:03:52.745860Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "83888e42-dc57-471c-9a08-f023e3dc2949",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "83888e42-dc57-471c-9a08-f023e3dc2949",
         "name": "ggshield-5suF2vRt", "description": "description", "created_at": "2024-08-05T09:03:53.434873Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/83888e42-dc57-471c-9a08-f023e3dc2949",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e8aad547-96a7-40a4-a05d-710cf536f3a7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e8aad547-96a7-40a4-a05d-710cf536f3a7",
         "name": "ggshield-Vqz4LULC", "description": "description", "created_at": "2024-08-05T09:21:25.593516Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e8aad547-96a7-40a4-a05d-710cf536f3a7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
         "name": "ggshield-lqX7PlwI", "description": "description", "created_at": "2024-08-05T09:21:26.211228Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b144b1fd-dc5f-4a36-abc7-a95d05331245",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b144b1fd-dc5f-4a36-abc7-a95d05331245",
         "name": "ggshield-uZr6LNDv", "description": "description", "created_at": "2024-08-27T07:44:46.267249Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b144b1fd-dc5f-4a36-abc7-a95d05331245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "903bf588-2a03-4318-be6c-b9e3198d1fd6",
-        "name": "ggshield-5Ty2Hu4r", "description": "description", "created_at": "2024-08-27T07:44:46.871854Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "903bf588-2a03-4318-be6c-b9e3198d1fd6", "name": "ggshield-5Ty2Hu4r",
+        "description": "description", "created_at": "2024-08-27T07:44:46.871854Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/903bf588-2a03-4318-be6c-b9e3198d1fd6",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "11222b98-7705-4180-99d1-6e719d8a05a9",
-        "name": "ggshield-qnLief7n", "description": "description", "created_at": "2024-08-27T08:20:15.846360Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "11222b98-7705-4180-99d1-6e719d8a05a9", "name": "ggshield-qnLief7n",
+        "description": "description", "created_at": "2024-08-27T08:20:15.846360Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/11222b98-7705-4180-99d1-6e719d8a05a9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "707b35fb-685b-4577-88b9-94cccc10e165",
-        "name": "ggshield-wqYwwgeK", "description": "description", "created_at": "2024-08-27T08:20:16.467770Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "707b35fb-685b-4577-88b9-94cccc10e165", "name": "ggshield-wqYwwgeK",
+        "description": "description", "created_at": "2024-08-27T08:20:16.467770Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/707b35fb-685b-4577-88b9-94cccc10e165",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "01c7668d-1467-4cac-a395-4b50fc278407",
-        "name": "ggshield-QkzL5Vyb", "description": "description", "created_at": "2024-09-24T08:50:15.865165Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "01c7668d-1467-4cac-a395-4b50fc278407", "name": "ggshield-QkzL5Vyb",
+        "description": "description", "created_at": "2024-09-24T08:50:15.865165Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/01c7668d-1467-4cac-a395-4b50fc278407",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
         "name": "ggshield-kkpkfk1s", "description": "description", "created_at": "2024-09-24T08:50:16.667172Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "730bdd87-31b2-4b42-a32a-5750bc595c9c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "730bdd87-31b2-4b42-a32a-5750bc595c9c",
         "name": "ggshield-dtxlZtWH", "description": "description", "created_at": "2024-10-01T13:18:29.918337Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/730bdd87-31b2-4b42-a32a-5750bc595c9c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b42c6945-05fc-4c5b-af83-e60478cd9db5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b42c6945-05fc-4c5b-af83-e60478cd9db5",
         "name": "ggshield-WPIELIcW", "description": "description", "created_at": "2024-10-01T13:18:30.820570Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b42c6945-05fc-4c5b-af83-e60478cd9db5",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
         "name": "ggshield-B8LwcRR0", "description": "description", "created_at": "2024-10-16T13:47:50.239094Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "81d30531-a54e-4f67-a46b-a7bac5783995",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "81d30531-a54e-4f67-a46b-a7bac5783995",
         "name": "ggshield-IjJFdqDS", "description": "description", "created_at": "2024-10-16T13:47:51.425195Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/81d30531-a54e-4f67-a46b-a7bac5783995",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a0b24134-0cbc-4ca5-b110-18b3311aef73",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a0b24134-0cbc-4ca5-b110-18b3311aef73",
         "name": "DO-demo", "description": "Digital Ocean Demo", "created_at": "2024-10-23T17:55:40.621634Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a0b24134-0cbc-4ca5-b110-18b3311aef73",
         "status": "revoked", "triggered_at": "2024-10-23T18:03:40.135215Z", "revoked_at":
         "2024-10-23T18:33:47.488182Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "50e53ab6-4950-48e6-9350-b5aaa88fafea", "name": "Demo",
-        "description": "Dev team 1", "created_at": "2024-10-27T21:01:47.725365Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/50e53ab6-4950-48e6-9350-b5aaa88fafea",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "50e53ab6-4950-48e6-9350-b5aaa88fafea", "name": "Demo", "description":
+        "Dev team 1", "created_at": "2024-10-27T21:01:47.725365Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/50e53ab6-4950-48e6-9350-b5aaa88fafea",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582569, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}], "token": "[REDACTED]"},
         {"id": "795decd4-4703-4073-9b3c-3ec2157f6182", "name": "Demo token", "description":
         "Take a look", "created_at": "2024-10-28T00:34:48.214122Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/795decd4-4703-4073-9b3c-3ec2157f6182",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582569, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
-        "name": "ggshield-c6YSc2Ie", "description": "description", "created_at": "2024-10-29T14:36:27.096968Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "c43ee48d-4646-40e8-bd12-3dfa30a6b3db", "name": "ggshield-c6YSc2Ie",
+        "description": "description", "created_at": "2024-10-29T14:36:27.096968Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
         "name": "ggshield-E6IPnu0f", "description": "description", "created_at": "2024-10-29T14:36:28.513178Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a454c002-679b-4250-aacf-28b5207543a4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a454c002-679b-4250-aacf-28b5207543a4",
         "name": "ggshield-HjwRkUAT", "description": "description", "created_at": "2024-11-27T12:32:44.877048Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a454c002-679b-4250-aacf-28b5207543a4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5af2ae0-f3f6-4301-82bc-b49108bd782b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5af2ae0-f3f6-4301-82bc-b49108bd782b",
         "name": "ggshield-hIlrbyRm", "description": "description", "created_at": "2024-11-27T12:32:45.728067Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c5af2ae0-f3f6-4301-82bc-b49108bd782b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "aed37b34-4721-43c2-99e2-2f2e78592f63",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "aed37b34-4721-43c2-99e2-2f2e78592f63",
         "name": "ggshield/setup.cfg", "description": "", "created_at": "2024-12-17T10:10:25.895137Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/aed37b34-4721-43c2-99e2-2f2e78592f63",
         "status": "triggered", "triggered_at": "2024-12-17T10:19:35.167833Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 309802, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476", "name": "pierredethoisy/dockerfile",
-        "description": "", "created_at": "2024-12-17T10:30:41.655876Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
+        "name": "pierredethoisy/dockerfile", "description": "", "created_at": "2024-12-17T10:30:41.655876Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
         "status": "triggered", "triggered_at": "2024-12-17T10:32:09.594850Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 309802, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "4b814f00-0897-479f-8a2d-a9593c5f18fa", "name": "WrongSecrets", "description":
-        "Honeytoken for the wrongsecrets repositort", "created_at": "2025-02-06T13:10:31.569094Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4b814f00-0897-479f-8a2d-a9593c5f18fa",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4b814f00-0897-479f-8a2d-a9593c5f18fa",
+        "name": "WrongSecrets", "description": "Honeytoken for the wrongsecrets repositort",
+        "created_at": "2025-02-06T13:10:31.569094Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4b814f00-0897-479f-8a2d-a9593c5f18fa",
         "status": "triggered", "triggered_at": "2025-02-06T13:16:26.325168Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "7dfdb8ee-56fc-486e-9b7a-e6ff248107fa", "name": "ggshield-AAcFXCwl",
-        "description": "description", "created_at": "2025-02-27T10:23:31.621722Z",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
+        "name": "ggshield-AAcFXCwl", "description": "description", "created_at": "2025-02-27T10:23:31.621722Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "97877334-808d-48c7-8802-2c54e9f43661",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "97877334-808d-48c7-8802-2c54e9f43661",
         "name": "ggshield-srahH0o3", "description": "description", "created_at": "2025-02-27T10:23:32.385844Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/97877334-808d-48c7-8802-2c54e9f43661",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ca642fe-2ce4-42b2-9097-5904093935c1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ca642fe-2ce4-42b2-9097-5904093935c1",
         "name": "ggshield-5Vx0aaQd", "description": "description", "created_at": "2025-02-27T10:31:34.080183Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ca642fe-2ce4-42b2-9097-5904093935c1",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d8590557-764f-4618-9b2e-277d536bd111",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d8590557-764f-4618-9b2e-277d536bd111",
         "name": "ggshield-QYqCVZ4i", "description": "description", "created_at": "2025-02-27T10:31:34.798380Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d8590557-764f-4618-9b2e-277d536bd111",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84b08c90-12f5-48ef-baee-ab8d8b15588c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84b08c90-12f5-48ef-baee-ab8d8b15588c",
         "name": "ggshield-4sJy2SkE", "description": "description", "created_at": "2025-02-27T10:53:01.890617Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84b08c90-12f5-48ef-baee-ab8d8b15588c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72204c1e-12c1-445f-b106-09488214d610",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72204c1e-12c1-445f-b106-09488214d610",
         "name": "ggshield-eqoLjiAS", "description": "description", "created_at": "2025-02-27T10:53:02.563136Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72204c1e-12c1-445f-b106-09488214d610",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
         "name": "ggshield-yaqMNJFA", "description": "description", "created_at": "2025-02-27T11:24:20.630794Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a5d5ca0-000f-4011-aaf2-b4f627c19649",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a5d5ca0-000f-4011-aaf2-b4f627c19649",
         "name": "ggshield-x12c7zPc", "description": "description", "created_at": "2025-02-27T11:24:21.465056Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8a5d5ca0-000f-4011-aaf2-b4f627c19649",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c823f31a-73a8-46cc-be4a-029d6d081793",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c823f31a-73a8-46cc-be4a-029d6d081793",
         "name": "ggshield-9Mq5rTUV", "description": "description", "created_at": "2025-02-27T16:44:10.862683Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c823f31a-73a8-46cc-be4a-029d6d081793",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49f1055b-b505-402b-8b79-e4b2c6cf2041",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49f1055b-b505-402b-8b79-e4b2c6cf2041",
         "name": "ggshield-4MmSKBvx", "description": "description", "created_at": "2025-02-27T16:44:11.663957Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/49f1055b-b505-402b-8b79-e4b2c6cf2041",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be8e40e8-b204-40de-8d37-247ac6ef7077",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be8e40e8-b204-40de-8d37-247ac6ef7077",
         "name": "ggshield-DBuxWn0n", "description": "description", "created_at": "2025-02-27T16:57:21.290157Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be8e40e8-b204-40de-8d37-247ac6ef7077",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d10551f8-36f0-4966-a684-d5f9eca89e8d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d10551f8-36f0-4966-a684-d5f9eca89e8d",
         "name": "ggshield-bukJ4Md2", "description": "description", "created_at": "2025-02-27T16:57:22.079317Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d10551f8-36f0-4966-a684-d5f9eca89e8d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d5385824-6a93-47cb-81f3-e818e64371d7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d5385824-6a93-47cb-81f3-e818e64371d7",
         "name": "ggshield-vI1CTIm2", "description": "description", "created_at": "2025-02-27T17:24:28.533666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d5385824-6a93-47cb-81f3-e818e64371d7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
         "name": "ggshield-C519GYI9", "description": "description", "created_at": "2025-02-27T17:24:29.231126Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
         "name": "ggshield-i8zN7WRH", "description": "description", "created_at": "2025-02-27T17:27:14.478281Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "661dae4d-5944-4a20-b7f7-f74913356479",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "661dae4d-5944-4a20-b7f7-f74913356479",
         "name": "ggshield-IX7GxSIs", "description": "description", "created_at": "2025-02-27T17:27:15.226298Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/661dae4d-5944-4a20-b7f7-f74913356479",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "adaea919-086f-4e37-b4e5-dc8208d0e4f5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "adaea919-086f-4e37-b4e5-dc8208d0e4f5",
         "name": "ggshield-rWApiuse", "description": "description", "created_at": "2025-03-03T09:15:26.314595Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/adaea919-086f-4e37-b4e5-dc8208d0e4f5",
         "status": "triggered", "triggered_at": "2026-02-18T14:51:12.198393Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
-        "key": "env", "value": "staging"}], "custom_tags": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
+        null, "tags": [], "custom_tags": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
         "key": "env", "value": "staging"}], "token": "[REDACTED]"}, {"id": "da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
         "name": "ggshield-jdbeH3gE", "description": "description", "created_at": "2025-03-03T09:15:27.049176Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22", "key": "env",
-        "value": "production"}], "custom_tags": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22",
-        "key": "env", "value": "production"}], "token": "[REDACTED]"}, {"id": "1f4708b2-0e51-458c-abca-c03e502b4a5a",
+        [], "custom_tags": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22", "key":
+        "env", "value": "production"}], "token": "[REDACTED]"}, {"id": "1f4708b2-0e51-458c-abca-c03e502b4a5a",
         "name": "ggshield-QgwFEPjx", "description": "description", "created_at": "2025-03-27T15:12:18.744612Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1f4708b2-0e51-458c-abca-c03e502b4a5a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "a4ced9be-6ad5-4d8a-b188-65a117bc0eba",
-        "name": "ggshield-44tVmSvF", "description": "description", "created_at": "2025-03-27T15:12:19.507492Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "a4ced9be-6ad5-4d8a-b188-65a117bc0eba", "name": "ggshield-44tVmSvF",
+        "description": "description", "created_at": "2025-03-27T15:12:19.507492Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a4ced9be-6ad5-4d8a-b188-65a117bc0eba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5710ee7d-6428-4074-a9ff-09399782242d",
-        "name": "ggshield-bF87lDBl", "description": "description", "created_at": "2025-03-27T15:21:17.135616Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5710ee7d-6428-4074-a9ff-09399782242d", "name": "ggshield-bF87lDBl",
+        "description": "description", "created_at": "2025-03-27T15:21:17.135616Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5710ee7d-6428-4074-a9ff-09399782242d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
-        "name": "ggshield-LbIDqGyA", "description": "description", "created_at": "2025-03-27T15:21:17.953340Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "4cbf7af9-9989-4185-8ef8-0f39e6f3d145", "name": "ggshield-LbIDqGyA",
+        "description": "description", "created_at": "2025-03-27T15:21:17.953340Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2dfa1936-f53f-4d0c-8a69-ae9bab297021",
-        "name": "ggshield-qz84En8W", "description": "description", "created_at": "2025-03-27T15:24:16.907610Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2dfa1936-f53f-4d0c-8a69-ae9bab297021", "name": "ggshield-qz84En8W",
+        "description": "description", "created_at": "2025-03-27T15:24:16.907610Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2dfa1936-f53f-4d0c-8a69-ae9bab297021",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "11213dc7-118d-4997-a96b-714640c3ad0b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "11213dc7-118d-4997-a96b-714640c3ad0b",
         "name": "ggshield-CSF39jm8", "description": "description", "created_at": "2025-03-27T15:24:17.721006Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/11213dc7-118d-4997-a96b-714640c3ad0b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "899dd0b0-20b2-45d2-b779-0331cc448935",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "899dd0b0-20b2-45d2-b779-0331cc448935",
         "name": "toto", "description": "tata", "created_at": "2025-05-12T09:58:35.161641Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/899dd0b0-20b2-45d2-b779-0331cc448935",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "62d71685-2eba-4b88-8edd-cc73e698cfa5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "62d71685-2eba-4b88-8edd-cc73e698cfa5",
         "name": "test-greg", "description": "test greg", "created_at": "2025-05-12T10:06:19.826522Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/62d71685-2eba-4b88-8edd-cc73e698cfa5",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:59.739856Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "e948f77d-5353-413e-b37d-8beba84890ff", "name": "test-greg-2", "description":
-        "test greg", "created_at": "2025-05-12T10:08:11.667578Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e948f77d-5353-413e-b37d-8beba84890ff",
+        "name": "test-greg-2", "description": "test greg", "created_at": "2025-05-12T10:08:11.667578Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:54.809724Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb", "name": "test-greg-3", "description":
-        "test greg", "created_at": "2025-05-12T10:08:58.561160Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        "name": "test-greg-3", "description": "test greg", "created_at": "2025-05-12T10:08:58.561160Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:50.784137Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6", "name": "test-greg-4", "description":
-        "test", "created_at": "2025-05-12T10:10:12.927058Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6",
+        "name": "test-greg-4", "description": "test", "created_at": "2025-05-12T10:10:12.927058Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:46.594085Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a", "name": "test-greg-5", "description":
-        "test", "created_at": "2025-05-12T10:12:50.615700Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
+        "name": "test-greg-5", "description": "test", "created_at": "2025-05-12T10:12:50.615700Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:41.387978Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "9fcf0732-6b8d-41d3-ae98-727bd5dde585", "name": "achille-hackathon",
-        "description": "achille hackathon", "created_at": "2025-05-12T12:01:23.542568Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9fcf0732-6b8d-41d3-ae98-727bd5dde585",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9fcf0732-6b8d-41d3-ae98-727bd5dde585",
+        "name": "achille-hackathon", "description": "achille hackathon", "created_at":
+        "2025-05-12T12:01:23.542568Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9fcf0732-6b8d-41d3-ae98-727bd5dde585",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38",
         "name": "TestHoneytoken", "description": "Testing GitGuardian API connectivity",
         "created_at": "2025-05-12T12:19:05.294638Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b0ddbd44-4054-4127-aa00-cd6727e70d38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
         "name": "AWS Credentials", "description": "Honeytoken for testing, to be injected
         as requested by the user.", "created_at": "2025-05-12T12:38:25.640506Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
         "status": "triggered", "triggered_at": "2026-02-18T13:45:03.781945Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 269050, "revoker_id":
+        null, "type": "AWS", "open_events_count": 9, "creator_id": 269050, "revoker_id":
         null, "creator_api_token_id": "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec", "name": "test-greg-7", "description":
-        "test", "created_at": "2025-05-12T12:54:37.703725Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ab824e92-6068-4a9d-ae36-86a94516f2ec",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec",
+        "name": "test-greg-7", "description": "test", "created_at": "2025-05-12T12:54:37.703725Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ab824e92-6068-4a9d-ae36-86a94516f2ec",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:34.521470Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b65d42a4-587f-4701-a595-8429cbcda70b", "name": "gg-mcp-server-honeytoken",
-        "description": "Honeytoken for security monitoring in the gg-mcp-server project.",
-        "created_at": "2025-05-12T12:54:44.402023Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b65d42a4-587f-4701-a595-8429cbcda70b",
-        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
-        "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
-        "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3fe4aa4f-49f6-42ad-a34a-0c108b544215",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b65d42a4-587f-4701-a595-8429cbcda70b",
+        "name": "gg-mcp-server-honeytoken", "description": "Honeytoken for security
+        monitoring in the gg-mcp-server project.", "created_at": "2025-05-12T12:54:44.402023Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b65d42a4-587f-4701-a595-8429cbcda70b",
+        "status": "triggered", "triggered_at": "2026-06-04T13:16:15.961464Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 4, "creator_id": 269050, "revoker_id":
+        null, "creator_api_token_id": "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id":
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3fe4aa4f-49f6-42ad-a34a-0c108b544215",
         "name": "default-honeytoken", "description": "General purpose honeytoken for
         security monitoring", "created_at": "2025-05-12T13:07:52.676810Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/3fe4aa4f-49f6-42ad-a34a-0c108b544215",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
         "name": "test", "description": "test", "created_at": "2025-05-12T13:09:38.965752Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9844e55d-982c-4458-b65b-592ad99ce77a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1026550, "revoker_id": null, "creator_api_token_id":
         "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
         "name": "Test Honeytoken", "description": "Testing honeytoken generation",
         "created_at": "2025-05-12T14:35:34.295363Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b2a7e759-81ab-465d-a578-e3ce42c18741",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
         "name": "test-greg-9", "description": "", "created_at": "2025-05-12T14:50:23.123299Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6d185a-6f59-4b7c-9248-dd05616090db",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:27.366114Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
+        null, "tags": [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
         "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "fbb93094-9778-4b8b-97d8-de99954a758a",
         "name": "AWS_Honeytoken", "description": "Honeytoken generated via MCP", "created_at":
@@ -1432,17 +1343,15 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "34e08af4-59a7-4a3b-b799-65acb8a2019d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "34e08af4-59a7-4a3b-b799-65acb8a2019d",
         "name": "AWS-MCP-Honeytoken", "description": "Honeytoken for monitoring potential
         AWS credential leaks", "created_at": "2025-05-12T15:07:16.157981Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/34e08af4-59a7-4a3b-b799-65acb8a2019d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "16805984-70d6-4049-844a-79bac3054f6f",
         "name": "AwsTestHoneytoken", "description": "Test honeytoken for development
         and monitoring", "created_at": "2025-05-12T15:09:00.390236Z", "gitguardian_url":
@@ -1450,10 +1359,8 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "d476c118-b210-403d-b685-3d7f0a514950",
         "name": "aws-development-access-key", "description": "Development environment
         AWS access key for monitoring credential leaks", "created_at": "2025-05-12T15:12:56.525944Z",
@@ -1461,9 +1368,7 @@ interactions:
         "status": "triggered", "triggered_at": "2026-02-18T14:50:57.626529Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 2, "creator_id": 270722, "revoker_id":
         null, "creator_api_token_id": "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
+        null, "tags": [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
         "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "0a112323-6906-4bd0-a660-1b45a0fc59ca",
         "name": "NHI-Explorer-Secret", "description": "AWS access key for NHI Explorer
@@ -1472,232 +1377,412 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "69dbbe3c-2dfc-4c93-916c-f70c42f4e2af",
         "name": "ggshield-Leb9CGys", "description": "description", "created_at": "2025-05-27T08:18:31.020533Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/69dbbe3c-2dfc-4c93-916c-f70c42f4e2af",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "029e2aba-796c-47d8-8d52-e14f9868acfc",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "029e2aba-796c-47d8-8d52-e14f9868acfc",
         "name": "ggshield-Fhjl6QxB", "description": "description", "created_at": "2025-05-27T08:18:31.873128Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/029e2aba-796c-47d8-8d52-e14f9868acfc",
         "status": "triggered", "triggered_at": "2025-06-17T09:30:39.728240Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "c77d47b6-8d61-46a7-b6a1-1715fc47c7eb", "name": "ggshield-U8JeiAjO",
-        "description": "description", "created_at": "2025-06-24T13:04:20.196705Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
+        "name": "ggshield-U8JeiAjO", "description": "description", "created_at": "2025-06-24T13:04:20.196705Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab",
-        "name": "ggshield-NiJSM24s", "description": "description", "created_at": "2025-06-24T13:04:21.255669Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab", "name": "ggshield-NiJSM24s",
+        "description": "description", "created_at": "2025-06-24T13:04:21.255669Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5692a982-6603-443e-bdb4-5ea1a5de6f64",
-        "name": "ggshield-JKhVuHaW", "description": "description", "created_at": "2025-06-24T13:06:56.046343Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5692a982-6603-443e-bdb4-5ea1a5de6f64", "name": "ggshield-JKhVuHaW",
+        "description": "description", "created_at": "2025-06-24T13:06:56.046343Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5692a982-6603-443e-bdb4-5ea1a5de6f64",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "17925c95-1df7-4e86-9c42-aabb5dbdea69",
-        "name": "ggshield-vfjAXCfY", "description": "description", "created_at": "2025-06-24T13:06:57.033247Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "17925c95-1df7-4e86-9c42-aabb5dbdea69", "name": "ggshield-vfjAXCfY",
+        "description": "description", "created_at": "2025-06-24T13:06:57.033247Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/17925c95-1df7-4e86-9c42-aabb5dbdea69",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "631ef101-122f-4592-9de1-2d6cb5becafa",
-        "name": "ggshield-dbhOtleP", "description": "description", "created_at": "2025-06-24T13:13:01.219899Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "631ef101-122f-4592-9de1-2d6cb5becafa", "name": "ggshield-dbhOtleP",
+        "description": "description", "created_at": "2025-06-24T13:13:01.219899Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/631ef101-122f-4592-9de1-2d6cb5becafa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "bebc1ca8-933d-45ca-b201-fbabc4eab464",
-        "name": "ggshield-7pQLMJYV", "description": "description", "created_at": "2025-06-24T13:13:01.978212Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "bebc1ca8-933d-45ca-b201-fbabc4eab464", "name": "ggshield-7pQLMJYV",
+        "description": "description", "created_at": "2025-06-24T13:13:01.978212Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bebc1ca8-933d-45ca-b201-fbabc4eab464",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "3983e8ff-7fd6-4fde-9117-9612d4258052",
-        "name": "ggshield-phDsJ9wy", "description": "description", "created_at": "2025-06-24T13:29:15.096198Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "3983e8ff-7fd6-4fde-9117-9612d4258052", "name": "ggshield-phDsJ9wy",
+        "description": "description", "created_at": "2025-06-24T13:29:15.096198Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3983e8ff-7fd6-4fde-9117-9612d4258052",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "9340e7fe-f79c-467e-9dcd-43ddaa77dc0c",
-        "name": "ggshield-Md0MBV0B", "description": "description", "created_at": "2025-06-24T13:29:16.049584Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "9340e7fe-f79c-467e-9dcd-43ddaa77dc0c", "name": "ggshield-Md0MBV0B",
+        "description": "description", "created_at": "2025-06-24T13:29:16.049584Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9340e7fe-f79c-467e-9dcd-43ddaa77dc0c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "08b51a6e-dd6c-4a4b-93f9-b955663c6524",
-        "name": "ggshield-ZoWflf5b", "description": "description", "created_at": "2025-06-24T13:31:49.045062Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "08b51a6e-dd6c-4a4b-93f9-b955663c6524", "name": "ggshield-ZoWflf5b",
+        "description": "description", "created_at": "2025-06-24T13:31:49.045062Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/08b51a6e-dd6c-4a4b-93f9-b955663c6524",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "96da938d-d6fa-4e44-9254-c568a27be484",
-        "name": "ggshield-PirK5h1Q", "description": "description", "created_at": "2025-06-24T13:31:49.827284Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "96da938d-d6fa-4e44-9254-c568a27be484", "name": "ggshield-PirK5h1Q",
+        "description": "description", "created_at": "2025-06-24T13:31:49.827284Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/96da938d-d6fa-4e44-9254-c568a27be484",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f2c61b85-e11d-4db0-a8af-7fc327310b39",
-        "name": "ggshield-ZQ4jUtQr", "description": "description", "created_at": "2025-06-24T13:45:17.477850Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f2c61b85-e11d-4db0-a8af-7fc327310b39", "name": "ggshield-ZQ4jUtQr",
+        "description": "description", "created_at": "2025-06-24T13:45:17.477850Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f2c61b85-e11d-4db0-a8af-7fc327310b39",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f99173ff-9ffe-492c-b8ae-54157df89bac",
-        "name": "ggshield-5uK6KYFh", "description": "description", "created_at": "2025-06-24T13:45:18.309642Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f99173ff-9ffe-492c-b8ae-54157df89bac", "name": "ggshield-5uK6KYFh",
+        "description": "description", "created_at": "2025-06-24T13:45:18.309642Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f99173ff-9ffe-492c-b8ae-54157df89bac",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768",
-        "name": "ggshield-MGXkbqc7", "description": "description", "created_at": "2025-06-24T13:50:43.295521Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768", "name": "ggshield-MGXkbqc7",
+        "description": "description", "created_at": "2025-06-24T13:50:43.295521Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f3252f2c-16a9-45e4-97e8-bed4b5752415",
-        "name": "ggshield-YJd3rq9q", "description": "description", "created_at": "2025-06-24T13:50:44.165951Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f3252f2c-16a9-45e4-97e8-bed4b5752415", "name": "ggshield-YJd3rq9q",
+        "description": "description", "created_at": "2025-06-24T13:50:44.165951Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f3252f2c-16a9-45e4-97e8-bed4b5752415",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "e22705f1-5497-449b-9614-3c2d89e3b705",
-        "name": "ggshield-l4abwnpa", "description": null, "created_at": "2025-06-26T12:32:05.993896Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e22705f1-5497-449b-9614-3c2d89e3b705",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "e22705f1-5497-449b-9614-3c2d89e3b705", "name": "ggshield-l4abwnpa",
+        "description": null, "created_at": "2025-06-26T12:32:05.993896Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e22705f1-5497-449b-9614-3c2d89e3b705",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
         "4ff03654-f280-4c31-8eef-5295d2b75a50", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7691445a-2cb0-4093-94ca-f2c5de877075",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7691445a-2cb0-4093-94ca-f2c5de877075",
         "name": "ggshield-Lwhu1Nax", "description": "description", "created_at": "2025-07-29T10:34:41.534666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7691445a-2cb0-4093-94ca-f2c5de877075",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "951e1f19-5804-444a-b275-b51dc5bf68ee",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "951e1f19-5804-444a-b275-b51dc5bf68ee",
         "name": "ggshield-u9ltlEmT", "description": "description", "created_at": "2025-07-29T10:34:42.385215Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/951e1f19-5804-444a-b275-b51dc5bf68ee",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
         "name": "ggshield-CC0Lj0vS", "description": "description", "created_at": "2025-07-29T10:40:27.317817Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
         "name": "ggshield-0k2Xha2i", "description": "description", "created_at": "2025-07-29T10:40:28.088246Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
         "status": "triggered", "triggered_at": "2025-08-22T16:59:58.315774Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "49e4fce7-aa48-42b0-9fc4-e16105ae08e5", "name": "ggshield-ncOpkfP8",
-        "description": "description", "created_at": "2025-08-27T11:43:11.666517Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
+        "name": "ggshield-ncOpkfP8", "description": "description", "created_at": "2025-08-27T11:43:11.666517Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2b15518b-3100-4736-bee6-b47fe8d26fc1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2b15518b-3100-4736-bee6-b47fe8d26fc1",
         "name": "ggshield-H2eDvilF", "description": "description", "created_at": "2025-08-27T11:43:12.618589Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2b15518b-3100-4736-bee6-b47fe8d26fc1",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "368a90bf-269b-4a60-95c2-1c77c86f7fd4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "368a90bf-269b-4a60-95c2-1c77c86f7fd4",
         "name": "ggshield-V6RzZJGL", "description": "description", "created_at": "2025-11-14T16:54:30.227288Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/368a90bf-269b-4a60-95c2-1c77c86f7fd4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "eae1aaaf-d700-475d-b65a-ffd79f84806d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "eae1aaaf-d700-475d-b65a-ffd79f84806d",
         "name": "ggshield-Pya2g1xF", "description": "description", "created_at": "2025-11-14T16:54:30.933576Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/eae1aaaf-d700-475d-b65a-ffd79f84806d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
         "name": "ggshield-Z2Ji3PxX", "description": "description", "created_at": "2026-03-31T13:26:20.710346Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
         "name": "ggshield-FsL9dCzu", "description": "description", "created_at": "2026-03-31T13:26:21.681383Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7daed77-1fa4-416d-88e2-473200b810aa",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7daed77-1fa4-416d-88e2-473200b810aa",
         "name": "ggshield-dqv39cn2", "description": "description", "created_at": "2026-03-31T13:32:28.824725Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e7daed77-1fa4-416d-88e2-473200b810aa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "601c59d9-7579-402e-90c4-59da055a8d3b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "601c59d9-7579-402e-90c4-59da055a8d3b",
         "name": "ggshield-YpbVgsRl", "description": "description", "created_at": "2026-03-31T13:32:29.820990Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/601c59d9-7579-402e-90c4-59da055a8d3b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "54e52712-a036-4e80-899b-c1a200610339",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "54e52712-a036-4e80-899b-c1a200610339",
         "name": "ggshield-DZ5zVj1p", "description": "description", "created_at": "2026-03-31T13:37:32.513332Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/54e52712-a036-4e80-899b-c1a200610339",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51dc5671-8053-4b87-8174-975ccf7f249c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51dc5671-8053-4b87-8174-975ccf7f249c",
         "name": "ggshield-DXGKK2gC", "description": "description", "created_at": "2026-03-31T13:37:33.559937Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/51dc5671-8053-4b87-8174-975ccf7f249c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}]'
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "name": "test Pierre", "description": "", "created_at": "2026-04-07T18:38:38.199572Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "ae435f66-1ea9-4dfe-b73f-49f451fc00ab", "name": "Demo
+        Romain", "description": "", "created_at": "2026-04-24T12:48:19.654369Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/ae435f66-1ea9-4dfe-b73f-49f451fc00ab",
+        "status": "triggered", "triggered_at": "2026-04-29T12:54:19.464710Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 6, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [{"id": "7a2469eb-2b6b-4248-8103-2b0f6b4fac9b", "key":
+        "romain", "value": null}], "token": "[REDACTED]"}, {"id": "10f6e20b-12ae-4591-aa09-7e1ff00ef408",
+        "name": "qa / xyz-e732d912", "description": "", "created_at": "2026-04-24T16:05:46.508625Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/10f6e20b-12ae-4591-aa09-7e1ff00ef408",
+        "status": "triggered", "triggered_at": "2026-04-24T16:13:17.276672Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9266c0f4-f0e0-41d2-a8c8-c164ccb84e47",
+        "name": "qa / test-nriv-e732d912", "description": "", "created_at": "2026-04-24T16:05:50.013606Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9266c0f4-f0e0-41d2-a8c8-c164ccb84e47",
+        "status": "triggered", "triggered_at": "2026-04-24T16:15:44.494587Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "name": "dev / Salome Test-e732d912", "description": "", "created_at": "2026-04-24T16:05:53.158978Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "status": "triggered", "triggered_at": "2026-04-24T16:16:21.895694Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "name": "qa / test-r8327r-e732d912", "description": "", "created_at": "2026-04-24T16:05:56.586568Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "status": "triggered", "triggered_at": "2026-04-24T16:18:31.419829Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2314a2ef-cec4-4e3d-834a-09b0c40c99d2",
+        "name": "qa / abc-e732d912", "description": "", "created_at": "2026-04-24T16:05:59.728317Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2314a2ef-cec4-4e3d-834a-09b0c40c99d2",
+        "status": "triggered", "triggered_at": "2026-04-24T16:25:50.024911Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "fe96d213-a002-4161-a7c9-cb3be4ad88f8",
+        "name": "qa / Handcrafted Metal Bike-e732d912", "description": "", "created_at":
+        "2026-04-24T16:06:02.936659Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fe96d213-a002-4161-a7c9-cb3be4ad88f8",
+        "status": "triggered", "triggered_at": "2026-04-24T16:35:48.958630Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a72f662-2357-4b93-b48a-00028e36cfff",
+        "name": "test1", "description": "tEST 2", "created_at": "2026-04-30T09:12:55.584248Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a72f662-2357-4b93-b48a-00028e36cfff",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "963fbabe-3d2c-4154-8281-2f13be7c06f7", "name": "test121",
+        "description": "testing 12", "created_at": "2026-04-30T11:31:57.689130Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/963fbabe-3d2c-4154-8281-2f13be7c06f7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "1acff09e-02c1-4a24-8869-568dfab124c9", "name": "test-pierredt",
+        "description": "hello", "created_at": "2026-05-06T19:57:39.689471Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/1acff09e-02c1-4a24-8869-568dfab124c9",
+        "status": "triggered", "triggered_at": "2026-05-06T19:59:18.645288Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 6, "creator_id": 309802, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "name": "qa / test-nriv-d2363bd5", "description": "", "created_at": "2026-05-19T08:29:37.247067Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "status": "triggered", "triggered_at": "2026-05-19T08:33:36.289678Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 1754656, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "03e7e668-6fbf-493a-8d1c-ac9d0c6c1b97",
+        "name": "qa / xyz-d2363bd5", "description": "", "created_at": "2026-05-19T08:29:41.396307Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/03e7e668-6fbf-493a-8d1c-ac9d0c6c1b97",
+        "status": "triggered", "triggered_at": "2026-05-19T08:34:30.001210Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 1754656, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "bb1adf06-28ea-4daf-b338-59d5ef094f67",
+        "name": "TheBigHoney", "description": "Big Honey Pot for our core secrets",
+        "created_at": "2026-05-19T11:51:12.957707Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bb1adf06-28ea-4daf-b338-59d5ef094f67",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "93abaf01-cac6-48f4-bfa1-735cfb7fde7d", "name": "ttoprjog",
+        "description": "Henri", "created_at": "2026-05-20T12:22:37.974250Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/93abaf01-cac6-48f4-bfa1-735cfb7fde7d",
+        "status": "revoked", "triggered_at": null, "revoked_at": "2026-05-20T12:23:19.883989Z",
+        "type": "AWS", "open_events_count": 0, "creator_id": 113168, "revoker_id":
+        113168, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be3d1024-d9df-466c-9e75-afc1ed88b8f5",
+        "name": "test-plc", "description": "", "created_at": "2026-05-26T07:26:21.052034Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be3d1024-d9df-466c-9e75-afc1ed88b8f5",
+        "status": "revoked", "triggered_at": "2026-05-26T08:44:57.678480Z", "revoked_at":
+        "2026-05-26T12:19:01.401494Z", "type": "AWS", "open_events_count": 0, "creator_id":
+        701514, "revoker_id": 701514, "creator_api_token_id": null, "revoker_api_token_id":
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "8409c955-f217-47c9-9cf1-3a6b557c65c9", "name": "Test", "description": "",
+        "created_at": "2026-05-26T14:12:05.347374Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8409c955-f217-47c9-9cf1-3a6b557c65c9",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754650, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "82f00514-d9d3-442c-b575-c40ff77db387", "name": "test-plc2",
+        "description": "", "created_at": "2026-05-27T13:13:33.943814Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/82f00514-d9d3-442c-b575-c40ff77db387",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 701514, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "2fb03282-9878-481c-be5b-eda6036f909d", "name": "ahah-plc", "description":
+        "", "created_at": "2026-06-01T12:43:48.383287Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2fb03282-9878-481c-be5b-eda6036f909d",
+        "status": "triggered", "triggered_at": "2026-06-04T21:49:55.543841Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 701514, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86344c0b-c360-4709-bb6b-fce628ace1d7",
+        "name": "honeytoken-toot-991c4137", "description": "", "created_at": "2026-06-05T17:59:07.240726Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86344c0b-c360-4709-bb6b-fce628ace1d7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
+        "97c1b533-d768-4054-94de-ae3d967a5128", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "949d59d0-c3c2-4d5e-ae3c-4f365b9b8456",
+        "name": "honeytoken-toot-0fefb095", "description": "", "created_at": "2026-06-05T17:59:07.748651Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/949d59d0-c3c2-4d5e-ae3c-4f365b9b8456",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
+        "97c1b533-d768-4054-94de-ae3d967a5128", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ab5965c-8f7e-44ec-b64e-1111e140586f",
+        "name": "ggshield-WOmcC4wM", "description": "description", "created_at": "2026-06-15T15:05:19.990102Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ab5965c-8f7e-44ec-b64e-1111e140586f",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "95786b03-4165-4245-8aef-fac41ff6a1de",
+        "name": "ggshield-E2HxYogl", "description": "description", "created_at": "2026-06-15T15:05:20.446208Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/95786b03-4165-4245-8aef-fac41ff6a1de",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "98271cf2-3025-4e7d-b120-afd29fe20c8f",
+        "name": "ggshield-32Xli2ct", "description": "description", "created_at": "2026-06-15T15:13:44.456933Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/98271cf2-3025-4e7d-b120-afd29fe20c8f",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "68f09d33-1cab-4b93-84a5-2861a7a01fbc",
+        "name": "ggshield-o2ocvFQZ", "description": "description", "created_at": "2026-06-15T15:13:45.228488Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/68f09d33-1cab-4b93-84a5-2861a7a01fbc",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ee69dfd0-fa9c-451d-947e-261c2edd4355",
+        "name": "ggshield-rGxN1k4I", "description": "description", "created_at": "2026-06-15T15:46:58.088837Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ee69dfd0-fa9c-451d-947e-261c2edd4355",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f91525c-02bd-4a0f-9c5d-c9949f7196f4",
+        "name": "ggshield-bZoVll0H", "description": "description", "created_at": "2026-06-15T15:46:58.839510Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f91525c-02bd-4a0f-9c5d-c9949f7196f4",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4a3a3699-fb2e-4e0f-ae02-4905fe8228ec",
+        "name": "ggshield-VuSeELel", "description": "description", "created_at": "2026-06-17T13:23:52.166183Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4a3a3699-fb2e-4e0f-ae02-4905fe8228ec",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "dd2d3e47-d804-41c5-b8b8-f640e6292096", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d82dc520-9ea5-4a38-a9d8-84bf2f94975b",
+        "name": "ggshield-yQlAvTpn", "description": "description", "created_at": "2026-06-17T13:23:52.682610Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d82dc520-9ea5-4a38-a9d8-84bf2f94975b",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "dd2d3e47-d804-41c5-b8b8-f640e6292096", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}]'
     headers:
+      CF-RAY:
+      - a10394f92eedebae-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:04 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, POST, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '139756'
+      - '145842'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:19 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '694'
+      - '740'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_honeytokens_show_token.yaml
+++ b/tests/cassettes/client/vcr/test_list_honeytokens_show_token.yaml
@@ -25,33 +25,29 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/411d33c0-7fad-4fc1-b94e-bb440c8f9c49",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:11.250010Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}, {"id": "858a3a76-f6f2-4c2e-b0bc-323d9a575413",
-        "name": "test_honey_token", "description": "description", "created_at": "2023-05-15T14:09:09.210845Z",
+        "token": "[REDACTED]"}, {"id": "858a3a76-f6f2-4c2e-b0bc-323d9a575413", "name":
+        "test_honey_token", "description": "description", "created_at": "2023-05-15T14:09:09.210845Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/858a3a76-f6f2-4c2e-b0bc-323d9a575413",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:17.165934Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}, {"id": "72a52279-8e9f-40de-a1d4-bc5fcc48795d",
-        "name": "passwordscon", "description": "", "created_at": "2023-05-16T10:03:49.677782Z",
+        "token": "[REDACTED]"}, {"id": "72a52279-8e9f-40de-a1d4-bc5fcc48795d", "name":
+        "passwordscon", "description": "", "created_at": "2023-05-16T10:03:49.677782Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72a52279-8e9f-40de-a1d4-bc5fcc48795d",
         "status": "triggered", "triggered_at": "2023-05-16T10:04:10.262805Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 222, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
-        "key": "location", "value": "test"}], "custom_tags": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
+        ["publicly_exposed"], "custom_tags": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
         "key": "location", "value": "test"}], "token": "[REDACTED]"}, {"id": "8bf5f99a-538d-4cfe-8e74-61cd7081ae25",
         "name": "PasswordsCon2", "description": "For presentation", "created_at":
         "2023-05-16T11:30:36.210395Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8bf5f99a-538d-4cfe-8e74-61cd7081ae25",
         "status": "triggered", "triggered_at": "2023-05-16T12:29:45.638074Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 344, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "45182b59-b659-41ef-9bb8-44a78740fade", "name": "solid-octo-repo", "description":
         "Placed in solid-octo repo, file ... on 16May2023", "created_at": "2023-05-16T11:51:06.384073Z",
@@ -59,47 +55,41 @@ interactions:
         "status": "triggered", "triggered_at": "2026-02-18T14:51:12.499369Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432", "key": "place",
-        "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
+        [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432", "key":
+        "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
         "name": "jira-OPS-124", "description": "honeytoken deployed in jira ticket
         OPS-124", "created_at": "2023-05-16T11:58:57.713307Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "63bbd74e-bb5f-4910-8e63-eed358af3bc8",
         "name": "improved-carnival repo", "description": "", "created_at": "2023-05-16T14:45:09.811724Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/63bbd74e-bb5f-4910-8e63-eed358af3bc8",
         "status": "revoked", "triggered_at": "2023-05-16T14:49:44.284195Z", "revoked_at":
         "2024-06-19T10:46:44.282148Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "72fcdb5c-e128-4ca5-8970-f1f52f95a78a",
         "name": "slack-chan-website", "description": "", "created_at": "2023-05-16T15:35:26.129025Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72fcdb5c-e128-4ca5-8970-f1f52f95a78a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
-        "key": "place", "value": "website"}], "custom_tags": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
         "key": "place", "value": "website"}], "token": "[REDACTED]"}, {"id": "84d43c23-6d4d-47f8-bf62-e7c1b0ae1625",
         "name": "analytic-repo", "description": "", "created_at": "2023-05-16T16:17:11.435058Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84d43c23-6d4d-47f8-bf62-e7c1b0ae1625",
         "status": "revoked", "triggered_at": "2023-05-16T16:27:55.091410Z", "revoked_at":
         "2023-12-11T14:01:44.427581Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "ef11a80c-6d8e-4fb5-8ee2-4556bae695c3",
         "name": "test ht public", "description": "", "created_at": "2023-05-17T17:00:24.966335Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef11a80c-6d8e-4fb5-8ee2-4556bae695c3",
         "status": "triggered", "triggered_at": "2023-05-17T17:02:33.386529Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 5012, "creator_id": 166199, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
-        "key": "location", "value": "slack"}], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
+        ["publicly_exposed"], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
         "key": "location", "value": "slack"}], "token": "[REDACTED]"}, {"id": "db7bf6ea-57cb-4d13-8ed9-dc59b2620e00",
         "name": "Honeytoken demo 17 may", "description": "This is a token for the
         live demo", "created_at": "2023-05-17T17:15:04.921233Z", "gitguardian_url":
@@ -107,173 +97,161 @@ interactions:
         "status": "triggered", "triggered_at": "2023-05-17T17:16:48.960267Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 5018, "creator_id": 166199, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "79db31fc-ffd1-4bc9-b6e4-3ef37a94712a", "name": "QubitConfrence", "description":
         "", "created_at": "2023-05-18T07:58:37.174577Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/79db31fc-ffd1-4bc9-b6e4-3ef37a94712a",
         "status": "triggered", "triggered_at": "2023-05-18T09:30:01.025933Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 215, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263", "name": "NDC-OSLO Demo", "description":
-        "Demo key for NDC Oslo confrence", "created_at": "2023-05-25T07:59:05.651290Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
+        "name": "NDC-OSLO Demo", "description": "Demo key for NDC Oslo confrence",
+        "created_at": "2023-05-25T07:59:05.651290Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
         "status": "triggered", "triggered_at": "2023-05-25T08:38:27.471330Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 221, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b6f2b765-a8e5-458f-b68a-4b5ef934bcc8", "name": "Pycon Italia", "description":
-        "", "created_at": "2023-05-28T09:34:01.581495Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
+        "name": "Pycon Italia", "description": "", "created_at": "2023-05-28T09:34:01.581495Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
         "status": "revoked", "triggered_at": "2023-05-28T09:45:30.255118Z", "revoked_at":
         "2024-12-10T12:17:08.199275Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "bb494eed-6ba4-4b98-b949-ad5f54d929dd", "name": "ggshield-uORy0any",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "bb494eed-6ba4-4b98-b949-ad5f54d929dd", "name": "ggshield-uORy0any",
         "description": "description", "created_at": "2023-05-30T10:30:39.803353Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bb494eed-6ba4-4b98-b949-ad5f54d929dd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1266b395-a545-42c1-b700-24dbae36447c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1266b395-a545-42c1-b700-24dbae36447c",
         "name": "test_honey_token_previous", "description": "description", "created_at":
         "2023-05-30T10:30:40.547255Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1266b395-a545-42c1-b700-24dbae36447c",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:41:43.173510Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "f60db759-7041-4dfe-80fa-91012d97fdd3",
         "name": "ggshield-tsCPoUcx", "description": "description", "created_at": "2023-05-30T10:37:14.527124Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f60db759-7041-4dfe-80fa-91012d97fdd3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
         "name": "ggshield-BA0VsBh3", "description": "description", "created_at": "2023-05-30T10:39:09.968782Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e7f275d-e115-44d3-8854-5c6472494951",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e7f275d-e115-44d3-8854-5c6472494951",
         "name": "ggshield-UXgNYVXL", "description": "description", "created_at": "2023-05-30T10:42:36.847031Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6e7f275d-e115-44d3-8854-5c6472494951",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7494298b-75c5-44e4-898c-77b3b9017113",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7494298b-75c5-44e4-898c-77b3b9017113",
         "name": "test_honey_token_abc", "description": "description", "created_at":
         "2023-05-30T10:42:37.520767Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7494298b-75c5-44e4-898c-77b3b9017113",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:45:41.905071Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "092dba62-9d82-41bd-84aa-95430d540edc", "name": "ggshield-224Lwv95",
-        "description": "description", "created_at": "2023-05-30T10:46:10.997022Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "092dba62-9d82-41bd-84aa-95430d540edc",
+        "name": "ggshield-224Lwv95", "description": "description", "created_at": "2023-05-30T10:46:10.997022Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/092dba62-9d82-41bd-84aa-95430d540edc",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
         "name": "test_honey_token_previous", "description": "description", "created_at":
         "2023-05-30T10:46:11.714531Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:07.762156Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "13f6dbf3-ae1a-4757-95f6-e0fbc830fc55", "name": "ggshield-agateau",
-        "description": null, "created_at": "2023-05-30T13:32:31.845201Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
+        "name": "ggshield-agateau", "description": null, "created_at": "2023-05-30T13:32:31.845201Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T13:33:03.363563Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 160089, "revoker_id":
         160089, "creator_api_token_id": "425e1a78-209e-4cd5-b08f-8450a0026ac0", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "f17302cd-850b-4b54-9054-60d26a76cf38", "name": "test demo 31may",
-        "description": "", "created_at": "2023-05-31T08:10:36.754144Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f17302cd-850b-4b54-9054-60d26a76cf38",
+        "name": "test demo 31may", "description": "", "created_at": "2023-05-31T08:10:36.754144Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "41d76272-ee3d-4639-93e8-29222b662b93",
         "name": "demo31may-public", "description": "", "created_at": "2023-05-31T08:13:48.373887Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/41d76272-ee3d-4639-93e8-29222b662b93",
         "status": "revoked", "triggered_at": "2023-05-31T08:15:09.926931Z", "revoked_at":
         "2024-12-10T12:16:03.693045Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "63728091-d083-47cc-9898-73c2636f2c7f", "name": "ggshield-ZIU1V3Bv", "description":
         null, "created_at": "2023-05-31T08:17:12.607879Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/63728091-d083-47cc-9898-73c2636f2c7f",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-31T08:17:38.021142Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "001c53df-b63c-4b81-a4fb-35e5b38bf328", "name": "DevOxx Poland", "description":
-        "", "created_at": "2023-05-31T12:28:39.713989Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/001c53df-b63c-4b81-a4fb-35e5b38bf328",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "001c53df-b63c-4b81-a4fb-35e5b38bf328",
+        "name": "DevOxx Poland", "description": "", "created_at": "2023-05-31T12:28:39.713989Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/001c53df-b63c-4b81-a4fb-35e5b38bf328",
         "status": "triggered", "triggered_at": "2023-05-31T14:09:21.767459Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 225, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05", "name": "ggshield-cptptJHt",
-        "description": "ggshield test", "created_at": "2023-06-02T08:47:41.149126Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05",
+        "name": "ggshield-cptptJHt", "description": "ggshield test", "created_at":
+        "2023-06-02T08:47:41.149126Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
-        "name": "ggshield-TtJwtxNE", "description": "ggshield test", "created_at":
-        "2023-06-02T08:48:20.148216Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72", "name": "ggshield-TtJwtxNE",
+        "description": "ggshield test", "created_at": "2023-06-02T08:48:20.148216Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "27379093-c6a4-4732-a64a-715c94e74fd7",
-        "name": "ggshield-TvFzKVed", "description": null, "created_at": "2023-06-09T08:01:57.360210Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/27379093-c6a4-4732-a64a-715c94e74fd7",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "27379093-c6a4-4732-a64a-715c94e74fd7", "name": "ggshield-TvFzKVed",
+        "description": null, "created_at": "2023-06-09T08:01:57.360210Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/27379093-c6a4-4732-a64a-715c94e74fd7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "62cb7048-4302-4b52-9163-e2ceff775b39", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc7214d0-c97a-44b3-b576-664f0a81c4f7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc7214d0-c97a-44b3-b576-664f0a81c4f7",
         "name": "repo analytics 19jun", "description": "", "created_at": "2023-06-19T09:11:21.788070Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc7214d0-c97a-44b3-b576-664f0a81c4f7",
         "status": "revoked", "triggered_at": "2023-06-20T17:24:35.145047Z", "revoked_at":
         "2023-12-11T14:50:27.627289Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb", "name": "ggshield-0etjSvZJ",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb", "name": "ggshield-0etjSvZJ",
         "description": "description", "created_at": "2023-07-05T08:27:14.048162Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-05T08:27:15.756813Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0e4f0dbd-b288-4990-9565-3cc7b0171a79",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:53.240550Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 160089, "revoker_id":
         296618, "creator_api_token_id": "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "14566c1f-0b52-4770-ab68-000704242633", "name": "ggshield-Rv2mUej7",
-        "description": "description", "created_at": "2023-07-05T08:55:23.864812Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "14566c1f-0b52-4770-ab68-000704242633",
+        "name": "ggshield-Rv2mUej7", "description": "description", "created_at": "2023-07-05T08:55:23.864812Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/14566c1f-0b52-4770-ab68-000704242633",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c8c94ffa-c0af-48c6-976a-6502a41811af",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c8c94ffa-c0af-48c6-976a-6502a41811af",
         "name": "honeytoken demo eric", "description": "demo here", "created_at":
         "2023-07-05T14:48:53.893911Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c8c94ffa-c0af-48c6-976a-6502a41811af",
         "status": "triggered", "triggered_at": "2023-07-05T14:49:33.528178Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
         "name": "Example TOken ", "description": "ubvcub", "created_at": "2023-07-12T13:16:10.775681Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
-        "key": "file", "value": ".env"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "0c3f182e-98f5-4a64-aadb-664fd7c9de88", "name": "ggshield-ewIAL7lq", "description":
@@ -282,58 +260,55 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
         "name": "ggshield-w1P1Ggsz", "description": "description", "created_at": "2023-07-27T08:56:55.435203Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a20a718-7b9e-4582-abdf-772053bffd72",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a20a718-7b9e-4582-abdf-772053bffd72",
         "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T08:56:56.138738Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a20a718-7b9e-4582-abdf-772053bffd72",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:58.657957Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "51f41814-f029-4ab4-b863-c0fecba025b3", "name": "ggshield-v3LhZCz8",
-        "description": "description", "created_at": "2023-07-27T09:01:36.117217Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51f41814-f029-4ab4-b863-c0fecba025b3",
+        "name": "ggshield-v3LhZCz8", "description": "description", "created_at": "2023-07-27T09:01:36.117217Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/51f41814-f029-4ab4-b863-c0fecba025b3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T09:01:36.764795Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-27T09:01:37.417151Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e842a635-eb7e-4617-8984-ac57fe909ef7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
         "name": "ggshield-5voYnhhy", "description": null, "created_at": "2023-07-27T13:50:51.332176Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T13:52:58.300149Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "521efd01-bbcc-4380-b548-ed7242c017ea",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "521efd01-bbcc-4380-b548-ed7242c017ea",
         "name": "ggshield-HLZpiznn", "description": null, "created_at": "2023-07-27T14:54:03.198466Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/521efd01-bbcc-4380-b548-ed7242c017ea",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0d81797a-6fc0-4a6e-a211-af16828c0c39",
-        "name": "Webinar Public ", "description": "from webinar ", "created_at": "2023-07-27T15:33:07.472730Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0d81797a-6fc0-4a6e-a211-af16828c0c39", "name": "Webinar
+        Public ", "description": "from webinar ", "created_at": "2023-07-27T15:33:07.472730Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0d81797a-6fc0-4a6e-a211-af16828c0c39",
         "status": "triggered", "triggered_at": "2023-07-27T15:34:48.902462Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 204, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "27e9ba01-4bb6-46ed-84c8-ff14366a3bde", "name": "Private network", "description":
@@ -342,60 +317,55 @@ interactions:
         "status": "triggered", "triggered_at": "2023-07-27T16:23:35.804271Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5670c657-618f-41d7-984b-d59656d905e4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5670c657-618f-41d7-984b-d59656d905e4",
         "name": "ggshield-3KTmbo8u", "description": null, "created_at": "2023-07-27T15:44:43.238742Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5670c657-618f-41d7-984b-d59656d905e4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5d3ad22c-e422-48d2-b7f5-6d52801599aa",
-        "name": "demo 31jul", "description": "", "created_at": "2023-07-31T15:27:18.323098Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d3ad22c-e422-48d2-b7f5-6d52801599aa",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5d3ad22c-e422-48d2-b7f5-6d52801599aa", "name": "demo
+        31jul", "description": "", "created_at": "2023-07-31T15:27:18.323098Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d3ad22c-e422-48d2-b7f5-6d52801599aa",
         "status": "revoked", "triggered_at": "2023-07-31T15:33:49.570793Z", "revoked_at":
         "2023-12-11T14:01:40.706751Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a", "name": "test
-        Antonin 1", "description": "", "created_at": "2023-08-03T08:42:25.251504Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fa63d76d-4297-4d41-8e77-b47d1a97a41a",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a", "name": "test Antonin 1", "description":
+        "", "created_at": "2023-08-03T08:42:25.251504Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fa63d76d-4297-4d41-8e77-b47d1a97a41a",
         "status": "revoked", "triggered_at": "2023-08-03T08:59:58.717709Z", "revoked_at":
         "2023-08-03T09:00:05.809852Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "a11570c6-f472-4fda-a493-30d65fd8e651", "name": "test Antonin 2", "description":
-        "", "created_at": "2023-08-03T14:09:46.046004Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a11570c6-f472-4fda-a493-30d65fd8e651",
+        "name": "test Antonin 2", "description": "", "created_at": "2023-08-03T14:09:46.046004Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40",
-        "name": "vBOY test segment", "description": "sdqsdqsdqsdqsd", "created_at":
-        "2023-08-07T12:45:52.890085Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40", "name": "vBOY
+        test segment", "description": "sdqsdqsdqsdqsd", "created_at": "2023-08-07T12:45:52.890085Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-08-07T12:46:45.470113Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "name": "vBOY test segment 2", "description": "sdqsdqsd", "created_at": "2023-08-07T12:47:49.515448Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "86670f84-e117-4f96-aa16-e399a0bb2cf2",
-        "name": "juuj", "description": "", "created_at": "2023-08-08T15:53:23.097840Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86670f84-e117-4f96-aa16-e399a0bb2cf2",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "86670f84-e117-4f96-aa16-e399a0bb2cf2", "name": "juuj",
+        "description": "", "created_at": "2023-08-08T15:53:23.097840Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/86670f84-e117-4f96-aa16-e399a0bb2cf2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
-        "name": "BSidesLV", "description": "Key leaked publically by leakymcgee again",
-        "created_at": "2023-08-10T00:11:42.132386Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "978bf5aa-1f8e-425b-ac4b-b617ddbc178e", "name": "BSidesLV",
+        "description": "Key leaked publically by leakymcgee again", "created_at":
+        "2023-08-10T00:11:42.132386Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
         "status": "triggered", "triggered_at": "2023-08-10T00:13:19.948280Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
-        "key": "date leaked", "value": "08/09/2023"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
-        "key": "format", "value": "public"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
+        ["publicly_exposed"], "custom_tags": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
         "key": "date leaked", "value": "08/09/2023"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
         "key": "format", "value": "public"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
@@ -405,9 +375,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-08-11T18:55:35.503991Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 61, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
+        ["publicly_exposed"], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "90d4c2b6-ecae-4ef9-a754-4561929b9e38",
         "name": "ggshield-mpkTH5jF", "description": "description", "created_at": "2023-08-16T08:28:18.684517Z",
@@ -415,34 +383,31 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
         "name": "ggshield-mzO8qHEz", "description": "description", "created_at": "2023-08-22T08:19:03.821471Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
         "name": "testket ", "description": "eew", "created_at": "2023-08-29T10:21:29.956291Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "46776cb3-6b11-41fc-b431-07609992f0cb",
-        "name": "HoneyTokenaLARTest", "description": "Testworkshop", "created_at":
-        "2023-08-29T12:07:20.692993Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/46776cb3-6b11-41fc-b431-07609992f0cb",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "46776cb3-6b11-41fc-b431-07609992f0cb", "name": "HoneyTokenaLARTest",
+        "description": "Testworkshop", "created_at": "2023-08-29T12:07:20.692993Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/46776cb3-6b11-41fc-b431-07609992f0cb",
         "status": "revoked", "triggered_at": "2023-08-29T12:09:16.581232Z", "revoked_at":
         "2023-08-29T12:42:37.841866Z", "type": "AWS", "open_events_count": 0, "creator_id":
         37699, "revoker_id": 37699, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "edd96a3b-5c71-4346-b5e2-2150e454dc91", "name": "Bsides Krakow", "description":
-        "Demo for leaking a key on GitHub", "created_at": "2023-09-02T13:20:53.501588Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/edd96a3b-5c71-4346-b5e2-2150e454dc91",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "edd96a3b-5c71-4346-b5e2-2150e454dc91",
+        "name": "Bsides Krakow", "description": "Demo for leaking a key on GitHub",
+        "created_at": "2023-09-02T13:20:53.501588Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/edd96a3b-5c71-4346-b5e2-2150e454dc91",
         "status": "triggered", "triggered_at": "2023-09-02T13:22:51.142717Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "de145bd4-b424-49ab-b95b-80126914bf2e",
         "name": "ctf-demo-test-honeytoken-django-app", "description": "", "created_at":
@@ -450,68 +415,59 @@ interactions:
         "status": "revoked", "triggered_at": "2023-09-06T07:42:55.177580Z", "revoked_at":
         "2023-09-06T10:03:30.948628Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "5564ed3c-3eec-4375-9fc8-e0ada71dce02", "name": "ctf-demo-test-honeytoken-micro-api",
-        "description": "", "created_at": "2023-09-05T19:18:08.504776Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/5564ed3c-3eec-4375-9fc8-e0ada71dce02",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5564ed3c-3eec-4375-9fc8-e0ada71dce02",
+        "name": "ctf-demo-test-honeytoken-micro-api", "description": "", "created_at":
+        "2023-09-05T19:18:08.504776Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5564ed3c-3eec-4375-9fc8-e0ada71dce02",
         "status": "revoked", "triggered_at": "2023-09-06T07:44:18.074891Z", "revoked_at":
         "2023-09-06T10:03:48.581110Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "f246c64a-3494-43ae-9d81-500df2f950c3", "name": "demo-honeytoken-ctf-personal-",
-        "description": "", "created_at": "2023-09-06T11:29:57.547211Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/f246c64a-3494-43ae-9d81-500df2f950c3",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f246c64a-3494-43ae-9d81-500df2f950c3",
+        "name": "demo-honeytoken-ctf-personal-", "description": "", "created_at":
+        "2023-09-06T11:29:57.547211Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f246c64a-3494-43ae-9d81-500df2f950c3",
         "status": "revoked", "triggered_at": "2023-09-06T12:18:14.949044Z", "revoked_at":
         "2024-12-10T12:15:49.265110Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
         "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "ff623703-9ca1-4fba-99dc-c20110894ed3",
         "name": "-demo-honeytoken-ctf-django-app-", "description": "", "created_at":
         "2023-09-06T11:33:27.376222Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff623703-9ca1-4fba-99dc-c20110894ed3",
         "status": "triggered", "triggered_at": "2023-09-06T14:19:10.580142Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 4, "creator_id": null, "revoker_id":
+        null, "type": "AWS", "open_events_count": 9, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "a58154f6-e66f-4079-82b7-aabec70c73ff",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "a58154f6-e66f-4079-82b7-aabec70c73ff",
         "name": "demo-honeytoken-ctf-micro-api", "description": "", "created_at":
         "2023-09-06T11:33:37.828240Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a58154f6-e66f-4079-82b7-aabec70c73ff",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-09-06T14:17:20.708816Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b01db549-a2fa-4527-913d-0715a1119530",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "b01db549-a2fa-4527-913d-0715a1119530",
         "name": "demo-honeytoken-ctf-internal-share-", "description": "", "created_at":
         "2023-09-06T11:33:48.881275Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b01db549-a2fa-4527-913d-0715a1119530",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-09-06T14:21:42.509905Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "89a1745a-f796-4ece-99f7-106671aea57c",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "89a1745a-f796-4ece-99f7-106671aea57c",
         "name": "-demo-honeytoken-ctf-micro-api-", "description": "", "created_at":
         "2023-09-06T14:19:32.695323Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/89a1745a-f796-4ece-99f7-106671aea57c",
         "status": "triggered", "triggered_at": "2023-09-06T14:24:18.462424Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "095d655f-a273-400f-ba01-eff8951242ed",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "095d655f-a273-400f-ba01-eff8951242ed",
         "name": "-demo-honeytoken-ctf-internal-share-", "description": "", "created_at":
         "2023-09-06T14:21:55.062468Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/095d655f-a273-400f-ba01-eff8951242ed",
         "status": "triggered", "triggered_at": "2023-09-08T16:58:49.455578Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 6, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "3664c283-d479-41ac-9ad9-30283731ee25",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "3664c283-d479-41ac-9ad9-30283731ee25",
         "name": "Balccon Demo", "description": "Demo key for Balccon ", "created_at":
         "2023-09-08T14:55:02.417580Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3664c283-d479-41ac-9ad9-30283731ee25",
         "status": "triggered", "triggered_at": "2023-09-08T14:56:49.516889Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
-        "key": "location", "value": "sourcecode"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
-        "key": "visability", "value": "public"}], "custom_tags": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
+        ["publicly_exposed"], "custom_tags": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
         "key": "location", "value": "sourcecode"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
         "key": "visability", "value": "public"}], "token": "[REDACTED]"}, {"id": "7ca5ca92-a0a1-48bf-9618-d7194beaa039",
@@ -520,9 +476,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-09-29T16:11:40.077048Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 344, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
-        "key": "confrence", "value": "grrcon"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}], "custom_tags": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
+        ["publicly_exposed"], "custom_tags": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
         "key": "confrence", "value": "grrcon"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}], "token": "[REDACTED]"}, {"id": "2544b3e6-57b2-48e2-a1a5-c4b6551987bb",
         "name": "SBB demo", "description": "Leaking key on GitHub", "created_at":
@@ -530,11 +484,8 @@ interactions:
         "status": "triggered", "triggered_at": "2024-08-17T15:36:55.810693Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key": "commiter",
-        "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca", "key":
-        "file", "value": ".env"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327", "key":
-        "vcs", "value": "github"}], "custom_tags": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda",
-        "key": "commiter", "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
+        [], "custom_tags": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key":
+        "commiter", "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "7d80793b-c702-441e-837e-b1d3da94d576",
         "name": "Hacktivity Key", "description": "Test Key Leak for Hacktivity", "created_at":
@@ -542,9 +493,7 @@ interactions:
         "status": "revoked", "triggered_at": "2023-10-05T14:42:57.752365Z", "revoked_at":
         "2024-12-10T12:17:33.875750Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "576dc1ce-ab72-4604-934f-526cff5a667e", "name": "BsidesCyprus", "description":
@@ -553,8 +502,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-10-07T11:35:53.017981Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 249, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "22fdf53a-e348-464a-a87f-5bcecb1a4e62", "name": "Slack test", "description":
         "blablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablabla
@@ -567,21 +515,20 @@ interactions:
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-06-03T09:50:06.667490Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 363707, "revoker_id":
         353920, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "137c9fee-4b3c-4231-92fd-98debf6557c2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "137c9fee-4b3c-4231-92fd-98debf6557c2",
         "name": "BSides ATL demo for session", "description": "This one will be triggered
         from 2 different spots online", "created_at": "2023-10-14T12:28:51.206659Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/137c9fee-4b3c-4231-92fd-98debf6557c2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 354585, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "cdaea884-25fb-49db-90ec-a18879be36c4",
-        "name": "Demo Honeytoken", "description": "Leaking on Public Demo", "created_at":
-        "2023-10-16T15:13:10.845487Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cdaea884-25fb-49db-90ec-a18879be36c4",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "cdaea884-25fb-49db-90ec-a18879be36c4", "name": "Demo
+        Honeytoken", "description": "Leaking on Public Demo", "created_at": "2023-10-16T15:13:10.845487Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cdaea884-25fb-49db-90ec-a18879be36c4",
         "status": "revoked", "triggered_at": "2023-10-16T15:14:25.574559Z", "revoked_at":
         "2023-10-27T15:01:19.053629Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "48f7c567-93d1-4925-9f77-d3919f120b88", "name": "ggshield-KlAkKRtE", "description":
         "description", "created_at": "2023-10-16T19:49:08.588391Z", "gitguardian_url":
@@ -589,52 +536,50 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
         "name": "Jason test", "description": "Token for Test ", "created_at": "2023-10-24T13:45:31.371710Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f8e0968-664a-49f3-af85-9cc468b960ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "fe392ff1-b3d7-462f-a26f-d094326f40ed",
-        "name": "Jason and team", "description": "akljdlaj", "created_at": "2023-10-24T14:23:20.991107Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fe392ff1-b3d7-462f-a26f-d094326f40ed", "name": "Jason
+        and team", "description": "akljdlaj", "created_at": "2023-10-24T14:23:20.991107Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fe392ff1-b3d7-462f-a26f-d094326f40ed",
         "status": "triggered", "triggered_at": "2024-05-10T22:15:09.224357Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29",
         "name": "Eric Demo Test 01", "description": "", "created_at": "2023-10-31T12:51:44.535200Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d69a098c-8b61-4102-bb2b-9a82958a3e29",
         "status": "revoked", "triggered_at": "2023-10-31T12:52:49.851916Z", "revoked_at":
         "2024-12-10T12:16:28.115539Z", "type": "AWS", "open_events_count": 0, "creator_id":
         136170, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb", "name": "test
-        eric dd 02", "description": "", "created_at": "2023-10-31T14:33:35.801324Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4affa602-902b-47ff-a1f4-721dc3e671bb",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb", "name": "test eric dd 02",
+        "description": "", "created_at": "2023-10-31T14:33:35.801324Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/4affa602-902b-47ff-a1f4-721dc3e671bb",
         "status": "triggered", "triggered_at": "2023-10-31T14:35:33.676298Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 2897, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "8df388e2-aeb5-42ca-b6d5-221a54a40339", "name": "ggshield-P47kTh7j",
-        "description": null, "created_at": "2023-11-09T15:44:33.671666Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/8df388e2-aeb5-42ca-b6d5-221a54a40339",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8df388e2-aeb5-42ca-b6d5-221a54a40339",
+        "name": "ggshield-P47kTh7j", "description": null, "created_at": "2023-11-09T15:44:33.671666Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8df388e2-aeb5-42ca-b6d5-221a54a40339",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "bd51c3d9-0943-43d5-8f87-359ecee03903",
-        "name": "ggshield-73VAsjsO", "description": null, "created_at": "2023-11-14T08:27:44.885242Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bd51c3d9-0943-43d5-8f87-359ecee03903",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "bd51c3d9-0943-43d5-8f87-359ecee03903", "name": "ggshield-73VAsjsO",
+        "description": null, "created_at": "2023-11-14T08:27:44.885242Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/bd51c3d9-0943-43d5-8f87-359ecee03903",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-11-14T08:28:08.188201Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
         "name": "DeepSec Demo", "description": "Demo for DeepSec Confrence ", "created_at":
         "2023-11-16T16:01:21.723176Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
         "status": "triggered", "triggered_at": "2023-11-16T16:01:58.603599Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "ae448808-3865-4797-a008-9eef6344f9da", "name": "Bsides Berlin", "description":
         "test key for a demo", "created_at": "2023-11-18T16:19:36.463172Z", "gitguardian_url":
@@ -642,9 +587,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-11-18T16:20:14.365596Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 105, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
-        "key": "repo", "value": "mackenziejj"}], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
+        ["publicly_exposed"], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
         "key": "repo", "value": "mackenziejj"}], "token": "[REDACTED]"}, {"id": "ecb3d61d-bdab-4636-a436-bef8079a005d",
         "name": "ggshield-ObfCUUCA", "description": "description", "created_at": "2023-11-28T08:50:32.130230Z",
@@ -652,48 +595,41 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d6d5d79d-08fa-4c8a-bd54-c34851866cde",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d6d5d79d-08fa-4c8a-bd54-c34851866cde",
         "name": "test1112", "description": "test publicly exposed honeytoken", "created_at":
         "2023-12-11T16:24:56.253683Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d6d5d79d-08fa-4c8a-bd54-c34851866cde",
         "status": "triggered", "triggered_at": "2023-12-11T16:26:07.733443Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "4046ccf5-7821-47f4-be7d-8240be69631b",
         "name": "ideal-journey-lena", "description": "", "created_at": "2023-12-11T16:29:20.759489Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4046ccf5-7821-47f4-be7d-8240be69631b",
-        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
-        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
+        "status": "triggered", "triggered_at": "2026-05-28T07:56:58.047592Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 5, "creator_id": 319222, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
         "name": "analytics-repo", "description": "", "created_at": "2023-12-11T17:37:24.471286Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
         "status": "triggered", "triggered_at": "2023-12-11T17:46:48.024345Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "b7daf77c-e3e0-4747-a7e2-485a1a6f05e2",
-        "key": "team", "value": "dev"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "b7daf77c-e3e0-4747-a7e2-485a1a6f05e2",
         "key": "team", "value": "dev"}], "token": "[REDACTED]"}, {"id": "52903632-f6ff-460e-8a68-80a942349979",
         "name": "Network Honeytoken", "description": "Aws Honeytoken on Network",
         "created_at": "2023-12-18T13:47:39.151311Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/52903632-f6ff-460e-8a68-80a942349979",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
-        "key": "network", "value": "directory"}], "custom_tags": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
         "key": "network", "value": "directory"}], "token": "[REDACTED]"}, {"id": "6c5d9856-835e-468c-9448-7bf0e77f1e53",
         "name": "improved carnival", "description": "", "created_at": "2023-12-21T13:43:01.544215Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6c5d9856-835e-468c-9448-7bf0e77f1e53",
         "status": "revoked", "triggered_at": "2023-12-21T13:57:59.435706Z", "revoked_at":
         "2023-12-22T09:33:18.668820Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "4dd77510-fc74-411f-9dbe-77619fa920dd",
         "name": "My Postman Public Collection", "description": "Will it ring?", "created_at":
@@ -701,242 +637,231 @@ interactions:
         "status": "triggered", "triggered_at": "2024-01-04T17:52:01.203498Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 811, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
         "name": "ggshield-JZV5XT71", "description": "description", "created_at": "2024-01-09T09:39:34.421404Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "name": "sss", "description": "test", "created_at": "2024-01-09T14:24:10.741214Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
-        "name": "AWS key honeytoken for Slack", "description": "Honeytoken on Slack
-        channel", "created_at": "2024-01-15T16:13:53.656688Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "123ecd19-e66f-4e5c-ad73-12f0a51eda5a", "name": "AWS
+        key honeytoken for Slack", "description": "Honeytoken on Slack channel", "created_at":
+        "2024-01-15T16:13:53.656688Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
         "status": "triggered", "triggered_at": "2024-01-15T16:14:14.960066Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 104, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "23ca2658-aecf-471c-abf0-add09962e320", "key": "ods",
-        "value": "slack"}], "custom_tags": [{"id": "23ca2658-aecf-471c-abf0-add09962e320",
-        "key": "ods", "value": "slack"}], "token": "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a",
+        [], "custom_tags": [{"id": "23ca2658-aecf-471c-abf0-add09962e320", "key":
+        "ods", "value": "slack"}], "token": "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a",
         "name": "BK Test Paris", "description": "Brandon while in Paris office", "created_at":
         "2024-01-17T11:12:14.759334Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/34d5205b-accd-429c-9efa-eda48989c83a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
-        "name": "Lauren Testing", "description": "Lauren wuz here", "created_at":
-        "2024-01-29T17:37:45.379096Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4", "name": "Lauren
+        Testing", "description": "Lauren wuz here", "created_at": "2024-01-29T17:37:45.379096Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 637596, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "07fb5f6f-23f1-42e8-bdb2-c95864412a16",
         "name": "My Little Honeytoken", "description": "for testing", "created_at":
         "2024-02-02T22:18:06.038874Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/07fb5f6f-23f1-42e8-bdb2-c95864412a16",
         "status": "triggered", "triggered_at": "2024-02-09T20:50:13.173911Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b00bfddb-98c2-48e4-ad38-0cb9bc79cad6", "name": "orga_083643/solid-octo",
-        "description": "", "created_at": "2024-02-09T14:45:12.139727Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
+        "name": "orga_083643/solid-octo", "description": "", "created_at": "2024-02-09T14:45:12.139727Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
         "status": "revoked", "triggered_at": "2024-02-09T14:52:11.339548Z", "revoked_at":
         "2024-05-29T13:09:29.773300Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 2508, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "cf0806c4-093d-4165-9ad3-7e7ded211d3f", "name": "DemoKey", "description":
-        "sss", "created_at": "2024-02-15T12:39:23.633481Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cf0806c4-093d-4165-9ad3-7e7ded211d3f",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cf0806c4-093d-4165-9ad3-7e7ded211d3f",
+        "name": "DemoKey", "description": "sss", "created_at": "2024-02-15T12:39:23.633481Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cf0806c4-093d-4165-9ad3-7e7ded211d3f",
         "status": "triggered", "triggered_at": "2024-02-15T12:45:44.649197Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "638f6f82-6679-4399-a336-dd7996f4beae", "name": "demo-2024-02-16dm",
-        "description": "demo", "created_at": "2024-02-16T19:39:33.970811Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/638f6f82-6679-4399-a336-dd7996f4beae",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "638f6f82-6679-4399-a336-dd7996f4beae",
+        "name": "demo-2024-02-16dm", "description": "demo", "created_at": "2024-02-16T19:39:33.970811Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/638f6f82-6679-4399-a336-dd7996f4beae",
         "status": "revoked", "triggered_at": "2024-02-16T19:40:02.759791Z", "revoked_at":
         "2024-02-16T20:10:11.153368Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "6fcc5cf2-4b47-497d-9a80-c2d794b96ebc", "name": "solid-octo",
-        "description": "", "created_at": "2024-02-19T13:06:26.880374Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "6fcc5cf2-4b47-497d-9a80-c2d794b96ebc", "name": "solid-octo", "description":
+        "", "created_at": "2024-02-19T13:06:26.880374Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
-        "key": "team", "value": "octo"}], "custom_tags": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
         "key": "team", "value": "octo"}], "token": "[REDACTED]"}, {"id": "1592023a-2f39-4ba6-a503-4c07132f1eb0",
         "name": "GGnikalston/rock-paper-scissors-f4c01375", "description": "", "created_at":
         "2024-02-20T13:32:45.163630Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1592023a-2f39-4ba6-a503-4c07132f1eb0",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d024b464-cd1e-4daf-9b1d-863dcf517a7a",
-        "name": "Demo -2024-02-22", "description": "", "created_at": "2024-02-22T18:53:26.142516Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d024b464-cd1e-4daf-9b1d-863dcf517a7a", "name": "Demo
+        -2024-02-22", "description": "", "created_at": "2024-02-22T18:53:26.142516Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d024b464-cd1e-4daf-9b1d-863dcf517a7a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 354585, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0a94480f-5361-47f8-bc23-45a331624e9d",
-        "name": "demo ", "description": "demo ", "created_at": "2024-02-22T19:02:29.338420Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0a94480f-5361-47f8-bc23-45a331624e9d",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0a94480f-5361-47f8-bc23-45a331624e9d", "name": "demo
+        ", "description": "demo ", "created_at": "2024-02-22T19:02:29.338420Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/0a94480f-5361-47f8-bc23-45a331624e9d",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T17:03:31.533534Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86136984-d415-41c2-bfc4-59da8f9584fd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86136984-d415-41c2-bfc4-59da8f9584fd",
         "name": "demo-2024-02-23-dm", "description": "", "created_at": "2024-02-23T15:38:04.895275Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86136984-d415-41c2-bfc4-59da8f9584fd",
         "status": "revoked", "triggered_at": "2024-02-23T15:49:03.613445Z", "revoked_at":
         "2024-02-23T15:59:54.768989Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "b38455f9-822c-4f21-8525-0d4f2fa63850", "name": "demo-dwayne-2024-02-23",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "b38455f9-822c-4f21-8525-0d4f2fa63850", "name": "demo-dwayne-2024-02-23",
         "description": "dfnijsbuisbfids", "created_at": "2024-02-23T15:45:47.636481Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b38455f9-822c-4f21-8525-0d4f2fa63850",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T16:28:23.939971Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "612055eb-7fb5-4ba3-ab10-aa481f3d9962",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "612055eb-7fb5-4ba3-ab10-aa481f3d9962",
         "name": "demo-dwayne-2024-02-23-v2", "description": "Demo for video", "created_at":
         "2024-02-23T16:28:49.949332Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/612055eb-7fb5-4ba3-ab10-aa481f3d9962",
         "status": "revoked", "triggered_at": "2024-02-23T16:31:01.657151Z", "revoked_at":
         "2024-02-23T16:52:50.712289Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e", "name": "myname-dwayneptoday",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e", "name": "myname-dwayneptoday",
         "description": "dfsdfsdf", "created_at": "2024-02-23T16:38:14.323313Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T17:03:21.653827Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1bba091c-fc4c-48b5-b558-46c191f67103",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1bba091c-fc4c-48b5-b558-46c191f67103",
         "name": "ggshield-ldC5hqqo", "description": "description", "created_at": "2024-02-27T13:42:36.686028Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1bba091c-fc4c-48b5-b558-46c191f67103",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d7764013-fdd5-4b08-b195-dff5a338906d",
-        "name": "ggshield-LRYYnjOa", "description": "description", "created_at": "2024-02-27T13:42:37.569678Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d7764013-fdd5-4b08-b195-dff5a338906d", "name": "ggshield-LRYYnjOa",
+        "description": "description", "created_at": "2024-02-27T13:42:37.569678Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d7764013-fdd5-4b08-b195-dff5a338906d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "def4a23d-3d12-4fe1-b8e0-02250e74e47a",
-        "name": "ggshield-itglxnie", "description": "description", "created_at": "2024-02-27T13:58:30.205444Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "def4a23d-3d12-4fe1-b8e0-02250e74e47a", "name": "ggshield-itglxnie",
+        "description": "description", "created_at": "2024-02-27T13:58:30.205444Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/def4a23d-3d12-4fe1-b8e0-02250e74e47a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "33d149f1-68f4-4446-ae4f-def0ce962724",
-        "name": "ggshield-2Mf02eVA", "description": "description", "created_at": "2024-02-27T13:58:31.125075Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "33d149f1-68f4-4446-ae4f-def0ce962724", "name": "ggshield-2Mf02eVA",
+        "description": "description", "created_at": "2024-02-27T13:58:31.125075Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/33d149f1-68f4-4446-ae4f-def0ce962724",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5ff5eee1-fc18-4474-86fa-c46321c903c8",
-        "name": "ggshield-rmnfzrW2", "description": "description", "created_at": "2024-02-27T14:02:45.009113Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5ff5eee1-fc18-4474-86fa-c46321c903c8", "name": "ggshield-rmnfzrW2",
+        "description": "description", "created_at": "2024-02-27T14:02:45.009113Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5ff5eee1-fc18-4474-86fa-c46321c903c8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "4dd6c06e-e2c0-4593-9be0-b0418ba7a370",
-        "name": "ggshield-5YTKZZTB", "description": "description", "created_at": "2024-02-27T14:02:45.717261Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "4dd6c06e-e2c0-4593-9be0-b0418ba7a370", "name": "ggshield-5YTKZZTB",
+        "description": "description", "created_at": "2024-02-27T14:02:45.717261Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4dd6c06e-e2c0-4593-9be0-b0418ba7a370",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "eba79796-4f46-4e10-b876-280f75138cc9",
-        "name": "ggshield-z3Y6zgih", "description": "description", "created_at": "2024-02-27T14:06:02.196977Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "eba79796-4f46-4e10-b876-280f75138cc9", "name": "ggshield-z3Y6zgih",
+        "description": "description", "created_at": "2024-02-27T14:06:02.196977Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/eba79796-4f46-4e10-b876-280f75138cc9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0ebc8091-454b-461e-a6f8-fd17bf412c76",
-        "name": "ggshield-jqk54PrI", "description": "description", "created_at": "2024-02-27T14:06:03.018091Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0ebc8091-454b-461e-a6f8-fd17bf412c76", "name": "ggshield-jqk54PrI",
+        "description": "description", "created_at": "2024-02-27T14:06:03.018091Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ebc8091-454b-461e-a6f8-fd17bf412c76",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "664af568-cfc7-4726-9fb4-0b61606b7386",
-        "name": "ggshield-horgQNnR", "description": "description", "created_at": "2024-02-27T14:19:39.357690Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "664af568-cfc7-4726-9fb4-0b61606b7386", "name": "ggshield-horgQNnR",
+        "description": "description", "created_at": "2024-02-27T14:19:39.357690Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/664af568-cfc7-4726-9fb4-0b61606b7386",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5d915aca-6f6f-4b4e-a996-2c1f53016114",
-        "name": "ggshield-LNgN8R1S", "description": "description", "created_at": "2024-02-27T14:19:40.283320Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5d915aca-6f6f-4b4e-a996-2c1f53016114", "name": "ggshield-LNgN8R1S",
+        "description": "description", "created_at": "2024-02-27T14:19:40.283320Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d915aca-6f6f-4b4e-a996-2c1f53016114",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245",
-        "name": "Test key ", "description": "ss", "created_at": "2024-02-29T13:49:52.467489Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245", "name": "Test
+        key ", "description": "ss", "created_at": "2024-02-29T13:49:52.467489Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e",
-        "name": "test-lena-1903", "description": "", "created_at": "2024-03-19T09:13:00.819618Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/443045cc-7fa4-441d-a161-b060bd7fbb3e",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e", "name": "test-lena-1903",
+        "description": "", "created_at": "2024-03-19T09:13:00.819618Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/443045cc-7fa4-441d-a161-b060bd7fbb3e",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-05-29T09:51:31.597203Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 319222, "revoker_id":
         319222, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
         "name": "ggshield-Psfrcoxl", "description": "description", "created_at": "2024-03-27T08:48:20.857237Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5a01f826-4f8f-4235-8867-ce58ac88ce1c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5a01f826-4f8f-4235-8867-ce58ac88ce1c",
         "name": "ggshield-inUFY47O", "description": "description", "created_at": "2024-03-27T08:48:21.791104Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5a01f826-4f8f-4235-8867-ce58ac88ce1c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d72113d0-c346-42c7-bd88-fd5fe0e716f3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d72113d0-c346-42c7-bd88-fd5fe0e716f3",
         "name": "ggshield-eY0ZOlXS", "description": "description", "created_at": "2024-04-30T09:25:38.689800Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d72113d0-c346-42c7-bd88-fd5fe0e716f3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "7f2873cd-3759-4727-a683-31cac57fe5d8",
-        "name": "ggshield-TvlX76OG", "description": "description", "created_at": "2024-04-30T09:25:39.573115Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "7f2873cd-3759-4727-a683-31cac57fe5d8", "name": "ggshield-TvlX76OG",
+        "description": "description", "created_at": "2024-04-30T09:25:39.573115Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7f2873cd-3759-4727-a683-31cac57fe5d8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "72e98633-9179-4a3e-8908-ea2319d19b3b",
-        "name": "ggshield-XYKDhLUY", "description": "description", "created_at": "2024-04-30T10:19:12.369644Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "72e98633-9179-4a3e-8908-ea2319d19b3b", "name": "ggshield-XYKDhLUY",
+        "description": "description", "created_at": "2024-04-30T10:19:12.369644Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72e98633-9179-4a3e-8908-ea2319d19b3b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
         "name": "ggshield-HRoZzrBq", "description": "description", "created_at": "2024-04-30T10:19:13.126568Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
         "name": "Test key", "description": "Access key", "created_at": "2024-05-22T12:16:55.833940Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c7101eaa-ea38-495d-b3b4-c016db23e859",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "a67f962c-9dde-40c2-b404-e7cd4449cc82",
         "name": "pouet", "description": "", "created_at": "2024-05-22T12:19:03.143437Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a67f962c-9dde-40c2-b404-e7cd4449cc82",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
-        "key": "visability", "value": "public"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
         "key": "visability", "value": "public"}], "token": "[REDACTED]"}, {"id": "9cca01c5-535f-4f89-a214-6c4c5579fd07",
@@ -944,487 +869,473 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9cca01c5-535f-4f89-a214-6c4c5579fd07",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
-        "name": "test lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
-        "status": "triggered", "triggered_at": "2024-06-06T08:19:18.422045Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 319222, "revoker_id":
-        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca", "key": "machine",
-        "value": "ggprdgim01"}], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99", "name": "test
+        lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
         "key": "machine", "value": "ggprdgim01"}], "token": "[REDACTED]"}, {"id":
         "a411fa2c-a465-4099-8353-3c42365aca50", "name": "test MINT", "description":
         "test MINT", "created_at": "2024-06-10T14:40:08.522247Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/a411fa2c-a465-4099-8353-3c42365aca50",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "12c4562e-deb8-4d14-bb23-e344e79b6f04",
-        "name": "ggshield-Wq4EyTMI", "description": "description", "created_at": "2024-06-25T08:36:52.179380Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "12c4562e-deb8-4d14-bb23-e344e79b6f04", "name": "ggshield-Wq4EyTMI",
+        "description": "description", "created_at": "2024-06-25T08:36:52.179380Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/12c4562e-deb8-4d14-bb23-e344e79b6f04",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3407738b-2095-47bb-9cbd-dd16de158d67",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3407738b-2095-47bb-9cbd-dd16de158d67",
         "name": "ggshield-65KCwJls", "description": "description", "created_at": "2024-06-25T08:36:52.873146Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3407738b-2095-47bb-9cbd-dd16de158d67",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
         "name": "ggshield-fb77weow", "description": "description", "created_at": "2024-06-26T09:27:38.724573Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9223e352-43b6-4e06-8d12-682d669cedd7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9223e352-43b6-4e06-8d12-682d669cedd7",
         "name": "ggshield-TRO3H56N", "description": "description", "created_at": "2024-06-26T09:27:39.479744Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9223e352-43b6-4e06-8d12-682d669cedd7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "17e088b8-2463-48f8-957b-41d017f1dc83",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "17e088b8-2463-48f8-957b-41d017f1dc83",
         "name": "ggshield-s7IOqS0q", "description": "description", "created_at": "2024-06-26T09:42:26.454643Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/17e088b8-2463-48f8-957b-41d017f1dc83",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e332d717-641d-4ea4-81fc-e98115178454",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e332d717-641d-4ea4-81fc-e98115178454",
         "name": "ggshield-JaAf9b0W", "description": "description", "created_at": "2024-06-26T09:42:27.174527Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e332d717-641d-4ea4-81fc-e98115178454",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26514e1f-4237-474b-b907-037b88427f29",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26514e1f-4237-474b-b907-037b88427f29",
         "name": "ggshield-Uuc8EiUn", "description": "description", "created_at": "2024-06-26T11:51:19.747630Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/26514e1f-4237-474b-b907-037b88427f29",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
         "name": "ggshield-GL7wc5WW", "description": "description", "created_at": "2024-06-26T11:51:20.402145Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
         "name": "test ericf", "description": "", "created_at": "2024-07-09T09:34:04.089955Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
         "status": "triggered", "triggered_at": "2024-07-09T09:34:57.541777Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "a507d04c-bb61-4f2a-93ea-601b8aa27940",
         "name": "ggshield-w1cOSspy", "description": "description", "created_at": "2024-07-31T15:31:09.349255Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a507d04c-bb61-4f2a-93ea-601b8aa27940",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dafa04c5-299a-4a13-9c35-c523e51763f3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dafa04c5-299a-4a13-9c35-c523e51763f3",
         "name": "ggshield-b7VHMqbK", "description": "description", "created_at": "2024-07-31T15:31:10.071786Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dafa04c5-299a-4a13-9c35-c523e51763f3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
         "name": "ggshield-Fu1nGsc9", "description": "description", "created_at": "2024-08-05T09:03:52.745860Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "83888e42-dc57-471c-9a08-f023e3dc2949",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "83888e42-dc57-471c-9a08-f023e3dc2949",
         "name": "ggshield-5suF2vRt", "description": "description", "created_at": "2024-08-05T09:03:53.434873Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/83888e42-dc57-471c-9a08-f023e3dc2949",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e8aad547-96a7-40a4-a05d-710cf536f3a7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e8aad547-96a7-40a4-a05d-710cf536f3a7",
         "name": "ggshield-Vqz4LULC", "description": "description", "created_at": "2024-08-05T09:21:25.593516Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e8aad547-96a7-40a4-a05d-710cf536f3a7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
         "name": "ggshield-lqX7PlwI", "description": "description", "created_at": "2024-08-05T09:21:26.211228Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b144b1fd-dc5f-4a36-abc7-a95d05331245",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b144b1fd-dc5f-4a36-abc7-a95d05331245",
         "name": "ggshield-uZr6LNDv", "description": "description", "created_at": "2024-08-27T07:44:46.267249Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b144b1fd-dc5f-4a36-abc7-a95d05331245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "903bf588-2a03-4318-be6c-b9e3198d1fd6",
-        "name": "ggshield-5Ty2Hu4r", "description": "description", "created_at": "2024-08-27T07:44:46.871854Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "903bf588-2a03-4318-be6c-b9e3198d1fd6", "name": "ggshield-5Ty2Hu4r",
+        "description": "description", "created_at": "2024-08-27T07:44:46.871854Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/903bf588-2a03-4318-be6c-b9e3198d1fd6",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "11222b98-7705-4180-99d1-6e719d8a05a9",
-        "name": "ggshield-qnLief7n", "description": "description", "created_at": "2024-08-27T08:20:15.846360Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "11222b98-7705-4180-99d1-6e719d8a05a9", "name": "ggshield-qnLief7n",
+        "description": "description", "created_at": "2024-08-27T08:20:15.846360Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/11222b98-7705-4180-99d1-6e719d8a05a9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "707b35fb-685b-4577-88b9-94cccc10e165",
-        "name": "ggshield-wqYwwgeK", "description": "description", "created_at": "2024-08-27T08:20:16.467770Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "707b35fb-685b-4577-88b9-94cccc10e165", "name": "ggshield-wqYwwgeK",
+        "description": "description", "created_at": "2024-08-27T08:20:16.467770Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/707b35fb-685b-4577-88b9-94cccc10e165",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "01c7668d-1467-4cac-a395-4b50fc278407",
-        "name": "ggshield-QkzL5Vyb", "description": "description", "created_at": "2024-09-24T08:50:15.865165Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "01c7668d-1467-4cac-a395-4b50fc278407", "name": "ggshield-QkzL5Vyb",
+        "description": "description", "created_at": "2024-09-24T08:50:15.865165Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/01c7668d-1467-4cac-a395-4b50fc278407",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
         "name": "ggshield-kkpkfk1s", "description": "description", "created_at": "2024-09-24T08:50:16.667172Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "730bdd87-31b2-4b42-a32a-5750bc595c9c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "730bdd87-31b2-4b42-a32a-5750bc595c9c",
         "name": "ggshield-dtxlZtWH", "description": "description", "created_at": "2024-10-01T13:18:29.918337Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/730bdd87-31b2-4b42-a32a-5750bc595c9c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b42c6945-05fc-4c5b-af83-e60478cd9db5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b42c6945-05fc-4c5b-af83-e60478cd9db5",
         "name": "ggshield-WPIELIcW", "description": "description", "created_at": "2024-10-01T13:18:30.820570Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b42c6945-05fc-4c5b-af83-e60478cd9db5",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
         "name": "ggshield-B8LwcRR0", "description": "description", "created_at": "2024-10-16T13:47:50.239094Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "81d30531-a54e-4f67-a46b-a7bac5783995",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "81d30531-a54e-4f67-a46b-a7bac5783995",
         "name": "ggshield-IjJFdqDS", "description": "description", "created_at": "2024-10-16T13:47:51.425195Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/81d30531-a54e-4f67-a46b-a7bac5783995",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a0b24134-0cbc-4ca5-b110-18b3311aef73",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a0b24134-0cbc-4ca5-b110-18b3311aef73",
         "name": "DO-demo", "description": "Digital Ocean Demo", "created_at": "2024-10-23T17:55:40.621634Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a0b24134-0cbc-4ca5-b110-18b3311aef73",
         "status": "revoked", "triggered_at": "2024-10-23T18:03:40.135215Z", "revoked_at":
         "2024-10-23T18:33:47.488182Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "50e53ab6-4950-48e6-9350-b5aaa88fafea", "name": "Demo",
-        "description": "Dev team 1", "created_at": "2024-10-27T21:01:47.725365Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/50e53ab6-4950-48e6-9350-b5aaa88fafea",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "50e53ab6-4950-48e6-9350-b5aaa88fafea", "name": "Demo", "description":
+        "Dev team 1", "created_at": "2024-10-27T21:01:47.725365Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/50e53ab6-4950-48e6-9350-b5aaa88fafea",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582569, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}], "token": "[REDACTED]"},
         {"id": "795decd4-4703-4073-9b3c-3ec2157f6182", "name": "Demo token", "description":
         "Take a look", "created_at": "2024-10-28T00:34:48.214122Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/795decd4-4703-4073-9b3c-3ec2157f6182",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582569, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
-        "name": "ggshield-c6YSc2Ie", "description": "description", "created_at": "2024-10-29T14:36:27.096968Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "c43ee48d-4646-40e8-bd12-3dfa30a6b3db", "name": "ggshield-c6YSc2Ie",
+        "description": "description", "created_at": "2024-10-29T14:36:27.096968Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
         "name": "ggshield-E6IPnu0f", "description": "description", "created_at": "2024-10-29T14:36:28.513178Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a454c002-679b-4250-aacf-28b5207543a4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a454c002-679b-4250-aacf-28b5207543a4",
         "name": "ggshield-HjwRkUAT", "description": "description", "created_at": "2024-11-27T12:32:44.877048Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a454c002-679b-4250-aacf-28b5207543a4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5af2ae0-f3f6-4301-82bc-b49108bd782b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5af2ae0-f3f6-4301-82bc-b49108bd782b",
         "name": "ggshield-hIlrbyRm", "description": "description", "created_at": "2024-11-27T12:32:45.728067Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c5af2ae0-f3f6-4301-82bc-b49108bd782b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "aed37b34-4721-43c2-99e2-2f2e78592f63",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "aed37b34-4721-43c2-99e2-2f2e78592f63",
         "name": "ggshield/setup.cfg", "description": "", "created_at": "2024-12-17T10:10:25.895137Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/aed37b34-4721-43c2-99e2-2f2e78592f63",
         "status": "triggered", "triggered_at": "2024-12-17T10:19:35.167833Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 309802, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476", "name": "pierredethoisy/dockerfile",
-        "description": "", "created_at": "2024-12-17T10:30:41.655876Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
+        "name": "pierredethoisy/dockerfile", "description": "", "created_at": "2024-12-17T10:30:41.655876Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
         "status": "triggered", "triggered_at": "2024-12-17T10:32:09.594850Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 309802, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "4b814f00-0897-479f-8a2d-a9593c5f18fa", "name": "WrongSecrets", "description":
-        "Honeytoken for the wrongsecrets repositort", "created_at": "2025-02-06T13:10:31.569094Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4b814f00-0897-479f-8a2d-a9593c5f18fa",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4b814f00-0897-479f-8a2d-a9593c5f18fa",
+        "name": "WrongSecrets", "description": "Honeytoken for the wrongsecrets repositort",
+        "created_at": "2025-02-06T13:10:31.569094Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4b814f00-0897-479f-8a2d-a9593c5f18fa",
         "status": "triggered", "triggered_at": "2025-02-06T13:16:26.325168Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "7dfdb8ee-56fc-486e-9b7a-e6ff248107fa", "name": "ggshield-AAcFXCwl",
-        "description": "description", "created_at": "2025-02-27T10:23:31.621722Z",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
+        "name": "ggshield-AAcFXCwl", "description": "description", "created_at": "2025-02-27T10:23:31.621722Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "97877334-808d-48c7-8802-2c54e9f43661",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "97877334-808d-48c7-8802-2c54e9f43661",
         "name": "ggshield-srahH0o3", "description": "description", "created_at": "2025-02-27T10:23:32.385844Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/97877334-808d-48c7-8802-2c54e9f43661",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ca642fe-2ce4-42b2-9097-5904093935c1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ca642fe-2ce4-42b2-9097-5904093935c1",
         "name": "ggshield-5Vx0aaQd", "description": "description", "created_at": "2025-02-27T10:31:34.080183Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ca642fe-2ce4-42b2-9097-5904093935c1",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d8590557-764f-4618-9b2e-277d536bd111",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d8590557-764f-4618-9b2e-277d536bd111",
         "name": "ggshield-QYqCVZ4i", "description": "description", "created_at": "2025-02-27T10:31:34.798380Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d8590557-764f-4618-9b2e-277d536bd111",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84b08c90-12f5-48ef-baee-ab8d8b15588c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84b08c90-12f5-48ef-baee-ab8d8b15588c",
         "name": "ggshield-4sJy2SkE", "description": "description", "created_at": "2025-02-27T10:53:01.890617Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84b08c90-12f5-48ef-baee-ab8d8b15588c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72204c1e-12c1-445f-b106-09488214d610",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72204c1e-12c1-445f-b106-09488214d610",
         "name": "ggshield-eqoLjiAS", "description": "description", "created_at": "2025-02-27T10:53:02.563136Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72204c1e-12c1-445f-b106-09488214d610",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
         "name": "ggshield-yaqMNJFA", "description": "description", "created_at": "2025-02-27T11:24:20.630794Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a5d5ca0-000f-4011-aaf2-b4f627c19649",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a5d5ca0-000f-4011-aaf2-b4f627c19649",
         "name": "ggshield-x12c7zPc", "description": "description", "created_at": "2025-02-27T11:24:21.465056Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8a5d5ca0-000f-4011-aaf2-b4f627c19649",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c823f31a-73a8-46cc-be4a-029d6d081793",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c823f31a-73a8-46cc-be4a-029d6d081793",
         "name": "ggshield-9Mq5rTUV", "description": "description", "created_at": "2025-02-27T16:44:10.862683Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c823f31a-73a8-46cc-be4a-029d6d081793",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49f1055b-b505-402b-8b79-e4b2c6cf2041",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49f1055b-b505-402b-8b79-e4b2c6cf2041",
         "name": "ggshield-4MmSKBvx", "description": "description", "created_at": "2025-02-27T16:44:11.663957Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/49f1055b-b505-402b-8b79-e4b2c6cf2041",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be8e40e8-b204-40de-8d37-247ac6ef7077",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be8e40e8-b204-40de-8d37-247ac6ef7077",
         "name": "ggshield-DBuxWn0n", "description": "description", "created_at": "2025-02-27T16:57:21.290157Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be8e40e8-b204-40de-8d37-247ac6ef7077",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d10551f8-36f0-4966-a684-d5f9eca89e8d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d10551f8-36f0-4966-a684-d5f9eca89e8d",
         "name": "ggshield-bukJ4Md2", "description": "description", "created_at": "2025-02-27T16:57:22.079317Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d10551f8-36f0-4966-a684-d5f9eca89e8d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d5385824-6a93-47cb-81f3-e818e64371d7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d5385824-6a93-47cb-81f3-e818e64371d7",
         "name": "ggshield-vI1CTIm2", "description": "description", "created_at": "2025-02-27T17:24:28.533666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d5385824-6a93-47cb-81f3-e818e64371d7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
         "name": "ggshield-C519GYI9", "description": "description", "created_at": "2025-02-27T17:24:29.231126Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
         "name": "ggshield-i8zN7WRH", "description": "description", "created_at": "2025-02-27T17:27:14.478281Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "661dae4d-5944-4a20-b7f7-f74913356479",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "661dae4d-5944-4a20-b7f7-f74913356479",
         "name": "ggshield-IX7GxSIs", "description": "description", "created_at": "2025-02-27T17:27:15.226298Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/661dae4d-5944-4a20-b7f7-f74913356479",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "adaea919-086f-4e37-b4e5-dc8208d0e4f5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "adaea919-086f-4e37-b4e5-dc8208d0e4f5",
         "name": "ggshield-rWApiuse", "description": "description", "created_at": "2025-03-03T09:15:26.314595Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/adaea919-086f-4e37-b4e5-dc8208d0e4f5",
         "status": "triggered", "triggered_at": "2026-02-18T14:51:12.198393Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
-        "key": "env", "value": "staging"}], "custom_tags": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
+        null, "tags": [], "custom_tags": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
         "key": "env", "value": "staging"}], "token": "[REDACTED]"}, {"id": "da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
         "name": "ggshield-jdbeH3gE", "description": "description", "created_at": "2025-03-03T09:15:27.049176Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22", "key": "env",
-        "value": "production"}], "custom_tags": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22",
-        "key": "env", "value": "production"}], "token": "[REDACTED]"}, {"id": "1f4708b2-0e51-458c-abca-c03e502b4a5a",
+        [], "custom_tags": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22", "key":
+        "env", "value": "production"}], "token": "[REDACTED]"}, {"id": "1f4708b2-0e51-458c-abca-c03e502b4a5a",
         "name": "ggshield-QgwFEPjx", "description": "description", "created_at": "2025-03-27T15:12:18.744612Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1f4708b2-0e51-458c-abca-c03e502b4a5a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "a4ced9be-6ad5-4d8a-b188-65a117bc0eba",
-        "name": "ggshield-44tVmSvF", "description": "description", "created_at": "2025-03-27T15:12:19.507492Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "a4ced9be-6ad5-4d8a-b188-65a117bc0eba", "name": "ggshield-44tVmSvF",
+        "description": "description", "created_at": "2025-03-27T15:12:19.507492Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a4ced9be-6ad5-4d8a-b188-65a117bc0eba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5710ee7d-6428-4074-a9ff-09399782242d",
-        "name": "ggshield-bF87lDBl", "description": "description", "created_at": "2025-03-27T15:21:17.135616Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5710ee7d-6428-4074-a9ff-09399782242d", "name": "ggshield-bF87lDBl",
+        "description": "description", "created_at": "2025-03-27T15:21:17.135616Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5710ee7d-6428-4074-a9ff-09399782242d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
-        "name": "ggshield-LbIDqGyA", "description": "description", "created_at": "2025-03-27T15:21:17.953340Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "4cbf7af9-9989-4185-8ef8-0f39e6f3d145", "name": "ggshield-LbIDqGyA",
+        "description": "description", "created_at": "2025-03-27T15:21:17.953340Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2dfa1936-f53f-4d0c-8a69-ae9bab297021",
-        "name": "ggshield-qz84En8W", "description": "description", "created_at": "2025-03-27T15:24:16.907610Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2dfa1936-f53f-4d0c-8a69-ae9bab297021", "name": "ggshield-qz84En8W",
+        "description": "description", "created_at": "2025-03-27T15:24:16.907610Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2dfa1936-f53f-4d0c-8a69-ae9bab297021",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "11213dc7-118d-4997-a96b-714640c3ad0b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "11213dc7-118d-4997-a96b-714640c3ad0b",
         "name": "ggshield-CSF39jm8", "description": "description", "created_at": "2025-03-27T15:24:17.721006Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/11213dc7-118d-4997-a96b-714640c3ad0b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "899dd0b0-20b2-45d2-b779-0331cc448935",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "899dd0b0-20b2-45d2-b779-0331cc448935",
         "name": "toto", "description": "tata", "created_at": "2025-05-12T09:58:35.161641Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/899dd0b0-20b2-45d2-b779-0331cc448935",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "62d71685-2eba-4b88-8edd-cc73e698cfa5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "62d71685-2eba-4b88-8edd-cc73e698cfa5",
         "name": "test-greg", "description": "test greg", "created_at": "2025-05-12T10:06:19.826522Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/62d71685-2eba-4b88-8edd-cc73e698cfa5",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:59.739856Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "e948f77d-5353-413e-b37d-8beba84890ff", "name": "test-greg-2", "description":
-        "test greg", "created_at": "2025-05-12T10:08:11.667578Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e948f77d-5353-413e-b37d-8beba84890ff",
+        "name": "test-greg-2", "description": "test greg", "created_at": "2025-05-12T10:08:11.667578Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:54.809724Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb", "name": "test-greg-3", "description":
-        "test greg", "created_at": "2025-05-12T10:08:58.561160Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        "name": "test-greg-3", "description": "test greg", "created_at": "2025-05-12T10:08:58.561160Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:50.784137Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6", "name": "test-greg-4", "description":
-        "test", "created_at": "2025-05-12T10:10:12.927058Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6",
+        "name": "test-greg-4", "description": "test", "created_at": "2025-05-12T10:10:12.927058Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:46.594085Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a", "name": "test-greg-5", "description":
-        "test", "created_at": "2025-05-12T10:12:50.615700Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
+        "name": "test-greg-5", "description": "test", "created_at": "2025-05-12T10:12:50.615700Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:41.387978Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "9fcf0732-6b8d-41d3-ae98-727bd5dde585", "name": "achille-hackathon",
-        "description": "achille hackathon", "created_at": "2025-05-12T12:01:23.542568Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9fcf0732-6b8d-41d3-ae98-727bd5dde585",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9fcf0732-6b8d-41d3-ae98-727bd5dde585",
+        "name": "achille-hackathon", "description": "achille hackathon", "created_at":
+        "2025-05-12T12:01:23.542568Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9fcf0732-6b8d-41d3-ae98-727bd5dde585",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38",
         "name": "TestHoneytoken", "description": "Testing GitGuardian API connectivity",
         "created_at": "2025-05-12T12:19:05.294638Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b0ddbd44-4054-4127-aa00-cd6727e70d38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
         "name": "AWS Credentials", "description": "Honeytoken for testing, to be injected
         as requested by the user.", "created_at": "2025-05-12T12:38:25.640506Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
         "status": "triggered", "triggered_at": "2026-02-18T13:45:03.781945Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 269050, "revoker_id":
+        null, "type": "AWS", "open_events_count": 9, "creator_id": 269050, "revoker_id":
         null, "creator_api_token_id": "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec", "name": "test-greg-7", "description":
-        "test", "created_at": "2025-05-12T12:54:37.703725Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ab824e92-6068-4a9d-ae36-86a94516f2ec",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec",
+        "name": "test-greg-7", "description": "test", "created_at": "2025-05-12T12:54:37.703725Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ab824e92-6068-4a9d-ae36-86a94516f2ec",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:34.521470Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b65d42a4-587f-4701-a595-8429cbcda70b", "name": "gg-mcp-server-honeytoken",
-        "description": "Honeytoken for security monitoring in the gg-mcp-server project.",
-        "created_at": "2025-05-12T12:54:44.402023Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b65d42a4-587f-4701-a595-8429cbcda70b",
-        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
-        "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
-        "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3fe4aa4f-49f6-42ad-a34a-0c108b544215",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b65d42a4-587f-4701-a595-8429cbcda70b",
+        "name": "gg-mcp-server-honeytoken", "description": "Honeytoken for security
+        monitoring in the gg-mcp-server project.", "created_at": "2025-05-12T12:54:44.402023Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b65d42a4-587f-4701-a595-8429cbcda70b",
+        "status": "triggered", "triggered_at": "2026-06-04T13:16:15.961464Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 4, "creator_id": 269050, "revoker_id":
+        null, "creator_api_token_id": "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id":
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3fe4aa4f-49f6-42ad-a34a-0c108b544215",
         "name": "default-honeytoken", "description": "General purpose honeytoken for
         security monitoring", "created_at": "2025-05-12T13:07:52.676810Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/3fe4aa4f-49f6-42ad-a34a-0c108b544215",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
         "name": "test", "description": "test", "created_at": "2025-05-12T13:09:38.965752Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9844e55d-982c-4458-b65b-592ad99ce77a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1026550, "revoker_id": null, "creator_api_token_id":
         "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
         "name": "Test Honeytoken", "description": "Testing honeytoken generation",
         "created_at": "2025-05-12T14:35:34.295363Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b2a7e759-81ab-465d-a578-e3ce42c18741",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
         "name": "test-greg-9", "description": "", "created_at": "2025-05-12T14:50:23.123299Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6d185a-6f59-4b7c-9248-dd05616090db",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:27.366114Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
+        null, "tags": [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
         "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "fbb93094-9778-4b8b-97d8-de99954a758a",
         "name": "AWS_Honeytoken", "description": "Honeytoken generated via MCP", "created_at":
@@ -1432,17 +1343,15 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "34e08af4-59a7-4a3b-b799-65acb8a2019d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "34e08af4-59a7-4a3b-b799-65acb8a2019d",
         "name": "AWS-MCP-Honeytoken", "description": "Honeytoken for monitoring potential
         AWS credential leaks", "created_at": "2025-05-12T15:07:16.157981Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/34e08af4-59a7-4a3b-b799-65acb8a2019d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "16805984-70d6-4049-844a-79bac3054f6f",
         "name": "AwsTestHoneytoken", "description": "Test honeytoken for development
         and monitoring", "created_at": "2025-05-12T15:09:00.390236Z", "gitguardian_url":
@@ -1450,10 +1359,8 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "d476c118-b210-403d-b685-3d7f0a514950",
         "name": "aws-development-access-key", "description": "Development environment
         AWS access key for monitoring credential leaks", "created_at": "2025-05-12T15:12:56.525944Z",
@@ -1461,9 +1368,7 @@ interactions:
         "status": "triggered", "triggered_at": "2026-02-18T14:50:57.626529Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 2, "creator_id": 270722, "revoker_id":
         null, "creator_api_token_id": "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
+        null, "tags": [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
         "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "0a112323-6906-4bd0-a660-1b45a0fc59ca",
         "name": "NHI-Explorer-Secret", "description": "AWS access key for NHI Explorer
@@ -1472,232 +1377,412 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "69dbbe3c-2dfc-4c93-916c-f70c42f4e2af",
         "name": "ggshield-Leb9CGys", "description": "description", "created_at": "2025-05-27T08:18:31.020533Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/69dbbe3c-2dfc-4c93-916c-f70c42f4e2af",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "029e2aba-796c-47d8-8d52-e14f9868acfc",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "029e2aba-796c-47d8-8d52-e14f9868acfc",
         "name": "ggshield-Fhjl6QxB", "description": "description", "created_at": "2025-05-27T08:18:31.873128Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/029e2aba-796c-47d8-8d52-e14f9868acfc",
         "status": "triggered", "triggered_at": "2025-06-17T09:30:39.728240Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "c77d47b6-8d61-46a7-b6a1-1715fc47c7eb", "name": "ggshield-U8JeiAjO",
-        "description": "description", "created_at": "2025-06-24T13:04:20.196705Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
+        "name": "ggshield-U8JeiAjO", "description": "description", "created_at": "2025-06-24T13:04:20.196705Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab",
-        "name": "ggshield-NiJSM24s", "description": "description", "created_at": "2025-06-24T13:04:21.255669Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab", "name": "ggshield-NiJSM24s",
+        "description": "description", "created_at": "2025-06-24T13:04:21.255669Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5692a982-6603-443e-bdb4-5ea1a5de6f64",
-        "name": "ggshield-JKhVuHaW", "description": "description", "created_at": "2025-06-24T13:06:56.046343Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5692a982-6603-443e-bdb4-5ea1a5de6f64", "name": "ggshield-JKhVuHaW",
+        "description": "description", "created_at": "2025-06-24T13:06:56.046343Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5692a982-6603-443e-bdb4-5ea1a5de6f64",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "17925c95-1df7-4e86-9c42-aabb5dbdea69",
-        "name": "ggshield-vfjAXCfY", "description": "description", "created_at": "2025-06-24T13:06:57.033247Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "17925c95-1df7-4e86-9c42-aabb5dbdea69", "name": "ggshield-vfjAXCfY",
+        "description": "description", "created_at": "2025-06-24T13:06:57.033247Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/17925c95-1df7-4e86-9c42-aabb5dbdea69",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "631ef101-122f-4592-9de1-2d6cb5becafa",
-        "name": "ggshield-dbhOtleP", "description": "description", "created_at": "2025-06-24T13:13:01.219899Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "631ef101-122f-4592-9de1-2d6cb5becafa", "name": "ggshield-dbhOtleP",
+        "description": "description", "created_at": "2025-06-24T13:13:01.219899Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/631ef101-122f-4592-9de1-2d6cb5becafa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "bebc1ca8-933d-45ca-b201-fbabc4eab464",
-        "name": "ggshield-7pQLMJYV", "description": "description", "created_at": "2025-06-24T13:13:01.978212Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "bebc1ca8-933d-45ca-b201-fbabc4eab464", "name": "ggshield-7pQLMJYV",
+        "description": "description", "created_at": "2025-06-24T13:13:01.978212Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bebc1ca8-933d-45ca-b201-fbabc4eab464",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "3983e8ff-7fd6-4fde-9117-9612d4258052",
-        "name": "ggshield-phDsJ9wy", "description": "description", "created_at": "2025-06-24T13:29:15.096198Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "3983e8ff-7fd6-4fde-9117-9612d4258052", "name": "ggshield-phDsJ9wy",
+        "description": "description", "created_at": "2025-06-24T13:29:15.096198Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3983e8ff-7fd6-4fde-9117-9612d4258052",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "9340e7fe-f79c-467e-9dcd-43ddaa77dc0c",
-        "name": "ggshield-Md0MBV0B", "description": "description", "created_at": "2025-06-24T13:29:16.049584Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "9340e7fe-f79c-467e-9dcd-43ddaa77dc0c", "name": "ggshield-Md0MBV0B",
+        "description": "description", "created_at": "2025-06-24T13:29:16.049584Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9340e7fe-f79c-467e-9dcd-43ddaa77dc0c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "08b51a6e-dd6c-4a4b-93f9-b955663c6524",
-        "name": "ggshield-ZoWflf5b", "description": "description", "created_at": "2025-06-24T13:31:49.045062Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "08b51a6e-dd6c-4a4b-93f9-b955663c6524", "name": "ggshield-ZoWflf5b",
+        "description": "description", "created_at": "2025-06-24T13:31:49.045062Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/08b51a6e-dd6c-4a4b-93f9-b955663c6524",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "96da938d-d6fa-4e44-9254-c568a27be484",
-        "name": "ggshield-PirK5h1Q", "description": "description", "created_at": "2025-06-24T13:31:49.827284Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "96da938d-d6fa-4e44-9254-c568a27be484", "name": "ggshield-PirK5h1Q",
+        "description": "description", "created_at": "2025-06-24T13:31:49.827284Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/96da938d-d6fa-4e44-9254-c568a27be484",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f2c61b85-e11d-4db0-a8af-7fc327310b39",
-        "name": "ggshield-ZQ4jUtQr", "description": "description", "created_at": "2025-06-24T13:45:17.477850Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f2c61b85-e11d-4db0-a8af-7fc327310b39", "name": "ggshield-ZQ4jUtQr",
+        "description": "description", "created_at": "2025-06-24T13:45:17.477850Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f2c61b85-e11d-4db0-a8af-7fc327310b39",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f99173ff-9ffe-492c-b8ae-54157df89bac",
-        "name": "ggshield-5uK6KYFh", "description": "description", "created_at": "2025-06-24T13:45:18.309642Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f99173ff-9ffe-492c-b8ae-54157df89bac", "name": "ggshield-5uK6KYFh",
+        "description": "description", "created_at": "2025-06-24T13:45:18.309642Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f99173ff-9ffe-492c-b8ae-54157df89bac",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768",
-        "name": "ggshield-MGXkbqc7", "description": "description", "created_at": "2025-06-24T13:50:43.295521Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768", "name": "ggshield-MGXkbqc7",
+        "description": "description", "created_at": "2025-06-24T13:50:43.295521Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f3252f2c-16a9-45e4-97e8-bed4b5752415",
-        "name": "ggshield-YJd3rq9q", "description": "description", "created_at": "2025-06-24T13:50:44.165951Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f3252f2c-16a9-45e4-97e8-bed4b5752415", "name": "ggshield-YJd3rq9q",
+        "description": "description", "created_at": "2025-06-24T13:50:44.165951Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f3252f2c-16a9-45e4-97e8-bed4b5752415",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "e22705f1-5497-449b-9614-3c2d89e3b705",
-        "name": "ggshield-l4abwnpa", "description": null, "created_at": "2025-06-26T12:32:05.993896Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e22705f1-5497-449b-9614-3c2d89e3b705",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "e22705f1-5497-449b-9614-3c2d89e3b705", "name": "ggshield-l4abwnpa",
+        "description": null, "created_at": "2025-06-26T12:32:05.993896Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e22705f1-5497-449b-9614-3c2d89e3b705",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
         "4ff03654-f280-4c31-8eef-5295d2b75a50", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7691445a-2cb0-4093-94ca-f2c5de877075",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7691445a-2cb0-4093-94ca-f2c5de877075",
         "name": "ggshield-Lwhu1Nax", "description": "description", "created_at": "2025-07-29T10:34:41.534666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7691445a-2cb0-4093-94ca-f2c5de877075",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "951e1f19-5804-444a-b275-b51dc5bf68ee",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "951e1f19-5804-444a-b275-b51dc5bf68ee",
         "name": "ggshield-u9ltlEmT", "description": "description", "created_at": "2025-07-29T10:34:42.385215Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/951e1f19-5804-444a-b275-b51dc5bf68ee",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
         "name": "ggshield-CC0Lj0vS", "description": "description", "created_at": "2025-07-29T10:40:27.317817Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
         "name": "ggshield-0k2Xha2i", "description": "description", "created_at": "2025-07-29T10:40:28.088246Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
         "status": "triggered", "triggered_at": "2025-08-22T16:59:58.315774Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "49e4fce7-aa48-42b0-9fc4-e16105ae08e5", "name": "ggshield-ncOpkfP8",
-        "description": "description", "created_at": "2025-08-27T11:43:11.666517Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
+        "name": "ggshield-ncOpkfP8", "description": "description", "created_at": "2025-08-27T11:43:11.666517Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2b15518b-3100-4736-bee6-b47fe8d26fc1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2b15518b-3100-4736-bee6-b47fe8d26fc1",
         "name": "ggshield-H2eDvilF", "description": "description", "created_at": "2025-08-27T11:43:12.618589Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2b15518b-3100-4736-bee6-b47fe8d26fc1",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "368a90bf-269b-4a60-95c2-1c77c86f7fd4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "368a90bf-269b-4a60-95c2-1c77c86f7fd4",
         "name": "ggshield-V6RzZJGL", "description": "description", "created_at": "2025-11-14T16:54:30.227288Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/368a90bf-269b-4a60-95c2-1c77c86f7fd4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "eae1aaaf-d700-475d-b65a-ffd79f84806d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "eae1aaaf-d700-475d-b65a-ffd79f84806d",
         "name": "ggshield-Pya2g1xF", "description": "description", "created_at": "2025-11-14T16:54:30.933576Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/eae1aaaf-d700-475d-b65a-ffd79f84806d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
         "name": "ggshield-Z2Ji3PxX", "description": "description", "created_at": "2026-03-31T13:26:20.710346Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
         "name": "ggshield-FsL9dCzu", "description": "description", "created_at": "2026-03-31T13:26:21.681383Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7daed77-1fa4-416d-88e2-473200b810aa",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7daed77-1fa4-416d-88e2-473200b810aa",
         "name": "ggshield-dqv39cn2", "description": "description", "created_at": "2026-03-31T13:32:28.824725Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e7daed77-1fa4-416d-88e2-473200b810aa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "601c59d9-7579-402e-90c4-59da055a8d3b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "601c59d9-7579-402e-90c4-59da055a8d3b",
         "name": "ggshield-YpbVgsRl", "description": "description", "created_at": "2026-03-31T13:32:29.820990Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/601c59d9-7579-402e-90c4-59da055a8d3b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "54e52712-a036-4e80-899b-c1a200610339",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "54e52712-a036-4e80-899b-c1a200610339",
         "name": "ggshield-DZ5zVj1p", "description": "description", "created_at": "2026-03-31T13:37:32.513332Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/54e52712-a036-4e80-899b-c1a200610339",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51dc5671-8053-4b87-8174-975ccf7f249c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51dc5671-8053-4b87-8174-975ccf7f249c",
         "name": "ggshield-DXGKK2gC", "description": "description", "created_at": "2026-03-31T13:37:33.559937Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/51dc5671-8053-4b87-8174-975ccf7f249c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}]'
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "name": "test Pierre", "description": "", "created_at": "2026-04-07T18:38:38.199572Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "ae435f66-1ea9-4dfe-b73f-49f451fc00ab", "name": "Demo
+        Romain", "description": "", "created_at": "2026-04-24T12:48:19.654369Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/ae435f66-1ea9-4dfe-b73f-49f451fc00ab",
+        "status": "triggered", "triggered_at": "2026-04-29T12:54:19.464710Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 6, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [{"id": "7a2469eb-2b6b-4248-8103-2b0f6b4fac9b", "key":
+        "romain", "value": null}], "token": "[REDACTED]"}, {"id": "10f6e20b-12ae-4591-aa09-7e1ff00ef408",
+        "name": "qa / xyz-e732d912", "description": "", "created_at": "2026-04-24T16:05:46.508625Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/10f6e20b-12ae-4591-aa09-7e1ff00ef408",
+        "status": "triggered", "triggered_at": "2026-04-24T16:13:17.276672Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9266c0f4-f0e0-41d2-a8c8-c164ccb84e47",
+        "name": "qa / test-nriv-e732d912", "description": "", "created_at": "2026-04-24T16:05:50.013606Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9266c0f4-f0e0-41d2-a8c8-c164ccb84e47",
+        "status": "triggered", "triggered_at": "2026-04-24T16:15:44.494587Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "name": "dev / Salome Test-e732d912", "description": "", "created_at": "2026-04-24T16:05:53.158978Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "status": "triggered", "triggered_at": "2026-04-24T16:16:21.895694Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "name": "qa / test-r8327r-e732d912", "description": "", "created_at": "2026-04-24T16:05:56.586568Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "status": "triggered", "triggered_at": "2026-04-24T16:18:31.419829Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2314a2ef-cec4-4e3d-834a-09b0c40c99d2",
+        "name": "qa / abc-e732d912", "description": "", "created_at": "2026-04-24T16:05:59.728317Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2314a2ef-cec4-4e3d-834a-09b0c40c99d2",
+        "status": "triggered", "triggered_at": "2026-04-24T16:25:50.024911Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "fe96d213-a002-4161-a7c9-cb3be4ad88f8",
+        "name": "qa / Handcrafted Metal Bike-e732d912", "description": "", "created_at":
+        "2026-04-24T16:06:02.936659Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fe96d213-a002-4161-a7c9-cb3be4ad88f8",
+        "status": "triggered", "triggered_at": "2026-04-24T16:35:48.958630Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a72f662-2357-4b93-b48a-00028e36cfff",
+        "name": "test1", "description": "tEST 2", "created_at": "2026-04-30T09:12:55.584248Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a72f662-2357-4b93-b48a-00028e36cfff",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "963fbabe-3d2c-4154-8281-2f13be7c06f7", "name": "test121",
+        "description": "testing 12", "created_at": "2026-04-30T11:31:57.689130Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/963fbabe-3d2c-4154-8281-2f13be7c06f7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "1acff09e-02c1-4a24-8869-568dfab124c9", "name": "test-pierredt",
+        "description": "hello", "created_at": "2026-05-06T19:57:39.689471Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/1acff09e-02c1-4a24-8869-568dfab124c9",
+        "status": "triggered", "triggered_at": "2026-05-06T19:59:18.645288Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 6, "creator_id": 309802, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "name": "qa / test-nriv-d2363bd5", "description": "", "created_at": "2026-05-19T08:29:37.247067Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "status": "triggered", "triggered_at": "2026-05-19T08:33:36.289678Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 1754656, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "03e7e668-6fbf-493a-8d1c-ac9d0c6c1b97",
+        "name": "qa / xyz-d2363bd5", "description": "", "created_at": "2026-05-19T08:29:41.396307Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/03e7e668-6fbf-493a-8d1c-ac9d0c6c1b97",
+        "status": "triggered", "triggered_at": "2026-05-19T08:34:30.001210Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 1754656, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "bb1adf06-28ea-4daf-b338-59d5ef094f67",
+        "name": "TheBigHoney", "description": "Big Honey Pot for our core secrets",
+        "created_at": "2026-05-19T11:51:12.957707Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bb1adf06-28ea-4daf-b338-59d5ef094f67",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "93abaf01-cac6-48f4-bfa1-735cfb7fde7d", "name": "ttoprjog",
+        "description": "Henri", "created_at": "2026-05-20T12:22:37.974250Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/93abaf01-cac6-48f4-bfa1-735cfb7fde7d",
+        "status": "revoked", "triggered_at": null, "revoked_at": "2026-05-20T12:23:19.883989Z",
+        "type": "AWS", "open_events_count": 0, "creator_id": 113168, "revoker_id":
+        113168, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be3d1024-d9df-466c-9e75-afc1ed88b8f5",
+        "name": "test-plc", "description": "", "created_at": "2026-05-26T07:26:21.052034Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be3d1024-d9df-466c-9e75-afc1ed88b8f5",
+        "status": "revoked", "triggered_at": "2026-05-26T08:44:57.678480Z", "revoked_at":
+        "2026-05-26T12:19:01.401494Z", "type": "AWS", "open_events_count": 0, "creator_id":
+        701514, "revoker_id": 701514, "creator_api_token_id": null, "revoker_api_token_id":
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "8409c955-f217-47c9-9cf1-3a6b557c65c9", "name": "Test", "description": "",
+        "created_at": "2026-05-26T14:12:05.347374Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8409c955-f217-47c9-9cf1-3a6b557c65c9",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754650, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "82f00514-d9d3-442c-b575-c40ff77db387", "name": "test-plc2",
+        "description": "", "created_at": "2026-05-27T13:13:33.943814Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/82f00514-d9d3-442c-b575-c40ff77db387",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 701514, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "2fb03282-9878-481c-be5b-eda6036f909d", "name": "ahah-plc", "description":
+        "", "created_at": "2026-06-01T12:43:48.383287Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2fb03282-9878-481c-be5b-eda6036f909d",
+        "status": "triggered", "triggered_at": "2026-06-04T21:49:55.543841Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 701514, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86344c0b-c360-4709-bb6b-fce628ace1d7",
+        "name": "honeytoken-toot-991c4137", "description": "", "created_at": "2026-06-05T17:59:07.240726Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86344c0b-c360-4709-bb6b-fce628ace1d7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
+        "97c1b533-d768-4054-94de-ae3d967a5128", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "949d59d0-c3c2-4d5e-ae3c-4f365b9b8456",
+        "name": "honeytoken-toot-0fefb095", "description": "", "created_at": "2026-06-05T17:59:07.748651Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/949d59d0-c3c2-4d5e-ae3c-4f365b9b8456",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
+        "97c1b533-d768-4054-94de-ae3d967a5128", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ab5965c-8f7e-44ec-b64e-1111e140586f",
+        "name": "ggshield-WOmcC4wM", "description": "description", "created_at": "2026-06-15T15:05:19.990102Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ab5965c-8f7e-44ec-b64e-1111e140586f",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "95786b03-4165-4245-8aef-fac41ff6a1de",
+        "name": "ggshield-E2HxYogl", "description": "description", "created_at": "2026-06-15T15:05:20.446208Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/95786b03-4165-4245-8aef-fac41ff6a1de",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "98271cf2-3025-4e7d-b120-afd29fe20c8f",
+        "name": "ggshield-32Xli2ct", "description": "description", "created_at": "2026-06-15T15:13:44.456933Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/98271cf2-3025-4e7d-b120-afd29fe20c8f",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "68f09d33-1cab-4b93-84a5-2861a7a01fbc",
+        "name": "ggshield-o2ocvFQZ", "description": "description", "created_at": "2026-06-15T15:13:45.228488Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/68f09d33-1cab-4b93-84a5-2861a7a01fbc",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ee69dfd0-fa9c-451d-947e-261c2edd4355",
+        "name": "ggshield-rGxN1k4I", "description": "description", "created_at": "2026-06-15T15:46:58.088837Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ee69dfd0-fa9c-451d-947e-261c2edd4355",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f91525c-02bd-4a0f-9c5d-c9949f7196f4",
+        "name": "ggshield-bZoVll0H", "description": "description", "created_at": "2026-06-15T15:46:58.839510Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f91525c-02bd-4a0f-9c5d-c9949f7196f4",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4a3a3699-fb2e-4e0f-ae02-4905fe8228ec",
+        "name": "ggshield-VuSeELel", "description": "description", "created_at": "2026-06-17T13:23:52.166183Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4a3a3699-fb2e-4e0f-ae02-4905fe8228ec",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "dd2d3e47-d804-41c5-b8b8-f640e6292096", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d82dc520-9ea5-4a38-a9d8-84bf2f94975b",
+        "name": "ggshield-yQlAvTpn", "description": "description", "created_at": "2026-06-17T13:23:52.682610Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d82dc520-9ea5-4a38-a9d8-84bf2f94975b",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "dd2d3e47-d804-41c5-b8b8-f640e6292096", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}]'
     headers:
+      CF-RAY:
+      - a10394ea79ee2068-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:02 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, POST, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '157664'
+      - '165896'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:17 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '1098'
+      - '1284'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_honeytokens_with_ordering.yaml
+++ b/tests/cassettes/client/vcr/test_list_honeytokens_with_ordering.yaml
@@ -20,205 +20,377 @@ interactions:
     uri: https://api.gitguardian.com/v1/honeytokens?ordering=-created_at&show_token=false&per_page=5
   response:
     body:
-      string: '[{"id": "51dc5671-8053-4b87-8174-975ccf7f249c", "name": "ggshield-DXGKK2gC",
+      string: '[{"id": "d82dc520-9ea5-4a38-a9d8-84bf2f94975b", "name": "ggshield-yQlAvTpn",
+        "description": "description", "created_at": "2026-06-17T13:23:52.682610Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d82dc520-9ea5-4a38-a9d8-84bf2f94975b",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "dd2d3e47-d804-41c5-b8b8-f640e6292096", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4a3a3699-fb2e-4e0f-ae02-4905fe8228ec",
+        "name": "ggshield-VuSeELel", "description": "description", "created_at": "2026-06-17T13:23:52.166183Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4a3a3699-fb2e-4e0f-ae02-4905fe8228ec",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "dd2d3e47-d804-41c5-b8b8-f640e6292096", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f91525c-02bd-4a0f-9c5d-c9949f7196f4",
+        "name": "ggshield-bZoVll0H", "description": "description", "created_at": "2026-06-15T15:46:58.839510Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f91525c-02bd-4a0f-9c5d-c9949f7196f4",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ee69dfd0-fa9c-451d-947e-261c2edd4355",
+        "name": "ggshield-rGxN1k4I", "description": "description", "created_at": "2026-06-15T15:46:58.088837Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ee69dfd0-fa9c-451d-947e-261c2edd4355",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "68f09d33-1cab-4b93-84a5-2861a7a01fbc",
+        "name": "ggshield-o2ocvFQZ", "description": "description", "created_at": "2026-06-15T15:13:45.228488Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/68f09d33-1cab-4b93-84a5-2861a7a01fbc",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "98271cf2-3025-4e7d-b120-afd29fe20c8f",
+        "name": "ggshield-32Xli2ct", "description": "description", "created_at": "2026-06-15T15:13:44.456933Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/98271cf2-3025-4e7d-b120-afd29fe20c8f",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "95786b03-4165-4245-8aef-fac41ff6a1de",
+        "name": "ggshield-E2HxYogl", "description": "description", "created_at": "2026-06-15T15:05:20.446208Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/95786b03-4165-4245-8aef-fac41ff6a1de",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ab5965c-8f7e-44ec-b64e-1111e140586f",
+        "name": "ggshield-WOmcC4wM", "description": "description", "created_at": "2026-06-15T15:05:19.990102Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ab5965c-8f7e-44ec-b64e-1111e140586f",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "949d59d0-c3c2-4d5e-ae3c-4f365b9b8456",
+        "name": "honeytoken-toot-0fefb095", "description": "", "created_at": "2026-06-05T17:59:07.748651Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/949d59d0-c3c2-4d5e-ae3c-4f365b9b8456",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
+        "97c1b533-d768-4054-94de-ae3d967a5128", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86344c0b-c360-4709-bb6b-fce628ace1d7",
+        "name": "honeytoken-toot-991c4137", "description": "", "created_at": "2026-06-05T17:59:07.240726Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86344c0b-c360-4709-bb6b-fce628ace1d7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
+        "97c1b533-d768-4054-94de-ae3d967a5128", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2fb03282-9878-481c-be5b-eda6036f909d",
+        "name": "ahah-plc", "description": "", "created_at": "2026-06-01T12:43:48.383287Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2fb03282-9878-481c-be5b-eda6036f909d",
+        "status": "triggered", "triggered_at": "2026-06-04T21:49:55.543841Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 701514, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "82f00514-d9d3-442c-b575-c40ff77db387",
+        "name": "test-plc2", "description": "", "created_at": "2026-05-27T13:13:33.943814Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/82f00514-d9d3-442c-b575-c40ff77db387",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 701514, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "8409c955-f217-47c9-9cf1-3a6b557c65c9", "name": "Test", "description": "",
+        "created_at": "2026-05-26T14:12:05.347374Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8409c955-f217-47c9-9cf1-3a6b557c65c9",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754650, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "be3d1024-d9df-466c-9e75-afc1ed88b8f5", "name": "test-plc",
+        "description": "", "created_at": "2026-05-26T07:26:21.052034Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/be3d1024-d9df-466c-9e75-afc1ed88b8f5",
+        "status": "revoked", "triggered_at": "2026-05-26T08:44:57.678480Z", "revoked_at":
+        "2026-05-26T12:19:01.401494Z", "type": "AWS", "open_events_count": 0, "creator_id":
+        701514, "revoker_id": 701514, "creator_api_token_id": null, "revoker_api_token_id":
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "93abaf01-cac6-48f4-bfa1-735cfb7fde7d", "name": "ttoprjog", "description":
+        "Henri", "created_at": "2026-05-20T12:22:37.974250Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/93abaf01-cac6-48f4-bfa1-735cfb7fde7d",
+        "status": "revoked", "triggered_at": null, "revoked_at": "2026-05-20T12:23:19.883989Z",
+        "type": "AWS", "open_events_count": 0, "creator_id": 113168, "revoker_id":
+        113168, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "bb1adf06-28ea-4daf-b338-59d5ef094f67",
+        "name": "TheBigHoney", "description": "Big Honey Pot for our core secrets",
+        "created_at": "2026-05-19T11:51:12.957707Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bb1adf06-28ea-4daf-b338-59d5ef094f67",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "03e7e668-6fbf-493a-8d1c-ac9d0c6c1b97", "name": "qa
+        / xyz-d2363bd5", "description": "", "created_at": "2026-05-19T08:29:41.396307Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/03e7e668-6fbf-493a-8d1c-ac9d0c6c1b97",
+        "status": "triggered", "triggered_at": "2026-05-19T08:34:30.001210Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 1754656, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "name": "qa / test-nriv-d2363bd5", "description": "", "created_at": "2026-05-19T08:29:37.247067Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "status": "triggered", "triggered_at": "2026-05-19T08:33:36.289678Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 1754656, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1acff09e-02c1-4a24-8869-568dfab124c9",
+        "name": "test-pierredt", "description": "hello", "created_at": "2026-05-06T19:57:39.689471Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1acff09e-02c1-4a24-8869-568dfab124c9",
+        "status": "triggered", "triggered_at": "2026-05-06T19:59:18.645288Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 6, "creator_id": 309802, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "963fbabe-3d2c-4154-8281-2f13be7c06f7",
+        "name": "test121", "description": "testing 12", "created_at": "2026-04-30T11:31:57.689130Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/963fbabe-3d2c-4154-8281-2f13be7c06f7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2a72f662-2357-4b93-b48a-00028e36cfff", "name": "test1",
+        "description": "tEST 2", "created_at": "2026-04-30T09:12:55.584248Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a72f662-2357-4b93-b48a-00028e36cfff",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fe96d213-a002-4161-a7c9-cb3be4ad88f8", "name": "qa
+        / Handcrafted Metal Bike-e732d912", "description": "", "created_at": "2026-04-24T16:06:02.936659Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fe96d213-a002-4161-a7c9-cb3be4ad88f8",
+        "status": "triggered", "triggered_at": "2026-04-24T16:35:48.958630Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2314a2ef-cec4-4e3d-834a-09b0c40c99d2",
+        "name": "qa / abc-e732d912", "description": "", "created_at": "2026-04-24T16:05:59.728317Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2314a2ef-cec4-4e3d-834a-09b0c40c99d2",
+        "status": "triggered", "triggered_at": "2026-04-24T16:25:50.024911Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "name": "qa / test-r8327r-e732d912", "description": "", "created_at": "2026-04-24T16:05:56.586568Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "status": "triggered", "triggered_at": "2026-04-24T16:18:31.419829Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "name": "dev / Salome Test-e732d912", "description": "", "created_at": "2026-04-24T16:05:53.158978Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "status": "triggered", "triggered_at": "2026-04-24T16:16:21.895694Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9266c0f4-f0e0-41d2-a8c8-c164ccb84e47",
+        "name": "qa / test-nriv-e732d912", "description": "", "created_at": "2026-04-24T16:05:50.013606Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9266c0f4-f0e0-41d2-a8c8-c164ccb84e47",
+        "status": "triggered", "triggered_at": "2026-04-24T16:15:44.494587Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "10f6e20b-12ae-4591-aa09-7e1ff00ef408",
+        "name": "qa / xyz-e732d912", "description": "", "created_at": "2026-04-24T16:05:46.508625Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/10f6e20b-12ae-4591-aa09-7e1ff00ef408",
+        "status": "triggered", "triggered_at": "2026-04-24T16:13:17.276672Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ae435f66-1ea9-4dfe-b73f-49f451fc00ab",
+        "name": "Demo Romain", "description": "", "created_at": "2026-04-24T12:48:19.654369Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ae435f66-1ea9-4dfe-b73f-49f451fc00ab",
+        "status": "triggered", "triggered_at": "2026-04-29T12:54:19.464710Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 6, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [{"id": "7a2469eb-2b6b-4248-8103-2b0f6b4fac9b", "key":
+        "romain", "value": null}], "token": "[REDACTED]"}, {"id": "84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "name": "test Pierre", "description": "", "created_at": "2026-04-07T18:38:38.199572Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "51dc5671-8053-4b87-8174-975ccf7f249c", "name": "ggshield-DXGKK2gC",
         "description": "description", "created_at": "2026-03-31T13:37:33.559937Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/51dc5671-8053-4b87-8174-975ccf7f249c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "54e52712-a036-4e80-899b-c1a200610339",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "54e52712-a036-4e80-899b-c1a200610339",
         "name": "ggshield-DZ5zVj1p", "description": "description", "created_at": "2026-03-31T13:37:32.513332Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/54e52712-a036-4e80-899b-c1a200610339",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "601c59d9-7579-402e-90c4-59da055a8d3b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "601c59d9-7579-402e-90c4-59da055a8d3b",
         "name": "ggshield-YpbVgsRl", "description": "description", "created_at": "2026-03-31T13:32:29.820990Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/601c59d9-7579-402e-90c4-59da055a8d3b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7daed77-1fa4-416d-88e2-473200b810aa",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7daed77-1fa4-416d-88e2-473200b810aa",
         "name": "ggshield-dqv39cn2", "description": "description", "created_at": "2026-03-31T13:32:28.824725Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e7daed77-1fa4-416d-88e2-473200b810aa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
         "name": "ggshield-FsL9dCzu", "description": "description", "created_at": "2026-03-31T13:26:21.681383Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
         "name": "ggshield-Z2Ji3PxX", "description": "description", "created_at": "2026-03-31T13:26:20.710346Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "eae1aaaf-d700-475d-b65a-ffd79f84806d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "eae1aaaf-d700-475d-b65a-ffd79f84806d",
         "name": "ggshield-Pya2g1xF", "description": "description", "created_at": "2025-11-14T16:54:30.933576Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/eae1aaaf-d700-475d-b65a-ffd79f84806d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "368a90bf-269b-4a60-95c2-1c77c86f7fd4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "368a90bf-269b-4a60-95c2-1c77c86f7fd4",
         "name": "ggshield-V6RzZJGL", "description": "description", "created_at": "2025-11-14T16:54:30.227288Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/368a90bf-269b-4a60-95c2-1c77c86f7fd4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2b15518b-3100-4736-bee6-b47fe8d26fc1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2b15518b-3100-4736-bee6-b47fe8d26fc1",
         "name": "ggshield-H2eDvilF", "description": "description", "created_at": "2025-08-27T11:43:12.618589Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2b15518b-3100-4736-bee6-b47fe8d26fc1",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
         "name": "ggshield-ncOpkfP8", "description": "description", "created_at": "2025-08-27T11:43:11.666517Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
         "name": "ggshield-0k2Xha2i", "description": "description", "created_at": "2025-07-29T10:40:28.088246Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
         "status": "triggered", "triggered_at": "2025-08-22T16:59:58.315774Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8", "name": "ggshield-CC0Lj0vS",
-        "description": "description", "created_at": "2025-07-29T10:40:27.317817Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
+        "name": "ggshield-CC0Lj0vS", "description": "description", "created_at": "2025-07-29T10:40:27.317817Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "951e1f19-5804-444a-b275-b51dc5bf68ee",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "951e1f19-5804-444a-b275-b51dc5bf68ee",
         "name": "ggshield-u9ltlEmT", "description": "description", "created_at": "2025-07-29T10:34:42.385215Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/951e1f19-5804-444a-b275-b51dc5bf68ee",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7691445a-2cb0-4093-94ca-f2c5de877075",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7691445a-2cb0-4093-94ca-f2c5de877075",
         "name": "ggshield-Lwhu1Nax", "description": "description", "created_at": "2025-07-29T10:34:41.534666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7691445a-2cb0-4093-94ca-f2c5de877075",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e22705f1-5497-449b-9614-3c2d89e3b705",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e22705f1-5497-449b-9614-3c2d89e3b705",
         "name": "ggshield-l4abwnpa", "description": null, "created_at": "2025-06-26T12:32:05.993896Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e22705f1-5497-449b-9614-3c2d89e3b705",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
         "4ff03654-f280-4c31-8eef-5295d2b75a50", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f3252f2c-16a9-45e4-97e8-bed4b5752415",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f3252f2c-16a9-45e4-97e8-bed4b5752415",
         "name": "ggshield-YJd3rq9q", "description": "description", "created_at": "2025-06-24T13:50:44.165951Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f3252f2c-16a9-45e4-97e8-bed4b5752415",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768",
-        "name": "ggshield-MGXkbqc7", "description": "description", "created_at": "2025-06-24T13:50:43.295521Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768", "name": "ggshield-MGXkbqc7",
+        "description": "description", "created_at": "2025-06-24T13:50:43.295521Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f99173ff-9ffe-492c-b8ae-54157df89bac",
-        "name": "ggshield-5uK6KYFh", "description": "description", "created_at": "2025-06-24T13:45:18.309642Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f99173ff-9ffe-492c-b8ae-54157df89bac", "name": "ggshield-5uK6KYFh",
+        "description": "description", "created_at": "2025-06-24T13:45:18.309642Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f99173ff-9ffe-492c-b8ae-54157df89bac",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f2c61b85-e11d-4db0-a8af-7fc327310b39",
-        "name": "ggshield-ZQ4jUtQr", "description": "description", "created_at": "2025-06-24T13:45:17.477850Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f2c61b85-e11d-4db0-a8af-7fc327310b39", "name": "ggshield-ZQ4jUtQr",
+        "description": "description", "created_at": "2025-06-24T13:45:17.477850Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f2c61b85-e11d-4db0-a8af-7fc327310b39",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "96da938d-d6fa-4e44-9254-c568a27be484",
-        "name": "ggshield-PirK5h1Q", "description": "description", "created_at": "2025-06-24T13:31:49.827284Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "96da938d-d6fa-4e44-9254-c568a27be484", "name": "ggshield-PirK5h1Q",
+        "description": "description", "created_at": "2025-06-24T13:31:49.827284Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/96da938d-d6fa-4e44-9254-c568a27be484",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "08b51a6e-dd6c-4a4b-93f9-b955663c6524",
-        "name": "ggshield-ZoWflf5b", "description": "description", "created_at": "2025-06-24T13:31:49.045062Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "08b51a6e-dd6c-4a4b-93f9-b955663c6524", "name": "ggshield-ZoWflf5b",
+        "description": "description", "created_at": "2025-06-24T13:31:49.045062Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/08b51a6e-dd6c-4a4b-93f9-b955663c6524",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "9340e7fe-f79c-467e-9dcd-43ddaa77dc0c",
-        "name": "ggshield-Md0MBV0B", "description": "description", "created_at": "2025-06-24T13:29:16.049584Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "9340e7fe-f79c-467e-9dcd-43ddaa77dc0c", "name": "ggshield-Md0MBV0B",
+        "description": "description", "created_at": "2025-06-24T13:29:16.049584Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9340e7fe-f79c-467e-9dcd-43ddaa77dc0c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "3983e8ff-7fd6-4fde-9117-9612d4258052",
-        "name": "ggshield-phDsJ9wy", "description": "description", "created_at": "2025-06-24T13:29:15.096198Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "3983e8ff-7fd6-4fde-9117-9612d4258052", "name": "ggshield-phDsJ9wy",
+        "description": "description", "created_at": "2025-06-24T13:29:15.096198Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3983e8ff-7fd6-4fde-9117-9612d4258052",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "bebc1ca8-933d-45ca-b201-fbabc4eab464",
-        "name": "ggshield-7pQLMJYV", "description": "description", "created_at": "2025-06-24T13:13:01.978212Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "bebc1ca8-933d-45ca-b201-fbabc4eab464", "name": "ggshield-7pQLMJYV",
+        "description": "description", "created_at": "2025-06-24T13:13:01.978212Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bebc1ca8-933d-45ca-b201-fbabc4eab464",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "631ef101-122f-4592-9de1-2d6cb5becafa",
-        "name": "ggshield-dbhOtleP", "description": "description", "created_at": "2025-06-24T13:13:01.219899Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "631ef101-122f-4592-9de1-2d6cb5becafa", "name": "ggshield-dbhOtleP",
+        "description": "description", "created_at": "2025-06-24T13:13:01.219899Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/631ef101-122f-4592-9de1-2d6cb5becafa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "17925c95-1df7-4e86-9c42-aabb5dbdea69",
-        "name": "ggshield-vfjAXCfY", "description": "description", "created_at": "2025-06-24T13:06:57.033247Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "17925c95-1df7-4e86-9c42-aabb5dbdea69", "name": "ggshield-vfjAXCfY",
+        "description": "description", "created_at": "2025-06-24T13:06:57.033247Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/17925c95-1df7-4e86-9c42-aabb5dbdea69",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5692a982-6603-443e-bdb4-5ea1a5de6f64",
-        "name": "ggshield-JKhVuHaW", "description": "description", "created_at": "2025-06-24T13:06:56.046343Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5692a982-6603-443e-bdb4-5ea1a5de6f64", "name": "ggshield-JKhVuHaW",
+        "description": "description", "created_at": "2025-06-24T13:06:56.046343Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5692a982-6603-443e-bdb4-5ea1a5de6f64",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab",
-        "name": "ggshield-NiJSM24s", "description": "description", "created_at": "2025-06-24T13:04:21.255669Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab", "name": "ggshield-NiJSM24s",
+        "description": "description", "created_at": "2025-06-24T13:04:21.255669Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
-        "name": "ggshield-U8JeiAjO", "description": "description", "created_at": "2025-06-24T13:04:20.196705Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "c77d47b6-8d61-46a7-b6a1-1715fc47c7eb", "name": "ggshield-U8JeiAjO",
+        "description": "description", "created_at": "2025-06-24T13:04:20.196705Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "029e2aba-796c-47d8-8d52-e14f9868acfc",
-        "name": "ggshield-Fhjl6QxB", "description": "description", "created_at": "2025-05-27T08:18:31.873128Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "029e2aba-796c-47d8-8d52-e14f9868acfc", "name": "ggshield-Fhjl6QxB",
+        "description": "description", "created_at": "2025-05-27T08:18:31.873128Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/029e2aba-796c-47d8-8d52-e14f9868acfc",
         "status": "triggered", "triggered_at": "2025-06-17T09:30:39.728240Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "69dbbe3c-2dfc-4c93-916c-f70c42f4e2af", "name": "ggshield-Leb9CGys",
-        "description": "description", "created_at": "2025-05-27T08:18:31.020533Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "69dbbe3c-2dfc-4c93-916c-f70c42f4e2af",
+        "name": "ggshield-Leb9CGys", "description": "description", "created_at": "2025-05-27T08:18:31.020533Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/69dbbe3c-2dfc-4c93-916c-f70c42f4e2af",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0a112323-6906-4bd0-a660-1b45a0fc59ca",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0a112323-6906-4bd0-a660-1b45a0fc59ca",
         "name": "NHI-Explorer-Secret", "description": "AWS access key for NHI Explorer
         project", "created_at": "2025-05-13T14:55:28.755591Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/0a112323-6906-4bd0-a660-1b45a0fc59ca",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "d476c118-b210-403d-b685-3d7f0a514950",
         "name": "aws-development-access-key", "description": "Development environment
         AWS access key for monitoring credential leaks", "created_at": "2025-05-12T15:12:56.525944Z",
@@ -226,9 +398,7 @@ interactions:
         "status": "triggered", "triggered_at": "2026-02-18T14:50:57.626529Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 2, "creator_id": 270722, "revoker_id":
         null, "creator_api_token_id": "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
+        null, "tags": [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
         "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "16805984-70d6-4049-844a-79bac3054f6f",
         "name": "AwsTestHoneytoken", "description": "Test honeytoken for development
@@ -237,10 +407,8 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "34e08af4-59a7-4a3b-b799-65acb8a2019d",
         "name": "AWS-MCP-Honeytoken", "description": "Honeytoken for monitoring potential
         AWS credential leaks", "created_at": "2025-05-12T15:07:16.157981Z", "gitguardian_url":
@@ -248,25 +416,21 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "fbb93094-9778-4b8b-97d8-de99954a758a",
         "name": "AWS_Honeytoken", "description": "Honeytoken generated via MCP", "created_at":
         "2025-05-12T15:01:37.478675Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fbb93094-9778-4b8b-97d8-de99954a758a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
         "name": "test-greg-9", "description": "", "created_at": "2025-05-12T14:50:23.123299Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6d185a-6f59-4b7c-9248-dd05616090db",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:27.366114Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
+        null, "tags": [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
         "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
         "name": "Test Honeytoken", "description": "Testing honeytoken generation",
@@ -274,297 +438,287 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
         "name": "test", "description": "test", "created_at": "2025-05-12T13:09:38.965752Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9844e55d-982c-4458-b65b-592ad99ce77a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1026550, "revoker_id": null, "creator_api_token_id":
         "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3fe4aa4f-49f6-42ad-a34a-0c108b544215",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3fe4aa4f-49f6-42ad-a34a-0c108b544215",
         "name": "default-honeytoken", "description": "General purpose honeytoken for
         security monitoring", "created_at": "2025-05-12T13:07:52.676810Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/3fe4aa4f-49f6-42ad-a34a-0c108b544215",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b65d42a4-587f-4701-a595-8429cbcda70b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b65d42a4-587f-4701-a595-8429cbcda70b",
         "name": "gg-mcp-server-honeytoken", "description": "Honeytoken for security
         monitoring in the gg-mcp-server project.", "created_at": "2025-05-12T12:54:44.402023Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b65d42a4-587f-4701-a595-8429cbcda70b",
-        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
-        "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
-        "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec",
+        "status": "triggered", "triggered_at": "2026-06-04T13:16:15.961464Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 4, "creator_id": 269050, "revoker_id":
+        null, "creator_api_token_id": "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id":
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec",
         "name": "test-greg-7", "description": "test", "created_at": "2025-05-12T12:54:37.703725Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ab824e92-6068-4a9d-ae36-86a94516f2ec",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:34.521470Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1", "name": "AWS Credentials",
-        "description": "Honeytoken for testing, to be injected as requested by the
-        user.", "created_at": "2025-05-12T12:38:25.640506Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
+        "name": "AWS Credentials", "description": "Honeytoken for testing, to be injected
+        as requested by the user.", "created_at": "2025-05-12T12:38:25.640506Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
         "status": "triggered", "triggered_at": "2026-02-18T13:45:03.781945Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 269050, "revoker_id":
+        null, "type": "AWS", "open_events_count": 9, "creator_id": 269050, "revoker_id":
         null, "creator_api_token_id": "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38", "name": "TestHoneytoken", "description":
-        "Testing GitGuardian API connectivity", "created_at": "2025-05-12T12:19:05.294638Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b0ddbd44-4054-4127-aa00-cd6727e70d38",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38",
+        "name": "TestHoneytoken", "description": "Testing GitGuardian API connectivity",
+        "created_at": "2025-05-12T12:19:05.294638Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b0ddbd44-4054-4127-aa00-cd6727e70d38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9fcf0732-6b8d-41d3-ae98-727bd5dde585",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9fcf0732-6b8d-41d3-ae98-727bd5dde585",
         "name": "achille-hackathon", "description": "achille hackathon", "created_at":
         "2025-05-12T12:01:23.542568Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9fcf0732-6b8d-41d3-ae98-727bd5dde585",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
         "name": "test-greg-5", "description": "test", "created_at": "2025-05-12T10:12:50.615700Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:41.387978Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6", "name": "test-greg-4", "description":
-        "test", "created_at": "2025-05-12T10:10:12.927058Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6",
+        "name": "test-greg-4", "description": "test", "created_at": "2025-05-12T10:10:12.927058Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:46.594085Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb", "name": "test-greg-3", "description":
-        "test greg", "created_at": "2025-05-12T10:08:58.561160Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        "name": "test-greg-3", "description": "test greg", "created_at": "2025-05-12T10:08:58.561160Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:50.784137Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "e948f77d-5353-413e-b37d-8beba84890ff", "name": "test-greg-2", "description":
-        "test greg", "created_at": "2025-05-12T10:08:11.667578Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e948f77d-5353-413e-b37d-8beba84890ff",
+        "name": "test-greg-2", "description": "test greg", "created_at": "2025-05-12T10:08:11.667578Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:54.809724Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "62d71685-2eba-4b88-8edd-cc73e698cfa5", "name": "test-greg", "description":
-        "test greg", "created_at": "2025-05-12T10:06:19.826522Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/62d71685-2eba-4b88-8edd-cc73e698cfa5",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "62d71685-2eba-4b88-8edd-cc73e698cfa5",
+        "name": "test-greg", "description": "test greg", "created_at": "2025-05-12T10:06:19.826522Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/62d71685-2eba-4b88-8edd-cc73e698cfa5",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:59.739856Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "899dd0b0-20b2-45d2-b779-0331cc448935", "name": "toto", "description":
-        "tata", "created_at": "2025-05-12T09:58:35.161641Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/899dd0b0-20b2-45d2-b779-0331cc448935",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "899dd0b0-20b2-45d2-b779-0331cc448935",
+        "name": "toto", "description": "tata", "created_at": "2025-05-12T09:58:35.161641Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/899dd0b0-20b2-45d2-b779-0331cc448935",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "11213dc7-118d-4997-a96b-714640c3ad0b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "11213dc7-118d-4997-a96b-714640c3ad0b",
         "name": "ggshield-CSF39jm8", "description": "description", "created_at": "2025-03-27T15:24:17.721006Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/11213dc7-118d-4997-a96b-714640c3ad0b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2dfa1936-f53f-4d0c-8a69-ae9bab297021",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2dfa1936-f53f-4d0c-8a69-ae9bab297021",
         "name": "ggshield-qz84En8W", "description": "description", "created_at": "2025-03-27T15:24:16.907610Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2dfa1936-f53f-4d0c-8a69-ae9bab297021",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
         "name": "ggshield-LbIDqGyA", "description": "description", "created_at": "2025-03-27T15:21:17.953340Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5710ee7d-6428-4074-a9ff-09399782242d",
-        "name": "ggshield-bF87lDBl", "description": "description", "created_at": "2025-03-27T15:21:17.135616Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5710ee7d-6428-4074-a9ff-09399782242d", "name": "ggshield-bF87lDBl",
+        "description": "description", "created_at": "2025-03-27T15:21:17.135616Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5710ee7d-6428-4074-a9ff-09399782242d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "a4ced9be-6ad5-4d8a-b188-65a117bc0eba",
-        "name": "ggshield-44tVmSvF", "description": "description", "created_at": "2025-03-27T15:12:19.507492Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "a4ced9be-6ad5-4d8a-b188-65a117bc0eba", "name": "ggshield-44tVmSvF",
+        "description": "description", "created_at": "2025-03-27T15:12:19.507492Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a4ced9be-6ad5-4d8a-b188-65a117bc0eba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "1f4708b2-0e51-458c-abca-c03e502b4a5a",
-        "name": "ggshield-QgwFEPjx", "description": "description", "created_at": "2025-03-27T15:12:18.744612Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "1f4708b2-0e51-458c-abca-c03e502b4a5a", "name": "ggshield-QgwFEPjx",
+        "description": "description", "created_at": "2025-03-27T15:12:18.744612Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1f4708b2-0e51-458c-abca-c03e502b4a5a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
-        "name": "ggshield-jdbeH3gE", "description": "description", "created_at": "2025-03-03T09:15:27.049176Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c", "name": "ggshield-jdbeH3gE",
+        "description": "description", "created_at": "2025-03-03T09:15:27.049176Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22", "key": "env",
-        "value": "production"}], "custom_tags": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22",
-        "key": "env", "value": "production"}], "token": "[REDACTED]"}, {"id": "adaea919-086f-4e37-b4e5-dc8208d0e4f5",
+        [], "custom_tags": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22", "key":
+        "env", "value": "production"}], "token": "[REDACTED]"}, {"id": "adaea919-086f-4e37-b4e5-dc8208d0e4f5",
         "name": "ggshield-rWApiuse", "description": "description", "created_at": "2025-03-03T09:15:26.314595Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/adaea919-086f-4e37-b4e5-dc8208d0e4f5",
         "status": "triggered", "triggered_at": "2026-02-18T14:51:12.198393Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
-        "key": "env", "value": "staging"}], "custom_tags": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
+        null, "tags": [], "custom_tags": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
         "key": "env", "value": "staging"}], "token": "[REDACTED]"}, {"id": "661dae4d-5944-4a20-b7f7-f74913356479",
         "name": "ggshield-IX7GxSIs", "description": "description", "created_at": "2025-02-27T17:27:15.226298Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/661dae4d-5944-4a20-b7f7-f74913356479",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
         "name": "ggshield-i8zN7WRH", "description": "description", "created_at": "2025-02-27T17:27:14.478281Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
         "name": "ggshield-C519GYI9", "description": "description", "created_at": "2025-02-27T17:24:29.231126Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d5385824-6a93-47cb-81f3-e818e64371d7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d5385824-6a93-47cb-81f3-e818e64371d7",
         "name": "ggshield-vI1CTIm2", "description": "description", "created_at": "2025-02-27T17:24:28.533666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d5385824-6a93-47cb-81f3-e818e64371d7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d10551f8-36f0-4966-a684-d5f9eca89e8d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d10551f8-36f0-4966-a684-d5f9eca89e8d",
         "name": "ggshield-bukJ4Md2", "description": "description", "created_at": "2025-02-27T16:57:22.079317Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d10551f8-36f0-4966-a684-d5f9eca89e8d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be8e40e8-b204-40de-8d37-247ac6ef7077",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be8e40e8-b204-40de-8d37-247ac6ef7077",
         "name": "ggshield-DBuxWn0n", "description": "description", "created_at": "2025-02-27T16:57:21.290157Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be8e40e8-b204-40de-8d37-247ac6ef7077",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49f1055b-b505-402b-8b79-e4b2c6cf2041",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49f1055b-b505-402b-8b79-e4b2c6cf2041",
         "name": "ggshield-4MmSKBvx", "description": "description", "created_at": "2025-02-27T16:44:11.663957Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/49f1055b-b505-402b-8b79-e4b2c6cf2041",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c823f31a-73a8-46cc-be4a-029d6d081793",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c823f31a-73a8-46cc-be4a-029d6d081793",
         "name": "ggshield-9Mq5rTUV", "description": "description", "created_at": "2025-02-27T16:44:10.862683Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c823f31a-73a8-46cc-be4a-029d6d081793",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a5d5ca0-000f-4011-aaf2-b4f627c19649",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a5d5ca0-000f-4011-aaf2-b4f627c19649",
         "name": "ggshield-x12c7zPc", "description": "description", "created_at": "2025-02-27T11:24:21.465056Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8a5d5ca0-000f-4011-aaf2-b4f627c19649",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
         "name": "ggshield-yaqMNJFA", "description": "description", "created_at": "2025-02-27T11:24:20.630794Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72204c1e-12c1-445f-b106-09488214d610",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72204c1e-12c1-445f-b106-09488214d610",
         "name": "ggshield-eqoLjiAS", "description": "description", "created_at": "2025-02-27T10:53:02.563136Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72204c1e-12c1-445f-b106-09488214d610",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84b08c90-12f5-48ef-baee-ab8d8b15588c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84b08c90-12f5-48ef-baee-ab8d8b15588c",
         "name": "ggshield-4sJy2SkE", "description": "description", "created_at": "2025-02-27T10:53:01.890617Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84b08c90-12f5-48ef-baee-ab8d8b15588c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d8590557-764f-4618-9b2e-277d536bd111",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d8590557-764f-4618-9b2e-277d536bd111",
         "name": "ggshield-QYqCVZ4i", "description": "description", "created_at": "2025-02-27T10:31:34.798380Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d8590557-764f-4618-9b2e-277d536bd111",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ca642fe-2ce4-42b2-9097-5904093935c1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ca642fe-2ce4-42b2-9097-5904093935c1",
         "name": "ggshield-5Vx0aaQd", "description": "description", "created_at": "2025-02-27T10:31:34.080183Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ca642fe-2ce4-42b2-9097-5904093935c1",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "97877334-808d-48c7-8802-2c54e9f43661",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "97877334-808d-48c7-8802-2c54e9f43661",
         "name": "ggshield-srahH0o3", "description": "description", "created_at": "2025-02-27T10:23:32.385844Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/97877334-808d-48c7-8802-2c54e9f43661",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
         "name": "ggshield-AAcFXCwl", "description": "description", "created_at": "2025-02-27T10:23:31.621722Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4b814f00-0897-479f-8a2d-a9593c5f18fa",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4b814f00-0897-479f-8a2d-a9593c5f18fa",
         "name": "WrongSecrets", "description": "Honeytoken for the wrongsecrets repositort",
         "created_at": "2025-02-06T13:10:31.569094Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4b814f00-0897-479f-8a2d-a9593c5f18fa",
         "status": "triggered", "triggered_at": "2025-02-06T13:16:26.325168Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476", "name": "pierredethoisy/dockerfile",
-        "description": "", "created_at": "2024-12-17T10:30:41.655876Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
+        "name": "pierredethoisy/dockerfile", "description": "", "created_at": "2024-12-17T10:30:41.655876Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
         "status": "triggered", "triggered_at": "2024-12-17T10:32:09.594850Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 309802, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "aed37b34-4721-43c2-99e2-2f2e78592f63", "name": "ggshield/setup.cfg",
-        "description": "", "created_at": "2024-12-17T10:10:25.895137Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/aed37b34-4721-43c2-99e2-2f2e78592f63",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "aed37b34-4721-43c2-99e2-2f2e78592f63",
+        "name": "ggshield/setup.cfg", "description": "", "created_at": "2024-12-17T10:10:25.895137Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/aed37b34-4721-43c2-99e2-2f2e78592f63",
         "status": "triggered", "triggered_at": "2024-12-17T10:19:35.167833Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 309802, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "c5af2ae0-f3f6-4301-82bc-b49108bd782b", "name": "ggshield-hIlrbyRm",
-        "description": "description", "created_at": "2024-11-27T12:32:45.728067Z",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5af2ae0-f3f6-4301-82bc-b49108bd782b",
+        "name": "ggshield-hIlrbyRm", "description": "description", "created_at": "2024-11-27T12:32:45.728067Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c5af2ae0-f3f6-4301-82bc-b49108bd782b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a454c002-679b-4250-aacf-28b5207543a4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a454c002-679b-4250-aacf-28b5207543a4",
         "name": "ggshield-HjwRkUAT", "description": "description", "created_at": "2024-11-27T12:32:44.877048Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a454c002-679b-4250-aacf-28b5207543a4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
         "name": "ggshield-E6IPnu0f", "description": "description", "created_at": "2024-10-29T14:36:28.513178Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
         "name": "ggshield-c6YSc2Ie", "description": "description", "created_at": "2024-10-29T14:36:27.096968Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "795decd4-4703-4073-9b3c-3ec2157f6182",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "795decd4-4703-4073-9b3c-3ec2157f6182",
         "name": "Demo token", "description": "Take a look", "created_at": "2024-10-28T00:34:48.214122Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/795decd4-4703-4073-9b3c-3ec2157f6182",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582569, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "50e53ab6-4950-48e6-9350-b5aaa88fafea",
-        "name": "Demo", "description": "Dev team 1", "created_at": "2024-10-27T21:01:47.725365Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "50e53ab6-4950-48e6-9350-b5aaa88fafea", "name": "Demo",
+        "description": "Dev team 1", "created_at": "2024-10-27T21:01:47.725365Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/50e53ab6-4950-48e6-9350-b5aaa88fafea",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582569, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}], "token": "[REDACTED]"},
         {"id": "a0b24134-0cbc-4ca5-b110-18b3311aef73", "name": "DO-demo", "description":
         "Digital Ocean Demo", "created_at": "2024-10-23T17:55:40.621634Z", "gitguardian_url":
@@ -572,189 +726,183 @@ interactions:
         "status": "revoked", "triggered_at": "2024-10-23T18:03:40.135215Z", "revoked_at":
         "2024-10-23T18:33:47.488182Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "81d30531-a54e-4f67-a46b-a7bac5783995", "name": "ggshield-IjJFdqDS",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "81d30531-a54e-4f67-a46b-a7bac5783995", "name": "ggshield-IjJFdqDS",
         "description": "description", "created_at": "2024-10-16T13:47:51.425195Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/81d30531-a54e-4f67-a46b-a7bac5783995",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
         "name": "ggshield-B8LwcRR0", "description": "description", "created_at": "2024-10-16T13:47:50.239094Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b42c6945-05fc-4c5b-af83-e60478cd9db5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b42c6945-05fc-4c5b-af83-e60478cd9db5",
         "name": "ggshield-WPIELIcW", "description": "description", "created_at": "2024-10-01T13:18:30.820570Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b42c6945-05fc-4c5b-af83-e60478cd9db5",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "730bdd87-31b2-4b42-a32a-5750bc595c9c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "730bdd87-31b2-4b42-a32a-5750bc595c9c",
         "name": "ggshield-dtxlZtWH", "description": "description", "created_at": "2024-10-01T13:18:29.918337Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/730bdd87-31b2-4b42-a32a-5750bc595c9c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
         "name": "ggshield-kkpkfk1s", "description": "description", "created_at": "2024-09-24T08:50:16.667172Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "01c7668d-1467-4cac-a395-4b50fc278407",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "01c7668d-1467-4cac-a395-4b50fc278407",
         "name": "ggshield-QkzL5Vyb", "description": "description", "created_at": "2024-09-24T08:50:15.865165Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/01c7668d-1467-4cac-a395-4b50fc278407",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "707b35fb-685b-4577-88b9-94cccc10e165",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "707b35fb-685b-4577-88b9-94cccc10e165",
         "name": "ggshield-wqYwwgeK", "description": "description", "created_at": "2024-08-27T08:20:16.467770Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/707b35fb-685b-4577-88b9-94cccc10e165",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "11222b98-7705-4180-99d1-6e719d8a05a9",
-        "name": "ggshield-qnLief7n", "description": "description", "created_at": "2024-08-27T08:20:15.846360Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "11222b98-7705-4180-99d1-6e719d8a05a9", "name": "ggshield-qnLief7n",
+        "description": "description", "created_at": "2024-08-27T08:20:15.846360Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/11222b98-7705-4180-99d1-6e719d8a05a9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "903bf588-2a03-4318-be6c-b9e3198d1fd6",
-        "name": "ggshield-5Ty2Hu4r", "description": "description", "created_at": "2024-08-27T07:44:46.871854Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "903bf588-2a03-4318-be6c-b9e3198d1fd6", "name": "ggshield-5Ty2Hu4r",
+        "description": "description", "created_at": "2024-08-27T07:44:46.871854Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/903bf588-2a03-4318-be6c-b9e3198d1fd6",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "b144b1fd-dc5f-4a36-abc7-a95d05331245",
-        "name": "ggshield-uZr6LNDv", "description": "description", "created_at": "2024-08-27T07:44:46.267249Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "b144b1fd-dc5f-4a36-abc7-a95d05331245", "name": "ggshield-uZr6LNDv",
+        "description": "description", "created_at": "2024-08-27T07:44:46.267249Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b144b1fd-dc5f-4a36-abc7-a95d05331245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
-        "name": "ggshield-lqX7PlwI", "description": "description", "created_at": "2024-08-05T09:21:26.211228Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "88c38ccf-471f-4e32-bf58-b1c2ebeb25bb", "name": "ggshield-lqX7PlwI",
+        "description": "description", "created_at": "2024-08-05T09:21:26.211228Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e8aad547-96a7-40a4-a05d-710cf536f3a7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e8aad547-96a7-40a4-a05d-710cf536f3a7",
         "name": "ggshield-Vqz4LULC", "description": "description", "created_at": "2024-08-05T09:21:25.593516Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e8aad547-96a7-40a4-a05d-710cf536f3a7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "83888e42-dc57-471c-9a08-f023e3dc2949",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "83888e42-dc57-471c-9a08-f023e3dc2949",
         "name": "ggshield-5suF2vRt", "description": "description", "created_at": "2024-08-05T09:03:53.434873Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/83888e42-dc57-471c-9a08-f023e3dc2949",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
         "name": "ggshield-Fu1nGsc9", "description": "description", "created_at": "2024-08-05T09:03:52.745860Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dafa04c5-299a-4a13-9c35-c523e51763f3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dafa04c5-299a-4a13-9c35-c523e51763f3",
         "name": "ggshield-b7VHMqbK", "description": "description", "created_at": "2024-07-31T15:31:10.071786Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dafa04c5-299a-4a13-9c35-c523e51763f3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a507d04c-bb61-4f2a-93ea-601b8aa27940",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a507d04c-bb61-4f2a-93ea-601b8aa27940",
         "name": "ggshield-w1cOSspy", "description": "description", "created_at": "2024-07-31T15:31:09.349255Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a507d04c-bb61-4f2a-93ea-601b8aa27940",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
         "name": "test ericf", "description": "", "created_at": "2024-07-09T09:34:04.089955Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
         "status": "triggered", "triggered_at": "2024-07-09T09:34:57.541777Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
         "name": "ggshield-GL7wc5WW", "description": "description", "created_at": "2024-06-26T11:51:20.402145Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26514e1f-4237-474b-b907-037b88427f29",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26514e1f-4237-474b-b907-037b88427f29",
         "name": "ggshield-Uuc8EiUn", "description": "description", "created_at": "2024-06-26T11:51:19.747630Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/26514e1f-4237-474b-b907-037b88427f29",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e332d717-641d-4ea4-81fc-e98115178454",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e332d717-641d-4ea4-81fc-e98115178454",
         "name": "ggshield-JaAf9b0W", "description": "description", "created_at": "2024-06-26T09:42:27.174527Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e332d717-641d-4ea4-81fc-e98115178454",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "17e088b8-2463-48f8-957b-41d017f1dc83",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "17e088b8-2463-48f8-957b-41d017f1dc83",
         "name": "ggshield-s7IOqS0q", "description": "description", "created_at": "2024-06-26T09:42:26.454643Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/17e088b8-2463-48f8-957b-41d017f1dc83",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9223e352-43b6-4e06-8d12-682d669cedd7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9223e352-43b6-4e06-8d12-682d669cedd7",
         "name": "ggshield-TRO3H56N", "description": "description", "created_at": "2024-06-26T09:27:39.479744Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9223e352-43b6-4e06-8d12-682d669cedd7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
         "name": "ggshield-fb77weow", "description": "description", "created_at": "2024-06-26T09:27:38.724573Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3407738b-2095-47bb-9cbd-dd16de158d67",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3407738b-2095-47bb-9cbd-dd16de158d67",
         "name": "ggshield-65KCwJls", "description": "description", "created_at": "2024-06-25T08:36:52.873146Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3407738b-2095-47bb-9cbd-dd16de158d67",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "12c4562e-deb8-4d14-bb23-e344e79b6f04",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "12c4562e-deb8-4d14-bb23-e344e79b6f04",
         "name": "ggshield-Wq4EyTMI", "description": "description", "created_at": "2024-06-25T08:36:52.179380Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/12c4562e-deb8-4d14-bb23-e344e79b6f04",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a411fa2c-a465-4099-8353-3c42365aca50",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a411fa2c-a465-4099-8353-3c42365aca50",
         "name": "test MINT", "description": "test MINT", "created_at": "2024-06-10T14:40:08.522247Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a411fa2c-a465-4099-8353-3c42365aca50",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
-        "name": "test lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
-        "status": "triggered", "triggered_at": "2024-06-06T08:19:18.422045Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 319222, "revoker_id":
-        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca", "key": "machine",
-        "value": "ggprdgim01"}], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99", "name": "test
+        lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
         "key": "machine", "value": "ggprdgim01"}], "token": "[REDACTED]"}, {"id":
         "9cca01c5-535f-4f89-a214-6c4c5579fd07", "name": "ggshield-3xRVfevR", "description":
         "description", "created_at": "2024-05-29T11:39:10.494259Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/9cca01c5-535f-4f89-a214-6c4c5579fd07",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "a67f962c-9dde-40c2-b404-e7cd4449cc82",
-        "name": "pouet", "description": "", "created_at": "2024-05-22T12:19:03.143437Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a67f962c-9dde-40c2-b404-e7cd4449cc82",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "a67f962c-9dde-40c2-b404-e7cd4449cc82", "name": "pouet",
+        "description": "", "created_at": "2024-05-22T12:19:03.143437Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/a67f962c-9dde-40c2-b404-e7cd4449cc82",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
-        "key": "visability", "value": "public"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
         "key": "visability", "value": "public"}], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
@@ -762,277 +910,260 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c7101eaa-ea38-495d-b3b4-c016db23e859",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
         "name": "ggshield-HRoZzrBq", "description": "description", "created_at": "2024-04-30T10:19:13.126568Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72e98633-9179-4a3e-8908-ea2319d19b3b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72e98633-9179-4a3e-8908-ea2319d19b3b",
         "name": "ggshield-XYKDhLUY", "description": "description", "created_at": "2024-04-30T10:19:12.369644Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72e98633-9179-4a3e-8908-ea2319d19b3b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7f2873cd-3759-4727-a683-31cac57fe5d8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7f2873cd-3759-4727-a683-31cac57fe5d8",
         "name": "ggshield-TvlX76OG", "description": "description", "created_at": "2024-04-30T09:25:39.573115Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7f2873cd-3759-4727-a683-31cac57fe5d8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d72113d0-c346-42c7-bd88-fd5fe0e716f3",
-        "name": "ggshield-eY0ZOlXS", "description": "description", "created_at": "2024-04-30T09:25:38.689800Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d72113d0-c346-42c7-bd88-fd5fe0e716f3", "name": "ggshield-eY0ZOlXS",
+        "description": "description", "created_at": "2024-04-30T09:25:38.689800Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d72113d0-c346-42c7-bd88-fd5fe0e716f3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5a01f826-4f8f-4235-8867-ce58ac88ce1c",
-        "name": "ggshield-inUFY47O", "description": "description", "created_at": "2024-03-27T08:48:21.791104Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5a01f826-4f8f-4235-8867-ce58ac88ce1c", "name": "ggshield-inUFY47O",
+        "description": "description", "created_at": "2024-03-27T08:48:21.791104Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5a01f826-4f8f-4235-8867-ce58ac88ce1c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
         "name": "ggshield-Psfrcoxl", "description": "description", "created_at": "2024-03-27T08:48:20.857237Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e",
         "name": "test-lena-1903", "description": "", "created_at": "2024-03-19T09:13:00.819618Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/443045cc-7fa4-441d-a161-b060bd7fbb3e",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-05-29T09:51:31.597203Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 319222, "revoker_id":
         319222, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245",
         "name": "Test key ", "description": "ss", "created_at": "2024-02-29T13:49:52.467489Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5d915aca-6f6f-4b4e-a996-2c1f53016114",
-        "name": "ggshield-LNgN8R1S", "description": "description", "created_at": "2024-02-27T14:19:40.283320Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5d915aca-6f6f-4b4e-a996-2c1f53016114", "name": "ggshield-LNgN8R1S",
+        "description": "description", "created_at": "2024-02-27T14:19:40.283320Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d915aca-6f6f-4b4e-a996-2c1f53016114",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "664af568-cfc7-4726-9fb4-0b61606b7386",
-        "name": "ggshield-horgQNnR", "description": "description", "created_at": "2024-02-27T14:19:39.357690Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "664af568-cfc7-4726-9fb4-0b61606b7386", "name": "ggshield-horgQNnR",
+        "description": "description", "created_at": "2024-02-27T14:19:39.357690Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/664af568-cfc7-4726-9fb4-0b61606b7386",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0ebc8091-454b-461e-a6f8-fd17bf412c76",
-        "name": "ggshield-jqk54PrI", "description": "description", "created_at": "2024-02-27T14:06:03.018091Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0ebc8091-454b-461e-a6f8-fd17bf412c76", "name": "ggshield-jqk54PrI",
+        "description": "description", "created_at": "2024-02-27T14:06:03.018091Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ebc8091-454b-461e-a6f8-fd17bf412c76",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "eba79796-4f46-4e10-b876-280f75138cc9",
-        "name": "ggshield-z3Y6zgih", "description": "description", "created_at": "2024-02-27T14:06:02.196977Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "eba79796-4f46-4e10-b876-280f75138cc9", "name": "ggshield-z3Y6zgih",
+        "description": "description", "created_at": "2024-02-27T14:06:02.196977Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/eba79796-4f46-4e10-b876-280f75138cc9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "4dd6c06e-e2c0-4593-9be0-b0418ba7a370",
-        "name": "ggshield-5YTKZZTB", "description": "description", "created_at": "2024-02-27T14:02:45.717261Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "4dd6c06e-e2c0-4593-9be0-b0418ba7a370", "name": "ggshield-5YTKZZTB",
+        "description": "description", "created_at": "2024-02-27T14:02:45.717261Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4dd6c06e-e2c0-4593-9be0-b0418ba7a370",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5ff5eee1-fc18-4474-86fa-c46321c903c8",
-        "name": "ggshield-rmnfzrW2", "description": "description", "created_at": "2024-02-27T14:02:45.009113Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5ff5eee1-fc18-4474-86fa-c46321c903c8", "name": "ggshield-rmnfzrW2",
+        "description": "description", "created_at": "2024-02-27T14:02:45.009113Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5ff5eee1-fc18-4474-86fa-c46321c903c8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "33d149f1-68f4-4446-ae4f-def0ce962724",
-        "name": "ggshield-2Mf02eVA", "description": "description", "created_at": "2024-02-27T13:58:31.125075Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "33d149f1-68f4-4446-ae4f-def0ce962724", "name": "ggshield-2Mf02eVA",
+        "description": "description", "created_at": "2024-02-27T13:58:31.125075Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/33d149f1-68f4-4446-ae4f-def0ce962724",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "def4a23d-3d12-4fe1-b8e0-02250e74e47a",
-        "name": "ggshield-itglxnie", "description": "description", "created_at": "2024-02-27T13:58:30.205444Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "def4a23d-3d12-4fe1-b8e0-02250e74e47a", "name": "ggshield-itglxnie",
+        "description": "description", "created_at": "2024-02-27T13:58:30.205444Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/def4a23d-3d12-4fe1-b8e0-02250e74e47a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d7764013-fdd5-4b08-b195-dff5a338906d",
-        "name": "ggshield-LRYYnjOa", "description": "description", "created_at": "2024-02-27T13:42:37.569678Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d7764013-fdd5-4b08-b195-dff5a338906d", "name": "ggshield-LRYYnjOa",
+        "description": "description", "created_at": "2024-02-27T13:42:37.569678Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d7764013-fdd5-4b08-b195-dff5a338906d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "1bba091c-fc4c-48b5-b558-46c191f67103",
-        "name": "ggshield-ldC5hqqo", "description": "description", "created_at": "2024-02-27T13:42:36.686028Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "1bba091c-fc4c-48b5-b558-46c191f67103", "name": "ggshield-ldC5hqqo",
+        "description": "description", "created_at": "2024-02-27T13:42:36.686028Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1bba091c-fc4c-48b5-b558-46c191f67103",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e",
-        "name": "myname-dwayneptoday", "description": "dfsdfsdf", "created_at": "2024-02-23T16:38:14.323313Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e", "name": "myname-dwayneptoday",
+        "description": "dfsdfsdf", "created_at": "2024-02-23T16:38:14.323313Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T17:03:21.653827Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "612055eb-7fb5-4ba3-ab10-aa481f3d9962",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "612055eb-7fb5-4ba3-ab10-aa481f3d9962",
         "name": "demo-dwayne-2024-02-23-v2", "description": "Demo for video", "created_at":
         "2024-02-23T16:28:49.949332Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/612055eb-7fb5-4ba3-ab10-aa481f3d9962",
         "status": "revoked", "triggered_at": "2024-02-23T16:31:01.657151Z", "revoked_at":
         "2024-02-23T16:52:50.712289Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "b38455f9-822c-4f21-8525-0d4f2fa63850", "name": "demo-dwayne-2024-02-23",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "b38455f9-822c-4f21-8525-0d4f2fa63850", "name": "demo-dwayne-2024-02-23",
         "description": "dfnijsbuisbfids", "created_at": "2024-02-23T15:45:47.636481Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b38455f9-822c-4f21-8525-0d4f2fa63850",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T16:28:23.939971Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86136984-d415-41c2-bfc4-59da8f9584fd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86136984-d415-41c2-bfc4-59da8f9584fd",
         "name": "demo-2024-02-23-dm", "description": "", "created_at": "2024-02-23T15:38:04.895275Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86136984-d415-41c2-bfc4-59da8f9584fd",
         "status": "revoked", "triggered_at": "2024-02-23T15:49:03.613445Z", "revoked_at":
         "2024-02-23T15:59:54.768989Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "0a94480f-5361-47f8-bc23-45a331624e9d", "name": "demo
-        ", "description": "demo ", "created_at": "2024-02-22T19:02:29.338420Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/0a94480f-5361-47f8-bc23-45a331624e9d",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "0a94480f-5361-47f8-bc23-45a331624e9d", "name": "demo ", "description":
+        "demo ", "created_at": "2024-02-22T19:02:29.338420Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0a94480f-5361-47f8-bc23-45a331624e9d",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T17:03:31.533534Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d024b464-cd1e-4daf-9b1d-863dcf517a7a",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d024b464-cd1e-4daf-9b1d-863dcf517a7a",
         "name": "Demo -2024-02-22", "description": "", "created_at": "2024-02-22T18:53:26.142516Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d024b464-cd1e-4daf-9b1d-863dcf517a7a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 354585, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "1592023a-2f39-4ba6-a503-4c07132f1eb0",
-        "name": "GGnikalston/rock-paper-scissors-f4c01375", "description": "", "created_at":
-        "2024-02-20T13:32:45.163630Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1592023a-2f39-4ba6-a503-4c07132f1eb0",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "1592023a-2f39-4ba6-a503-4c07132f1eb0", "name": "GGnikalston/rock-paper-scissors-f4c01375",
+        "description": "", "created_at": "2024-02-20T13:32:45.163630Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/1592023a-2f39-4ba6-a503-4c07132f1eb0",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
-        "name": "solid-octo", "description": "", "created_at": "2024-02-19T13:06:26.880374Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "6fcc5cf2-4b47-497d-9a80-c2d794b96ebc", "name": "solid-octo",
+        "description": "", "created_at": "2024-02-19T13:06:26.880374Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
-        "key": "team", "value": "octo"}], "custom_tags": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
         "key": "team", "value": "octo"}], "token": "[REDACTED]"}, {"id": "638f6f82-6679-4399-a336-dd7996f4beae",
         "name": "demo-2024-02-16dm", "description": "demo", "created_at": "2024-02-16T19:39:33.970811Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/638f6f82-6679-4399-a336-dd7996f4beae",
         "status": "revoked", "triggered_at": "2024-02-16T19:40:02.759791Z", "revoked_at":
         "2024-02-16T20:10:11.153368Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "cf0806c4-093d-4165-9ad3-7e7ded211d3f", "name": "DemoKey",
-        "description": "sss", "created_at": "2024-02-15T12:39:23.633481Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/cf0806c4-093d-4165-9ad3-7e7ded211d3f",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "cf0806c4-093d-4165-9ad3-7e7ded211d3f", "name": "DemoKey", "description":
+        "sss", "created_at": "2024-02-15T12:39:23.633481Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cf0806c4-093d-4165-9ad3-7e7ded211d3f",
         "status": "triggered", "triggered_at": "2024-02-15T12:45:44.649197Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b00bfddb-98c2-48e4-ad38-0cb9bc79cad6", "name": "orga_083643/solid-octo",
-        "description": "", "created_at": "2024-02-09T14:45:12.139727Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
+        "name": "orga_083643/solid-octo", "description": "", "created_at": "2024-02-09T14:45:12.139727Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
         "status": "revoked", "triggered_at": "2024-02-09T14:52:11.339548Z", "revoked_at":
         "2024-05-29T13:09:29.773300Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 2508, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "07fb5f6f-23f1-42e8-bdb2-c95864412a16", "name": "My Little Honeytoken",
-        "description": "for testing", "created_at": "2024-02-02T22:18:06.038874Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/07fb5f6f-23f1-42e8-bdb2-c95864412a16",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "07fb5f6f-23f1-42e8-bdb2-c95864412a16",
+        "name": "My Little Honeytoken", "description": "for testing", "created_at":
+        "2024-02-02T22:18:06.038874Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/07fb5f6f-23f1-42e8-bdb2-c95864412a16",
         "status": "triggered", "triggered_at": "2024-02-09T20:50:13.173911Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4", "name": "Lauren Testing", "description":
-        "Lauren wuz here", "created_at": "2024-01-29T17:37:45.379096Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
+        "name": "Lauren Testing", "description": "Lauren wuz here", "created_at":
+        "2024-01-29T17:37:45.379096Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 637596, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a",
         "name": "BK Test Paris", "description": "Brandon while in Paris office", "created_at":
         "2024-01-17T11:12:14.759334Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/34d5205b-accd-429c-9efa-eda48989c83a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
-        "name": "AWS key honeytoken for Slack", "description": "Honeytoken on Slack
-        channel", "created_at": "2024-01-15T16:13:53.656688Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "123ecd19-e66f-4e5c-ad73-12f0a51eda5a", "name": "AWS
+        key honeytoken for Slack", "description": "Honeytoken on Slack channel", "created_at":
+        "2024-01-15T16:13:53.656688Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
         "status": "triggered", "triggered_at": "2024-01-15T16:14:14.960066Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 104, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "23ca2658-aecf-471c-abf0-add09962e320", "key": "ods",
-        "value": "slack"}], "custom_tags": [{"id": "23ca2658-aecf-471c-abf0-add09962e320",
-        "key": "ods", "value": "slack"}], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
+        [], "custom_tags": [{"id": "23ca2658-aecf-471c-abf0-add09962e320", "key":
+        "ods", "value": "slack"}], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "name": "sss", "description": "test", "created_at": "2024-01-09T14:24:10.741214Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
-        "name": "ggshield-JZV5XT71", "description": "description", "created_at": "2024-01-09T09:39:34.421404Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c", "name": "ggshield-JZV5XT71",
+        "description": "description", "created_at": "2024-01-09T09:39:34.421404Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4dd77510-fc74-411f-9dbe-77619fa920dd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4dd77510-fc74-411f-9dbe-77619fa920dd",
         "name": "My Postman Public Collection", "description": "Will it ring?", "created_at":
         "2024-01-02T16:36:46.008155Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4dd77510-fc74-411f-9dbe-77619fa920dd",
         "status": "triggered", "triggered_at": "2024-01-04T17:52:01.203498Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 811, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6c5d9856-835e-468c-9448-7bf0e77f1e53",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6c5d9856-835e-468c-9448-7bf0e77f1e53",
         "name": "improved carnival", "description": "", "created_at": "2023-12-21T13:43:01.544215Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6c5d9856-835e-468c-9448-7bf0e77f1e53",
         "status": "revoked", "triggered_at": "2023-12-21T13:57:59.435706Z", "revoked_at":
         "2023-12-22T09:33:18.668820Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "52903632-f6ff-460e-8a68-80a942349979",
         "name": "Network Honeytoken", "description": "Aws Honeytoken on Network",
         "created_at": "2023-12-18T13:47:39.151311Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/52903632-f6ff-460e-8a68-80a942349979",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
-        "key": "network", "value": "directory"}], "custom_tags": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
         "key": "network", "value": "directory"}], "token": "[REDACTED]"}, {"id": "7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
         "name": "analytics-repo", "description": "", "created_at": "2023-12-11T17:37:24.471286Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
         "status": "triggered", "triggered_at": "2023-12-11T17:46:48.024345Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "b7daf77c-e3e0-4747-a7e2-485a1a6f05e2",
-        "key": "team", "value": "dev"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "b7daf77c-e3e0-4747-a7e2-485a1a6f05e2",
         "key": "team", "value": "dev"}], "token": "[REDACTED]"}, {"id": "4046ccf5-7821-47f4-be7d-8240be69631b",
         "name": "ideal-journey-lena", "description": "", "created_at": "2023-12-11T16:29:20.759489Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4046ccf5-7821-47f4-be7d-8240be69631b",
-        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
-        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d6d5d79d-08fa-4c8a-bd54-c34851866cde",
+        "status": "triggered", "triggered_at": "2026-05-28T07:56:58.047592Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 5, "creator_id": 319222, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d6d5d79d-08fa-4c8a-bd54-c34851866cde",
         "name": "test1112", "description": "test publicly exposed honeytoken", "created_at":
         "2023-12-11T16:24:56.253683Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d6d5d79d-08fa-4c8a-bd54-c34851866cde",
         "status": "triggered", "triggered_at": "2023-12-11T16:26:07.733443Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "ecb3d61d-bdab-4636-a436-bef8079a005d",
         "name": "ggshield-ObfCUUCA", "description": "description", "created_at": "2023-11-28T08:50:32.130230Z",
@@ -1040,15 +1171,13 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ae448808-3865-4797-a008-9eef6344f9da",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ae448808-3865-4797-a008-9eef6344f9da",
         "name": "Bsides Berlin", "description": "test key for a demo", "created_at":
         "2023-11-18T16:19:36.463172Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ae448808-3865-4797-a008-9eef6344f9da",
         "status": "triggered", "triggered_at": "2023-11-18T16:20:14.365596Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 105, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
-        "key": "repo", "value": "mackenziejj"}], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
+        ["publicly_exposed"], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
         "key": "repo", "value": "mackenziejj"}], "token": "[REDACTED]"}, {"id": "c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
         "name": "DeepSec Demo", "description": "Demo for DeepSec Confrence ", "created_at":
@@ -1056,69 +1185,66 @@ interactions:
         "status": "triggered", "triggered_at": "2023-11-16T16:01:58.603599Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "bd51c3d9-0943-43d5-8f87-359ecee03903", "name": "ggshield-73VAsjsO", "description":
         null, "created_at": "2023-11-14T08:27:44.885242Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bd51c3d9-0943-43d5-8f87-359ecee03903",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-11-14T08:28:08.188201Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8df388e2-aeb5-42ca-b6d5-221a54a40339",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "8df388e2-aeb5-42ca-b6d5-221a54a40339",
         "name": "ggshield-P47kTh7j", "description": null, "created_at": "2023-11-09T15:44:33.671666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8df388e2-aeb5-42ca-b6d5-221a54a40339",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb",
-        "name": "test eric dd 02", "description": "", "created_at": "2023-10-31T14:33:35.801324Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb", "name": "test
+        eric dd 02", "description": "", "created_at": "2023-10-31T14:33:35.801324Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4affa602-902b-47ff-a1f4-721dc3e671bb",
         "status": "triggered", "triggered_at": "2023-10-31T14:35:33.676298Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 2897, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29", "name": "Eric Demo Test 01",
-        "description": "", "created_at": "2023-10-31T12:51:44.535200Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/d69a098c-8b61-4102-bb2b-9a82958a3e29",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29",
+        "name": "Eric Demo Test 01", "description": "", "created_at": "2023-10-31T12:51:44.535200Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d69a098c-8b61-4102-bb2b-9a82958a3e29",
         "status": "revoked", "triggered_at": "2023-10-31T12:52:49.851916Z", "revoked_at":
         "2024-12-10T12:16:28.115539Z", "type": "AWS", "open_events_count": 0, "creator_id":
         136170, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "fe392ff1-b3d7-462f-a26f-d094326f40ed", "name": "Jason
-        and team", "description": "akljdlaj", "created_at": "2023-10-24T14:23:20.991107Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fe392ff1-b3d7-462f-a26f-d094326f40ed",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "fe392ff1-b3d7-462f-a26f-d094326f40ed", "name": "Jason and team", "description":
+        "akljdlaj", "created_at": "2023-10-24T14:23:20.991107Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/fe392ff1-b3d7-462f-a26f-d094326f40ed",
         "status": "triggered", "triggered_at": "2024-05-10T22:15:09.224357Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
         "name": "Jason test", "description": "Token for Test ", "created_at": "2023-10-24T13:45:31.371710Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f8e0968-664a-49f3-af85-9cc468b960ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "48f7c567-93d1-4925-9f77-d3919f120b88",
-        "name": "ggshield-KlAkKRtE", "description": "description", "created_at": "2023-10-16T19:49:08.588391Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "48f7c567-93d1-4925-9f77-d3919f120b88", "name": "ggshield-KlAkKRtE",
+        "description": "description", "created_at": "2023-10-16T19:49:08.588391Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/48f7c567-93d1-4925-9f77-d3919f120b88",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cdaea884-25fb-49db-90ec-a18879be36c4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cdaea884-25fb-49db-90ec-a18879be36c4",
         "name": "Demo Honeytoken", "description": "Leaking on Public Demo", "created_at":
         "2023-10-16T15:13:10.845487Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cdaea884-25fb-49db-90ec-a18879be36c4",
         "status": "revoked", "triggered_at": "2023-10-16T15:14:25.574559Z", "revoked_at":
         "2023-10-27T15:01:19.053629Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "137c9fee-4b3c-4231-92fd-98debf6557c2", "name": "BSides ATL demo for session",
         "description": "This one will be triggered from 2 different spots online",
         "created_at": "2023-10-14T12:28:51.206659Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/137c9fee-4b3c-4231-92fd-98debf6557c2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 354585, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "22fdf53a-e348-464a-a87f-5bcecb1a4e62",
-        "name": "Slack test", "description": "blablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablabla
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "22fdf53a-e348-464a-a87f-5bcecb1a4e62", "name": "Slack
+        test", "description": "blablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablabla
         blablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablabla
         blablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablabla
         blablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablabla
@@ -1128,14 +1254,13 @@ interactions:
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-06-03T09:50:06.667490Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 363707, "revoker_id":
         353920, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "576dc1ce-ab72-4604-934f-526cff5a667e",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "576dc1ce-ab72-4604-934f-526cff5a667e",
         "name": "BsidesCyprus", "description": "Live demo ", "created_at": "2023-10-07T11:34:54.740226Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/576dc1ce-ab72-4604-934f-526cff5a667e",
         "status": "triggered", "triggered_at": "2023-10-07T11:35:53.017981Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 249, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "7d80793b-c702-441e-837e-b1d3da94d576", "name": "Hacktivity Key", "description":
         "Test Key Leak for Hacktivity", "created_at": "2023-10-05T14:41:56.632793Z",
@@ -1143,9 +1268,7 @@ interactions:
         "status": "revoked", "triggered_at": "2023-10-05T14:42:57.752365Z", "revoked_at":
         "2024-12-10T12:17:33.875750Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "2544b3e6-57b2-48e2-a1a5-c4b6551987bb", "name": "SBB demo", "description":
@@ -1154,11 +1277,8 @@ interactions:
         "status": "triggered", "triggered_at": "2024-08-17T15:36:55.810693Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key": "commiter",
-        "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca", "key":
-        "file", "value": ".env"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327", "key":
-        "vcs", "value": "github"}], "custom_tags": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda",
-        "key": "commiter", "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
+        [], "custom_tags": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key":
+        "commiter", "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "7ca5ca92-a0a1-48bf-9618-d7194beaa039",
         "name": "Demo GrrCon", "description": "Leaking a secret at GrrCon on GitHub.com",
@@ -1166,9 +1286,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-09-29T16:11:40.077048Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 344, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
-        "key": "confrence", "value": "grrcon"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}], "custom_tags": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
+        ["publicly_exposed"], "custom_tags": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
         "key": "confrence", "value": "grrcon"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}], "token": "[REDACTED]"}, {"id": "3664c283-d479-41ac-9ad9-30283731ee25",
         "name": "Balccon Demo", "description": "Demo key for Balccon ", "created_at":
@@ -1176,10 +1294,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-09-08T14:56:49.516889Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
-        "key": "location", "value": "sourcecode"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
-        "key": "visability", "value": "public"}], "custom_tags": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
+        ["publicly_exposed"], "custom_tags": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
         "key": "location", "value": "sourcecode"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
         "key": "visability", "value": "public"}], "token": "[REDACTED]"}, {"id": "095d655f-a273-400f-ba01-eff8951242ed",
@@ -1188,67 +1303,59 @@ interactions:
         "status": "triggered", "triggered_at": "2023-09-08T16:58:49.455578Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 6, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "89a1745a-f796-4ece-99f7-106671aea57c",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "89a1745a-f796-4ece-99f7-106671aea57c",
         "name": "-demo-honeytoken-ctf-micro-api-", "description": "", "created_at":
         "2023-09-06T14:19:32.695323Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/89a1745a-f796-4ece-99f7-106671aea57c",
         "status": "triggered", "triggered_at": "2023-09-06T14:24:18.462424Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "b01db549-a2fa-4527-913d-0715a1119530",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "b01db549-a2fa-4527-913d-0715a1119530",
         "name": "demo-honeytoken-ctf-internal-share-", "description": "", "created_at":
         "2023-09-06T11:33:48.881275Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b01db549-a2fa-4527-913d-0715a1119530",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-09-06T14:21:42.509905Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a58154f6-e66f-4079-82b7-aabec70c73ff",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "a58154f6-e66f-4079-82b7-aabec70c73ff",
         "name": "demo-honeytoken-ctf-micro-api", "description": "", "created_at":
         "2023-09-06T11:33:37.828240Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a58154f6-e66f-4079-82b7-aabec70c73ff",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-09-06T14:17:20.708816Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ff623703-9ca1-4fba-99dc-c20110894ed3",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "ff623703-9ca1-4fba-99dc-c20110894ed3",
         "name": "-demo-honeytoken-ctf-django-app-", "description": "", "created_at":
         "2023-09-06T11:33:27.376222Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff623703-9ca1-4fba-99dc-c20110894ed3",
         "status": "triggered", "triggered_at": "2023-09-06T14:19:10.580142Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 4, "creator_id": null, "revoker_id":
+        null, "type": "AWS", "open_events_count": 9, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "f246c64a-3494-43ae-9d81-500df2f950c3",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "f246c64a-3494-43ae-9d81-500df2f950c3",
         "name": "demo-honeytoken-ctf-personal-", "description": "", "created_at":
         "2023-09-06T11:29:57.547211Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f246c64a-3494-43ae-9d81-500df2f950c3",
         "status": "revoked", "triggered_at": "2023-09-06T12:18:14.949044Z", "revoked_at":
         "2024-12-10T12:15:49.265110Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
         "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "5564ed3c-3eec-4375-9fc8-e0ada71dce02",
         "name": "ctf-demo-test-honeytoken-micro-api", "description": "", "created_at":
         "2023-09-05T19:18:08.504776Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5564ed3c-3eec-4375-9fc8-e0ada71dce02",
         "status": "revoked", "triggered_at": "2023-09-06T07:44:18.074891Z", "revoked_at":
         "2023-09-06T10:03:48.581110Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "de145bd4-b424-49ab-b95b-80126914bf2e", "name": "ctf-demo-test-honeytoken-django-app",
-        "description": "", "created_at": "2023-09-05T19:13:53.491842Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/de145bd4-b424-49ab-b95b-80126914bf2e",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "de145bd4-b424-49ab-b95b-80126914bf2e",
+        "name": "ctf-demo-test-honeytoken-django-app", "description": "", "created_at":
+        "2023-09-05T19:13:53.491842Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/de145bd4-b424-49ab-b95b-80126914bf2e",
         "status": "revoked", "triggered_at": "2023-09-06T07:42:55.177580Z", "revoked_at":
         "2023-09-06T10:03:30.948628Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "edd96a3b-5c71-4346-b5e2-2150e454dc91", "name": "Bsides Krakow", "description":
-        "Demo for leaking a key on GitHub", "created_at": "2023-09-02T13:20:53.501588Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/edd96a3b-5c71-4346-b5e2-2150e454dc91",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "edd96a3b-5c71-4346-b5e2-2150e454dc91",
+        "name": "Bsides Krakow", "description": "Demo for leaking a key on GitHub",
+        "created_at": "2023-09-02T13:20:53.501588Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/edd96a3b-5c71-4346-b5e2-2150e454dc91",
         "status": "triggered", "triggered_at": "2023-09-02T13:22:51.142717Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "46776cb3-6b11-41fc-b431-07609992f0cb",
         "name": "HoneyTokenaLARTest", "description": "Testworkshop", "created_at":
@@ -1256,33 +1363,31 @@ interactions:
         "status": "revoked", "triggered_at": "2023-08-29T12:09:16.581232Z", "revoked_at":
         "2023-08-29T12:42:37.841866Z", "type": "AWS", "open_events_count": 0, "creator_id":
         37699, "revoker_id": 37699, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51", "name": "testket ", "description":
-        "eew", "created_at": "2023-08-29T10:21:29.956291Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
+        "name": "testket ", "description": "eew", "created_at": "2023-08-29T10:21:29.956291Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
-        "name": "ggshield-mzO8qHEz", "description": "description", "created_at": "2023-08-22T08:19:03.821471Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "dc69f522-32ec-4f5f-b6be-516fb00a2bcd", "name": "ggshield-mzO8qHEz",
+        "description": "description", "created_at": "2023-08-22T08:19:03.821471Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "90d4c2b6-ecae-4ef9-a754-4561929b9e38",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "90d4c2b6-ecae-4ef9-a754-4561929b9e38",
         "name": "ggshield-mpkTH5jF", "description": "description", "created_at": "2023-08-16T08:28:18.684517Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/90d4c2b6-ecae-4ef9-a754-4561929b9e38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f418401f-9c6e-4490-893c-b640283c93c3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f418401f-9c6e-4490-893c-b640283c93c3",
         "name": "defcon-appsecvillage", "description": "publically leaked keys", "created_at":
         "2023-08-11T18:53:51.136748Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f418401f-9c6e-4490-893c-b640283c93c3",
         "status": "triggered", "triggered_at": "2023-08-11T18:55:35.503991Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 61, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
+        ["publicly_exposed"], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
         "name": "BSidesLV", "description": "Key leaked publically by leakymcgee again",
@@ -1290,11 +1395,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-08-10T00:13:19.948280Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
-        "key": "date leaked", "value": "08/09/2023"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
-        "key": "format", "value": "public"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
+        ["publicly_exposed"], "custom_tags": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
         "key": "date leaked", "value": "08/09/2023"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
         "key": "format", "value": "public"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
@@ -1303,117 +1404,112 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86670f84-e117-4f96-aa16-e399a0bb2cf2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
-        "name": "vBOY test segment 2", "description": "sdqsdqsd", "created_at": "2023-08-07T12:47:49.515448Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7", "name": "vBOY
+        test segment 2", "description": "sdqsdqsd", "created_at": "2023-08-07T12:47:49.515448Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40",
-        "name": "vBOY test segment", "description": "sdqsdqsdqsdqsd", "created_at":
-        "2023-08-07T12:45:52.890085Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40", "name": "vBOY
+        test segment", "description": "sdqsdqsdqsdqsd", "created_at": "2023-08-07T12:45:52.890085Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-08-07T12:46:45.470113Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a11570c6-f472-4fda-a493-30d65fd8e651",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "a11570c6-f472-4fda-a493-30d65fd8e651",
         "name": "test Antonin 2", "description": "", "created_at": "2023-08-03T14:09:46.046004Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a",
-        "name": "test Antonin 1", "description": "", "created_at": "2023-08-03T08:42:25.251504Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a", "name": "test
+        Antonin 1", "description": "", "created_at": "2023-08-03T08:42:25.251504Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fa63d76d-4297-4d41-8e77-b47d1a97a41a",
         "status": "revoked", "triggered_at": "2023-08-03T08:59:58.717709Z", "revoked_at":
         "2023-08-03T09:00:05.809852Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "5d3ad22c-e422-48d2-b7f5-6d52801599aa", "name": "demo 31jul", "description":
-        "", "created_at": "2023-07-31T15:27:18.323098Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d3ad22c-e422-48d2-b7f5-6d52801599aa",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5d3ad22c-e422-48d2-b7f5-6d52801599aa",
+        "name": "demo 31jul", "description": "", "created_at": "2023-07-31T15:27:18.323098Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d3ad22c-e422-48d2-b7f5-6d52801599aa",
         "status": "revoked", "triggered_at": "2023-07-31T15:33:49.570793Z", "revoked_at":
         "2023-12-11T14:01:40.706751Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "5670c657-618f-41d7-984b-d59656d905e4", "name": "ggshield-3KTmbo8u",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "5670c657-618f-41d7-984b-d59656d905e4", "name": "ggshield-3KTmbo8u",
         "description": null, "created_at": "2023-07-27T15:44:43.238742Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/5670c657-618f-41d7-984b-d59656d905e4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "27e9ba01-4bb6-46ed-84c8-ff14366a3bde",
-        "name": "Private network", "description": "Inside private network ", "created_at":
-        "2023-07-27T15:39:32.979325Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/27e9ba01-4bb6-46ed-84c8-ff14366a3bde",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "27e9ba01-4bb6-46ed-84c8-ff14366a3bde", "name": "Private
+        network", "description": "Inside private network ", "created_at": "2023-07-27T15:39:32.979325Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/27e9ba01-4bb6-46ed-84c8-ff14366a3bde",
         "status": "triggered", "triggered_at": "2023-07-27T16:23:35.804271Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0d81797a-6fc0-4a6e-a211-af16828c0c39",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0d81797a-6fc0-4a6e-a211-af16828c0c39",
         "name": "Webinar Public ", "description": "from webinar ", "created_at": "2023-07-27T15:33:07.472730Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0d81797a-6fc0-4a6e-a211-af16828c0c39",
         "status": "triggered", "triggered_at": "2023-07-27T15:34:48.902462Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 204, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "521efd01-bbcc-4380-b548-ed7242c017ea", "name": "ggshield-HLZpiznn", "description":
         null, "created_at": "2023-07-27T14:54:03.198466Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/521efd01-bbcc-4380-b548-ed7242c017ea",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
-        "name": "ggshield-5voYnhhy", "description": null, "created_at": "2023-07-27T13:50:51.332176Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0659fa04-b5f8-4f5b-a0d1-66cb53fc9709", "name": "ggshield-5voYnhhy",
+        "description": null, "created_at": "2023-07-27T13:50:51.332176Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T13:52:58.300149Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-27T09:01:37.417151Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e842a635-eb7e-4617-8984-ac57fe909ef7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T09:01:36.764795Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51f41814-f029-4ab4-b863-c0fecba025b3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51f41814-f029-4ab4-b863-c0fecba025b3",
         "name": "ggshield-v3LhZCz8", "description": "description", "created_at": "2023-07-27T09:01:36.117217Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/51f41814-f029-4ab4-b863-c0fecba025b3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a20a718-7b9e-4582-abdf-772053bffd72",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a20a718-7b9e-4582-abdf-772053bffd72",
         "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T08:56:56.138738Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a20a718-7b9e-4582-abdf-772053bffd72",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:58.657957Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "812090ee-17e2-4df4-a6d6-0da0e4d64cd3", "name": "ggshield-w1P1Ggsz",
-        "description": "description", "created_at": "2023-07-27T08:56:55.435203Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
+        "name": "ggshield-w1P1Ggsz", "description": "description", "created_at": "2023-07-27T08:56:55.435203Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0c3f182e-98f5-4a64-aadb-664fd7c9de88",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0c3f182e-98f5-4a64-aadb-664fd7c9de88",
         "name": "ggshield-ewIAL7lq", "description": "description", "created_at": "2023-07-27T08:54:41.926242Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0c3f182e-98f5-4a64-aadb-664fd7c9de88",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
         "name": "Example TOken ", "description": "ubvcub", "created_at": "2023-07-12T13:16:10.775681Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
-        "key": "file", "value": ".env"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "c8c94ffa-c0af-48c6-976a-6502a41811af", "name": "honeytoken demo eric", "description":
@@ -1422,205 +1518,190 @@ interactions:
         "status": "triggered", "triggered_at": "2023-07-05T14:49:33.528178Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "14566c1f-0b52-4770-ab68-000704242633",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "14566c1f-0b52-4770-ab68-000704242633",
         "name": "ggshield-Rv2mUej7", "description": "description", "created_at": "2023-07-05T08:55:23.864812Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/14566c1f-0b52-4770-ab68-000704242633",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-05T08:27:15.756813Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0e4f0dbd-b288-4990-9565-3cc7b0171a79",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:53.240550Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 160089, "revoker_id":
         296618, "creator_api_token_id": "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb", "name": "ggshield-0etjSvZJ",
-        "description": "description", "created_at": "2023-07-05T08:27:14.048162Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb",
+        "name": "ggshield-0etjSvZJ", "description": "description", "created_at": "2023-07-05T08:27:14.048162Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc7214d0-c97a-44b3-b576-664f0a81c4f7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc7214d0-c97a-44b3-b576-664f0a81c4f7",
         "name": "repo analytics 19jun", "description": "", "created_at": "2023-06-19T09:11:21.788070Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc7214d0-c97a-44b3-b576-664f0a81c4f7",
         "status": "revoked", "triggered_at": "2023-06-20T17:24:35.145047Z", "revoked_at":
         "2023-12-11T14:50:27.627289Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "27379093-c6a4-4732-a64a-715c94e74fd7", "name": "ggshield-TvFzKVed",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "27379093-c6a4-4732-a64a-715c94e74fd7", "name": "ggshield-TvFzKVed",
         "description": null, "created_at": "2023-06-09T08:01:57.360210Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/27379093-c6a4-4732-a64a-715c94e74fd7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "62cb7048-4302-4b52-9163-e2ceff775b39", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
         "name": "ggshield-TtJwtxNE", "description": "ggshield test", "created_at":
         "2023-06-02T08:48:20.148216Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05",
-        "name": "ggshield-cptptJHt", "description": "ggshield test", "created_at":
-        "2023-06-02T08:47:41.149126Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05", "name": "ggshield-cptptJHt",
+        "description": "ggshield test", "created_at": "2023-06-02T08:47:41.149126Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "001c53df-b63c-4b81-a4fb-35e5b38bf328",
-        "name": "DevOxx Poland", "description": "", "created_at": "2023-05-31T12:28:39.713989Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/001c53df-b63c-4b81-a4fb-35e5b38bf328",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "001c53df-b63c-4b81-a4fb-35e5b38bf328", "name": "DevOxx
+        Poland", "description": "", "created_at": "2023-05-31T12:28:39.713989Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/001c53df-b63c-4b81-a4fb-35e5b38bf328",
         "status": "triggered", "triggered_at": "2023-05-31T14:09:21.767459Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 225, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "63728091-d083-47cc-9898-73c2636f2c7f", "name": "ggshield-ZIU1V3Bv",
-        "description": null, "created_at": "2023-05-31T08:17:12.607879Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/63728091-d083-47cc-9898-73c2636f2c7f",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "63728091-d083-47cc-9898-73c2636f2c7f",
+        "name": "ggshield-ZIU1V3Bv", "description": null, "created_at": "2023-05-31T08:17:12.607879Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/63728091-d083-47cc-9898-73c2636f2c7f",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-31T08:17:38.021142Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "41d76272-ee3d-4639-93e8-29222b662b93", "name": "demo31may-public",
-        "description": "", "created_at": "2023-05-31T08:13:48.373887Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/41d76272-ee3d-4639-93e8-29222b662b93",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "41d76272-ee3d-4639-93e8-29222b662b93",
+        "name": "demo31may-public", "description": "", "created_at": "2023-05-31T08:13:48.373887Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/41d76272-ee3d-4639-93e8-29222b662b93",
         "status": "revoked", "triggered_at": "2023-05-31T08:15:09.926931Z", "revoked_at":
         "2024-12-10T12:16:03.693045Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "f17302cd-850b-4b54-9054-60d26a76cf38", "name": "test demo 31may", "description":
         "", "created_at": "2023-05-31T08:10:36.754144Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
         "name": "ggshield-agateau", "description": null, "created_at": "2023-05-30T13:32:31.845201Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T13:33:03.363563Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 160089, "revoker_id":
         160089, "creator_api_token_id": "425e1a78-209e-4cd5-b08f-8450a0026ac0", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b", "name": "test_honey_token_previous",
-        "description": "description", "created_at": "2023-05-30T10:46:11.714531Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
+        "name": "test_honey_token_previous", "description": "description", "created_at":
+        "2023-05-30T10:46:11.714531Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:07.762156Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "092dba62-9d82-41bd-84aa-95430d540edc", "name": "ggshield-224Lwv95",
-        "description": "description", "created_at": "2023-05-30T10:46:10.997022Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "092dba62-9d82-41bd-84aa-95430d540edc",
+        "name": "ggshield-224Lwv95", "description": "description", "created_at": "2023-05-30T10:46:10.997022Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/092dba62-9d82-41bd-84aa-95430d540edc",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7494298b-75c5-44e4-898c-77b3b9017113",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7494298b-75c5-44e4-898c-77b3b9017113",
         "name": "test_honey_token_abc", "description": "description", "created_at":
         "2023-05-30T10:42:37.520767Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7494298b-75c5-44e4-898c-77b3b9017113",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:45:41.905071Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "6e7f275d-e115-44d3-8854-5c6472494951", "name": "ggshield-UXgNYVXL",
-        "description": "description", "created_at": "2023-05-30T10:42:36.847031Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e7f275d-e115-44d3-8854-5c6472494951",
+        "name": "ggshield-UXgNYVXL", "description": "description", "created_at": "2023-05-30T10:42:36.847031Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6e7f275d-e115-44d3-8854-5c6472494951",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
         "name": "ggshield-BA0VsBh3", "description": "description", "created_at": "2023-05-30T10:39:09.968782Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f60db759-7041-4dfe-80fa-91012d97fdd3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f60db759-7041-4dfe-80fa-91012d97fdd3",
         "name": "ggshield-tsCPoUcx", "description": "description", "created_at": "2023-05-30T10:37:14.527124Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f60db759-7041-4dfe-80fa-91012d97fdd3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1266b395-a545-42c1-b700-24dbae36447c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1266b395-a545-42c1-b700-24dbae36447c",
         "name": "test_honey_token_previous", "description": "description", "created_at":
         "2023-05-30T10:30:40.547255Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1266b395-a545-42c1-b700-24dbae36447c",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:41:43.173510Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "bb494eed-6ba4-4b98-b949-ad5f54d929dd",
         "name": "ggshield-uORy0any", "description": "description", "created_at": "2023-05-30T10:30:39.803353Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bb494eed-6ba4-4b98-b949-ad5f54d929dd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
         "name": "Pycon Italia", "description": "", "created_at": "2023-05-28T09:34:01.581495Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
         "status": "revoked", "triggered_at": "2023-05-28T09:45:30.255118Z", "revoked_at":
         "2024-12-10T12:17:08.199275Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263", "name": "NDC-OSLO
-        Demo", "description": "Demo key for NDC Oslo confrence", "created_at": "2023-05-25T07:59:05.651290Z",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263", "name": "NDC-OSLO Demo", "description":
+        "Demo key for NDC Oslo confrence", "created_at": "2023-05-25T07:59:05.651290Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
         "status": "triggered", "triggered_at": "2023-05-25T08:38:27.471330Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 221, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "79db31fc-ffd1-4bc9-b6e4-3ef37a94712a", "name": "QubitConfrence", "description":
-        "", "created_at": "2023-05-18T07:58:37.174577Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/79db31fc-ffd1-4bc9-b6e4-3ef37a94712a",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "79db31fc-ffd1-4bc9-b6e4-3ef37a94712a",
+        "name": "QubitConfrence", "description": "", "created_at": "2023-05-18T07:58:37.174577Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/79db31fc-ffd1-4bc9-b6e4-3ef37a94712a",
         "status": "triggered", "triggered_at": "2023-05-18T09:30:01.025933Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 215, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "db7bf6ea-57cb-4d13-8ed9-dc59b2620e00", "name": "Honeytoken demo 17
-        may", "description": "This is a token for the live demo", "created_at": "2023-05-17T17:15:04.921233Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/db7bf6ea-57cb-4d13-8ed9-dc59b2620e00",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "db7bf6ea-57cb-4d13-8ed9-dc59b2620e00",
+        "name": "Honeytoken demo 17 may", "description": "This is a token for the
+        live demo", "created_at": "2023-05-17T17:15:04.921233Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/db7bf6ea-57cb-4d13-8ed9-dc59b2620e00",
         "status": "triggered", "triggered_at": "2023-05-17T17:16:48.960267Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 5018, "creator_id": 166199, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "ef11a80c-6d8e-4fb5-8ee2-4556bae695c3", "name": "test ht public", "description":
         "", "created_at": "2023-05-17T17:00:24.966335Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef11a80c-6d8e-4fb5-8ee2-4556bae695c3",
         "status": "triggered", "triggered_at": "2023-05-17T17:02:33.386529Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 5012, "creator_id": 166199, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
-        "key": "location", "value": "slack"}], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
+        ["publicly_exposed"], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
         "key": "location", "value": "slack"}], "token": "[REDACTED]"}, {"id": "84d43c23-6d4d-47f8-bf62-e7c1b0ae1625",
         "name": "analytic-repo", "description": "", "created_at": "2023-05-16T16:17:11.435058Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84d43c23-6d4d-47f8-bf62-e7c1b0ae1625",
         "status": "revoked", "triggered_at": "2023-05-16T16:27:55.091410Z", "revoked_at":
         "2023-12-11T14:01:44.427581Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "72fcdb5c-e128-4ca5-8970-f1f52f95a78a",
         "name": "slack-chan-website", "description": "", "created_at": "2023-05-16T15:35:26.129025Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72fcdb5c-e128-4ca5-8970-f1f52f95a78a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
-        "key": "place", "value": "website"}], "custom_tags": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
         "key": "place", "value": "website"}], "token": "[REDACTED]"}, {"id": "63bbd74e-bb5f-4910-8e63-eed358af3bc8",
         "name": "improved-carnival repo", "description": "", "created_at": "2023-05-16T14:45:09.811724Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/63bbd74e-bb5f-4910-8e63-eed358af3bc8",
         "status": "revoked", "triggered_at": "2023-05-16T14:49:44.284195Z", "revoked_at":
         "2024-06-19T10:46:44.282148Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
         "name": "jira-OPS-124", "description": "honeytoken deployed in jira ticket
         OPS-124", "created_at": "2023-05-16T11:58:57.713307Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "45182b59-b659-41ef-9bb8-44a78740fade",
         "name": "solid-octo-repo", "description": "Placed in solid-octo repo, file
         ... on 16May2023", "created_at": "2023-05-16T11:51:06.384073Z", "gitguardian_url":
@@ -1628,74 +1709,77 @@ interactions:
         "status": "triggered", "triggered_at": "2026-02-18T14:51:12.499369Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432", "key": "place",
-        "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "8bf5f99a-538d-4cfe-8e74-61cd7081ae25",
+        [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432", "key":
+        "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "8bf5f99a-538d-4cfe-8e74-61cd7081ae25",
         "name": "PasswordsCon2", "description": "For presentation", "created_at":
         "2023-05-16T11:30:36.210395Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8bf5f99a-538d-4cfe-8e74-61cd7081ae25",
         "status": "triggered", "triggered_at": "2023-05-16T12:29:45.638074Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 344, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "72a52279-8e9f-40de-a1d4-bc5fcc48795d", "name": "passwordscon", "description":
         "", "created_at": "2023-05-16T10:03:49.677782Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72a52279-8e9f-40de-a1d4-bc5fcc48795d",
         "status": "triggered", "triggered_at": "2023-05-16T10:04:10.262805Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 222, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
-        "key": "location", "value": "test"}], "custom_tags": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
+        ["publicly_exposed"], "custom_tags": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
         "key": "location", "value": "test"}], "token": "[REDACTED]"}, {"id": "858a3a76-f6f2-4c2e-b0bc-323d9a575413",
         "name": "test_honey_token", "description": "description", "created_at": "2023-05-15T14:09:09.210845Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/858a3a76-f6f2-4c2e-b0bc-323d9a575413",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:17.165934Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}, {"id": "411d33c0-7fad-4fc1-b94e-bb440c8f9c49",
-        "name": "ggshield-wv7vMain", "description": "description", "created_at": "2023-05-15T14:09:08.478482Z",
+        "token": "[REDACTED]"}, {"id": "411d33c0-7fad-4fc1-b94e-bb440c8f9c49", "name":
+        "ggshield-wv7vMain", "description": "description", "created_at": "2023-05-15T14:09:08.478482Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/411d33c0-7fad-4fc1-b94e-bb440c8f9c49",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:11.250010Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}]'
+        "token": "[REDACTED]"}]'
     headers:
+      CF-RAY:
+      - a10394e0a91c6f52-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:00 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, POST, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '139756'
+      - '145842'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:15 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '722'
+      - '767'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_honeytokens_with_search.yaml
+++ b/tests/cassettes/client/vcr/test_list_honeytokens_with_search.yaml
@@ -25,144 +25,131 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/858a3a76-f6f2-4c2e-b0bc-323d9a575413",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:17.165934Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}, {"id": "ef11a80c-6d8e-4fb5-8ee2-4556bae695c3",
-        "name": "test ht public", "description": "", "created_at": "2023-05-17T17:00:24.966335Z",
+        "token": "[REDACTED]"}, {"id": "ef11a80c-6d8e-4fb5-8ee2-4556bae695c3", "name":
+        "test ht public", "description": "", "created_at": "2023-05-17T17:00:24.966335Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef11a80c-6d8e-4fb5-8ee2-4556bae695c3",
         "status": "triggered", "triggered_at": "2023-05-17T17:02:33.386529Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 5012, "creator_id": 166199, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
-        "key": "location", "value": "slack"}], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
+        ["publicly_exposed"], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
         "key": "location", "value": "slack"}], "token": "[REDACTED]"}, {"id": "1266b395-a545-42c1-b700-24dbae36447c",
         "name": "test_honey_token_previous", "description": "description", "created_at":
         "2023-05-30T10:30:40.547255Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1266b395-a545-42c1-b700-24dbae36447c",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:41:43.173510Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "7494298b-75c5-44e4-898c-77b3b9017113",
         "name": "test_honey_token_abc", "description": "description", "created_at":
         "2023-05-30T10:42:37.520767Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7494298b-75c5-44e4-898c-77b3b9017113",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:45:41.905071Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b", "name": "test_honey_token_previous",
-        "description": "description", "created_at": "2023-05-30T10:46:11.714531Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
+        "name": "test_honey_token_previous", "description": "description", "created_at":
+        "2023-05-30T10:46:11.714531Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:07.762156Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "f17302cd-850b-4b54-9054-60d26a76cf38", "name": "test demo 31may",
-        "description": "", "created_at": "2023-05-31T08:10:36.754144Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f17302cd-850b-4b54-9054-60d26a76cf38",
+        "name": "test demo 31may", "description": "", "created_at": "2023-05-31T08:10:36.754144Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05",
         "name": "ggshield-cptptJHt", "description": "ggshield test", "created_at":
         "2023-06-02T08:47:41.149126Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
-        "name": "ggshield-TtJwtxNE", "description": "ggshield test", "created_at":
-        "2023-06-02T08:48:20.148216Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72", "name": "ggshield-TtJwtxNE",
+        "description": "ggshield test", "created_at": "2023-06-02T08:48:20.148216Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79",
-        "name": "test_honey_token_error_403", "description": "description", "created_at":
-        "2023-07-05T08:27:15.756813Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0e4f0dbd-b288-4990-9565-3cc7b0171a79",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79", "name": "test_honey_token_error_403",
+        "description": "description", "created_at": "2023-07-05T08:27:15.756813Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0e4f0dbd-b288-4990-9565-3cc7b0171a79",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:53.240550Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 160089, "revoker_id":
         296618, "creator_api_token_id": "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "2a20a718-7b9e-4582-abdf-772053bffd72", "name": "test_honey_token",
-        "description": "description", "created_at": "2023-07-27T08:56:56.138738Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a20a718-7b9e-4582-abdf-772053bffd72",
+        "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T08:56:56.138738Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a20a718-7b9e-4582-abdf-772053bffd72",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:58.657957Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba", "name": "test_honey_token",
-        "description": "description", "created_at": "2023-07-27T09:01:36.764795Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
+        "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T09:01:36.764795Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-27T09:01:37.417151Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e842a635-eb7e-4617-8984-ac57fe909ef7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a",
         "name": "test Antonin 1", "description": "", "created_at": "2023-08-03T08:42:25.251504Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fa63d76d-4297-4d41-8e77-b47d1a97a41a",
         "status": "revoked", "triggered_at": "2023-08-03T08:59:58.717709Z", "revoked_at":
         "2023-08-03T09:00:05.809852Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "a11570c6-f472-4fda-a493-30d65fd8e651", "name": "test Antonin 2", "description":
-        "", "created_at": "2023-08-03T14:09:46.046004Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a11570c6-f472-4fda-a493-30d65fd8e651",
+        "name": "test Antonin 2", "description": "", "created_at": "2023-08-03T14:09:46.046004Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40",
-        "name": "vBOY test segment", "description": "sdqsdqsdqsdqsd", "created_at":
-        "2023-08-07T12:45:52.890085Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40", "name": "vBOY
+        test segment", "description": "sdqsdqsdqsdqsd", "created_at": "2023-08-07T12:45:52.890085Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-08-07T12:46:45.470113Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "name": "vBOY test segment 2", "description": "sdqsdqsd", "created_at": "2023-08-07T12:47:49.515448Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
-        "name": "testket ", "description": "eew", "created_at": "2023-08-29T10:21:29.956291Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51", "name": "testket
+        ", "description": "eew", "created_at": "2023-08-29T10:21:29.956291Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "46776cb3-6b11-41fc-b431-07609992f0cb",
-        "name": "HoneyTokenaLARTest", "description": "Testworkshop", "created_at":
-        "2023-08-29T12:07:20.692993Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/46776cb3-6b11-41fc-b431-07609992f0cb",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "46776cb3-6b11-41fc-b431-07609992f0cb", "name": "HoneyTokenaLARTest",
+        "description": "Testworkshop", "created_at": "2023-08-29T12:07:20.692993Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/46776cb3-6b11-41fc-b431-07609992f0cb",
         "status": "revoked", "triggered_at": "2023-08-29T12:09:16.581232Z", "revoked_at":
         "2023-08-29T12:42:37.841866Z", "type": "AWS", "open_events_count": 0, "creator_id":
         37699, "revoker_id": 37699, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "de145bd4-b424-49ab-b95b-80126914bf2e", "name": "ctf-demo-test-honeytoken-django-app",
-        "description": "", "created_at": "2023-09-05T19:13:53.491842Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/de145bd4-b424-49ab-b95b-80126914bf2e",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "de145bd4-b424-49ab-b95b-80126914bf2e",
+        "name": "ctf-demo-test-honeytoken-django-app", "description": "", "created_at":
+        "2023-09-05T19:13:53.491842Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/de145bd4-b424-49ab-b95b-80126914bf2e",
         "status": "revoked", "triggered_at": "2023-09-06T07:42:55.177580Z", "revoked_at":
         "2023-09-06T10:03:30.948628Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "5564ed3c-3eec-4375-9fc8-e0ada71dce02", "name": "ctf-demo-test-honeytoken-micro-api",
-        "description": "", "created_at": "2023-09-05T19:18:08.504776Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/5564ed3c-3eec-4375-9fc8-e0ada71dce02",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5564ed3c-3eec-4375-9fc8-e0ada71dce02",
+        "name": "ctf-demo-test-honeytoken-micro-api", "description": "", "created_at":
+        "2023-09-05T19:18:08.504776Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5564ed3c-3eec-4375-9fc8-e0ada71dce02",
         "status": "revoked", "triggered_at": "2023-09-06T07:44:18.074891Z", "revoked_at":
         "2023-09-06T10:03:48.581110Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "7d80793b-c702-441e-837e-b1d3da94d576", "name": "Hacktivity Key", "description":
-        "Test Key Leak for Hacktivity", "created_at": "2023-10-05T14:41:56.632793Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7d80793b-c702-441e-837e-b1d3da94d576",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7d80793b-c702-441e-837e-b1d3da94d576",
+        "name": "Hacktivity Key", "description": "Test Key Leak for Hacktivity", "created_at":
+        "2023-10-05T14:41:56.632793Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7d80793b-c702-441e-837e-b1d3da94d576",
         "status": "revoked", "triggered_at": "2023-10-05T14:42:57.752365Z", "revoked_at":
         "2024-12-10T12:17:33.875750Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "22fdf53a-e348-464a-a87f-5bcecb1a4e62", "name": "Slack test", "description":
@@ -176,35 +163,32 @@ interactions:
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-06-03T09:50:06.667490Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 363707, "revoker_id":
         353920, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
         "name": "Jason test", "description": "Token for Test ", "created_at": "2023-10-24T13:45:31.371710Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f8e0968-664a-49f3-af85-9cc468b960ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29",
-        "name": "Eric Demo Test 01", "description": "", "created_at": "2023-10-31T12:51:44.535200Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29", "name": "Eric
+        Demo Test 01", "description": "", "created_at": "2023-10-31T12:51:44.535200Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d69a098c-8b61-4102-bb2b-9a82958a3e29",
         "status": "revoked", "triggered_at": "2023-10-31T12:52:49.851916Z", "revoked_at":
         "2024-12-10T12:16:28.115539Z", "type": "AWS", "open_events_count": 0, "creator_id":
         136170, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb", "name": "test
-        eric dd 02", "description": "", "created_at": "2023-10-31T14:33:35.801324Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4affa602-902b-47ff-a1f4-721dc3e671bb",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb", "name": "test eric dd 02",
+        "description": "", "created_at": "2023-10-31T14:33:35.801324Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/4affa602-902b-47ff-a1f4-721dc3e671bb",
         "status": "triggered", "triggered_at": "2023-10-31T14:35:33.676298Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 2897, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "ae448808-3865-4797-a008-9eef6344f9da", "name": "Bsides Berlin", "description":
-        "test key for a demo", "created_at": "2023-11-18T16:19:36.463172Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/ae448808-3865-4797-a008-9eef6344f9da",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ae448808-3865-4797-a008-9eef6344f9da",
+        "name": "Bsides Berlin", "description": "test key for a demo", "created_at":
+        "2023-11-18T16:19:36.463172Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ae448808-3865-4797-a008-9eef6344f9da",
         "status": "triggered", "triggered_at": "2023-11-18T16:20:14.365596Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 105, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
-        "key": "repo", "value": "mackenziejj"}], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
+        ["publicly_exposed"], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
         "key": "repo", "value": "mackenziejj"}], "token": "[REDACTED]"}, {"id": "d6d5d79d-08fa-4c8a-bd54-c34851866cde",
         "name": "test1112", "description": "test publicly exposed honeytoken", "created_at":
@@ -212,150 +196,138 @@ interactions:
         "status": "triggered", "triggered_at": "2023-12-11T16:26:07.733443Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "name": "sss", "description": "test", "created_at": "2024-01-09T14:24:10.741214Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a",
-        "name": "BK Test Paris", "description": "Brandon while in Paris office", "created_at":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a", "name": "BK
+        Test Paris", "description": "Brandon while in Paris office", "created_at":
         "2024-01-17T11:12:14.759334Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/34d5205b-accd-429c-9efa-eda48989c83a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
-        "name": "Lauren Testing", "description": "Lauren wuz here", "created_at":
-        "2024-01-29T17:37:45.379096Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4", "name": "Lauren
+        Testing", "description": "Lauren wuz here", "created_at": "2024-01-29T17:37:45.379096Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 637596, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "07fb5f6f-23f1-42e8-bdb2-c95864412a16",
         "name": "My Little Honeytoken", "description": "for testing", "created_at":
         "2024-02-02T22:18:06.038874Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/07fb5f6f-23f1-42e8-bdb2-c95864412a16",
         "status": "triggered", "triggered_at": "2024-02-09T20:50:13.173911Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "2e904370-faa8-4842-8e5e-552902fdd245", "name": "Test key ", "description":
-        "ss", "created_at": "2024-02-29T13:49:52.467489Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245",
+        "name": "Test key ", "description": "ss", "created_at": "2024-02-29T13:49:52.467489Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e",
-        "name": "test-lena-1903", "description": "", "created_at": "2024-03-19T09:13:00.819618Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/443045cc-7fa4-441d-a161-b060bd7fbb3e",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e", "name": "test-lena-1903",
+        "description": "", "created_at": "2024-03-19T09:13:00.819618Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/443045cc-7fa4-441d-a161-b060bd7fbb3e",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-05-29T09:51:31.597203Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 319222, "revoker_id":
         319222, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
         "name": "Test key", "description": "Access key", "created_at": "2024-05-22T12:16:55.833940Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c7101eaa-ea38-495d-b3b4-c016db23e859",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
         "name": "test lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
-        "status": "triggered", "triggered_at": "2024-06-06T08:19:18.422045Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 319222, "revoker_id":
-        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca", "key": "machine",
-        "value": "ggprdgim01"}], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
         "key": "machine", "value": "ggprdgim01"}], "token": "[REDACTED]"}, {"id":
         "a411fa2c-a465-4099-8353-3c42365aca50", "name": "test MINT", "description":
         "test MINT", "created_at": "2024-06-10T14:40:08.522247Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/a411fa2c-a465-4099-8353-3c42365aca50",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
-        "name": "test ericf", "description": "", "created_at": "2024-07-09T09:34:04.089955Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5", "name": "test
+        ericf", "description": "", "created_at": "2024-07-09T09:34:04.089955Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
         "status": "triggered", "triggered_at": "2024-07-09T09:34:57.541777Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "62d71685-2eba-4b88-8edd-cc73e698cfa5",
         "name": "test-greg", "description": "test greg", "created_at": "2025-05-12T10:06:19.826522Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/62d71685-2eba-4b88-8edd-cc73e698cfa5",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:59.739856Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "e948f77d-5353-413e-b37d-8beba84890ff", "name": "test-greg-2", "description":
-        "test greg", "created_at": "2025-05-12T10:08:11.667578Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e948f77d-5353-413e-b37d-8beba84890ff",
+        "name": "test-greg-2", "description": "test greg", "created_at": "2025-05-12T10:08:11.667578Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:54.809724Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb", "name": "test-greg-3", "description":
-        "test greg", "created_at": "2025-05-12T10:08:58.561160Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        "name": "test-greg-3", "description": "test greg", "created_at": "2025-05-12T10:08:58.561160Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:50.784137Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6", "name": "test-greg-4", "description":
-        "test", "created_at": "2025-05-12T10:10:12.927058Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6",
+        "name": "test-greg-4", "description": "test", "created_at": "2025-05-12T10:10:12.927058Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:46.594085Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a", "name": "test-greg-5", "description":
-        "test", "created_at": "2025-05-12T10:12:50.615700Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
+        "name": "test-greg-5", "description": "test", "created_at": "2025-05-12T10:12:50.615700Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:41.387978Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38", "name": "TestHoneytoken", "description":
-        "Testing GitGuardian API connectivity", "created_at": "2025-05-12T12:19:05.294638Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b0ddbd44-4054-4127-aa00-cd6727e70d38",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38",
+        "name": "TestHoneytoken", "description": "Testing GitGuardian API connectivity",
+        "created_at": "2025-05-12T12:19:05.294638Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b0ddbd44-4054-4127-aa00-cd6727e70d38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
         "name": "AWS Credentials", "description": "Honeytoken for testing, to be injected
         as requested by the user.", "created_at": "2025-05-12T12:38:25.640506Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
         "status": "triggered", "triggered_at": "2026-02-18T13:45:03.781945Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 269050, "revoker_id":
+        null, "type": "AWS", "open_events_count": 9, "creator_id": 269050, "revoker_id":
         null, "creator_api_token_id": "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec", "name": "test-greg-7", "description":
-        "test", "created_at": "2025-05-12T12:54:37.703725Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ab824e92-6068-4a9d-ae36-86a94516f2ec",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec",
+        "name": "test-greg-7", "description": "test", "created_at": "2025-05-12T12:54:37.703725Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ab824e92-6068-4a9d-ae36-86a94516f2ec",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:34.521470Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "9844e55d-982c-4458-b65b-592ad99ce77a", "name": "test", "description":
-        "test", "created_at": "2025-05-12T13:09:38.965752Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9844e55d-982c-4458-b65b-592ad99ce77a",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
+        "name": "test", "description": "test", "created_at": "2025-05-12T13:09:38.965752Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9844e55d-982c-4458-b65b-592ad99ce77a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1026550, "revoker_id": null, "creator_api_token_id":
         "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
         "name": "Test Honeytoken", "description": "Testing honeytoken generation",
         "created_at": "2025-05-12T14:35:34.295363Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b2a7e759-81ab-465d-a578-e3ce42c18741",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
         "name": "test-greg-9", "description": "", "created_at": "2025-05-12T14:50:23.123299Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6d185a-6f59-4b7c-9248-dd05616090db",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:27.366114Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
+        null, "tags": [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
         "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "16805984-70d6-4049-844a-79bac3054f6f",
         "name": "AwsTestHoneytoken", "description": "Test honeytoken for development
@@ -364,44 +336,117 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "token": "[REDACTED]"}]'
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "name": "test Pierre", "description": "", "created_at": "2026-04-07T18:38:38.199572Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "9266c0f4-f0e0-41d2-a8c8-c164ccb84e47", "name": "qa
+        / test-nriv-e732d912", "description": "", "created_at": "2026-04-24T16:05:50.013606Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9266c0f4-f0e0-41d2-a8c8-c164ccb84e47",
+        "status": "triggered", "triggered_at": "2026-04-24T16:15:44.494587Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "name": "dev / Salome Test-e732d912", "description": "", "created_at": "2026-04-24T16:05:53.158978Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "status": "triggered", "triggered_at": "2026-04-24T16:16:21.895694Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "name": "qa / test-r8327r-e732d912", "description": "", "created_at": "2026-04-24T16:05:56.586568Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "status": "triggered", "triggered_at": "2026-04-24T16:18:31.419829Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a72f662-2357-4b93-b48a-00028e36cfff",
+        "name": "test1", "description": "tEST 2", "created_at": "2026-04-30T09:12:55.584248Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a72f662-2357-4b93-b48a-00028e36cfff",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "963fbabe-3d2c-4154-8281-2f13be7c06f7", "name": "test121",
+        "description": "testing 12", "created_at": "2026-04-30T11:31:57.689130Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/963fbabe-3d2c-4154-8281-2f13be7c06f7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "1acff09e-02c1-4a24-8869-568dfab124c9", "name": "test-pierredt",
+        "description": "hello", "created_at": "2026-05-06T19:57:39.689471Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/1acff09e-02c1-4a24-8869-568dfab124c9",
+        "status": "triggered", "triggered_at": "2026-05-06T19:59:18.645288Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 6, "creator_id": 309802, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "name": "qa / test-nriv-d2363bd5", "description": "", "created_at": "2026-05-19T08:29:37.247067Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "status": "triggered", "triggered_at": "2026-05-19T08:33:36.289678Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 1754656, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be3d1024-d9df-466c-9e75-afc1ed88b8f5",
+        "name": "test-plc", "description": "", "created_at": "2026-05-26T07:26:21.052034Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be3d1024-d9df-466c-9e75-afc1ed88b8f5",
+        "status": "revoked", "triggered_at": "2026-05-26T08:44:57.678480Z", "revoked_at":
+        "2026-05-26T12:19:01.401494Z", "type": "AWS", "open_events_count": 0, "creator_id":
+        701514, "revoker_id": 701514, "creator_api_token_id": null, "revoker_api_token_id":
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "8409c955-f217-47c9-9cf1-3a6b557c65c9", "name": "Test", "description": "",
+        "created_at": "2026-05-26T14:12:05.347374Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8409c955-f217-47c9-9cf1-3a6b557c65c9",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754650, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "82f00514-d9d3-442c-b575-c40ff77db387", "name": "test-plc2",
+        "description": "", "created_at": "2026-05-27T13:13:33.943814Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/82f00514-d9d3-442c-b575-c40ff77db387",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 701514, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}]'
     headers:
+      CF-RAY:
+      - a10394daebe50413-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:43:59 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, POST, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '29870'
+      - '33390'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:14 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '445'
+      - '509'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incident_members.yaml
+++ b/tests/cassettes/client/vcr/test_list_incident_members.yaml
@@ -21,71 +21,80 @@ interactions:
   response:
     body:
       string: '[{"id": 21460, "detector": {"name": "aws_iam", "display_name": "AWS
-        IAM Keys", "nature": "specific", "family": "credentials", "detector_group_name":
-        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2020-10-29T13:19:59.005564Z",
-        "secret_id": 70588, "secret_hash": "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG",
-        "hmsl_hash": "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2026-03-11T22:41:04.525493Z", "resolver_id": 492181, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "invalid", "severity": "medium",
-        "assignee_id": null, "assignee_email": "vincent.boyer@gitguardian.com", "share_url":
-        "[REDACTED]", "feedback_list": [{"created_at": "2022-07-20T13:22:52.756189Z",
-        "updated_at": "2022-07-20T13:22:52.756207Z", "email": "stanislas.crepin@gitguardian.com",
-        "member_id": null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
-        "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
-        "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
-        give or has given access to any sensitive information or services?", "boolean":
-        true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
-        this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
-        "remarks_text", "field_label": "Additional remarks", "text": "Hasn''t been
-        revoked yet because X"}]}], "risk_score": 100, "is_vaulted": false, "ignore_reason":
-        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        IAM Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2020-10-29T13:19:59.005564Z", "secret_id": 70588, "secret_hash":
+        "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG", "hmsl_hash":
+        "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
+        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
+        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
+        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
+        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
+        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
+        given access to any sensitive information or services?", "boolean": true},
+        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
+        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
+        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
+        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
+        "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
         0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
         0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["PUBLICLY_LEAKED"],
-        "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["REVOCABLE_BY_GG",
+        "PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
         "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}]'
     headers:
+      CF-RAY:
+      - a1039549a8ac4e30-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:16 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '2149'
+      - '2219'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:32 GMT
       link:
       - <https://api.gitguardian.com/v1/incidents/secrets?cursor=cD0yMTQ2MA%3D%3D&per_page=1>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '80'
+      - '97'
       x-frame-options:
       - DENY
       x-per-page:
       - '1'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -159,43 +168,51 @@ interactions:
         "Pierre DE THOISY", "email": "pierre.dethoisy@gitguardian.com", "incident_id":
         21460, "incident_permission": "full_access"}]'
     headers:
+      CF-RAY:
+      - a103954c1be6d8d2-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:16 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '3385'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:32 GMT
       link:
       - <https://api.gitguardian.com/v1/incidents/secrets/21460/members?cursor=cD0zMDk4MDI%3D>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '40'
+      - '46'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incident_notes.yaml
+++ b/tests/cassettes/client/vcr/test_list_incident_notes.yaml
@@ -21,71 +21,80 @@ interactions:
   response:
     body:
       string: '[{"id": 21460, "detector": {"name": "aws_iam", "display_name": "AWS
-        IAM Keys", "nature": "specific", "family": "credentials", "detector_group_name":
-        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2020-10-29T13:19:59.005564Z",
-        "secret_id": 70588, "secret_hash": "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG",
-        "hmsl_hash": "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2026-03-11T22:41:04.525493Z", "resolver_id": 492181, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "invalid", "severity": "medium",
-        "assignee_id": null, "assignee_email": "vincent.boyer@gitguardian.com", "share_url":
-        "[REDACTED]", "feedback_list": [{"created_at": "2022-07-20T13:22:52.756189Z",
-        "updated_at": "2022-07-20T13:22:52.756207Z", "email": "stanislas.crepin@gitguardian.com",
-        "member_id": null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
-        "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
-        "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
-        give or has given access to any sensitive information or services?", "boolean":
-        true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
-        this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
-        "remarks_text", "field_label": "Additional remarks", "text": "Hasn''t been
-        revoked yet because X"}]}], "risk_score": 100, "is_vaulted": false, "ignore_reason":
-        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        IAM Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2020-10-29T13:19:59.005564Z", "secret_id": 70588, "secret_hash":
+        "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG", "hmsl_hash":
+        "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
+        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
+        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
+        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
+        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
+        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
+        given access to any sensitive information or services?", "boolean": true},
+        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
+        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
+        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
+        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
+        "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
         0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
         0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["PUBLICLY_LEAKED"],
-        "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["REVOCABLE_BY_GG",
+        "PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
         "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}]'
     headers:
+      CF-RAY:
+      - a103954f1a327012-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:17 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '2149'
+      - '2219'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:33 GMT
       link:
       - <https://api.gitguardian.com/v1/incidents/secrets?cursor=cD0yMTQ2MA%3D%3D&per_page=1>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '80'
+      - '96'
       x-frame-options:
       - DENY
       x-per-page:
       - '1'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -114,42 +123,48 @@ interactions:
     body:
       string: '[]'
     headers:
+      CF-RAY:
+      - a10395516e449e96-CDG
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:17 GMT
+      Server:
+      - cloudflare
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, POST, HEAD, OPTIONS
-      content-length:
-      - '2'
+      cf-cache-status:
+      - DYNAMIC
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:34 GMT
       link:
       - ''
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '29'
+      - '84'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_basic.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_basic.yaml
@@ -21,36 +21,37 @@ interactions:
   response:
     body:
       string: '[{"id": 21460, "detector": {"name": "aws_iam", "display_name": "AWS
-        IAM Keys", "nature": "specific", "family": "credentials", "detector_group_name":
-        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2020-10-29T13:19:59.005564Z",
-        "secret_id": 70588, "secret_hash": "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG",
-        "hmsl_hash": "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2026-03-11T22:41:04.525493Z", "resolver_id": 492181, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "invalid", "severity": "medium",
-        "assignee_id": null, "assignee_email": "vincent.boyer@gitguardian.com", "share_url":
-        "[REDACTED]", "feedback_list": [{"created_at": "2022-07-20T13:22:52.756189Z",
-        "updated_at": "2022-07-20T13:22:52.756207Z", "email": "stanislas.crepin@gitguardian.com",
-        "member_id": null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
-        "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
-        "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
-        give or has given access to any sensitive information or services?", "boolean":
-        true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
-        this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
-        "remarks_text", "field_label": "Additional remarks", "text": "Hasn''t been
-        revoked yet because X"}]}], "risk_score": 100, "is_vaulted": false, "ignore_reason":
-        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        IAM Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2020-10-29T13:19:59.005564Z", "secret_id": 70588, "secret_hash":
+        "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG", "hmsl_hash":
+        "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
+        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
+        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
+        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
+        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
+        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
+        given access to any sensitive information or services?", "boolean": true},
+        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
+        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
+        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
+        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
+        "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
         0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
         0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["PUBLICLY_LEAKED"],
-        "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["REVOCABLE_BY_GG",
+        "PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
         "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}, {"id": 21461, "detector": {"name": "private_key_dsa",
         "display_name": "DSA Private Key", "nature": "specific", "family": "cryptographic_key",
-        "detector_group_name": "private_key_dsa", "detector_group_display_name": "DSA
-        Private Key"}, "date": "2020-10-29T09:19:54.249454Z", "secret_id": 70589,
+        "category": "private_key", "detector_group_name": "private_key_dsa", "detector_group_display_name":
+        "DSA Private Key"}, "date": "2020-10-29T09:19:54.249454Z", "secret_id": 70589,
         "secret_hash": "FNJbfEKG/ZXHjBfeEDa+45ryvtA8AC1egwR+QsSqIDlRVNh2Z/McHLTpLI6+WVL/",
         "hmsl_hash": "ae092263bbe1c8bbcc5e8e4dd785681b62e9d48226d66cb28f5d305fa5ef8e68",
         "occurrences_count": 2, "status": "ASSIGNED", "triggered_at": "2021-02-11T14:23:22.947605Z",
@@ -67,108 +68,117 @@ interactions:
         true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
         this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
         "remarks_text", "field_label": "Additional remarks", "text": "important info."}]}],
-        "risk_score": 72, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21461",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "DSA Private Key", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link":
-        "https://sandboxgitguardian.atlassian.net/browse/JB-15"}, {"id": "JB-14",
-        "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-14"}],
+        "risk_score": 72, "severity_rule_id": 11883, "is_vaulted": false, "ignore_reason":
+        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21461", "tags": ["PUBLICLY_LEAKED"],
+        "incident_name": "DSA Private Key", "public_exposure": {"source_publicly_visible":
+        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-15"},
+        {"id": "JB-14", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-14"}],
         "custom_tags": []}, {"id": 21462, "detector": {"name": "salesforce_oauth2",
         "display_name": "Salesforce Oauth2 Keys", "nature": "specific", "family":
-        "credentials", "detector_group_name": "salesforce_oauth2_keys", "detector_group_display_name":
-        "Salesforce Oauth2 Keys"}, "date": "2020-10-29T07:19:30.598398Z", "secret_id":
-        70590, "secret_hash": "c7Kwkwc1D3iO0XnbILGE93uD0GJXOV0CL1t/0icvVnmQUzR2LCAWyy4SR5jhsuGk",
+        "credentials", "category": "crm", "detector_group_name": "salesforce_oauth2_keys",
+        "detector_group_display_name": "Salesforce Oauth2 Keys"}, "date": "2020-10-29T07:19:30.598398Z",
+        "secret_id": 70590, "secret_hash": "c7Kwkwc1D3iO0XnbILGE93uD0GJXOV0CL1t/0icvVnmQUzR2LCAWyy4SR5jhsuGk",
         "hmsl_hash": "e2671771c77564e0f9b6dea27d7b71faa3e9566445b52e7ed403fc8f5e100390",
         "occurrences_count": 2, "status": "IGNORED", "triggered_at": "2021-02-11T14:23:22.947632Z",
         "ignored_at": "2025-07-28T09:27:09.871747Z", "ignorer_id": 492181, "ignorer_api_token_id":
         null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
         "secret_revoked": false, "validity": "invalid", "severity": "high", "assignee_id":
         10, "assignee_email": "bruce-wayne-gg@protonmail.com", "share_url": "[REDACTED]",
-        "feedback_list": [], "risk_score": 23, "is_vaulted": false, "ignore_reason":
-        "invalid", "occurrences": null, "secret_presence": {"files_requiring_code_fix":
-        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
-        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21462", "tags": ["PUBLICLY_LEAKED"],
-        "incident_name": "Salesforce Oauth2 Keys", "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [], "custom_tags": []}, {"id": 21463, "detector": {"name":
-        "private_key_rsa", "display_name": "RSA Private Key", "nature": "specific",
-        "family": "cryptographic_key", "detector_group_name": "private_key_rsa", "detector_group_display_name":
-        "RSA Private Key"}, "date": "2020-10-29T06:20:15.521071Z", "secret_id": 70591,
-        "secret_hash": "rm3JVOM1diLeHDKQaemsg9nNbygNQEAth6YpABj++z5JxBYo7vN5xZFHxYj+duJV",
+        "feedback_list": [], "risk_score": 23, "severity_rule_id": 31, "is_vaulted":
+        false, "ignore_reason": "invalid", "occurrences": null, "secret_presence":
+        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
+        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
+        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21462",
+        "tags": ["PUBLICLY_LEAKED"], "incident_name": "Salesforce Oauth2 Keys", "public_exposure":
+        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "destination_tickets": [], "custom_tags": []}, {"id": 21463, "detector":
+        {"name": "private_key_rsa", "display_name": "RSA Private Key", "nature": "specific",
+        "family": "cryptographic_key", "category": "private_key", "detector_group_name":
+        "private_key_rsa", "detector_group_display_name": "RSA Private Key"}, "date":
+        "2020-10-29T06:20:15.521071Z", "secret_id": 70591, "secret_hash": "rm3JVOM1diLeHDKQaemsg9nNbygNQEAth6YpABj++z5JxBYo7vN5xZFHxYj+duJV",
         "hmsl_hash": "8a0925c807e5f9986368746f18b8cbb748379d31e4187cbb0b1dd0cda8a4a170",
         "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947664Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         "2023-04-21T12:50:04.503620Z", "resolver_id": null, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "no_checker", "severity": "high",
+        null, "secret_revoked": true, "validity": "failed_to_check", "severity": "high",
         "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 72, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21463",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "RSA Private Key", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [], "custom_tags": []}, {"id": 21464, "detector":
-        {"name": "aws_iam", "display_name": "AWS IAM Keys", "nature": "specific",
-        "family": "credentials", "detector_group_name": "aws_iam", "detector_group_display_name":
-        "AWS IAM Keys"}, "date": "2020-10-29T04:19:56.388169Z", "secret_id": 70592,
-        "secret_hash": "Vk90LgwiOvekJz1ekAbpTtG//qwTheghhQ6DeOBCFVHzghwkL4Qc71cZRqNcojMG",
+        [], "risk_score": 57, "severity_rule_id": 31, "is_vaulted": false, "ignore_reason":
+        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21463", "tags": ["PUBLICLY_LEAKED"],
+        "incident_name": "RSA Private Key", "public_exposure": {"source_publicly_visible":
+        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "destination_tickets": [], "custom_tags": []}, {"id": 21464, "detector": {"name":
+        "aws_iam", "display_name": "AWS IAM Keys", "nature": "specific", "family":
+        "credentials", "category": "cloud_provider", "detector_group_name": "aws_iam",
+        "detector_group_display_name": "AWS IAM Keys"}, "date": "2020-10-29T04:19:56.388169Z",
+        "secret_id": 70592, "secret_hash": "Vk90LgwiOvekJz1ekAbpTtG//qwTheghhQ6DeOBCFVHzghwkL4Qc71cZRqNcojMG",
         "hmsl_hash": "ebfb0b865d12332d62237b9893b78ca51e6a14ca773935a4771972074708af4c",
         "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947692Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         "2026-03-11T22:41:04.525493Z", "resolver_id": 492181, "resolver_api_token_id":
         null, "secret_revoked": true, "validity": "invalid", "severity": "high", "assignee_id":
         10, "assignee_email": "bruce-wayne-gg@protonmail.com", "share_url": "[REDACTED]",
-        "feedback_list": [], "risk_score": 100, "is_vaulted": false, "ignore_reason":
-        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        "feedback_list": [], "risk_score": 100, "severity_rule_id": 28, "is_vaulted":
+        false, "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
         0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
         0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21464", "tags": ["PUBLICLY_LEAKED"],
-        "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21464", "tags": ["REVOCABLE_BY_GG",
+        "PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
         "destination_tickets": [{"id": "AEF-2326", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-2326"}],
         "custom_tags": []}]'
     headers:
+      CF-RAY:
+      - a103951cce766fed-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:10 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '8647'
+      - '8926'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:25 GMT
       link:
       - <https://api.gitguardian.com/v1/incidents/secrets?cursor=cD0yMTQ2NA%3D%3D&per_page=5>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '101'
+      - '1273'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_basic.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_basic.yaml
@@ -21,244 +21,241 @@ interactions:
   response:
     body:
       string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?page=2&page_size=5",
-        "previous": null, "results": [{"id": 29487335, "account": 8, "criterion":
-        "Stripe Webhook Secret", "date": "2026-04-02T16:22:33.518000Z", "last_trigger_published_at":
-        "2026-04-02T16:22:33.518000Z", "last_triggered_at": "2026-04-02T16:22:34.233032Z",
-        "last_trigger_detected_at": "2026-04-02T16:22:34.233032Z", "hash": "JquJu98wTd0k40t3UsNgP22P+ywFCrsGM1VDRg3oZBdGXhRWbjOMbKAG+JtXZUOK",
+        "previous": null, "results": [{"id": 34205503, "account": 8, "criterion":
+        "microsoft_azure_storage_connection_string", "date": "2026-06-23T11:13:31.325324Z",
+        "last_trigger_published_at": "2026-06-23T11:13:31.325324Z", "last_triggered_at":
+        "2026-06-23T11:13:31.343453Z", "last_trigger_detected_at": "2026-06-23T11:13:31.343453Z",
+        "hash": "HdPZ4cjZuziAqsakdlsUnJDapTz3ns5pX8vPzfhvGQvpWWWX25LITKmJimoqGr3z",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Stripe Webhook Secret", "severity_rule_config": null, "declarative_secret_status":
-        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": true,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 62, "displayed_occurrence": {"id": 256867982, "issue": 29487335,
-        "account": 8, "kind": "RLTM", "element": "KAN-8?focusedCommentId=10014", "element_type":
-        "JIRA_COMMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "o40+pCpgMCFgcapQEEdZ3imjEpSONYcgy0J+gLe5ygKDJctj7Ro4REsJrqbUl0yj",
-        "published_at": "2026-04-02T16:22:33.518000Z", "date": "2026-04-02T16:22:33.518000Z",
-        "detected_at": "2026-04-02T16:22:34.031682Z", "is_vcs_type": false, "last_detected_at":
-        "2026-04-02T16:22:33.518000Z", "last_seen_at": "2026-04-02T16:22:33.518000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-8?focusedCommentId=10014",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 148603941, "secrets_engine_version": "2.159.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 25, "indice_end":
-        63, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
-        "2026-04-02T16:22:34.268883Z", "last_presence_check_at": "2026-04-02T16:22:34.268883Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 1}, {"id": 29487333, "account": 8, "criterion":
-        "Slack Bot Token", "date": "2026-04-02T16:22:26.591000Z", "last_trigger_published_at":
-        "2026-04-02T16:22:26.591000Z", "last_triggered_at": "2026-04-02T16:22:27.578209Z",
-        "last_trigger_detected_at": "2026-04-02T16:22:27.578209Z", "hash": "UeONCI+H/I19fHV7Ge45VQxOI0/YUY6CYZu9psQ6W53s6W+UOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-04-02T16:22:27.592459Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": true,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 11, "displayed_occurrence": {"id": 256867977, "issue": 29487333,
-        "account": 8, "kind": "RLTM", "element": "KAN-4?focusedCommentId=10005", "element_type":
-        "JIRA_COMMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "BBZtIrA/2GAvXPBnlTveHP2iPqy+rHM0BxNchD6gRp+/+mUjQPrqnyjHph0vjkPi",
-        "published_at": "2026-04-02T16:22:26.591000Z", "date": "2026-04-02T16:22:26.591000Z",
-        "detected_at": "2026-04-02T16:22:27.022003Z", "is_vcs_type": false, "last_detected_at":
-        "2026-04-02T16:22:26.591000Z", "last_seen_at": "2026-04-02T16:22:26.591000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-4?focusedCommentId=10005",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 148603933, "secrets_engine_version": "2.159.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 25, "indice_end":
-        81, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
-        "2026-04-02T16:22:27.644022Z", "last_presence_check_at": "2026-04-02T16:22:27.644022Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": ["REVOCABLE_BY_GG"],
-        "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
-        29305270, "account": 8, "criterion": "OpenAI API Key", "date": "2026-03-27T13:47:01Z",
-        "last_trigger_published_at": "2026-03-27T13:47:01Z", "last_triggered_at":
-        "2026-03-28T05:01:36.397561Z", "last_trigger_detected_at": "2026-03-28T05:01:36.397561Z",
-        "hash": "MTJFo5AaJdAJ7giIaJE2+Vn/3hEL1nR7oKsu0ry8AAS38W2S95GRLqiXIWrK60u6",
-        "ignored": true, "ignored_at": "2026-03-28T05:01:36.405919Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "OpenAI API Key", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "name": "gg-tools"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-tools / OneDrive", "type": "microsoft_onedrive", "path": "gg-tools
-        / OneDrive", "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata":
-        null, "is_vaulted": false, "similar_issue_count": 0, "score": 6, "displayed_occurrence":
-        {"id": 255746729, "issue": 29305270, "account": 8, "kind": "RLTM", "element":
-        "{\"drive_id\": \"b!ifwT0vIqDE2MYP5tWpOaVJKsAA38ZA1PqHTPWAaO0Ovk8yFkaTlITKSgS6Y2Zlvu\",
-        \"parent_reference_path\": \"/drives/b!ifwT0vIqDE2MYP5tWpOaVJKsAA38ZA1PqHTPWAaO0Ovk8yFkaTlITKSgS6Y2Zlvu/root:/Recordings\",
-        \"file_id\": \"01ICX32E3NSJA7PEQVFZAKEEXG4DH65RP4\"}", "element_type": "SHAREPOINT_ONEDRIVE_FILE",
-        "author_name": "gg-tools", "author_info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "value": null, "value_hash": "CFPFVOpXX+26OfRN+bRLyvVCXnQmU1Cpu36m73v5F4pgz7WMu+D6UW65wQZMF7kQ",
-        "published_at": "2026-03-27T13:47:01Z", "date": "2026-03-27T13:47:01Z", "detected_at":
-        "2026-03-28T04:58:40.843022Z", "is_vcs_type": false, "last_detected_at": "2026-03-27T13:47:01Z",
-        "last_seen_at": "2026-03-27T13:47:01Z", "data": {}, "url": "https://gitguardianengineering-my.sharepoint.com/personal/gg-tools_gitguardianengineering_onmicrosoft_com/Documents/Recordings/secret.txt",
-        "source": {"id": 19962591, "url": "https://onedrive.com/", "type": "microsoft_onedrive",
-        "display_name": "gg-tools / OneDrive", "visibility": "private", "monitored":
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
+        "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
+        "detected_at": "2026-06-23T11:13:31.325324Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
+        "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
         true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null}, "regression": false, "content": 147214824, "secrets_engine_version":
-        "2.159.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 8, "indice_end": 59, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "Recordings/secret.txt", "filename":
-        "secret.txt", "presence": "visible", "last_presence_seen_at": "2026-03-28T05:01:36.456203Z",
-        "last_presence_check_at": "2026-03-28T05:01:36.456203Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": []},
-        "has_dropped_occurrences": false, "tags": ["REVOCABLE_BY_GG"], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 1}, {"id": 29236129, "account": 8, "criterion":
-        "Slack Bot Token", "date": "2026-03-26T16:10:40Z", "last_trigger_published_at":
-        "2026-03-26T16:10:40Z", "last_triggered_at": "2026-03-26T16:10:55.648969Z",
-        "last_trigger_detected_at": "2026-03-26T16:10:55.648969Z", "hash": "0Y7z2cw2c6cwAdy+TeYUL5BKR7Lb/hDQRLHld5PCWUkg5Q0OOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-03-26T16:10:55.689671Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "pierrelalanne/test_repo", "type": "gh_repository", "path": "pierrelalanne/test_repo",
-        "source_criticality": "critical"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 0, "displayed_occurrence":
-        {"id": 253938087, "issue": 29236129, "account": 8, "kind": "RLTM", "element":
-        "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
-        "value": null, "value_hash": "CEL9N36auQTdl9e+bqgAsGyWN0vVPYlqvHWSQMXxC/1zmdQrKYk359La8N2L+SIi",
-        "published_at": "2026-03-26T16:10:40Z", "date": "2026-03-26T16:10:40Z", "detected_at":
-        "2026-03-26T16:10:51.878216Z", "is_vcs_type": true, "last_detected_at": "2026-03-26T16:10:40Z",
-        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R1",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
-        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 146712049,
-        "secrets_engine_version": "2.159.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 60, "indice_end": 102, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 1, "post_line_end": 1}], "most_sensitive_match_name":
-        "apikey", "insights": [{"name": "test_file", "source": "document", "metadata":
-        null}], "filepath": "test_limits_1_secret.txt", "filename": "test_limits_1_secret.txt",
-        "presence": "visible", "last_presence_seen_at": "2026-03-26T16:10:55.988339Z",
-        "last_presence_check_at": "2026-03-26T16:10:55.988339Z", "first_presence_deleted_at":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
+        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
+        34186239, "account": 8, "criterion": "Generic Password", "date": "2026-06-22T15:14:57Z",
+        "last_trigger_published_at": "2026-06-22T15:14:57Z", "last_triggered_at":
+        "2026-06-22T15:16:49.799821Z", "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z",
+        "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Generic Password", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
+        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
+        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
+        "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
+        "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
+        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 113, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_63.txt", "filename":
+        "configuration_63.txt", "presence": "visible", "last_presence_seen_at": "2026-06-22T15:16:49.824313Z",
+        "last_presence_check_at": "2026-06-22T15:16:49.824313Z", "first_presence_deleted_at":
         null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}, {"type": "DEFAULT_BRANCH", "metadata":
-        null}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG",
-        "TEST_FILE"], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
-        29236130, "account": 8, "criterion": "Slack Bot Token", "date": "2026-03-26T16:10:40Z",
-        "last_trigger_published_at": "2026-03-26T16:10:40Z", "last_triggered_at":
-        "2026-03-26T16:10:55.649133Z", "last_trigger_detected_at": "2026-03-26T16:10:55.649133Z",
-        "hash": "1d291ZrFV0RBbVE8r2t6EFI1jgdXhzZkb4RYrNKH10mjkZ9yOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-03-26T16:10:55.695057Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "pierrelalanne/test_repo", "type": "gh_repository", "path": "pierrelalanne/test_repo",
-        "source_criticality": "critical"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 10, "score": 0, "displayed_occurrence":
-        {"id": 253938082, "issue": 29236130, "account": 8, "kind": "RLTM", "element":
-        "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
-        "value": null, "value_hash": "8CeYKeR2kMER0aBlyGThkdNGWeRYfKFLPj1kOQJO8lH2bXzFs7jhuR1VfR21VK1W",
-        "published_at": "2026-03-26T16:10:40Z", "date": "2026-03-26T16:10:40Z", "detected_at":
-        "2026-03-26T16:10:51.878216Z", "is_vcs_type": true, "last_detected_at": "2026-03-26T16:10:40Z",
-        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R20",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
-        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 146712049,
-        "secrets_engine_version": "2.159.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 896, "indice_end": 938, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 20, "post_line_end": 20}], "most_sensitive_match_name":
-        "apikey", "insights": [{"name": "test_file", "source": "document", "metadata":
-        null}], "filepath": "test_limits_1_secret.txt", "filename": "test_limits_1_secret.txt",
-        "presence": "visible", "last_presence_seen_at": "2026-03-26T16:10:55.988339Z",
-        "last_presence_check_at": "2026-03-26T16:10:55.988339Z", "first_presence_deleted_at":
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 34181686, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-22T11:25:45.739149Z", "last_trigger_published_at": "2026-06-22T11:25:45.739149Z",
+        "last_triggered_at": "2026-06-22T11:25:45.762592Z", "last_trigger_detected_at":
+        "2026-06-22T11:25:45.762592Z", "hash": "gVrL/pjjFLo7sSikPS1pWtPJbr+oWSSVz8IB6+2ViJDSJKiK25LITKmJimoqGr3z",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": true, "resolved_at": "2026-06-22T11:26:52.971214Z", "resolver":
+        1751937, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
+        "none", "ignorer_type": "none", "resolver_display_name": "candidate.playground+eu@gitguardian.com",
+        "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
+        "none", "status": "RESOLVED", "issue_name": "Microsoft Azure Storage Connection
+        String", "severity_rule_config": null, "declarative_secret_status": "revoked",
+        "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "", "name": "Kashyapa P.A. Jayasekera"}],
+        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "GGFRLTA127
+        \u2014 kashyapap.jayasekera", "type": "endpoints", "path": "GGFRLTA127 \u2014
+        kashyapap.jayasekera", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274639444, "issue": 34181686, "account": 8, "kind": "RLTM", "element":
+        "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "AAr6ayAj6Hs2pOICdVUlEyuXlsQ78K3HFGOJgWA/yAiQrRuQH9Kv1GxUH36IT99d",
+        "published_at": "2026-06-22T11:25:45.739149Z", "date": "2026-06-22T11:25:45.739149Z",
+        "detected_at": "2026-06-22T11:25:45.739149Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-22T11:25:45.739149Z", "last_seen_at": "2026-06-22T11:25:45.739149Z",
+        "data": {"line": 20, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-22T11:25:45.739149Z", "last_presence_check_at":
+        "2026-06-22T11:25:45.739149Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 6}, {"id":
+        34122510, "account": 8, "criterion": "Generic Password", "date": "2026-06-19T13:41:03Z",
+        "last_trigger_published_at": "2026-06-19T13:41:03Z", "last_triggered_at":
+        "2026-06-19T13:43:05.020137Z", "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z",
+        "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Generic Password", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
+        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
+        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
+        "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
+        "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 129, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_62.txt", "filename":
+        "configuration_62.txt", "presence": "visible", "last_presence_seen_at": "2026-06-19T13:43:05.062490Z",
+        "last_presence_check_at": "2026-06-19T13:43:05.062490Z", "first_presence_deleted_at":
         null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}, {"type": "DEFAULT_BRANCH", "metadata":
-        null}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG",
-        "TEST_FILE"], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}]}'
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 34038186, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-16T18:55:43.166667Z", "last_trigger_published_at": "2026-06-16T18:55:43.166667Z",
+        "last_triggered_at": "2026-06-16T18:55:43.185061Z", "last_trigger_detected_at":
+        "2026-06-16T18:55:43.185061Z", "hash": "JFTpQX+4P/dEcXJJ2iw+u54JYDsJnqLtrdws1wjFQ8t9LtHh25LITKmJimoqGr3z",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
+        "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
+        "detected_at": "2026-06-16T18:55:43.166667Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
+        "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
+        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}]}'
     headers:
+      CF-RAY:
+      - a1039553ae06a40a-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:18 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '23376'
+      - '22534'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:34 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '131'
+      - '137'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_combined_filters.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_combined_filters.yaml
@@ -21,174 +21,65 @@ interactions:
   response:
     body:
       string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?ordering=-date&page=2&page_size=5&severity__in=10%2C20&status__in=TRIGGERED%2CASSIGNED",
-        "previous": null, "results": [{"id": 29186788, "account": 8, "criterion":
-        "GitLab Token", "date": "2026-03-25T16:53:05.035206Z", "last_trigger_published_at":
-        "2026-03-25T16:53:05.035206Z", "last_triggered_at": "2026-03-25T16:53:05.853859Z",
-        "last_trigger_detected_at": "2026-03-25T16:53:05.853859Z", "hash": "SJOfhHk3hANA5qiK6fypwRpA6pyKIbh2xmK/JYKpXtMCszyZxGkRAPRx8mJAAtol",
+        "previous": null, "results": [{"id": 33929626, "account": 8, "criterion":
+        "Artifactory Token", "date": "2026-06-12T10:26:58.151000Z", "last_trigger_published_at":
+        "2026-06-12T10:26:58.151000Z", "last_triggered_at": "2026-06-12T11:58:00.658791Z",
+        "last_trigger_detected_at": "2026-06-12T11:58:00.658791Z", "hash": "XoKoErcCGXQNocX6b4MGPd8hwhobdx0SCEYMSWCwKkzVE9LnmfERIIoosvzjJs1k",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": 910203, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "celine.agbo@gitguardian.com", "manual_severity_setter_type": "user", "status":
+        "ASSIGNED", "issue_name": "Artifactory Token", "severity_rule_config": {"id":
+        11895, "gg_created_at": "2026-05-20T08:56:10.055460Z", "gg_updated_at": "2026-05-20T08:56:10.055463Z",
+        "index": 130, "severity": 10, "rule": {"id": 513, "gg_created_at": "2025-03-18T08:57:54.142453Z",
+        "gg_updated_at": "2025-03-18T08:57:54.142456Z", "name": "Package manager related
+        secret", "description": "The detector relates to a package manager", "json_rule":
+        {"operator": "EQ", "arg1": {"path": "issue.secret.detector.metadata.category",
+        "default": null}, "arg2": {"value": "package_registry"}}, "is_global": true,
+        "scope": "private", "author": null}}, "declarative_secret_status": null, "assignee":
+        550880, "last_presence_check_at": null, "secret": "[REDACTED]", "severity":
+        20, "authors": [{"info": "ggtestintegrations@proton.me", "name": "GG Test
+        Integrations"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
+        [{"id": 27177247, "name": "gg-test-integrations / Payment Systems", "type":
+        "jira_cloud_project", "path": "gg-test-integrations / Payment Systems", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 86, "displayed_occurrence": {"id": 272781097, "issue": 33929626,
+        "account": 8, "kind": "RLTM", "element": "PAY-4", "element_type": "JIRA_TICKET",
+        "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
+        "value": null, "value_hash": "T71tr/N63V71e27iMbDQa9L9Oh/xkgVEZdomur2uk2WyqO/9fr4lNYuUjUFpuLDi",
+        "published_at": "2026-06-12T10:26:58.151000Z", "date": "2026-06-12T10:26:58.151000Z",
+        "detected_at": "2026-06-12T11:57:58.655858Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-12T10:26:58.151000Z", "last_seen_at": "2026-06-12T10:26:58.151000Z",
+        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/PAY-4",
+        "source": {"id": 27177247, "url": "https://gg-test-integrations.atlassian.net/browse/PAY",
+        "type": "jira_cloud_project", "display_name": "gg-test-integrations / Payment
+        Systems", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168812050, "secrets_engine_version":
+        "2.165.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
+        "indice_start": 5333, "indice_end": 5406, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
+        "apikey", "insights": [], "filepath": null, "filename": null, "presence":
+        "visible", "last_presence_seen_at": "2026-06-12T18:28:18.251022Z", "last_presence_check_at":
+        "2026-06-12T18:28:18.251022Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
+        33211589, "account": 8, "criterion": "MongoDB URI", "date": "2026-05-27T09:42:47Z",
+        "last_trigger_published_at": "2026-05-27T09:42:47Z", "last_triggered_at":
+        "2026-05-27T09:51:38.902002Z", "last_trigger_detected_at": "2026-05-27T09:51:38.902002Z",
+        "hash": "dX7xqTqTRiPdxjxHbmvvsqr7fWCc2yGu6359hN8zQhe1adbofeuh40iUuZt2nZY1",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "GitLab Token", "severity_rule_config": {"id": 10877, "gg_created_at": "2026-02-12T15:13:37.684430Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684433Z", "index": 200, "severity":
-        20, "rule": {"id": 520, "gg_created_at": "2025-03-18T08:57:54.142633Z", "gg_updated_at":
-        "2025-03-18T08:57:54.142636Z", "name": "The secret is in a sensitive file",
-        "description": "Secret found in a sensitive file (.env, .pem key, dotfiles)",
-        "json_rule": {"operator": "CONTAINS_ANY", "arg1": {"path": "tag_names", "default":
-        null}, "arg2": {"value": ["SENSITIVE_FILE"]}}, "is_global": true, "scope":
-        "any", "author": null}}, "declarative_secret_status": null, "assignee": null,
-        "last_presence_check_at": null, "secret": "[REDACTED]", "severity": 100, "authors":
-        [{"info": "", "name": "GitGuardian Sandbox [internal]"}], "user_permission":
-        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        3, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "totaaa", "type": "custom_source",
-        "path": "totaaa", "source_criticality": "unknown"}, {"name": "totaaab", "type":
-        "custom_source", "path": "totaaab", "source_criticality": "unknown"}, {"name":
-        "totaaabccb", "type": "custom_source", "path": "totaaabccb", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 0, "score": 9, "displayed_occurrence": {"id": 253371418,
-        "issue": 29186788, "account": 8, "kind": "RLTM", "element": "", "element_type":
-        "CUSTOM_ELEMENT", "author_name": "GitGuardian Sandbox [internal]", "author_info":
-        "", "value": null, "value_hash": "bYdCbHZ101hGcZ6Q6XqcVQkGryoOAuqw4QxVXQLjQfpBf5OllP448kL+4h/ug/8v",
-        "published_at": "2026-03-25T16:53:05.035206Z", "date": "2026-03-25T16:53:05.035206Z",
-        "detected_at": "2026-03-25T16:53:05.737995Z", "is_vcs_type": false, "last_detected_at":
-        "2026-03-25T16:53:05.035206Z", "last_seen_at": "2026-03-25T16:53:05.035206Z",
-        "data": {}, "url": "", "source": {"id": 26968497, "url": "", "type": "custom_source",
-        "display_name": "totaaa", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 146400014, "secrets_engine_version": "2.158.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 123, "indice_end":
-        149, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [{"name": "sensitive_filepath", "source": "document", "metadata": {"sensitive_patterns":
-        [{"tags": [], "comment": "", "pattern": "\\.?env(?![^\\.])", "category": "filename",
-        "description": "Environment configuration file"}]}}], "filepath": "/tmp/tmpvcmhu56nggshield/home/hhubert/.env",
-        "filename": ".env", "presence": "visible", "last_presence_seen_at": "2026-03-25T16:53:05.897743Z",
-        "last_presence_check_at": "2026-03-25T16:53:05.897743Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": [{"type":
-        "SENSITIVE_FILE", "metadata": null}]}, "has_dropped_occurrences": false, "tags":
-        ["REVOCABLE_BY_GG", "SENSITIVE_FILE"], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 3}, {"id": 27395126, "account": 8, "criterion": "AWS
-        Keys", "date": "2026-02-19T14:36:24Z", "last_trigger_published_at": "2026-02-19T14:36:24Z",
-        "last_triggered_at": "2026-02-19T14:40:08.909390Z", "last_trigger_detected_at":
-        "2026-02-19T14:40:08.909390Z", "hash": "ldopSL0HhOyMPVqrCoyqhrM0YiRtyDjCRKal/yZRhL1LxHMKL4Qc71cZRqNcojMG",
-        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
-        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
-        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
-        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
-        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "AWS IAM Keys", "severity_rule_config": {"id": 10860, "gg_created_at": "2026-02-12T15:13:37.684167Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684171Z", "index": 30, "severity": 10,
-        "rule": {"id": 503, "gg_created_at": "2025-03-18T08:57:54.142008Z", "gg_updated_at":
-        "2025-04-02T13:15:43.307296Z", "name": "Valid secrets related to highly sensitive
-        detectors", "description": "Secrets related to highly sensitive detectors
-        were valid when the incident was discovered. You can edit this rule to create
-        your own list of sensitive detectors", "json_rule": {"operator": "AND", "args":
-        [{"operator": "EQ", "arg1": {"path": "issue.secret.validity_status", "default":
-        null}, "arg2": {"value": "valid"}}, {"operator": "IN", "arg1": {"path": "issue.secret.detector.detector_group_name",
-        "default": null}, "arg2": {"value": ["github_app_token", "ldap_credentials",
-        "github_oauth_token", "googlecloud_keys", "jira_basic_auth", "python_package_index_key",
-        "aws_iam_sts", "npm_token", "gitlab_token", "smtp_credentials", "github_fine_grained_pat",
-        "gitlab_enterprise_token", "github_access_token", "aws_iam"]}}]}, "is_global":
-        true, "scope": "any", "author": null}}, "declarative_secret_status": null,
-        "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "Martin Faucheux / Repo A",
-        "type": "gl_project", "path": "martin-faucheux/repo-a", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 0, "score": 36, "displayed_occurrence": {"id": 245063312,
-        "issue": 27395126, "account": 8, "kind": "RLTM", "element": "7a6a765a03f640cf002e7d23040dad8a17fe4255",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
-        "value": null, "value_hash": "dLLMC28h0JB8KLz6ViyG9URvAnikbB5BBECedrqc2JmDHqkd2KVpMdI0NbaCVmKj",
-        "published_at": "2026-02-19T14:36:24Z", "date": "2026-02-19T14:36:24Z", "detected_at":
-        "2026-02-19T14:40:06.772801Z", "is_vcs_type": true, "last_detected_at": "2026-02-19T14:36:24Z",
-        "last_seen_at": "2026-02-19T14:36:24Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/martin-faucheux/repo-a/commit/7a6a765a03f640cf002e7d23040dad8a17fe4255#710a727ecafa5cfe744810c543a838230918ff04_0_4",
-        "source": {"id": 16218988, "url": "https://gitlab-01.aws-qa-gitguardian.com/martin-faucheux/repo-a",
-        "type": "gl_project", "display_name": "Martin Faucheux / Repo A", "visibility":
-        "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 134461307,
-        "secrets_engine_version": "2.156.0", "matches": [{"name": "client_id", "string_matched":
-        "[REDACTED]", "indice_start": 45, "indice_end": 65, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 3, "post_line_end": 3}, {"name":
-        "client_secret", "string_matched": "[REDACTED]", "indice_start": 81, "indice_end":
-        121, "pre_line_start": null, "pre_line_end": null, "post_line_start": 4, "post_line_end":
-        4}], "most_sensitive_match_name": "client_secret", "insights": [{"name": "test_file",
-        "source": "document", "metadata": null}], "filepath": "aws_example.py", "filename":
-        "aws_example.py", "presence": "visible", "last_presence_seen_at": "2026-02-19T14:40:08.948798Z",
-        "last_presence_check_at": "2026-02-19T14:40:08.948798Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": false, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}]}, "has_dropped_occurrences": false,
-        "tags": ["TEST_FILE"], "public_exposure": {"source_publicly_visible": false,
-        "public_incident_linked": false, "leaked_outside_perimeter": false}, "occurrences_count":
-        1}, {"id": 26879946, "account": 8, "criterion": "AWS Keys", "date": "2026-02-05T16:48:19Z",
-        "last_trigger_published_at": "2026-02-05T16:48:19Z", "last_triggered_at":
-        "2026-02-05T16:51:59.912161Z", "last_trigger_detected_at": "2026-02-05T16:51:59.912161Z",
-        "hash": "BPRo0pF0ZesUJFhK1FAEiWQsj9wNtT2WYZ15WbzmXjC7vE/VL4Qc71cZRqNcojMG",
-        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
-        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
-        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
-        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
-        "none", "manual_severity_setter_type": "none", "status": "ASSIGNED", "issue_name":
-        "AWS IAM Keys", "severity_rule_config": {"id": 10860, "gg_created_at": "2026-02-12T15:13:37.684167Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684171Z", "index": 30, "severity": 10,
-        "rule": {"id": 503, "gg_created_at": "2025-03-18T08:57:54.142008Z", "gg_updated_at":
-        "2025-04-02T13:15:43.307296Z", "name": "Valid secrets related to highly sensitive
-        detectors", "description": "Secrets related to highly sensitive detectors
-        were valid when the incident was discovered. You can edit this rule to create
-        your own list of sensitive detectors", "json_rule": {"operator": "AND", "args":
-        [{"operator": "EQ", "arg1": {"path": "issue.secret.validity_status", "default":
-        null}, "arg2": {"value": "valid"}}, {"operator": "IN", "arg1": {"path": "issue.secret.detector.detector_group_name",
-        "default": null}, "arg2": {"value": ["github_app_token", "ldap_credentials",
-        "github_oauth_token", "googlecloud_keys", "jira_basic_auth", "python_package_index_key",
-        "aws_iam_sts", "npm_token", "gitlab_token", "smtp_credentials", "github_fine_grained_pat",
-        "gitlab_enterprise_token", "github_access_token", "aws_iam"]}}]}, "is_global":
-        true, "scope": "any", "author": null}}, "declarative_secret_status": null,
-        "assignee": 581873, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        8, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "gim-qa-gitlabSandbox-auto
-        / gim-qa-gitlabSandbox-staging", "type": "gl_project", "path": "gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
-        "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
-        {"id": 242021853, "issue": 26879946, "account": 8, "kind": "RLTM", "element":
-        "e2cbc193a76a13b94e135c12a055d2083a233a89", "element_type": "GIT_COMMIT",
-        "author_name": "dev", "author_info": "gim+dev@gitguardian.com", "value": null,
-        "value_hash": "7AkVngiwT5n4ZZihQovCHs2qrlx0MOfD853AYv4HHS0DiM0Vk9YtctC+FFM1Iw+v",
-        "published_at": "2026-02-05T16:48:19Z", "date": "2026-02-05T16:48:19Z", "detected_at":
-        "2026-02-05T16:51:53.166126Z", "is_vcs_type": true, "last_detected_at": "2026-02-05T16:48:19Z",
-        "last_seen_at": "2026-02-05T16:48:19Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging/commit/e2cbc193a76a13b94e135c12a055d2083a233a89#2dd906314026edd7e5fa25025afd4353424625a7_0_19",
-        "source": {"id": 16219056, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
-        "type": "gl_project", "display_name": "gim-qa-gitlabSandbox-auto / gim-qa-gitlabSandbox-staging",
-        "visibility": "private", "monitored": true, "source_criticality": "unknown",
-        "deleted_at": null, "default_branch": "main"}, "regression": false, "content":
-        130291193, "secrets_engine_version": "2.156.0", "matches": [{"name": "client_id",
-        "string_matched": "[REDACTED]", "indice_start": 124, "indice_end": 144, "pre_line_start":
-        null, "pre_line_end": null, "post_line_start": 4, "post_line_end": 4}, {"name":
-        "client_secret", "string_matched": "[REDACTED]", "indice_start": 981, "indice_end":
-        1021, "pre_line_start": null, "pre_line_end": null, "post_line_start": 19,
-        "post_line_end": 19}], "most_sensitive_match_name": "client_secret", "insights":
-        [], "filepath": "ec2_instance_management.py", "filename": "ec2_instance_management.py",
-        "presence": "visible", "last_presence_seen_at": "2026-02-18T22:30:08.818671Z",
-        "last_presence_check_at": "2026-02-18T22:30:08.818671Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": false, "change_type": "addition", "full_tags":
-        []}, "has_dropped_occurrences": false, "tags": [], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 8}, {"id": 27376617, "account": 8, "criterion": "PostgreSQL
-        URI", "date": "2026-02-03T15:03:39Z", "last_trigger_published_at": "2026-02-03T15:03:39Z",
-        "last_triggered_at": "2026-02-18T22:23:47.640669Z", "last_trigger_detected_at":
-        "2026-02-18T22:23:47.640669Z", "hash": "w8plTKT2Ax3sZ5tlV9qlvmUA0pdIAWVowmytVrQQ4fNGeLrECUnJ9mpXO6ItKClD",
-        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
-        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
-        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
-        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
-        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "PostgreSQL Credentials", "severity_rule_config": {"id": 10873, "gg_created_at":
-        "2026-02-12T15:13:37.684368Z", "gg_updated_at": "2026-02-12T15:13:37.684372Z",
+        "MongoDB Credentials", "severity_rule_config": {"id": 11898, "gg_created_at":
+        "2026-05-20T08:56:10.055489Z", "gg_updated_at": "2026-05-20T08:56:10.055492Z",
         "index": 160, "severity": 20, "rule": {"id": 516, "gg_created_at": "2025-03-18T08:57:54.142529Z",
         "gg_updated_at": "2025-03-18T08:57:54.142532Z", "name": "Specific Database
         Credentials", "description": "Specific Database Credentials", "json_rule":
@@ -197,144 +88,275 @@ interactions:
         {"path": "issue.secret.detector.nature", "default": null}, "arg2": {"value":
         "specific"}}]}, "is_global": true, "scope": "private", "author": null}}, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"},
-        {"info": "xavier.blanchot@gitguardian.com", "name": "Xavier Blanchot"}], "user_permission":
-        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        3, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 2, "sources": [{"name": "Loic / demo-shield", "type":
-        "gl_project", "path": "Loic/demo-shield", "source_criticality": "unknown"},
-        {"name": "Xavier Blanchot / qa-sca", "type": "gl_project", "path": "xblanchot/qa-sca",
-        "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata": [{"source":
-        "awssecretsmanager"}], "is_vaulted": true, "similar_issue_count": 0, "score":
-        36, "displayed_occurrence": {"id": 244951754, "issue": 27376617, "account":
-        8, "kind": "HIST", "element": "7f75f6e85952d5ac1c625bd3fcf40d003b0ba8c4",
-        "element_type": "GIT_COMMIT", "author_name": "Xavier Blanchot", "author_info":
-        "xavier.blanchot@gitguardian.com", "value": null, "value_hash": "bkjQSYtajI81lN0vpeFk3i7WIys+D668iT37NvZh1WNr+R2mo0AV7BPnZLC8/g/J",
-        "published_at": "2026-02-03T14:54:25Z", "date": "2026-02-03T14:54:25Z", "detected_at":
-        "2026-02-18T22:33:23.391472Z", "is_vcs_type": true, "last_detected_at": "2026-02-03T14:54:25Z",
-        "last_seen_at": "2026-02-03T14:54:25Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/Loic/demo-shield/commit/7f75f6e85952d5ac1c625bd3fcf40d003b0ba8c4#06b6a8978505059f2298eeea18b85735506e50b0_None_25",
-        "source": {"id": 24090906, "url": "https://gitlab-01.aws-qa-gitguardian.com/Loic/demo-shield",
-        "type": "gl_project", "display_name": "Loic / demo-shield", "visibility":
-        "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
-        null, "default_branch": "master"}, "regression": false, "content": 134320072,
-        "secrets_engine_version": "2.156.0", "matches": [{"name": "connection_uri",
-        "string_matched": "[REDACTED]", "indice_start": 593, "indice_end": 700, "pre_line_start":
-        null, "pre_line_end": null, "post_line_start": 25, "post_line_end": 25}, {"name":
-        "scheme", "string_matched": "[REDACTED]", "indice_start": 593, "indice_end":
-        603, "pre_line_start": null, "pre_line_end": null, "post_line_start": 25,
-        "post_line_end": 25}, {"name": "username", "string_matched": "[REDACTED]",
-        "indice_start": 606, "indice_end": 611, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 25, "post_line_end": 25}, {"name": "password", "string_matched":
-        "[REDACTED]", "indice_start": 612, "indice_end": 629, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 25, "post_line_end": 25}, {"name":
-        "host", "string_matched": "[REDACTED]", "indice_start": 630, "indice_end":
-        679, "pre_line_start": null, "pre_line_end": null, "post_line_start": 25,
-        "post_line_end": 25}, {"name": "port", "string_matched": "[REDACTED]", "indice_start":
-        680, "indice_end": 684, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        25, "post_line_end": 25}, {"name": "database", "string_matched": "[REDACTED]",
-        "indice_start": 685, "indice_end": 700, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 25, "post_line_end": 25}], "most_sensitive_match_name":
-        "password", "insights": [{"name": "test_file", "source": "document", "metadata":
-        null}], "filepath": "test_xav.py", "filename": "test_xav.py", "presence":
-        "visible", "last_presence_seen_at": "2026-02-18T22:33:24.059192Z", "last_presence_check_at":
-        "2026-02-18T22:33:24.059192Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": "addition", "full_tags": [{"type": "FROM_HISTORICAL_SCAN",
-        "metadata": null}, {"type": "TEST_FILE", "metadata": null}]}, "has_dropped_occurrences":
-        false, "tags": ["FROM_HISTORICAL_SCAN", "PUBLICLY_LEAKED", "TEST_FILE"], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": true, "leaked_outside_perimeter":
-        false}, "occurrences_count": 3}, {"id": 26805044, "account": 8, "criterion":
-        "MongoDB URI", "date": "2026-01-26T13:46:06Z", "last_trigger_published_at":
-        "2026-01-26T13:46:06Z", "last_triggered_at": "2026-02-04T13:38:51.988904Z",
-        "last_trigger_detected_at": "2026-02-04T13:38:51.988904Z", "hash": "8qhQemKmiS/Am6ESHIGDwqPZn9s9ntwfojgd4GNyXYj+jIKRfeuh40iUuZt2nZY1",
-        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
-        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
-        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
-        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
-        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "MongoDB Credentials", "severity_rule_config": {"id": 10873, "gg_created_at":
-        "2026-02-12T15:13:37.684368Z", "gg_updated_at": "2026-02-12T15:13:37.684372Z",
-        "index": 160, "severity": 20, "rule": {"id": 516, "gg_created_at": "2025-03-18T08:57:54.142529Z",
-        "gg_updated_at": "2025-03-18T08:57:54.142532Z", "name": "Specific Database
-        Credentials", "description": "Specific Database Credentials", "json_rule":
-        {"operator": "AND", "args": [{"operator": "EQ", "arg1": {"path": "issue.secret.detector.metadata.category",
-        "default": null}, "arg2": {"value": "data_storage"}}, {"operator": "EQ", "arg1":
-        {"path": "issue.secret.detector.nature", "default": null}, "arg2": {"value":
-        "specific"}}]}, "is_global": true, "scope": "private", "author": null}}, "declarative_secret_status":
-        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        4, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "RomainJ / demo", "type":
-        "gl_project", "path": "romain/demo", "source_criticality": "unknown"}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 1,
-        "score": 49, "displayed_occurrence": {"id": 241287735, "issue": 26805044,
-        "account": 8, "kind": "HIST", "element": "7c8a5a83a8529f3942f648e6a79ae21b08afdb07",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
-        "value": null, "value_hash": "fmih/YlCd4UrrB/ETqBfjzlVfSG7RBhEUvyvat2FzYNAy8zVUK4iCeYsKrlknGkQ",
-        "published_at": "2026-01-26T13:46:06Z", "date": "2026-01-26T13:46:06Z", "detected_at":
-        "2026-02-04T13:38:46.386256Z", "is_vcs_type": true, "last_detected_at": "2026-01-26T13:46:06Z",
-        "last_seen_at": "2026-01-26T13:46:06Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/7c8a5a83a8529f3942f648e6a79ae21b08afdb07#8b00584865b28d12f057cc2064a51a05b33603f1_8_9",
+        "severity": 100, "authors": [{"info": "romain.jouhannet@gitguardian.com",
+        "name": "Romain Jouhannet"}], "user_permission": 7, "is_publicly_shared":
+        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
+        [{"id": 23485702, "name": "RomainJ / demo", "type": "gl_project", "path":
+        "romain/demo", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 0, "score": 49, "displayed_occurrence": {"id":
+        269728665, "issue": 33211589, "account": 8, "kind": "HIST", "element": "d189cab00bc31c4bed372402e031de0559fa9d70",
+        "element_type": "GIT_COMMIT", "author_name": "Romain Jouhannet", "author_info":
+        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "4WO+NtMg1huWU4tghYRv7bPopKssi564RukxBZVA2Opur15IVmYm2YNGhd2mwbCp",
+        "published_at": "2026-05-27T09:42:47Z", "date": "2026-05-27T09:42:47Z", "detected_at":
+        "2026-05-27T09:51:34.675578Z", "is_vcs_type": true, "last_detected_at": "2026-05-27T09:42:47Z",
+        "last_seen_at": "2026-05-27T09:42:47Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/d189cab00bc31c4bed372402e031de0559fa9d70#e1755a4a1df75fb12321bae878788f6ca914d373_None_1",
         "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
         "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        "main"}, "regression": false, "content": 129708164, "secrets_engine_version":
-        "2.155.4", "matches": [{"name": "connection_uri", "string_matched": "[REDACTED]",
-        "indice_start": 128, "indice_end": 195, "pre_line_start": 8, "pre_line_end":
-        8, "post_line_start": 9, "post_line_end": 9}, {"name": "scheme", "string_matched":
-        "[REDACTED]", "indice_start": 128, "indice_end": 139, "pre_line_start": 8,
-        "pre_line_end": 8, "post_line_start": 9, "post_line_end": 9}, {"name": "username",
-        "string_matched": "[REDACTED]", "indice_start": 142, "indice_end": 150, "pre_line_start":
-        8, "pre_line_end": 8, "post_line_start": 9, "post_line_end": 9}, {"name":
-        "password", "string_matched": "[REDACTED]", "indice_start": 151, "indice_end":
-        163, "pre_line_start": 8, "pre_line_end": 8, "post_line_start": 9, "post_line_end":
-        9}, {"name": "host", "string_matched": "[REDACTED]", "indice_start": 164,
-        "indice_end": 184, "pre_line_start": 8, "pre_line_end": 8, "post_line_start":
-        9, "post_line_end": 9}, {"name": "database", "string_matched": "[REDACTED]",
-        "indice_start": 185, "indice_end": 191, "pre_line_start": 8, "pre_line_end":
-        8, "post_line_start": 9, "post_line_end": 9}, {"name": "query", "string_matched":
-        "[REDACTED]", "indice_start": 192, "indice_end": 195, "pre_line_start": 8,
-        "pre_line_end": 8, "post_line_start": 9, "post_line_end": 9}], "most_sensitive_match_name":
-        "password", "insights": [], "filepath": "bluethroat.py", "filename": "bluethroat.py",
-        "presence": "visible", "last_presence_seen_at": "2026-02-18T22:33:05.054565Z",
-        "last_presence_check_at": "2026-02-18T22:33:05.054565Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": "context", "full_tags":
-        [{"type": "FROM_HISTORICAL_SCAN", "metadata": null}]}, "has_dropped_occurrences":
-        false, "tags": ["FROM_HISTORICAL_SCAN"], "public_exposure": {"source_publicly_visible":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 164835166,
+        "secrets_engine_version": "2.163.1", "matches": [{"name": "connection_uri",
+        "string_matched": "[REDACTED]", "indice_start": 41, "indice_end": 132, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 1, "post_line_end": 1}, {"name":
+        "scheme", "string_matched": "[REDACTED]", "indice_start": 41, "indice_end":
+        52, "pre_line_start": null, "pre_line_end": null, "post_line_start": 1, "post_line_end":
+        1}, {"name": "username", "string_matched": "[REDACTED]", "indice_start": 55,
+        "indice_end": 63, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        1, "post_line_end": 1}, {"name": "password", "string_matched": "[REDACTED]",
+        "indice_start": 64, "indice_end": 76, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 1, "post_line_end": 1}, {"name": "host", "string_matched":
+        "[REDACTED]", "indice_start": 77, "indice_end": 97, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 1, "post_line_end": 1}, {"name":
+        "database", "string_matched": "[REDACTED]", "indice_start": 98, "indice_end":
+        104, "pre_line_start": null, "pre_line_end": null, "post_line_start": 1, "post_line_end":
+        1}, {"name": "query", "string_matched": "[REDACTED]", "indice_start": 105,
+        "indice_end": 132, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        1, "post_line_end": 1}], "most_sensitive_match_name": "password", "insights":
+        [], "filepath": "009396acf5bf911afb1f53bd58573d91e4e2edca", "filename": "009396acf5bf911afb1f53bd58573d91e4e2edca",
+        "presence": "visible", "last_presence_seen_at": "2026-05-27T09:51:39.164163Z",
+        "last_presence_check_at": "2026-05-27T09:51:39.164163Z", "first_presence_deleted_at":
+        null, "seen_in_default_branch": null, "change_type": "addition", "full_tags":
+        [{"type": "FROM_HISTORICAL_SCAN", "metadata": null, "field": "content"}]},
+        "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH", "FROM_HISTORICAL_SCAN"],
+        "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 2}, {"id":
+        33211407, "account": 8, "criterion": "MongoDB URI", "date": "2026-05-27T09:28:55Z",
+        "last_trigger_published_at": "2026-05-27T09:28:55Z", "last_triggered_at":
+        "2026-05-27T09:33:03.018451Z", "last_trigger_detected_at": "2026-05-27T09:33:03.018451Z",
+        "hash": "f3/8VwzVd7DQeZGQ5/KE3RVyckzjIEeBi3597wegzcjbsKhZfeuh40iUuZt2nZY1",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "MongoDB Credentials", "severity_rule_config": {"id": 11898, "gg_created_at":
+        "2026-05-20T08:56:10.055489Z", "gg_updated_at": "2026-05-20T08:56:10.055492Z",
+        "index": 160, "severity": 20, "rule": {"id": 516, "gg_created_at": "2025-03-18T08:57:54.142529Z",
+        "gg_updated_at": "2025-03-18T08:57:54.142532Z", "name": "Specific Database
+        Credentials", "description": "Specific Database Credentials", "json_rule":
+        {"operator": "AND", "args": [{"operator": "EQ", "arg1": {"path": "issue.secret.detector.metadata.category",
+        "default": null}, "arg2": {"value": "data_storage"}}, {"operator": "EQ", "arg1":
+        {"path": "issue.secret.detector.nature", "default": null}, "arg2": {"value":
+        "specific"}}]}, "is_global": true, "scope": "private", "author": null}}, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "romain.jouhannet@gitguardian.com",
+        "name": "Romain Jouhannet"}], "user_permission": 7, "is_publicly_shared":
+        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
+        [{"id": 23485702, "name": "RomainJ / demo", "type": "gl_project", "path":
+        "romain/demo", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 1, "score": 49, "displayed_occurrence": {"id":
+        269727691, "issue": 33211407, "account": 8, "kind": "RLTM", "element": "d6361a080aa92dc554cd2b55f6f3a7dcf26d1dcb",
+        "element_type": "GIT_COMMIT", "author_name": "Romain Jouhannet", "author_info":
+        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "YU5lBhVgALxxn8rYMmJe6Uh0y3sUhot77BxviUqvi2cqEVzhNyDcgwtJW6F//p33",
+        "published_at": "2026-05-27T09:28:55Z", "date": "2026-05-27T09:28:55Z", "detected_at":
+        "2026-05-27T09:32:59.686337Z", "is_vcs_type": true, "last_detected_at": "2026-05-27T09:28:55Z",
+        "last_seen_at": "2026-05-27T09:28:55Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/d6361a080aa92dc554cd2b55f6f3a7dcf26d1dcb#3a94abefa57e93ce6945d8a053c37e4e2598dbee_0_7",
+        "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
+        "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 164831857,
+        "secrets_engine_version": "2.163.1", "matches": [{"name": "connection_uri",
+        "string_matched": "[REDACTED]", "indice_start": 159, "indice_end": 250, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 7, "post_line_end": 7}, {"name":
+        "scheme", "string_matched": "[REDACTED]", "indice_start": 159, "indice_end":
+        170, "pre_line_start": null, "pre_line_end": null, "post_line_start": 7, "post_line_end":
+        7}, {"name": "username", "string_matched": "[REDACTED]", "indice_start": 173,
+        "indice_end": 181, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        7, "post_line_end": 7}, {"name": "password", "string_matched": "[REDACTED]",
+        "indice_start": 182, "indice_end": 194, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 7, "post_line_end": 7}, {"name": "host", "string_matched":
+        "[REDACTED]", "indice_start": 195, "indice_end": 215, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 7, "post_line_end": 7}, {"name":
+        "database", "string_matched": "[REDACTED]", "indice_start": 216, "indice_end":
+        222, "pre_line_start": null, "pre_line_end": null, "post_line_start": 7, "post_line_end":
+        7}, {"name": "query", "string_matched": "[REDACTED]", "indice_start": 223,
+        "indice_end": 250, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        7, "post_line_end": 7}], "most_sensitive_match_name": "password", "insights":
+        [], "filepath": "go-away-bird.py", "filename": "go-away-bird.py", "presence":
+        "visible", "last_presence_seen_at": "2026-05-27T09:51:39.193873Z", "last_presence_check_at":
+        "2026-05-27T09:51:39.193873Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        true, "change_type": "addition", "full_tags": [{"type": "DEFAULT_BRANCH",
+        "metadata": null, "field": "content"}]}, "has_dropped_occurrences": false,
+        "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
         false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 4}]}'
+        "occurrences_count": 1}, {"id": 33211409, "account": 8, "criterion": "MongoDB
+        URI", "date": "2026-05-27T09:28:55Z", "last_trigger_published_at": "2026-05-27T09:28:55Z",
+        "last_triggered_at": "2026-05-27T09:33:03.018587Z", "last_trigger_detected_at":
+        "2026-05-27T09:33:03.018587Z", "hash": "moGvUliRX8qewDsI4A+2brZjdcsh4ZKDzShm/YWXFgktPfL3feuh40iUuZt2nZY1",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "MongoDB Credentials", "severity_rule_config": {"id": 11898, "gg_created_at":
+        "2026-05-20T08:56:10.055489Z", "gg_updated_at": "2026-05-20T08:56:10.055492Z",
+        "index": 160, "severity": 20, "rule": {"id": 516, "gg_created_at": "2025-03-18T08:57:54.142529Z",
+        "gg_updated_at": "2025-03-18T08:57:54.142532Z", "name": "Specific Database
+        Credentials", "description": "Specific Database Credentials", "json_rule":
+        {"operator": "AND", "args": [{"operator": "EQ", "arg1": {"path": "issue.secret.detector.metadata.category",
+        "default": null}, "arg2": {"value": "data_storage"}}, {"operator": "EQ", "arg1":
+        {"path": "issue.secret.detector.nature", "default": null}, "arg2": {"value":
+        "specific"}}]}, "is_global": true, "scope": "private", "author": null}}, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "romain.jouhannet@gitguardian.com",
+        "name": "Romain Jouhannet"}], "user_permission": 7, "is_publicly_shared":
+        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
+        [{"id": 23485702, "name": "RomainJ / demo", "type": "gl_project", "path":
+        "romain/demo", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 1, "score": 49, "displayed_occurrence": {"id":
+        269727692, "issue": 33211409, "account": 8, "kind": "RLTM", "element": "d6361a080aa92dc554cd2b55f6f3a7dcf26d1dcb",
+        "element_type": "GIT_COMMIT", "author_name": "Romain Jouhannet", "author_info":
+        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "dGSO0UNu3ir5xB1mNC4rhS2IL21oXm+7tSQPn+qUFGZ3HkBlVp3JYrpf4ubmlbDB",
+        "published_at": "2026-05-27T09:28:55Z", "date": "2026-05-27T09:28:55Z", "detected_at":
+        "2026-05-27T09:32:59.686337Z", "is_vcs_type": true, "last_detected_at": "2026-05-27T09:28:55Z",
+        "last_seen_at": "2026-05-27T09:28:55Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/d6361a080aa92dc554cd2b55f6f3a7dcf26d1dcb#7b83dc4c52bef56016855ec981bdf4b8425c6486_0_7",
+        "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
+        "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 164831858,
+        "secrets_engine_version": "2.163.1", "matches": [{"name": "connection_uri",
+        "string_matched": "[REDACTED]", "indice_start": 159, "indice_end": 250, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 7, "post_line_end": 7}, {"name":
+        "scheme", "string_matched": "[REDACTED]", "indice_start": 159, "indice_end":
+        170, "pre_line_start": null, "pre_line_end": null, "post_line_start": 7, "post_line_end":
+        7}, {"name": "username", "string_matched": "[REDACTED]", "indice_start": 173,
+        "indice_end": 181, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        7, "post_line_end": 7}, {"name": "password", "string_matched": "[REDACTED]",
+        "indice_start": 182, "indice_end": 194, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 7, "post_line_end": 7}, {"name": "host", "string_matched":
+        "[REDACTED]", "indice_start": 195, "indice_end": 215, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 7, "post_line_end": 7}, {"name":
+        "database", "string_matched": "[REDACTED]", "indice_start": 216, "indice_end":
+        222, "pre_line_start": null, "pre_line_end": null, "post_line_start": 7, "post_line_end":
+        7}, {"name": "query", "string_matched": "[REDACTED]", "indice_start": 223,
+        "indice_end": 250, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        7, "post_line_end": 7}], "most_sensitive_match_name": "password", "insights":
+        [], "filepath": "palmchat.py", "filename": "palmchat.py", "presence": "visible",
+        "last_presence_seen_at": "2026-05-27T09:51:39.193873Z", "last_presence_check_at":
+        "2026-05-27T09:51:39.193873Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        true, "change_type": "addition", "full_tags": [{"type": "DEFAULT_BRANCH",
+        "metadata": null, "field": "content"}]}, "has_dropped_occurrences": false,
+        "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 33049834, "account": 8, "criterion": "MongoDB
+        URI", "date": "2026-05-21T12:49:39Z", "last_trigger_published_at": "2026-05-21T12:49:39Z",
+        "last_triggered_at": "2026-05-21T12:51:05.194725Z", "last_trigger_detected_at":
+        "2026-05-21T12:51:05.194725Z", "hash": "DbxT4zPpJzBcaEwkFxemH2PT7pGdQ10v/GPqGgREciXMu4bFfeuh40iUuZt2nZY1",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": 614347, "regression":
+        true, "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "romain.jouhannet@gitguardian.com", "resolver_type":
+        "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
+        "none", "status": "ASSIGNED", "issue_name": "MongoDB Credentials", "severity_rule_config":
+        {"id": 11898, "gg_created_at": "2026-05-20T08:56:10.055489Z", "gg_updated_at":
+        "2026-05-20T08:56:10.055492Z", "index": 160, "severity": 20, "rule": {"id":
+        516, "gg_created_at": "2025-03-18T08:57:54.142529Z", "gg_updated_at": "2025-03-18T08:57:54.142532Z",
+        "name": "Specific Database Credentials", "description": "Specific Database
+        Credentials", "json_rule": {"operator": "AND", "args": [{"operator": "EQ",
+        "arg1": {"path": "issue.secret.detector.metadata.category", "default": null},
+        "arg2": {"value": "data_storage"}}, {"operator": "EQ", "arg1": {"path": "issue.secret.detector.nature",
+        "default": null}, "arg2": {"value": "specific"}}]}, "is_global": true, "scope":
+        "private", "author": null}}, "declarative_secret_status": "revoked", "assignee":
+        694621, "last_presence_check_at": null, "secret": "[REDACTED]", "severity":
+        100, "authors": [{"info": "romain.jouhannet@gitguardian.com", "name": "Romain
+        Jouhannet"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 6, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
+        [{"id": 23485702, "name": "RomainJ / demo", "type": "gl_project", "path":
+        "romain/demo", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 5, "score": 49, "displayed_occurrence": {"id":
+        268701358, "issue": 33049834, "account": 8, "kind": "RLTM", "element": "f13f8127edb3e5d386cb44679c12e5d6c3ce05be",
+        "element_type": "GIT_COMMIT", "author_name": "Romain Jouhannet", "author_info":
+        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "ElUKHxkW6poM78sJZq6fX/NNHh82/5I40MrYWprOWor+UttOwqRf0MFMFvJD2sMv",
+        "published_at": "2026-05-21T12:49:39Z", "date": "2026-05-21T12:49:39Z", "detected_at":
+        "2026-05-21T12:51:02.846566Z", "is_vcs_type": true, "last_detected_at": "2026-05-21T12:51:02.846566Z",
+        "last_seen_at": "2026-05-21T12:51:02.846566Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/f13f8127edb3e5d386cb44679c12e5d6c3ce05be#f9553d98ad319e9f50f10ef0cf086752c16a337b_5_6",
+        "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
+        "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": true, "content": 163473773,
+        "secrets_engine_version": "2.163.0", "matches": [{"name": "connection_uri",
+        "string_matched": "[REDACTED]", "indice_start": 157, "indice_end": 248, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 6, "post_line_end": 6}, {"name":
+        "scheme", "string_matched": "[REDACTED]", "indice_start": 157, "indice_end":
+        168, "pre_line_start": null, "pre_line_end": null, "post_line_start": 6, "post_line_end":
+        6}, {"name": "username", "string_matched": "[REDACTED]", "indice_start": 171,
+        "indice_end": 179, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        6, "post_line_end": 6}, {"name": "password", "string_matched": "[REDACTED]",
+        "indice_start": 180, "indice_end": 192, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 6, "post_line_end": 6}, {"name": "host", "string_matched":
+        "[REDACTED]", "indice_start": 193, "indice_end": 213, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 6, "post_line_end": 6}, {"name":
+        "database", "string_matched": "[REDACTED]", "indice_start": 214, "indice_end":
+        220, "pre_line_start": null, "pre_line_end": null, "post_line_start": 6, "post_line_end":
+        6}, {"name": "query", "string_matched": "[REDACTED]", "indice_start": 221,
+        "indice_end": 248, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        6, "post_line_end": 6}], "most_sensitive_match_name": "password", "insights":
+        [], "filepath": "new_occurence.py", "filename": "new_occurence.py", "presence":
+        "visible", "last_presence_seen_at": "2026-05-27T09:51:39.193873Z", "last_presence_check_at":
+        "2026-05-27T09:51:39.193873Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        true, "change_type": "addition", "full_tags": [{"type": "DEFAULT_BRANCH",
+        "metadata": null, "field": "content"}]}, "has_dropped_occurrences": false,
+        "tags": ["DEFAULT_BRANCH", "FROM_HISTORICAL_SCAN", "REGRESSION"], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 6}]}'
     headers:
+      CF-RAY:
+      - a1039586e8006fb7-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:26 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '30128'
+      - '30592'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:43 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '124'
+      - '172'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_pagination.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_pagination.yaml
@@ -21,119 +21,126 @@ interactions:
   response:
     body:
       string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?page=2&page_size=2",
-        "previous": null, "results": [{"id": 29487335, "account": 8, "criterion":
-        "Stripe Webhook Secret", "date": "2026-04-02T16:22:33.518000Z", "last_trigger_published_at":
-        "2026-04-02T16:22:33.518000Z", "last_triggered_at": "2026-04-02T16:22:34.233032Z",
-        "last_trigger_detected_at": "2026-04-02T16:22:34.233032Z", "hash": "JquJu98wTd0k40t3UsNgP22P+ywFCrsGM1VDRg3oZBdGXhRWbjOMbKAG+JtXZUOK",
+        "previous": null, "results": [{"id": 34205503, "account": 8, "criterion":
+        "microsoft_azure_storage_connection_string", "date": "2026-06-23T11:13:31.325324Z",
+        "last_trigger_published_at": "2026-06-23T11:13:31.325324Z", "last_triggered_at":
+        "2026-06-23T11:13:31.343453Z", "last_trigger_detected_at": "2026-06-23T11:13:31.343453Z",
+        "hash": "HdPZ4cjZuziAqsakdlsUnJDapTz3ns5pX8vPzfhvGQvpWWWX25LITKmJimoqGr3z",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Stripe Webhook Secret", "severity_rule_config": null, "declarative_secret_status":
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
+        "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
+        "detected_at": "2026-06-23T11:13:31.325324Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
+        "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
+        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
+        34186239, "account": 8, "criterion": "Generic Password", "date": "2026-06-22T15:14:57Z",
+        "last_trigger_published_at": "2026-06-22T15:14:57Z", "last_triggered_at":
+        "2026-06-22T15:16:49.799821Z", "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z",
+        "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": true,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 62, "displayed_occurrence": {"id": 256867982, "issue": 29487335,
-        "account": 8, "kind": "RLTM", "element": "KAN-8?focusedCommentId=10014", "element_type":
-        "JIRA_COMMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "o40+pCpgMCFgcapQEEdZ3imjEpSONYcgy0J+gLe5ygKDJctj7Ro4REsJrqbUl0yj",
-        "published_at": "2026-04-02T16:22:33.518000Z", "date": "2026-04-02T16:22:33.518000Z",
-        "detected_at": "2026-04-02T16:22:34.031682Z", "is_vcs_type": false, "last_detected_at":
-        "2026-04-02T16:22:33.518000Z", "last_seen_at": "2026-04-02T16:22:33.518000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-8?focusedCommentId=10014",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 148603941, "secrets_engine_version": "2.159.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 25, "indice_end":
-        63, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
-        "2026-04-02T16:22:34.268883Z", "last_presence_check_at": "2026-04-02T16:22:34.268883Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 1}, {"id": 29487333, "account": 8, "criterion":
-        "Slack Bot Token", "date": "2026-04-02T16:22:26.591000Z", "last_trigger_published_at":
-        "2026-04-02T16:22:26.591000Z", "last_triggered_at": "2026-04-02T16:22:27.578209Z",
-        "last_trigger_detected_at": "2026-04-02T16:22:27.578209Z", "hash": "UeONCI+H/I19fHV7Ge45VQxOI0/YUY6CYZu9psQ6W53s6W+UOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-04-02T16:22:27.592459Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": true,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 11, "displayed_occurrence": {"id": 256867977, "issue": 29487333,
-        "account": 8, "kind": "RLTM", "element": "KAN-4?focusedCommentId=10005", "element_type":
-        "JIRA_COMMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "BBZtIrA/2GAvXPBnlTveHP2iPqy+rHM0BxNchD6gRp+/+mUjQPrqnyjHph0vjkPi",
-        "published_at": "2026-04-02T16:22:26.591000Z", "date": "2026-04-02T16:22:26.591000Z",
-        "detected_at": "2026-04-02T16:22:27.022003Z", "is_vcs_type": false, "last_detected_at":
-        "2026-04-02T16:22:26.591000Z", "last_seen_at": "2026-04-02T16:22:26.591000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-4?focusedCommentId=10005",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 148603933, "secrets_engine_version": "2.159.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 25, "indice_end":
-        81, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
-        "2026-04-02T16:22:27.644022Z", "last_presence_check_at": "2026-04-02T16:22:27.644022Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": ["REVOCABLE_BY_GG"],
-        "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}]}'
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
+        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
+        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
+        "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
+        "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
+        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 113, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_63.txt", "filename":
+        "configuration_63.txt", "presence": "visible", "last_presence_seen_at": "2026-06-22T15:16:49.824313Z",
+        "last_presence_check_at": "2026-06-22T15:16:49.824313Z", "first_presence_deleted_at":
+        null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}]}'
     headers:
+      CF-RAY:
+      - a103957d1e347029-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:24 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '9129'
+      - '9065'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:41 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '130'
+      - '134'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -162,122 +169,126 @@ interactions:
     body:
       string: '{"count": null, "page": 2, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?page=3&page_size=2",
         "previous": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?page_size=2",
-        "results": [{"id": 29305270, "account": 8, "criterion": "OpenAI API Key",
-        "date": "2026-03-27T13:47:01Z", "last_trigger_published_at": "2026-03-27T13:47:01Z",
-        "last_triggered_at": "2026-03-28T05:01:36.397561Z", "last_trigger_detected_at":
-        "2026-03-28T05:01:36.397561Z", "hash": "MTJFo5AaJdAJ7giIaJE2+Vn/3hEL1nR7oKsu0ry8AAS38W2S95GRLqiXIWrK60u6",
-        "ignored": true, "ignored_at": "2026-03-28T05:01:36.405919Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "OpenAI API Key", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "name": "gg-tools"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-tools / OneDrive", "type": "microsoft_onedrive", "path": "gg-tools
-        / OneDrive", "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata":
-        null, "is_vaulted": false, "similar_issue_count": 0, "score": 6, "displayed_occurrence":
-        {"id": 255746729, "issue": 29305270, "account": 8, "kind": "RLTM", "element":
-        "{\"drive_id\": \"b!ifwT0vIqDE2MYP5tWpOaVJKsAA38ZA1PqHTPWAaO0Ovk8yFkaTlITKSgS6Y2Zlvu\",
-        \"parent_reference_path\": \"/drives/b!ifwT0vIqDE2MYP5tWpOaVJKsAA38ZA1PqHTPWAaO0Ovk8yFkaTlITKSgS6Y2Zlvu/root:/Recordings\",
-        \"file_id\": \"01ICX32E3NSJA7PEQVFZAKEEXG4DH65RP4\"}", "element_type": "SHAREPOINT_ONEDRIVE_FILE",
-        "author_name": "gg-tools", "author_info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "value": null, "value_hash": "CFPFVOpXX+26OfRN+bRLyvVCXnQmU1Cpu36m73v5F4pgz7WMu+D6UW65wQZMF7kQ",
-        "published_at": "2026-03-27T13:47:01Z", "date": "2026-03-27T13:47:01Z", "detected_at":
-        "2026-03-28T04:58:40.843022Z", "is_vcs_type": false, "last_detected_at": "2026-03-27T13:47:01Z",
-        "last_seen_at": "2026-03-27T13:47:01Z", "data": {}, "url": "https://gitguardianengineering-my.sharepoint.com/personal/gg-tools_gitguardianengineering_onmicrosoft_com/Documents/Recordings/secret.txt",
-        "source": {"id": 19962591, "url": "https://onedrive.com/", "type": "microsoft_onedrive",
-        "display_name": "gg-tools / OneDrive", "visibility": "private", "monitored":
+        "results": [{"id": 34181686, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-22T11:25:45.739149Z", "last_trigger_published_at": "2026-06-22T11:25:45.739149Z",
+        "last_triggered_at": "2026-06-22T11:25:45.762592Z", "last_trigger_detected_at":
+        "2026-06-22T11:25:45.762592Z", "hash": "gVrL/pjjFLo7sSikPS1pWtPJbr+oWSSVz8IB6+2ViJDSJKiK25LITKmJimoqGr3z",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": true, "resolved_at": "2026-06-22T11:26:52.971214Z", "resolver":
+        1751937, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
+        "none", "ignorer_type": "none", "resolver_display_name": "candidate.playground+eu@gitguardian.com",
+        "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
+        "none", "status": "RESOLVED", "issue_name": "Microsoft Azure Storage Connection
+        String", "severity_rule_config": null, "declarative_secret_status": "revoked",
+        "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "", "name": "Kashyapa P.A. Jayasekera"}],
+        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "GGFRLTA127
+        \u2014 kashyapap.jayasekera", "type": "endpoints", "path": "GGFRLTA127 \u2014
+        kashyapap.jayasekera", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274639444, "issue": 34181686, "account": 8, "kind": "RLTM", "element":
+        "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "AAr6ayAj6Hs2pOICdVUlEyuXlsQ78K3HFGOJgWA/yAiQrRuQH9Kv1GxUH36IT99d",
+        "published_at": "2026-06-22T11:25:45.739149Z", "date": "2026-06-22T11:25:45.739149Z",
+        "detected_at": "2026-06-22T11:25:45.739149Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-22T11:25:45.739149Z", "last_seen_at": "2026-06-22T11:25:45.739149Z",
+        "data": {"line": 20, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
         true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null}, "regression": false, "content": 147214824, "secrets_engine_version":
-        "2.159.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 8, "indice_end": 59, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "Recordings/secret.txt", "filename":
-        "secret.txt", "presence": "visible", "last_presence_seen_at": "2026-03-28T05:01:36.456203Z",
-        "last_presence_check_at": "2026-03-28T05:01:36.456203Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": []},
-        "has_dropped_occurrences": false, "tags": ["REVOCABLE_BY_GG"], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 1}, {"id": 29236129, "account": 8, "criterion":
-        "Slack Bot Token", "date": "2026-03-26T16:10:40Z", "last_trigger_published_at":
-        "2026-03-26T16:10:40Z", "last_triggered_at": "2026-03-26T16:10:55.648969Z",
-        "last_trigger_detected_at": "2026-03-26T16:10:55.648969Z", "hash": "0Y7z2cw2c6cwAdy+TeYUL5BKR7Lb/hDQRLHld5PCWUkg5Q0OOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-03-26T16:10:55.689671Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "pierrelalanne/test_repo", "type": "gh_repository", "path": "pierrelalanne/test_repo",
-        "source_criticality": "critical"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 0, "displayed_occurrence":
-        {"id": 253938087, "issue": 29236129, "account": 8, "kind": "RLTM", "element":
-        "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
-        "value": null, "value_hash": "CEL9N36auQTdl9e+bqgAsGyWN0vVPYlqvHWSQMXxC/1zmdQrKYk359La8N2L+SIi",
-        "published_at": "2026-03-26T16:10:40Z", "date": "2026-03-26T16:10:40Z", "detected_at":
-        "2026-03-26T16:10:51.878216Z", "is_vcs_type": true, "last_detected_at": "2026-03-26T16:10:40Z",
-        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R1",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
-        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 146712049,
-        "secrets_engine_version": "2.159.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 60, "indice_end": 102, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 1, "post_line_end": 1}], "most_sensitive_match_name":
-        "apikey", "insights": [{"name": "test_file", "source": "document", "metadata":
-        null}], "filepath": "test_limits_1_secret.txt", "filename": "test_limits_1_secret.txt",
-        "presence": "visible", "last_presence_seen_at": "2026-03-26T16:10:55.988339Z",
-        "last_presence_check_at": "2026-03-26T16:10:55.988339Z", "first_presence_deleted_at":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-22T11:25:45.739149Z", "last_presence_check_at":
+        "2026-06-22T11:25:45.739149Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 6}, {"id":
+        34122510, "account": 8, "criterion": "Generic Password", "date": "2026-06-19T13:41:03Z",
+        "last_trigger_published_at": "2026-06-19T13:41:03Z", "last_triggered_at":
+        "2026-06-19T13:43:05.020137Z", "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z",
+        "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Generic Password", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
+        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
+        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
+        "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
+        "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 129, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_62.txt", "filename":
+        "configuration_62.txt", "presence": "visible", "last_presence_seen_at": "2026-06-19T13:43:05.062490Z",
+        "last_presence_check_at": "2026-06-19T13:43:05.062490Z", "first_presence_deleted_at":
         null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}, {"type": "DEFAULT_BRANCH", "metadata":
-        null}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG",
-        "TEST_FILE"], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}]}'
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}]}'
     headers:
+      CF-RAY:
+      - a103957f68e86fe8-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:25 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '9708'
+      - '9224'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:42 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '150'
+      - '99'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_unassigned.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_unassigned.yaml
@@ -21,244 +21,241 @@ interactions:
   response:
     body:
       string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?assignee_member_id=0&page=2&page_size=5",
-        "previous": null, "results": [{"id": 29487335, "account": 8, "criterion":
-        "Stripe Webhook Secret", "date": "2026-04-02T16:22:33.518000Z", "last_trigger_published_at":
-        "2026-04-02T16:22:33.518000Z", "last_triggered_at": "2026-04-02T16:22:34.233032Z",
-        "last_trigger_detected_at": "2026-04-02T16:22:34.233032Z", "hash": "JquJu98wTd0k40t3UsNgP22P+ywFCrsGM1VDRg3oZBdGXhRWbjOMbKAG+JtXZUOK",
+        "previous": null, "results": [{"id": 34205503, "account": 8, "criterion":
+        "microsoft_azure_storage_connection_string", "date": "2026-06-23T11:13:31.325324Z",
+        "last_trigger_published_at": "2026-06-23T11:13:31.325324Z", "last_triggered_at":
+        "2026-06-23T11:13:31.343453Z", "last_trigger_detected_at": "2026-06-23T11:13:31.343453Z",
+        "hash": "HdPZ4cjZuziAqsakdlsUnJDapTz3ns5pX8vPzfhvGQvpWWWX25LITKmJimoqGr3z",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Stripe Webhook Secret", "severity_rule_config": null, "declarative_secret_status":
-        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": true,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 62, "displayed_occurrence": {"id": 256867982, "issue": 29487335,
-        "account": 8, "kind": "RLTM", "element": "KAN-8?focusedCommentId=10014", "element_type":
-        "JIRA_COMMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "o40+pCpgMCFgcapQEEdZ3imjEpSONYcgy0J+gLe5ygKDJctj7Ro4REsJrqbUl0yj",
-        "published_at": "2026-04-02T16:22:33.518000Z", "date": "2026-04-02T16:22:33.518000Z",
-        "detected_at": "2026-04-02T16:22:34.031682Z", "is_vcs_type": false, "last_detected_at":
-        "2026-04-02T16:22:33.518000Z", "last_seen_at": "2026-04-02T16:22:33.518000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-8?focusedCommentId=10014",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 148603941, "secrets_engine_version": "2.159.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 25, "indice_end":
-        63, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
-        "2026-04-02T16:22:34.268883Z", "last_presence_check_at": "2026-04-02T16:22:34.268883Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 1}, {"id": 29487333, "account": 8, "criterion":
-        "Slack Bot Token", "date": "2026-04-02T16:22:26.591000Z", "last_trigger_published_at":
-        "2026-04-02T16:22:26.591000Z", "last_triggered_at": "2026-04-02T16:22:27.578209Z",
-        "last_trigger_detected_at": "2026-04-02T16:22:27.578209Z", "hash": "UeONCI+H/I19fHV7Ge45VQxOI0/YUY6CYZu9psQ6W53s6W+UOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-04-02T16:22:27.592459Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": true,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 11, "displayed_occurrence": {"id": 256867977, "issue": 29487333,
-        "account": 8, "kind": "RLTM", "element": "KAN-4?focusedCommentId=10005", "element_type":
-        "JIRA_COMMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "BBZtIrA/2GAvXPBnlTveHP2iPqy+rHM0BxNchD6gRp+/+mUjQPrqnyjHph0vjkPi",
-        "published_at": "2026-04-02T16:22:26.591000Z", "date": "2026-04-02T16:22:26.591000Z",
-        "detected_at": "2026-04-02T16:22:27.022003Z", "is_vcs_type": false, "last_detected_at":
-        "2026-04-02T16:22:26.591000Z", "last_seen_at": "2026-04-02T16:22:26.591000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-4?focusedCommentId=10005",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 148603933, "secrets_engine_version": "2.159.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 25, "indice_end":
-        81, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
-        "2026-04-02T16:22:27.644022Z", "last_presence_check_at": "2026-04-02T16:22:27.644022Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": ["REVOCABLE_BY_GG"],
-        "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
-        29305270, "account": 8, "criterion": "OpenAI API Key", "date": "2026-03-27T13:47:01Z",
-        "last_trigger_published_at": "2026-03-27T13:47:01Z", "last_triggered_at":
-        "2026-03-28T05:01:36.397561Z", "last_trigger_detected_at": "2026-03-28T05:01:36.397561Z",
-        "hash": "MTJFo5AaJdAJ7giIaJE2+Vn/3hEL1nR7oKsu0ry8AAS38W2S95GRLqiXIWrK60u6",
-        "ignored": true, "ignored_at": "2026-03-28T05:01:36.405919Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "OpenAI API Key", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "name": "gg-tools"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-tools / OneDrive", "type": "microsoft_onedrive", "path": "gg-tools
-        / OneDrive", "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata":
-        null, "is_vaulted": false, "similar_issue_count": 0, "score": 6, "displayed_occurrence":
-        {"id": 255746729, "issue": 29305270, "account": 8, "kind": "RLTM", "element":
-        "{\"drive_id\": \"b!ifwT0vIqDE2MYP5tWpOaVJKsAA38ZA1PqHTPWAaO0Ovk8yFkaTlITKSgS6Y2Zlvu\",
-        \"parent_reference_path\": \"/drives/b!ifwT0vIqDE2MYP5tWpOaVJKsAA38ZA1PqHTPWAaO0Ovk8yFkaTlITKSgS6Y2Zlvu/root:/Recordings\",
-        \"file_id\": \"01ICX32E3NSJA7PEQVFZAKEEXG4DH65RP4\"}", "element_type": "SHAREPOINT_ONEDRIVE_FILE",
-        "author_name": "gg-tools", "author_info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "value": null, "value_hash": "CFPFVOpXX+26OfRN+bRLyvVCXnQmU1Cpu36m73v5F4pgz7WMu+D6UW65wQZMF7kQ",
-        "published_at": "2026-03-27T13:47:01Z", "date": "2026-03-27T13:47:01Z", "detected_at":
-        "2026-03-28T04:58:40.843022Z", "is_vcs_type": false, "last_detected_at": "2026-03-27T13:47:01Z",
-        "last_seen_at": "2026-03-27T13:47:01Z", "data": {}, "url": "https://gitguardianengineering-my.sharepoint.com/personal/gg-tools_gitguardianengineering_onmicrosoft_com/Documents/Recordings/secret.txt",
-        "source": {"id": 19962591, "url": "https://onedrive.com/", "type": "microsoft_onedrive",
-        "display_name": "gg-tools / OneDrive", "visibility": "private", "monitored":
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
+        "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
+        "detected_at": "2026-06-23T11:13:31.325324Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
+        "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
         true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null}, "regression": false, "content": 147214824, "secrets_engine_version":
-        "2.159.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 8, "indice_end": 59, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "Recordings/secret.txt", "filename":
-        "secret.txt", "presence": "visible", "last_presence_seen_at": "2026-03-28T05:01:36.456203Z",
-        "last_presence_check_at": "2026-03-28T05:01:36.456203Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": []},
-        "has_dropped_occurrences": false, "tags": ["REVOCABLE_BY_GG"], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 1}, {"id": 29236129, "account": 8, "criterion":
-        "Slack Bot Token", "date": "2026-03-26T16:10:40Z", "last_trigger_published_at":
-        "2026-03-26T16:10:40Z", "last_triggered_at": "2026-03-26T16:10:55.648969Z",
-        "last_trigger_detected_at": "2026-03-26T16:10:55.648969Z", "hash": "0Y7z2cw2c6cwAdy+TeYUL5BKR7Lb/hDQRLHld5PCWUkg5Q0OOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-03-26T16:10:55.689671Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "pierrelalanne/test_repo", "type": "gh_repository", "path": "pierrelalanne/test_repo",
-        "source_criticality": "critical"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 0, "displayed_occurrence":
-        {"id": 253938087, "issue": 29236129, "account": 8, "kind": "RLTM", "element":
-        "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
-        "value": null, "value_hash": "CEL9N36auQTdl9e+bqgAsGyWN0vVPYlqvHWSQMXxC/1zmdQrKYk359La8N2L+SIi",
-        "published_at": "2026-03-26T16:10:40Z", "date": "2026-03-26T16:10:40Z", "detected_at":
-        "2026-03-26T16:10:51.878216Z", "is_vcs_type": true, "last_detected_at": "2026-03-26T16:10:40Z",
-        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R1",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
-        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 146712049,
-        "secrets_engine_version": "2.159.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 60, "indice_end": 102, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 1, "post_line_end": 1}], "most_sensitive_match_name":
-        "apikey", "insights": [{"name": "test_file", "source": "document", "metadata":
-        null}], "filepath": "test_limits_1_secret.txt", "filename": "test_limits_1_secret.txt",
-        "presence": "visible", "last_presence_seen_at": "2026-03-26T16:10:55.988339Z",
-        "last_presence_check_at": "2026-03-26T16:10:55.988339Z", "first_presence_deleted_at":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
+        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
+        34186239, "account": 8, "criterion": "Generic Password", "date": "2026-06-22T15:14:57Z",
+        "last_trigger_published_at": "2026-06-22T15:14:57Z", "last_triggered_at":
+        "2026-06-22T15:16:49.799821Z", "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z",
+        "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Generic Password", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
+        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
+        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
+        "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
+        "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
+        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 113, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_63.txt", "filename":
+        "configuration_63.txt", "presence": "visible", "last_presence_seen_at": "2026-06-22T15:16:49.824313Z",
+        "last_presence_check_at": "2026-06-22T15:16:49.824313Z", "first_presence_deleted_at":
         null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}, {"type": "DEFAULT_BRANCH", "metadata":
-        null}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG",
-        "TEST_FILE"], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
-        29236130, "account": 8, "criterion": "Slack Bot Token", "date": "2026-03-26T16:10:40Z",
-        "last_trigger_published_at": "2026-03-26T16:10:40Z", "last_triggered_at":
-        "2026-03-26T16:10:55.649133Z", "last_trigger_detected_at": "2026-03-26T16:10:55.649133Z",
-        "hash": "1d291ZrFV0RBbVE8r2t6EFI1jgdXhzZkb4RYrNKH10mjkZ9yOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-03-26T16:10:55.695057Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "pierrelalanne/test_repo", "type": "gh_repository", "path": "pierrelalanne/test_repo",
-        "source_criticality": "critical"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 10, "score": 0, "displayed_occurrence":
-        {"id": 253938082, "issue": 29236130, "account": 8, "kind": "RLTM", "element":
-        "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
-        "value": null, "value_hash": "8CeYKeR2kMER0aBlyGThkdNGWeRYfKFLPj1kOQJO8lH2bXzFs7jhuR1VfR21VK1W",
-        "published_at": "2026-03-26T16:10:40Z", "date": "2026-03-26T16:10:40Z", "detected_at":
-        "2026-03-26T16:10:51.878216Z", "is_vcs_type": true, "last_detected_at": "2026-03-26T16:10:40Z",
-        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R20",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
-        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 146712049,
-        "secrets_engine_version": "2.159.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 896, "indice_end": 938, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 20, "post_line_end": 20}], "most_sensitive_match_name":
-        "apikey", "insights": [{"name": "test_file", "source": "document", "metadata":
-        null}], "filepath": "test_limits_1_secret.txt", "filename": "test_limits_1_secret.txt",
-        "presence": "visible", "last_presence_seen_at": "2026-03-26T16:10:55.988339Z",
-        "last_presence_check_at": "2026-03-26T16:10:55.988339Z", "first_presence_deleted_at":
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 34181686, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-22T11:25:45.739149Z", "last_trigger_published_at": "2026-06-22T11:25:45.739149Z",
+        "last_triggered_at": "2026-06-22T11:25:45.762592Z", "last_trigger_detected_at":
+        "2026-06-22T11:25:45.762592Z", "hash": "gVrL/pjjFLo7sSikPS1pWtPJbr+oWSSVz8IB6+2ViJDSJKiK25LITKmJimoqGr3z",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": true, "resolved_at": "2026-06-22T11:26:52.971214Z", "resolver":
+        1751937, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
+        "none", "ignorer_type": "none", "resolver_display_name": "candidate.playground+eu@gitguardian.com",
+        "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
+        "none", "status": "RESOLVED", "issue_name": "Microsoft Azure Storage Connection
+        String", "severity_rule_config": null, "declarative_secret_status": "revoked",
+        "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "", "name": "Kashyapa P.A. Jayasekera"}],
+        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "GGFRLTA127
+        \u2014 kashyapap.jayasekera", "type": "endpoints", "path": "GGFRLTA127 \u2014
+        kashyapap.jayasekera", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274639444, "issue": 34181686, "account": 8, "kind": "RLTM", "element":
+        "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "AAr6ayAj6Hs2pOICdVUlEyuXlsQ78K3HFGOJgWA/yAiQrRuQH9Kv1GxUH36IT99d",
+        "published_at": "2026-06-22T11:25:45.739149Z", "date": "2026-06-22T11:25:45.739149Z",
+        "detected_at": "2026-06-22T11:25:45.739149Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-22T11:25:45.739149Z", "last_seen_at": "2026-06-22T11:25:45.739149Z",
+        "data": {"line": 20, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-22T11:25:45.739149Z", "last_presence_check_at":
+        "2026-06-22T11:25:45.739149Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 6}, {"id":
+        34122510, "account": 8, "criterion": "Generic Password", "date": "2026-06-19T13:41:03Z",
+        "last_trigger_published_at": "2026-06-19T13:41:03Z", "last_triggered_at":
+        "2026-06-19T13:43:05.020137Z", "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z",
+        "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Generic Password", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
+        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
+        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
+        "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
+        "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 129, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_62.txt", "filename":
+        "configuration_62.txt", "presence": "visible", "last_presence_seen_at": "2026-06-19T13:43:05.062490Z",
+        "last_presence_check_at": "2026-06-19T13:43:05.062490Z", "first_presence_deleted_at":
         null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}, {"type": "DEFAULT_BRANCH", "metadata":
-        null}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG",
-        "TEST_FILE"], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}]}'
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 34038186, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-16T18:55:43.166667Z", "last_trigger_published_at": "2026-06-16T18:55:43.166667Z",
+        "last_triggered_at": "2026-06-16T18:55:43.185061Z", "last_trigger_detected_at":
+        "2026-06-16T18:55:43.185061Z", "hash": "JFTpQX+4P/dEcXJJ2iw+u54JYDsJnqLtrdws1wjFQ8t9LtHh25LITKmJimoqGr3z",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
+        "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
+        "detected_at": "2026-06-16T18:55:43.166667Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
+        "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
+        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}]}'
     headers:
+      CF-RAY:
+      - a103956f48b9bc81-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:22 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '23391'
+      - '22555'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:40 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '125'
+      - '130'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_date_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_date_filter.yaml
@@ -21,8 +21,53 @@ interactions:
   response:
     body:
       string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?date__ge=2024-01-01&date__le=2025-12-31&page=2&page_size=5",
-        "previous": null, "results": [{"id": 23429983, "account": 8, "criterion":
-        "AWS Keys", "date": "2025-12-16T17:22:08Z", "last_trigger_published_at": "2025-12-16T17:22:08Z",
+        "previous": null, "results": [{"id": 30818247, "account": 8, "criterion":
+        "Claude API Key", "date": "2025-12-19T08:54:54Z", "last_trigger_published_at":
+        "2025-12-19T08:54:54Z", "last_triggered_at": "2026-04-22T15:59:49.925044Z",
+        "last_trigger_detected_at": "2026-04-22T15:59:49.925044Z", "hash": "sZn1CS8E1GrE0Qu3CkjUdxHljt+LVX+8WiX9g95Qb0jNvobDiWeX8ZNFxTsysfz1",
+        "ignored": true, "ignored_at": "2026-04-22T15:59:49.932528Z", "ignore_reason":
+        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
+        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
+        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
+        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
+        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
+        "Claude API Key", "severity_rule_config": null, "declarative_secret_status":
+        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "", "name": ""}], "user_permission":
+        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 0, "sources": [{"id": 27612802, "name": "docker-trial/test",
+        "type": "jfrog_container_registry_v2_repository", "path": "docker-trial/test",
+        "source_criticality": "unknown", "monitoring_status": "active", "deleted_at":
+        "2026-06-10T13:57:55.109144+00:00"}], "custom_tags": [], "vault_metadata":
+        null, "is_vaulted": false, "similar_issue_count": 0, "score": 12, "displayed_occurrence":
+        {"id": 261862866, "issue": 30818247, "account": 8, "kind": "HIST", "element":
+        "{\"repository_name\": \"docker-trial/test\", \"file_path\": \"main.py\"}",
+        "element_type": "CONTAINER_LAYER", "author_name": "", "author_info": "", "value":
+        null, "value_hash": "2nKj1DQO5oDFeuLQmxhAastnTOwNkPpXetDLhcYw4GEtonYb1Lvc8iON0EcSEZAD",
+        "published_at": "2025-12-19T08:54:54Z", "date": "2025-12-19T08:54:54Z", "detected_at":
+        "2026-04-22T15:56:46.122179Z", "is_vcs_type": false, "last_detected_at": "2025-12-19T08:54:54Z",
+        "last_seen_at": "2025-12-19T08:54:54Z", "data": {"blob_sha": "sha256:c8ebd6a8b0125c8cff3e4ca275c6438f986265c8a46a919821d67af68825af05",
+        "image_tag": "v1", "manifest_sha": "sha256:55e18847e9d4e4ff60d0b8cde21c964dcad01d8960c15c7e43107957a198c8c0",
+        "manifest_digest": "sha256:926faa6d63311f8bfe03a7cc10275b9a79fd544c78ae2d89bea790e2cc469103"},
+        "url": "https://gitguardianengineering.jfrog.io/ui/repos/tree/General/docker-trial/test/v1/sha256__c8ebd6a8b0125c8cff3e4ca275c6438f986265c8a46a919821d67af68825af05",
+        "source": {"id": 27612802, "url": "https://gitguardianengineering.jfrog.io/ui/repos/tree/General/docker-trial/test",
+        "type": "jfrog_container_registry_v2_repository", "display_name": "docker-trial/test",
+        "visibility": "private", "monitored": true, "source_criticality": "unknown",
+        "deleted_at": "2026-06-10T13:57:55.109144Z", "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 154961672, "secrets_engine_version":
+        "2.161.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
+        "indice_start": 8, "indice_end": 116, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
+        "apikey", "insights": [], "filepath": "main.py", "filename": "main.py", "presence":
+        "visible", "last_presence_seen_at": "2026-04-22T15:59:49.957496Z", "last_presence_check_at":
+        "2026-04-22T15:59:49.957496Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": [{"type": "FROM_HISTORICAL_SCAN",
+        "metadata": null, "field": "content"}]}, "has_dropped_occurrences": false,
+        "tags": ["FROM_HISTORICAL_SCAN"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 23429983, "account": 8, "criterion": "AWS
+        Keys", "date": "2025-12-16T17:22:08Z", "last_trigger_published_at": "2025-12-16T17:22:08Z",
         "last_triggered_at": "2025-12-16T18:22:25.117146Z", "last_trigger_detected_at":
         "2025-12-16T18:22:25.117146Z", "hash": "Bxk/2SaXQPI8yl7xAhB3l3Q9xdra8RHtG7PEK3Wc2BUYBzgKL4Qc71cZRqNcojMG",
         "ignored": true, "ignored_at": "2025-12-16T18:22:25.122585Z", "ignore_reason":
@@ -37,11 +82,12 @@ interactions:
         "name": "gg-tools"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
         0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "Alina''s site (document libraries) / Documents", "type": "sharepoint_online_drive",
-        "path": "Alina''s site (document libraries) / Documents", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 0, "score": 9, "displayed_occurrence": {"id": 230344889,
-        "issue": 23429983, "account": 8, "kind": "RLTM", "element": "{\"drive_id\":
+        [{"id": 23920761, "name": "Alina''s site (document libraries) / Documents",
+        "type": "sharepoint_online_drive", "path": "Alina''s site (document libraries)
+        / Documents", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 0, "score": 9, "displayed_occurrence": {"id":
+        230344889, "issue": 23429983, "account": 8, "kind": "RLTM", "element": "{\"drive_id\":
         \"b!EFtsUNZdNkyikeU9z6xQzkUMGeBD9bdJo5M6BS3bW67zTZ14Z8npSqr01XpQaXIh\", \"parent_reference_path\":
         \"/drives/b!EFtsUNZdNkyikeU9z6xQzkUMGeBD9bdJo5M6BS3bW67zTZ14Z8npSqr01XpQaXIh/root:\",
         \"file_id\": \"01Y5MCAQY6HCFEWMVSWZCJJ2PCDHL3I2YO\"}", "element_type": "SHAREPOINT_ONEDRIVE_FILE",
@@ -53,24 +99,70 @@ interactions:
         "source": {"id": 23920761, "url": "https://gitguardianengineering.sharepoint.com/sites/Alina%27ssite/Shared%20Documents",
         "type": "sharepoint_online_drive", "display_name": "Alina''s site (document
         libraries) / Documents", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 112471538, "secrets_engine_version": "2.153.1", "matches": [{"name":
-        "client_id", "string_matched": "[REDACTED]", "indice_start": 500, "indice_end":
-        520, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}, {"name": "client_secret", "string_matched": "[REDACTED]",
-        "indice_start": 546, "indice_end": 586, "pre_line_start": null, "pre_line_end":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 112471538, "secrets_engine_version":
+        "2.153.1", "matches": [{"name": "client_id", "string_matched": "[REDACTED]",
+        "indice_start": 500, "indice_end": 520, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": null, "post_line_end": null}, {"name": "client_secret",
+        "string_matched": "[REDACTED]", "indice_start": 546, "indice_end": 586, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": null, "post_line_end": null}],
+        "most_sensitive_match_name": "client_secret", "insights": [], "filepath":
+        "small_with_secret.csv.gz", "filename": "small_with_secret.csv.gz", "presence":
+        "visible", "last_presence_seen_at": "2026-01-12T15:33:36.829567Z", "last_presence_check_at":
+        "2026-01-12T15:33:36.829567Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": ["FROM_HISTORICAL_SCAN", "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 2}, {"id": 30818249, "account": 8, "criterion": "OpenAI
+        API Key", "date": "2025-12-16T14:04:16Z", "last_trigger_published_at": "2025-12-16T14:04:16Z",
+        "last_triggered_at": "2026-04-22T15:59:51.444425Z", "last_trigger_detected_at":
+        "2026-04-22T15:59:51.444425Z", "hash": "II9Qwlpl0Bl6FzoPrmN3j93/FQ4rM9Db4MskA1gX/KPzJx0j95GRLqiXIWrK60u6",
+        "ignored": true, "ignored_at": "2026-04-22T15:59:51.450807Z", "ignore_reason":
+        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
+        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
+        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
+        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
+        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
+        "OpenAI API Key", "severity_rule_config": null, "declarative_secret_status":
+        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "", "name": ""}], "user_permission":
+        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 0, "sources": [{"id": 27612799, "name": "docker-trial/nrivmultiarch",
+        "type": "jfrog_container_registry_v2_repository", "path": "docker-trial/nrivmultiarch",
+        "source_criticality": "unknown", "monitoring_status": "active", "deleted_at":
+        "2026-06-10T13:57:55.109144+00:00"}], "custom_tags": [], "vault_metadata":
+        null, "is_vaulted": false, "similar_issue_count": 0, "score": 6, "displayed_occurrence":
+        {"id": 261862868, "issue": 30818249, "account": 8, "kind": "HIST", "element":
+        "{\"repository_name\": \"docker-trial/nrivmultiarch\", \"file_path\": \"main.py\"}",
+        "element_type": "CONTAINER_LAYER", "author_name": "", "author_info": "", "value":
+        null, "value_hash": "Ni20Rn8Vo4vvNRZYqmNPrIglWEKFxB4cVjNFTlMKWsLoXtzZugPyjPebArtyjHWH",
+        "published_at": "2025-12-16T14:04:16Z", "date": "2025-12-16T14:04:16Z", "detected_at":
+        "2026-04-22T15:56:45.433426Z", "is_vcs_type": false, "last_detected_at": "2025-12-16T14:04:16Z",
+        "last_seen_at": "2025-12-16T14:04:16Z", "data": {"blob_sha": "sha256:988b4e7f13c383b4893858fccf63b16d55b7cc11d83feef92a22ce06f7b59e90",
+        "image_tag": "sha256:8429ca6db5eb1a190b6aff32305fb849f8125ce3fdabbaa14dd8cec07ebdf3a7",
+        "manifest_sha": "sha256:7617aed4ec1aa5b4f69e963b389a4c0e76e5aed1be9a8fc8baf2f0d34fbd34d1",
+        "manifest_digest": "sha256:8429ca6db5eb1a190b6aff32305fb849f8125ce3fdabbaa14dd8cec07ebdf3a7"},
+        "url": "https://gitguardianengineering.jfrog.io/ui/repos/tree/General/docker-trial/nrivmultiarch/sha256:8429ca6db5eb1a190b6aff32305fb849f8125ce3fdabbaa14dd8cec07ebdf3a7/sha256__988b4e7f13c383b4893858fccf63b16d55b7cc11d83feef92a22ce06f7b59e90",
+        "source": {"id": 27612799, "url": "https://gitguardianengineering.jfrog.io/ui/repos/tree/General/docker-trial/nrivmultiarch",
+        "type": "jfrog_container_registry_v2_repository", "display_name": "docker-trial/nrivmultiarch",
+        "visibility": "private", "monitored": true, "source_criticality": "unknown",
+        "deleted_at": "2026-06-10T13:57:55.109144Z", "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 154961676, "secrets_engine_version":
+        "2.161.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
+        "indice_start": 8, "indice_end": 59, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
-        "client_secret", "insights": [], "filepath": "small_with_secret.csv.gz", "filename":
-        "small_with_secret.csv.gz", "presence": "visible", "last_presence_seen_at":
-        "2026-01-12T15:33:36.829567Z", "last_presence_check_at": "2026-01-12T15:33:36.829567Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": ["FROM_HISTORICAL_SCAN"],
-        "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 2}, {"id":
-        26805045, "account": 8, "criterion": "Generic High Entropy Secret", "date":
-        "2025-12-14T19:04:50Z", "last_trigger_published_at": "2025-12-14T19:04:50Z",
-        "last_triggered_at": "2026-02-04T13:38:51.989716Z", "last_trigger_detected_at":
-        "2026-02-04T13:38:51.989716Z", "hash": "BeW5KalXvUOy4RWl94KMO3C7iql7YdgzmiUOxsSbIvEcfisXp+KkPCNpyNbtXqJM",
+        "apikey", "insights": [], "filepath": "main.py", "filename": "main.py", "presence":
+        "visible", "last_presence_seen_at": "2026-04-22T15:59:51.473874Z", "last_presence_check_at":
+        "2026-04-22T15:59:51.473874Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": [{"type": "FROM_HISTORICAL_SCAN",
+        "metadata": null, "field": "content"}]}, "has_dropped_occurrences": false,
+        "tags": ["FROM_HISTORICAL_SCAN", "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 26805045, "account": 8, "criterion": "Generic
+        High Entropy Secret", "date": "2025-12-14T19:04:50Z", "last_trigger_published_at":
+        "2025-12-14T19:04:50Z", "last_triggered_at": "2026-02-04T13:38:51.989716Z",
+        "last_trigger_detected_at": "2026-02-04T13:38:51.989716Z", "hash": "BeW5KalXvUOy4RWl94KMO3C7iql7YdgzmiUOxsSbIvEcfisXp+KkPCNpyNbtXqJM",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -80,35 +172,40 @@ interactions:
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
         "severity": 100, "authors": [{"info": "romain.jouhannet@gitguardian.com",
         "name": "Romain Jouhannet"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
+        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 4, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "RomainJ / demo", "type": "gl_project", "path": "romain/demo", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 0, "score": 30, "displayed_occurrence": {"id": 241287721,
-        "issue": 26805045, "account": 8, "kind": "HIST", "element": "fd56543c0a2594907b36ab59c885bd1d536a4957",
-        "element_type": "GIT_COMMIT", "author_name": "Romain Jouhannet", "author_info":
-        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "WE9RdxAVX6gbgtYpkWDapCSNR52nN4Dtf6NepeWQWpH1122NxY2lk0p41XlD3KA6",
+        [{"id": 23485702, "name": "RomainJ / demo", "type": "gl_project", "path":
+        "romain/demo", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}, {"id": 27769329, "name": "business / demo2", "type":
+        "gl_project", "path": "business/demo-2", "source_criticality": "unknown",
+        "monitoring_status": "active", "deleted_at": null}], "custom_tags": [], "vault_metadata":
+        null, "is_vaulted": false, "similar_issue_count": 16, "score": 30, "displayed_occurrence":
+        {"id": 241287721, "issue": 26805045, "account": 8, "kind": "HIST", "element":
+        "fd56543c0a2594907b36ab59c885bd1d536a4957", "element_type": "GIT_COMMIT",
+        "author_name": "Romain Jouhannet", "author_info": "romain.jouhannet@gitguardian.com",
+        "value": null, "value_hash": "WE9RdxAVX6gbgtYpkWDapCSNR52nN4Dtf6NepeWQWpH1122NxY2lk0p41XlD3KA6",
         "published_at": "2025-12-14T19:04:50Z", "date": "2025-12-14T19:04:50Z", "detected_at":
         "2026-02-04T13:38:46.386256Z", "is_vcs_type": true, "last_detected_at": "2025-12-14T19:04:50Z",
         "last_seen_at": "2025-12-14T19:04:50Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/fd56543c0a2594907b36ab59c885bd1d536a4957#2ec5fbc02574c84a8b8e3dcae097ffd0be069994_None_20",
         "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
         "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        "main"}, "regression": false, "content": 129708166, "secrets_engine_version":
-        "2.155.4", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 901, "indice_end": 963, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 20, "post_line_end": 20}], "most_sensitive_match_name":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 129708166,
+        "secrets_engine_version": "2.155.4", "matches": [{"name": "apikey", "string_matched":
+        "[REDACTED]", "indice_start": 901, "indice_end": 963, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 20, "post_line_end": 20}], "most_sensitive_match_name":
         "apikey", "insights": [], "filepath": "spinetail.py", "filename": "spinetail.py",
-        "presence": "visible", "last_presence_seen_at": "2026-02-18T22:33:05.054565Z",
-        "last_presence_check_at": "2026-02-18T22:33:05.054565Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": "addition", "full_tags":
-        [{"type": "FROM_HISTORICAL_SCAN", "metadata": null}]}, "has_dropped_occurrences":
-        false, "tags": ["FROM_HISTORICAL_SCAN"], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 2}, {"id": 26805047, "account": 8, "criterion": "Google
-        API Key", "date": "2025-12-14T19:04:50Z", "last_trigger_published_at": "2025-12-14T19:04:50Z",
-        "last_triggered_at": "2026-02-04T13:38:51.992367Z", "last_trigger_detected_at":
-        "2026-02-04T13:38:51.992367Z", "hash": "RiwXqKF/MH9aVvqy3SHVyjungan9+gseDRXLFLEeYlR4tCfeiwQ5Z8PP16EaJtIX",
+        "presence": "visible", "last_presence_seen_at": "2026-05-27T09:51:39.193873Z",
+        "last_presence_check_at": "2026-05-27T09:51:39.193873Z", "first_presence_deleted_at":
+        null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
+        [{"type": "FROM_HISTORICAL_SCAN", "metadata": null, "field": "content"}, {"type":
+        "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH", "FROM_HISTORICAL_SCAN"], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 4}, {"id": 26805047, "account": 8, "criterion":
+        "Google API Key", "date": "2025-12-14T19:04:50Z", "last_trigger_published_at":
+        "2025-12-14T19:04:50Z", "last_triggered_at": "2026-02-04T13:38:51.992367Z",
+        "last_trigger_detected_at": "2026-02-04T13:38:51.992367Z", "hash": "RiwXqKF/MH9aVvqy3SHVyjungan9+gseDRXLFLEeYlR4tCfeiwQ5Z8PP16EaJtIX",
         "ignored": true, "ignored_at": "2026-02-04T13:38:52.095775Z", "ignore_reason":
         "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
         null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
@@ -120,164 +217,78 @@ interactions:
         "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"},
         {"info": "romain.jouhannet@gitguardian.com", "name": "Romain Jouhannet"}],
         "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "RomainJ / demo", "type":
-        "gl_project", "path": "romain/demo", "source_criticality": "unknown"}], "custom_tags":
-        [], "vault_metadata": [{"source": "hashicorpvault"}], "is_vaulted": true,
-        "similar_issue_count": 3, "score": 0, "displayed_occurrence": {"id": 241287716,
-        "issue": 26805047, "account": 8, "kind": "HIST", "element": "fd56543c0a2594907b36ab59c885bd1d536a4957",
-        "element_type": "GIT_COMMIT", "author_name": "Romain Jouhannet", "author_info":
-        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "SJwViF0/DsMYa+t+dBEiZx2csnwTDMqh1ro0cKTbBj5LYGqhjI9qf5LnmIYCvOW2",
+        12, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 0, "sources": [{"id": 23485702, "name": "RomainJ
+        / demo", "type": "gl_project", "path": "romain/demo", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}, {"id": 27769329,
+        "name": "business / demo2", "type": "gl_project", "path": "business/demo-2",
+        "source_criticality": "unknown", "monitoring_status": "active", "deleted_at":
+        null}], "custom_tags": [], "vault_metadata": [{"source": "hashicorpvault"}],
+        "is_vaulted": true, "similar_issue_count": 4, "score": 0, "displayed_occurrence":
+        {"id": 241287716, "issue": 26805047, "account": 8, "kind": "HIST", "element":
+        "fd56543c0a2594907b36ab59c885bd1d536a4957", "element_type": "GIT_COMMIT",
+        "author_name": "Romain Jouhannet", "author_info": "romain.jouhannet@gitguardian.com",
+        "value": null, "value_hash": "SJwViF0/DsMYa+t+dBEiZx2csnwTDMqh1ro0cKTbBj5LYGqhjI9qf5LnmIYCvOW2",
         "published_at": "2025-12-14T19:04:50Z", "date": "2025-12-14T19:04:50Z", "detected_at":
         "2026-02-04T13:38:46.386256Z", "is_vcs_type": true, "last_detected_at": "2025-12-14T19:04:50Z",
         "last_seen_at": "2025-12-14T19:04:50Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/fd56543c0a2594907b36ab59c885bd1d536a4957#2ec5fbc02574c84a8b8e3dcae097ffd0be069994_None_12",
         "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
         "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        "main"}, "regression": false, "content": 129708166, "secrets_engine_version":
-        "2.155.4", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 483, "indice_end": 522, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 12, "post_line_end": 12}], "most_sensitive_match_name":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 129708166,
+        "secrets_engine_version": "2.155.4", "matches": [{"name": "apikey", "string_matched":
+        "[REDACTED]", "indice_start": 483, "indice_end": 522, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 12, "post_line_end": 12}], "most_sensitive_match_name":
         "apikey", "insights": [], "filepath": "spinetail.py", "filename": "spinetail.py",
-        "presence": "visible", "last_presence_seen_at": "2026-02-18T22:33:05.054565Z",
-        "last_presence_check_at": "2026-02-18T22:33:05.054565Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": "addition", "full_tags":
-        [{"type": "FROM_HISTORICAL_SCAN", "metadata": null}]}, "has_dropped_occurrences":
-        false, "tags": ["FROM_HISTORICAL_SCAN"], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 6}, {"id": 26805048, "account": 8, "criterion": "MongoDB
-        URI", "date": "2025-12-14T19:04:50Z", "last_trigger_published_at": "2025-12-14T19:04:50Z",
-        "last_triggered_at": "2026-02-04T13:38:51.992800Z", "last_trigger_detected_at":
-        "2026-02-04T13:38:51.992800Z", "hash": "U0UpslQfYEt5UuEASStW1TUUjSlPPFgH/4x3zFEikLa/81d7feuh40iUuZt2nZY1",
-        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
-        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
-        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
-        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
-        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "MongoDB Credentials", "severity_rule_config": {"id": 10873, "gg_created_at":
-        "2026-02-12T15:13:37.684368Z", "gg_updated_at": "2026-02-12T15:13:37.684372Z",
-        "index": 160, "severity": 20, "rule": {"id": 516, "gg_created_at": "2025-03-18T08:57:54.142529Z",
-        "gg_updated_at": "2025-03-18T08:57:54.142532Z", "name": "Specific Database
-        Credentials", "description": "Specific Database Credentials", "json_rule":
-        {"operator": "AND", "args": [{"operator": "EQ", "arg1": {"path": "issue.secret.detector.metadata.category",
-        "default": null}, "arg2": {"value": "data_storage"}}, {"operator": "EQ", "arg1":
-        {"path": "issue.secret.detector.nature", "default": null}, "arg2": {"value":
-        "specific"}}]}, "is_global": true, "scope": "private", "author": null}}, "declarative_secret_status":
-        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "romain.jouhannet@gitguardian.com",
-        "name": "Romain Jouhannet"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "RomainJ / demo", "type": "gl_project", "path": "romain/demo", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 11, "score": 49, "displayed_occurrence": {"id": 241287710,
-        "issue": 26805048, "account": 8, "kind": "HIST", "element": "fd56543c0a2594907b36ab59c885bd1d536a4957",
-        "element_type": "GIT_COMMIT", "author_name": "Romain Jouhannet", "author_info":
-        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "MaZxnaQEbYuJeCHedgQlQjI92lEcfqKmpHQiHzv49fT/ENa8G+Sw9gDmAbwsAhz4",
-        "published_at": "2025-12-14T19:04:50Z", "date": "2025-12-14T19:04:50Z", "detected_at":
-        "2026-02-04T13:38:46.386256Z", "is_vcs_type": true, "last_detected_at": "2025-12-14T19:04:50Z",
-        "last_seen_at": "2025-12-14T19:04:50Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/fd56543c0a2594907b36ab59c885bd1d536a4957#2ec5fbc02574c84a8b8e3dcae097ffd0be069994_None_8",
-        "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
-        "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
-        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        "main"}, "regression": false, "content": 129708166, "secrets_engine_version":
-        "2.155.4", "matches": [{"name": "connection_uri", "string_matched": "[REDACTED]",
-        "indice_start": 232, "indice_end": 323, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 8, "post_line_end": 8}, {"name": "scheme", "string_matched":
-        "[REDACTED]", "indice_start": 232, "indice_end": 243, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 8, "post_line_end": 8}, {"name":
-        "username", "string_matched": "[REDACTED]", "indice_start": 246, "indice_end":
-        254, "pre_line_start": null, "pre_line_end": null, "post_line_start": 8, "post_line_end":
-        8}, {"name": "password", "string_matched": "[REDACTED]", "indice_start": 255,
-        "indice_end": 267, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        8, "post_line_end": 8}, {"name": "host", "string_matched": "[REDACTED]", "indice_start":
-        268, "indice_end": 288, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        8, "post_line_end": 8}, {"name": "database", "string_matched": "[REDACTED]",
-        "indice_start": 289, "indice_end": 295, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 8, "post_line_end": 8}, {"name": "query", "string_matched":
-        "[REDACTED]", "indice_start": 296, "indice_end": 323, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 8, "post_line_end": 8}], "most_sensitive_match_name":
-        "password", "insights": [], "filepath": "spinetail.py", "filename": "spinetail.py",
-        "presence": "visible", "last_presence_seen_at": "2026-02-18T22:33:05.054565Z",
-        "last_presence_check_at": "2026-02-18T22:33:05.054565Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": "addition", "full_tags":
-        [{"type": "FROM_HISTORICAL_SCAN", "metadata": null}]}, "has_dropped_occurrences":
-        false, "tags": ["FROM_HISTORICAL_SCAN"], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 2}, {"id": 23316251, "account": 8, "criterion": "Figma
-        Personal Access Token", "date": "2025-12-11T10:20:33Z", "last_trigger_published_at":
-        "2025-12-11T10:20:33Z", "last_triggered_at": "2025-12-12T13:42:33.638019Z",
-        "last_trigger_detected_at": "2025-12-12T13:42:33.638019Z", "hash": "GE2F9myvPOY9d2s6Nfmk51d56pRf/vuWKlf6ibIMmsAAR5GdnkQX790L2ERUA9iz",
-        "ignored": true, "ignored_at": "2025-12-12T13:42:33.647628Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Figma Personal Access Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "", "name": ""}], "user_permission":
-        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "nriv/agar", "type": "azure_cr_repository",
-        "path": "nriv/agar", "source_criticality": "unknown"}], "custom_tags": [],
-        "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0, "score":
-        9, "displayed_occurrence": {"id": 229731464, "issue": 23316251, "account":
-        8, "kind": "HIST", "element": "{\"repository_name\": \"nriv/agar\", \"file_path\":
-        \"main.py\"}", "element_type": "CONTAINER_LAYER", "author_name": "", "author_info":
-        "", "value": null, "value_hash": "OsUesR0NJgwb7nf5Kfb6ySEtDSjDPObGt6O9YVAGqq+VsBrAMp3Kne4OXFGvqCq/",
-        "published_at": "2025-12-11T10:20:33Z", "date": "2025-12-11T10:20:33Z", "detected_at":
-        "2025-12-12T13:42:26.560038Z", "is_vcs_type": false, "last_detected_at": "2025-12-11T10:20:33Z",
-        "last_seen_at": "2025-12-11T10:20:33Z", "data": {"blob_sha": "sha256:245f3fc099b23fceb1a7fecd560f72d771d78b1fbc25f50aba1e22ee4da2f5e8",
-        "image_tag": "v1bis", "manifest_sha": "sha256:a5c5c93bb3e7d6d54cf3ebbc9939122eac28366e5dfdad0083f519ca5b32d287"},
-        "url": "https://portal.azure.com/#browse/Microsoft.ContainerRegistry%2Fregistries",
-        "source": {"id": 24713021, "url": "https://portal.azure.com/#browse/Microsoft.ContainerRegistry%2Fregistries",
-        "type": "azure_cr_repository", "display_name": "nriv/agar", "visibility":
-        "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
-        null, "default_branch": null}, "regression": false, "content": 111314743,
-        "secrets_engine_version": "2.153.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 10, "indice_end": 55, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "main.py", "filename": "main.py", "presence":
-        "visible", "last_presence_seen_at": "2025-12-12T13:42:33.744261Z", "last_presence_check_at":
-        "2025-12-12T13:42:33.744261Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": [{"type": "FROM_HISTORICAL_SCAN",
-        "metadata": null}]}, "has_dropped_occurrences": false, "tags": ["FROM_HISTORICAL_SCAN"],
-        "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}]}'
+        "presence": "visible", "last_presence_seen_at": "2026-05-27T09:51:39.193873Z",
+        "last_presence_check_at": "2026-05-27T09:51:39.193873Z", "first_presence_deleted_at":
+        null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
+        [{"type": "FROM_HISTORICAL_SCAN", "metadata": null, "field": "content"}, {"type":
+        "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH", "FROM_HISTORICAL_SCAN"], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 12}]}'
     headers:
+      CF-RAY:
+      - a10395ab0e6802c1-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:32 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '25266'
+      - '25461'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:49 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '129'
+      - '171'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_detector_category.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_detector_category.yaml
@@ -21,244 +21,241 @@ interactions:
   response:
     body:
       string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?detector_category__in=specific&page=2&page_size=5",
-        "previous": null, "results": [{"id": 29487335, "account": 8, "criterion":
-        "Stripe Webhook Secret", "date": "2026-04-02T16:22:33.518000Z", "last_trigger_published_at":
-        "2026-04-02T16:22:33.518000Z", "last_triggered_at": "2026-04-02T16:22:34.233032Z",
-        "last_trigger_detected_at": "2026-04-02T16:22:34.233032Z", "hash": "JquJu98wTd0k40t3UsNgP22P+ywFCrsGM1VDRg3oZBdGXhRWbjOMbKAG+JtXZUOK",
+        "previous": null, "results": [{"id": 34205503, "account": 8, "criterion":
+        "microsoft_azure_storage_connection_string", "date": "2026-06-23T11:13:31.325324Z",
+        "last_trigger_published_at": "2026-06-23T11:13:31.325324Z", "last_triggered_at":
+        "2026-06-23T11:13:31.343453Z", "last_trigger_detected_at": "2026-06-23T11:13:31.343453Z",
+        "hash": "HdPZ4cjZuziAqsakdlsUnJDapTz3ns5pX8vPzfhvGQvpWWWX25LITKmJimoqGr3z",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Stripe Webhook Secret", "severity_rule_config": null, "declarative_secret_status":
-        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": true,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 62, "displayed_occurrence": {"id": 256867982, "issue": 29487335,
-        "account": 8, "kind": "RLTM", "element": "KAN-8?focusedCommentId=10014", "element_type":
-        "JIRA_COMMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "o40+pCpgMCFgcapQEEdZ3imjEpSONYcgy0J+gLe5ygKDJctj7Ro4REsJrqbUl0yj",
-        "published_at": "2026-04-02T16:22:33.518000Z", "date": "2026-04-02T16:22:33.518000Z",
-        "detected_at": "2026-04-02T16:22:34.031682Z", "is_vcs_type": false, "last_detected_at":
-        "2026-04-02T16:22:33.518000Z", "last_seen_at": "2026-04-02T16:22:33.518000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-8?focusedCommentId=10014",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 148603941, "secrets_engine_version": "2.159.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 25, "indice_end":
-        63, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
-        "2026-04-02T16:22:34.268883Z", "last_presence_check_at": "2026-04-02T16:22:34.268883Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 1}, {"id": 29487333, "account": 8, "criterion":
-        "Slack Bot Token", "date": "2026-04-02T16:22:26.591000Z", "last_trigger_published_at":
-        "2026-04-02T16:22:26.591000Z", "last_triggered_at": "2026-04-02T16:22:27.578209Z",
-        "last_trigger_detected_at": "2026-04-02T16:22:27.578209Z", "hash": "UeONCI+H/I19fHV7Ge45VQxOI0/YUY6CYZu9psQ6W53s6W+UOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-04-02T16:22:27.592459Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": true,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 11, "displayed_occurrence": {"id": 256867977, "issue": 29487333,
-        "account": 8, "kind": "RLTM", "element": "KAN-4?focusedCommentId=10005", "element_type":
-        "JIRA_COMMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "BBZtIrA/2GAvXPBnlTveHP2iPqy+rHM0BxNchD6gRp+/+mUjQPrqnyjHph0vjkPi",
-        "published_at": "2026-04-02T16:22:26.591000Z", "date": "2026-04-02T16:22:26.591000Z",
-        "detected_at": "2026-04-02T16:22:27.022003Z", "is_vcs_type": false, "last_detected_at":
-        "2026-04-02T16:22:26.591000Z", "last_seen_at": "2026-04-02T16:22:26.591000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-4?focusedCommentId=10005",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 148603933, "secrets_engine_version": "2.159.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 25, "indice_end":
-        81, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
-        "2026-04-02T16:22:27.644022Z", "last_presence_check_at": "2026-04-02T16:22:27.644022Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": ["REVOCABLE_BY_GG"],
-        "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
-        29305270, "account": 8, "criterion": "OpenAI API Key", "date": "2026-03-27T13:47:01Z",
-        "last_trigger_published_at": "2026-03-27T13:47:01Z", "last_triggered_at":
-        "2026-03-28T05:01:36.397561Z", "last_trigger_detected_at": "2026-03-28T05:01:36.397561Z",
-        "hash": "MTJFo5AaJdAJ7giIaJE2+Vn/3hEL1nR7oKsu0ry8AAS38W2S95GRLqiXIWrK60u6",
-        "ignored": true, "ignored_at": "2026-03-28T05:01:36.405919Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "OpenAI API Key", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "name": "gg-tools"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-tools / OneDrive", "type": "microsoft_onedrive", "path": "gg-tools
-        / OneDrive", "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata":
-        null, "is_vaulted": false, "similar_issue_count": 0, "score": 6, "displayed_occurrence":
-        {"id": 255746729, "issue": 29305270, "account": 8, "kind": "RLTM", "element":
-        "{\"drive_id\": \"b!ifwT0vIqDE2MYP5tWpOaVJKsAA38ZA1PqHTPWAaO0Ovk8yFkaTlITKSgS6Y2Zlvu\",
-        \"parent_reference_path\": \"/drives/b!ifwT0vIqDE2MYP5tWpOaVJKsAA38ZA1PqHTPWAaO0Ovk8yFkaTlITKSgS6Y2Zlvu/root:/Recordings\",
-        \"file_id\": \"01ICX32E3NSJA7PEQVFZAKEEXG4DH65RP4\"}", "element_type": "SHAREPOINT_ONEDRIVE_FILE",
-        "author_name": "gg-tools", "author_info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "value": null, "value_hash": "CFPFVOpXX+26OfRN+bRLyvVCXnQmU1Cpu36m73v5F4pgz7WMu+D6UW65wQZMF7kQ",
-        "published_at": "2026-03-27T13:47:01Z", "date": "2026-03-27T13:47:01Z", "detected_at":
-        "2026-03-28T04:58:40.843022Z", "is_vcs_type": false, "last_detected_at": "2026-03-27T13:47:01Z",
-        "last_seen_at": "2026-03-27T13:47:01Z", "data": {}, "url": "https://gitguardianengineering-my.sharepoint.com/personal/gg-tools_gitguardianengineering_onmicrosoft_com/Documents/Recordings/secret.txt",
-        "source": {"id": 19962591, "url": "https://onedrive.com/", "type": "microsoft_onedrive",
-        "display_name": "gg-tools / OneDrive", "visibility": "private", "monitored":
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
+        "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
+        "detected_at": "2026-06-23T11:13:31.325324Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
+        "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
         true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null}, "regression": false, "content": 147214824, "secrets_engine_version":
-        "2.159.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 8, "indice_end": 59, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "Recordings/secret.txt", "filename":
-        "secret.txt", "presence": "visible", "last_presence_seen_at": "2026-03-28T05:01:36.456203Z",
-        "last_presence_check_at": "2026-03-28T05:01:36.456203Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": []},
-        "has_dropped_occurrences": false, "tags": ["REVOCABLE_BY_GG"], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 1}, {"id": 29236129, "account": 8, "criterion":
-        "Slack Bot Token", "date": "2026-03-26T16:10:40Z", "last_trigger_published_at":
-        "2026-03-26T16:10:40Z", "last_triggered_at": "2026-03-26T16:10:55.648969Z",
-        "last_trigger_detected_at": "2026-03-26T16:10:55.648969Z", "hash": "0Y7z2cw2c6cwAdy+TeYUL5BKR7Lb/hDQRLHld5PCWUkg5Q0OOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-03-26T16:10:55.689671Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "pierrelalanne/test_repo", "type": "gh_repository", "path": "pierrelalanne/test_repo",
-        "source_criticality": "critical"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 0, "displayed_occurrence":
-        {"id": 253938087, "issue": 29236129, "account": 8, "kind": "RLTM", "element":
-        "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
-        "value": null, "value_hash": "CEL9N36auQTdl9e+bqgAsGyWN0vVPYlqvHWSQMXxC/1zmdQrKYk359La8N2L+SIi",
-        "published_at": "2026-03-26T16:10:40Z", "date": "2026-03-26T16:10:40Z", "detected_at":
-        "2026-03-26T16:10:51.878216Z", "is_vcs_type": true, "last_detected_at": "2026-03-26T16:10:40Z",
-        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R1",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
-        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 146712049,
-        "secrets_engine_version": "2.159.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 60, "indice_end": 102, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 1, "post_line_end": 1}], "most_sensitive_match_name":
-        "apikey", "insights": [{"name": "test_file", "source": "document", "metadata":
-        null}], "filepath": "test_limits_1_secret.txt", "filename": "test_limits_1_secret.txt",
-        "presence": "visible", "last_presence_seen_at": "2026-03-26T16:10:55.988339Z",
-        "last_presence_check_at": "2026-03-26T16:10:55.988339Z", "first_presence_deleted_at":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
+        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
+        34186239, "account": 8, "criterion": "Generic Password", "date": "2026-06-22T15:14:57Z",
+        "last_trigger_published_at": "2026-06-22T15:14:57Z", "last_triggered_at":
+        "2026-06-22T15:16:49.799821Z", "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z",
+        "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Generic Password", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
+        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
+        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
+        "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
+        "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
+        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 113, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_63.txt", "filename":
+        "configuration_63.txt", "presence": "visible", "last_presence_seen_at": "2026-06-22T15:16:49.824313Z",
+        "last_presence_check_at": "2026-06-22T15:16:49.824313Z", "first_presence_deleted_at":
         null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}, {"type": "DEFAULT_BRANCH", "metadata":
-        null}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG",
-        "TEST_FILE"], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
-        29236130, "account": 8, "criterion": "Slack Bot Token", "date": "2026-03-26T16:10:40Z",
-        "last_trigger_published_at": "2026-03-26T16:10:40Z", "last_triggered_at":
-        "2026-03-26T16:10:55.649133Z", "last_trigger_detected_at": "2026-03-26T16:10:55.649133Z",
-        "hash": "1d291ZrFV0RBbVE8r2t6EFI1jgdXhzZkb4RYrNKH10mjkZ9yOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-03-26T16:10:55.695057Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "pierrelalanne/test_repo", "type": "gh_repository", "path": "pierrelalanne/test_repo",
-        "source_criticality": "critical"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 10, "score": 0, "displayed_occurrence":
-        {"id": 253938082, "issue": 29236130, "account": 8, "kind": "RLTM", "element":
-        "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
-        "value": null, "value_hash": "8CeYKeR2kMER0aBlyGThkdNGWeRYfKFLPj1kOQJO8lH2bXzFs7jhuR1VfR21VK1W",
-        "published_at": "2026-03-26T16:10:40Z", "date": "2026-03-26T16:10:40Z", "detected_at":
-        "2026-03-26T16:10:51.878216Z", "is_vcs_type": true, "last_detected_at": "2026-03-26T16:10:40Z",
-        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R20",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
-        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 146712049,
-        "secrets_engine_version": "2.159.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 896, "indice_end": 938, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 20, "post_line_end": 20}], "most_sensitive_match_name":
-        "apikey", "insights": [{"name": "test_file", "source": "document", "metadata":
-        null}], "filepath": "test_limits_1_secret.txt", "filename": "test_limits_1_secret.txt",
-        "presence": "visible", "last_presence_seen_at": "2026-03-26T16:10:55.988339Z",
-        "last_presence_check_at": "2026-03-26T16:10:55.988339Z", "first_presence_deleted_at":
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 34181686, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-22T11:25:45.739149Z", "last_trigger_published_at": "2026-06-22T11:25:45.739149Z",
+        "last_triggered_at": "2026-06-22T11:25:45.762592Z", "last_trigger_detected_at":
+        "2026-06-22T11:25:45.762592Z", "hash": "gVrL/pjjFLo7sSikPS1pWtPJbr+oWSSVz8IB6+2ViJDSJKiK25LITKmJimoqGr3z",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": true, "resolved_at": "2026-06-22T11:26:52.971214Z", "resolver":
+        1751937, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
+        "none", "ignorer_type": "none", "resolver_display_name": "candidate.playground+eu@gitguardian.com",
+        "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
+        "none", "status": "RESOLVED", "issue_name": "Microsoft Azure Storage Connection
+        String", "severity_rule_config": null, "declarative_secret_status": "revoked",
+        "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "", "name": "Kashyapa P.A. Jayasekera"}],
+        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "GGFRLTA127
+        \u2014 kashyapap.jayasekera", "type": "endpoints", "path": "GGFRLTA127 \u2014
+        kashyapap.jayasekera", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274639444, "issue": 34181686, "account": 8, "kind": "RLTM", "element":
+        "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "AAr6ayAj6Hs2pOICdVUlEyuXlsQ78K3HFGOJgWA/yAiQrRuQH9Kv1GxUH36IT99d",
+        "published_at": "2026-06-22T11:25:45.739149Z", "date": "2026-06-22T11:25:45.739149Z",
+        "detected_at": "2026-06-22T11:25:45.739149Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-22T11:25:45.739149Z", "last_seen_at": "2026-06-22T11:25:45.739149Z",
+        "data": {"line": 20, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-22T11:25:45.739149Z", "last_presence_check_at":
+        "2026-06-22T11:25:45.739149Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 6}, {"id":
+        34122510, "account": 8, "criterion": "Generic Password", "date": "2026-06-19T13:41:03Z",
+        "last_trigger_published_at": "2026-06-19T13:41:03Z", "last_triggered_at":
+        "2026-06-19T13:43:05.020137Z", "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z",
+        "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Generic Password", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
+        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
+        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
+        "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
+        "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 129, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_62.txt", "filename":
+        "configuration_62.txt", "presence": "visible", "last_presence_seen_at": "2026-06-19T13:43:05.062490Z",
+        "last_presence_check_at": "2026-06-19T13:43:05.062490Z", "first_presence_deleted_at":
         null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}, {"type": "DEFAULT_BRANCH", "metadata":
-        null}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG",
-        "TEST_FILE"], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}]}'
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 34038186, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-16T18:55:43.166667Z", "last_trigger_published_at": "2026-06-16T18:55:43.166667Z",
+        "last_triggered_at": "2026-06-16T18:55:43.185061Z", "last_trigger_detected_at":
+        "2026-06-16T18:55:43.185061Z", "hash": "JFTpQX+4P/dEcXJJ2iw+u54JYDsJnqLtrdws1wjFQ8t9LtHh25LITKmJimoqGr3z",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
+        "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
+        "detected_at": "2026-06-16T18:55:43.166667Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
+        "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
+        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}]}'
     headers:
+      CF-RAY:
+      - a1039594d8d03d5d-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:28 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '23407'
+      - '22565'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:44 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '135'
+      - '120'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_detector_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_detector_filter.yaml
@@ -21,244 +21,241 @@ interactions:
   response:
     body:
       string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?detector_group_name__in=AWS+Keys&page=2&page_size=5",
-        "previous": null, "results": [{"id": 29487335, "account": 8, "criterion":
-        "Stripe Webhook Secret", "date": "2026-04-02T16:22:33.518000Z", "last_trigger_published_at":
-        "2026-04-02T16:22:33.518000Z", "last_triggered_at": "2026-04-02T16:22:34.233032Z",
-        "last_trigger_detected_at": "2026-04-02T16:22:34.233032Z", "hash": "JquJu98wTd0k40t3UsNgP22P+ywFCrsGM1VDRg3oZBdGXhRWbjOMbKAG+JtXZUOK",
+        "previous": null, "results": [{"id": 34205503, "account": 8, "criterion":
+        "microsoft_azure_storage_connection_string", "date": "2026-06-23T11:13:31.325324Z",
+        "last_trigger_published_at": "2026-06-23T11:13:31.325324Z", "last_triggered_at":
+        "2026-06-23T11:13:31.343453Z", "last_trigger_detected_at": "2026-06-23T11:13:31.343453Z",
+        "hash": "HdPZ4cjZuziAqsakdlsUnJDapTz3ns5pX8vPzfhvGQvpWWWX25LITKmJimoqGr3z",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Stripe Webhook Secret", "severity_rule_config": null, "declarative_secret_status":
-        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": true,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 62, "displayed_occurrence": {"id": 256867982, "issue": 29487335,
-        "account": 8, "kind": "RLTM", "element": "KAN-8?focusedCommentId=10014", "element_type":
-        "JIRA_COMMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "o40+pCpgMCFgcapQEEdZ3imjEpSONYcgy0J+gLe5ygKDJctj7Ro4REsJrqbUl0yj",
-        "published_at": "2026-04-02T16:22:33.518000Z", "date": "2026-04-02T16:22:33.518000Z",
-        "detected_at": "2026-04-02T16:22:34.031682Z", "is_vcs_type": false, "last_detected_at":
-        "2026-04-02T16:22:33.518000Z", "last_seen_at": "2026-04-02T16:22:33.518000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-8?focusedCommentId=10014",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 148603941, "secrets_engine_version": "2.159.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 25, "indice_end":
-        63, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
-        "2026-04-02T16:22:34.268883Z", "last_presence_check_at": "2026-04-02T16:22:34.268883Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 1}, {"id": 29487333, "account": 8, "criterion":
-        "Slack Bot Token", "date": "2026-04-02T16:22:26.591000Z", "last_trigger_published_at":
-        "2026-04-02T16:22:26.591000Z", "last_triggered_at": "2026-04-02T16:22:27.578209Z",
-        "last_trigger_detected_at": "2026-04-02T16:22:27.578209Z", "hash": "UeONCI+H/I19fHV7Ge45VQxOI0/YUY6CYZu9psQ6W53s6W+UOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-04-02T16:22:27.592459Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": true,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 11, "displayed_occurrence": {"id": 256867977, "issue": 29487333,
-        "account": 8, "kind": "RLTM", "element": "KAN-4?focusedCommentId=10005", "element_type":
-        "JIRA_COMMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "BBZtIrA/2GAvXPBnlTveHP2iPqy+rHM0BxNchD6gRp+/+mUjQPrqnyjHph0vjkPi",
-        "published_at": "2026-04-02T16:22:26.591000Z", "date": "2026-04-02T16:22:26.591000Z",
-        "detected_at": "2026-04-02T16:22:27.022003Z", "is_vcs_type": false, "last_detected_at":
-        "2026-04-02T16:22:26.591000Z", "last_seen_at": "2026-04-02T16:22:26.591000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-4?focusedCommentId=10005",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 148603933, "secrets_engine_version": "2.159.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 25, "indice_end":
-        81, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
-        "2026-04-02T16:22:27.644022Z", "last_presence_check_at": "2026-04-02T16:22:27.644022Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": ["REVOCABLE_BY_GG"],
-        "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
-        29305270, "account": 8, "criterion": "OpenAI API Key", "date": "2026-03-27T13:47:01Z",
-        "last_trigger_published_at": "2026-03-27T13:47:01Z", "last_triggered_at":
-        "2026-03-28T05:01:36.397561Z", "last_trigger_detected_at": "2026-03-28T05:01:36.397561Z",
-        "hash": "MTJFo5AaJdAJ7giIaJE2+Vn/3hEL1nR7oKsu0ry8AAS38W2S95GRLqiXIWrK60u6",
-        "ignored": true, "ignored_at": "2026-03-28T05:01:36.405919Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "OpenAI API Key", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "name": "gg-tools"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-tools / OneDrive", "type": "microsoft_onedrive", "path": "gg-tools
-        / OneDrive", "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata":
-        null, "is_vaulted": false, "similar_issue_count": 0, "score": 6, "displayed_occurrence":
-        {"id": 255746729, "issue": 29305270, "account": 8, "kind": "RLTM", "element":
-        "{\"drive_id\": \"b!ifwT0vIqDE2MYP5tWpOaVJKsAA38ZA1PqHTPWAaO0Ovk8yFkaTlITKSgS6Y2Zlvu\",
-        \"parent_reference_path\": \"/drives/b!ifwT0vIqDE2MYP5tWpOaVJKsAA38ZA1PqHTPWAaO0Ovk8yFkaTlITKSgS6Y2Zlvu/root:/Recordings\",
-        \"file_id\": \"01ICX32E3NSJA7PEQVFZAKEEXG4DH65RP4\"}", "element_type": "SHAREPOINT_ONEDRIVE_FILE",
-        "author_name": "gg-tools", "author_info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "value": null, "value_hash": "CFPFVOpXX+26OfRN+bRLyvVCXnQmU1Cpu36m73v5F4pgz7WMu+D6UW65wQZMF7kQ",
-        "published_at": "2026-03-27T13:47:01Z", "date": "2026-03-27T13:47:01Z", "detected_at":
-        "2026-03-28T04:58:40.843022Z", "is_vcs_type": false, "last_detected_at": "2026-03-27T13:47:01Z",
-        "last_seen_at": "2026-03-27T13:47:01Z", "data": {}, "url": "https://gitguardianengineering-my.sharepoint.com/personal/gg-tools_gitguardianengineering_onmicrosoft_com/Documents/Recordings/secret.txt",
-        "source": {"id": 19962591, "url": "https://onedrive.com/", "type": "microsoft_onedrive",
-        "display_name": "gg-tools / OneDrive", "visibility": "private", "monitored":
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
+        "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
+        "detected_at": "2026-06-23T11:13:31.325324Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
+        "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
         true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null}, "regression": false, "content": 147214824, "secrets_engine_version":
-        "2.159.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 8, "indice_end": 59, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "Recordings/secret.txt", "filename":
-        "secret.txt", "presence": "visible", "last_presence_seen_at": "2026-03-28T05:01:36.456203Z",
-        "last_presence_check_at": "2026-03-28T05:01:36.456203Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": []},
-        "has_dropped_occurrences": false, "tags": ["REVOCABLE_BY_GG"], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 1}, {"id": 29236129, "account": 8, "criterion":
-        "Slack Bot Token", "date": "2026-03-26T16:10:40Z", "last_trigger_published_at":
-        "2026-03-26T16:10:40Z", "last_triggered_at": "2026-03-26T16:10:55.648969Z",
-        "last_trigger_detected_at": "2026-03-26T16:10:55.648969Z", "hash": "0Y7z2cw2c6cwAdy+TeYUL5BKR7Lb/hDQRLHld5PCWUkg5Q0OOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-03-26T16:10:55.689671Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "pierrelalanne/test_repo", "type": "gh_repository", "path": "pierrelalanne/test_repo",
-        "source_criticality": "critical"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 0, "displayed_occurrence":
-        {"id": 253938087, "issue": 29236129, "account": 8, "kind": "RLTM", "element":
-        "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
-        "value": null, "value_hash": "CEL9N36auQTdl9e+bqgAsGyWN0vVPYlqvHWSQMXxC/1zmdQrKYk359La8N2L+SIi",
-        "published_at": "2026-03-26T16:10:40Z", "date": "2026-03-26T16:10:40Z", "detected_at":
-        "2026-03-26T16:10:51.878216Z", "is_vcs_type": true, "last_detected_at": "2026-03-26T16:10:40Z",
-        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R1",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
-        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 146712049,
-        "secrets_engine_version": "2.159.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 60, "indice_end": 102, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 1, "post_line_end": 1}], "most_sensitive_match_name":
-        "apikey", "insights": [{"name": "test_file", "source": "document", "metadata":
-        null}], "filepath": "test_limits_1_secret.txt", "filename": "test_limits_1_secret.txt",
-        "presence": "visible", "last_presence_seen_at": "2026-03-26T16:10:55.988339Z",
-        "last_presence_check_at": "2026-03-26T16:10:55.988339Z", "first_presence_deleted_at":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
+        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
+        34186239, "account": 8, "criterion": "Generic Password", "date": "2026-06-22T15:14:57Z",
+        "last_trigger_published_at": "2026-06-22T15:14:57Z", "last_triggered_at":
+        "2026-06-22T15:16:49.799821Z", "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z",
+        "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Generic Password", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
+        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
+        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
+        "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
+        "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
+        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 113, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_63.txt", "filename":
+        "configuration_63.txt", "presence": "visible", "last_presence_seen_at": "2026-06-22T15:16:49.824313Z",
+        "last_presence_check_at": "2026-06-22T15:16:49.824313Z", "first_presence_deleted_at":
         null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}, {"type": "DEFAULT_BRANCH", "metadata":
-        null}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG",
-        "TEST_FILE"], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
-        29236130, "account": 8, "criterion": "Slack Bot Token", "date": "2026-03-26T16:10:40Z",
-        "last_trigger_published_at": "2026-03-26T16:10:40Z", "last_triggered_at":
-        "2026-03-26T16:10:55.649133Z", "last_trigger_detected_at": "2026-03-26T16:10:55.649133Z",
-        "hash": "1d291ZrFV0RBbVE8r2t6EFI1jgdXhzZkb4RYrNKH10mjkZ9yOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-03-26T16:10:55.695057Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "pierrelalanne/test_repo", "type": "gh_repository", "path": "pierrelalanne/test_repo",
-        "source_criticality": "critical"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 10, "score": 0, "displayed_occurrence":
-        {"id": 253938082, "issue": 29236130, "account": 8, "kind": "RLTM", "element":
-        "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
-        "value": null, "value_hash": "8CeYKeR2kMER0aBlyGThkdNGWeRYfKFLPj1kOQJO8lH2bXzFs7jhuR1VfR21VK1W",
-        "published_at": "2026-03-26T16:10:40Z", "date": "2026-03-26T16:10:40Z", "detected_at":
-        "2026-03-26T16:10:51.878216Z", "is_vcs_type": true, "last_detected_at": "2026-03-26T16:10:40Z",
-        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R20",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
-        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 146712049,
-        "secrets_engine_version": "2.159.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 896, "indice_end": 938, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 20, "post_line_end": 20}], "most_sensitive_match_name":
-        "apikey", "insights": [{"name": "test_file", "source": "document", "metadata":
-        null}], "filepath": "test_limits_1_secret.txt", "filename": "test_limits_1_secret.txt",
-        "presence": "visible", "last_presence_seen_at": "2026-03-26T16:10:55.988339Z",
-        "last_presence_check_at": "2026-03-26T16:10:55.988339Z", "first_presence_deleted_at":
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 34181686, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-22T11:25:45.739149Z", "last_trigger_published_at": "2026-06-22T11:25:45.739149Z",
+        "last_triggered_at": "2026-06-22T11:25:45.762592Z", "last_trigger_detected_at":
+        "2026-06-22T11:25:45.762592Z", "hash": "gVrL/pjjFLo7sSikPS1pWtPJbr+oWSSVz8IB6+2ViJDSJKiK25LITKmJimoqGr3z",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": true, "resolved_at": "2026-06-22T11:26:52.971214Z", "resolver":
+        1751937, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
+        "none", "ignorer_type": "none", "resolver_display_name": "candidate.playground+eu@gitguardian.com",
+        "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
+        "none", "status": "RESOLVED", "issue_name": "Microsoft Azure Storage Connection
+        String", "severity_rule_config": null, "declarative_secret_status": "revoked",
+        "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "", "name": "Kashyapa P.A. Jayasekera"}],
+        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "GGFRLTA127
+        \u2014 kashyapap.jayasekera", "type": "endpoints", "path": "GGFRLTA127 \u2014
+        kashyapap.jayasekera", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274639444, "issue": 34181686, "account": 8, "kind": "RLTM", "element":
+        "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "AAr6ayAj6Hs2pOICdVUlEyuXlsQ78K3HFGOJgWA/yAiQrRuQH9Kv1GxUH36IT99d",
+        "published_at": "2026-06-22T11:25:45.739149Z", "date": "2026-06-22T11:25:45.739149Z",
+        "detected_at": "2026-06-22T11:25:45.739149Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-22T11:25:45.739149Z", "last_seen_at": "2026-06-22T11:25:45.739149Z",
+        "data": {"line": 20, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-22T11:25:45.739149Z", "last_presence_check_at":
+        "2026-06-22T11:25:45.739149Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 6}, {"id":
+        34122510, "account": 8, "criterion": "Generic Password", "date": "2026-06-19T13:41:03Z",
+        "last_trigger_published_at": "2026-06-19T13:41:03Z", "last_triggered_at":
+        "2026-06-19T13:43:05.020137Z", "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z",
+        "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Generic Password", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
+        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
+        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
+        "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
+        "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 129, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_62.txt", "filename":
+        "configuration_62.txt", "presence": "visible", "last_presence_seen_at": "2026-06-19T13:43:05.062490Z",
+        "last_presence_check_at": "2026-06-19T13:43:05.062490Z", "first_presence_deleted_at":
         null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}, {"type": "DEFAULT_BRANCH", "metadata":
-        null}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG",
-        "TEST_FILE"], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}]}'
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 34038186, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-16T18:55:43.166667Z", "last_trigger_published_at": "2026-06-16T18:55:43.166667Z",
+        "last_triggered_at": "2026-06-16T18:55:43.185061Z", "last_trigger_detected_at":
+        "2026-06-16T18:55:43.185061Z", "hash": "JFTpQX+4P/dEcXJJ2iw+u54JYDsJnqLtrdws1wjFQ8t9LtHh25LITKmJimoqGr3z",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
+        "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
+        "detected_at": "2026-06-16T18:55:43.166667Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
+        "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
+        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}]}'
     headers:
+      CF-RAY:
+      - a1039567b9bc250f-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:21 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '23409'
+      - '22567'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:39 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '163'
+      - '135'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_feedback.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_feedback.yaml
@@ -21,244 +21,241 @@ interactions:
   response:
     body:
       string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?feedback=true&page=2&page_size=5",
-        "previous": null, "results": [{"id": 29487335, "account": 8, "criterion":
-        "Stripe Webhook Secret", "date": "2026-04-02T16:22:33.518000Z", "last_trigger_published_at":
-        "2026-04-02T16:22:33.518000Z", "last_triggered_at": "2026-04-02T16:22:34.233032Z",
-        "last_trigger_detected_at": "2026-04-02T16:22:34.233032Z", "hash": "JquJu98wTd0k40t3UsNgP22P+ywFCrsGM1VDRg3oZBdGXhRWbjOMbKAG+JtXZUOK",
+        "previous": null, "results": [{"id": 34205503, "account": 8, "criterion":
+        "microsoft_azure_storage_connection_string", "date": "2026-06-23T11:13:31.325324Z",
+        "last_trigger_published_at": "2026-06-23T11:13:31.325324Z", "last_triggered_at":
+        "2026-06-23T11:13:31.343453Z", "last_trigger_detected_at": "2026-06-23T11:13:31.343453Z",
+        "hash": "HdPZ4cjZuziAqsakdlsUnJDapTz3ns5pX8vPzfhvGQvpWWWX25LITKmJimoqGr3z",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Stripe Webhook Secret", "severity_rule_config": null, "declarative_secret_status":
-        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": true,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 62, "displayed_occurrence": {"id": 256867982, "issue": 29487335,
-        "account": 8, "kind": "RLTM", "element": "KAN-8?focusedCommentId=10014", "element_type":
-        "JIRA_COMMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "o40+pCpgMCFgcapQEEdZ3imjEpSONYcgy0J+gLe5ygKDJctj7Ro4REsJrqbUl0yj",
-        "published_at": "2026-04-02T16:22:33.518000Z", "date": "2026-04-02T16:22:33.518000Z",
-        "detected_at": "2026-04-02T16:22:34.031682Z", "is_vcs_type": false, "last_detected_at":
-        "2026-04-02T16:22:33.518000Z", "last_seen_at": "2026-04-02T16:22:33.518000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-8?focusedCommentId=10014",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 148603941, "secrets_engine_version": "2.159.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 25, "indice_end":
-        63, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
-        "2026-04-02T16:22:34.268883Z", "last_presence_check_at": "2026-04-02T16:22:34.268883Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 1}, {"id": 29487333, "account": 8, "criterion":
-        "Slack Bot Token", "date": "2026-04-02T16:22:26.591000Z", "last_trigger_published_at":
-        "2026-04-02T16:22:26.591000Z", "last_triggered_at": "2026-04-02T16:22:27.578209Z",
-        "last_trigger_detected_at": "2026-04-02T16:22:27.578209Z", "hash": "UeONCI+H/I19fHV7Ge45VQxOI0/YUY6CYZu9psQ6W53s6W+UOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-04-02T16:22:27.592459Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": true,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 11, "displayed_occurrence": {"id": 256867977, "issue": 29487333,
-        "account": 8, "kind": "RLTM", "element": "KAN-4?focusedCommentId=10005", "element_type":
-        "JIRA_COMMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "BBZtIrA/2GAvXPBnlTveHP2iPqy+rHM0BxNchD6gRp+/+mUjQPrqnyjHph0vjkPi",
-        "published_at": "2026-04-02T16:22:26.591000Z", "date": "2026-04-02T16:22:26.591000Z",
-        "detected_at": "2026-04-02T16:22:27.022003Z", "is_vcs_type": false, "last_detected_at":
-        "2026-04-02T16:22:26.591000Z", "last_seen_at": "2026-04-02T16:22:26.591000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-4?focusedCommentId=10005",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 148603933, "secrets_engine_version": "2.159.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 25, "indice_end":
-        81, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
-        "2026-04-02T16:22:27.644022Z", "last_presence_check_at": "2026-04-02T16:22:27.644022Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": ["REVOCABLE_BY_GG"],
-        "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
-        29305270, "account": 8, "criterion": "OpenAI API Key", "date": "2026-03-27T13:47:01Z",
-        "last_trigger_published_at": "2026-03-27T13:47:01Z", "last_triggered_at":
-        "2026-03-28T05:01:36.397561Z", "last_trigger_detected_at": "2026-03-28T05:01:36.397561Z",
-        "hash": "MTJFo5AaJdAJ7giIaJE2+Vn/3hEL1nR7oKsu0ry8AAS38W2S95GRLqiXIWrK60u6",
-        "ignored": true, "ignored_at": "2026-03-28T05:01:36.405919Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "OpenAI API Key", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "name": "gg-tools"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-tools / OneDrive", "type": "microsoft_onedrive", "path": "gg-tools
-        / OneDrive", "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata":
-        null, "is_vaulted": false, "similar_issue_count": 0, "score": 6, "displayed_occurrence":
-        {"id": 255746729, "issue": 29305270, "account": 8, "kind": "RLTM", "element":
-        "{\"drive_id\": \"b!ifwT0vIqDE2MYP5tWpOaVJKsAA38ZA1PqHTPWAaO0Ovk8yFkaTlITKSgS6Y2Zlvu\",
-        \"parent_reference_path\": \"/drives/b!ifwT0vIqDE2MYP5tWpOaVJKsAA38ZA1PqHTPWAaO0Ovk8yFkaTlITKSgS6Y2Zlvu/root:/Recordings\",
-        \"file_id\": \"01ICX32E3NSJA7PEQVFZAKEEXG4DH65RP4\"}", "element_type": "SHAREPOINT_ONEDRIVE_FILE",
-        "author_name": "gg-tools", "author_info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "value": null, "value_hash": "CFPFVOpXX+26OfRN+bRLyvVCXnQmU1Cpu36m73v5F4pgz7WMu+D6UW65wQZMF7kQ",
-        "published_at": "2026-03-27T13:47:01Z", "date": "2026-03-27T13:47:01Z", "detected_at":
-        "2026-03-28T04:58:40.843022Z", "is_vcs_type": false, "last_detected_at": "2026-03-27T13:47:01Z",
-        "last_seen_at": "2026-03-27T13:47:01Z", "data": {}, "url": "https://gitguardianengineering-my.sharepoint.com/personal/gg-tools_gitguardianengineering_onmicrosoft_com/Documents/Recordings/secret.txt",
-        "source": {"id": 19962591, "url": "https://onedrive.com/", "type": "microsoft_onedrive",
-        "display_name": "gg-tools / OneDrive", "visibility": "private", "monitored":
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
+        "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
+        "detected_at": "2026-06-23T11:13:31.325324Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
+        "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
         true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null}, "regression": false, "content": 147214824, "secrets_engine_version":
-        "2.159.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 8, "indice_end": 59, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "Recordings/secret.txt", "filename":
-        "secret.txt", "presence": "visible", "last_presence_seen_at": "2026-03-28T05:01:36.456203Z",
-        "last_presence_check_at": "2026-03-28T05:01:36.456203Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": []},
-        "has_dropped_occurrences": false, "tags": ["REVOCABLE_BY_GG"], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 1}, {"id": 29236129, "account": 8, "criterion":
-        "Slack Bot Token", "date": "2026-03-26T16:10:40Z", "last_trigger_published_at":
-        "2026-03-26T16:10:40Z", "last_triggered_at": "2026-03-26T16:10:55.648969Z",
-        "last_trigger_detected_at": "2026-03-26T16:10:55.648969Z", "hash": "0Y7z2cw2c6cwAdy+TeYUL5BKR7Lb/hDQRLHld5PCWUkg5Q0OOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-03-26T16:10:55.689671Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "pierrelalanne/test_repo", "type": "gh_repository", "path": "pierrelalanne/test_repo",
-        "source_criticality": "critical"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 0, "displayed_occurrence":
-        {"id": 253938087, "issue": 29236129, "account": 8, "kind": "RLTM", "element":
-        "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
-        "value": null, "value_hash": "CEL9N36auQTdl9e+bqgAsGyWN0vVPYlqvHWSQMXxC/1zmdQrKYk359La8N2L+SIi",
-        "published_at": "2026-03-26T16:10:40Z", "date": "2026-03-26T16:10:40Z", "detected_at":
-        "2026-03-26T16:10:51.878216Z", "is_vcs_type": true, "last_detected_at": "2026-03-26T16:10:40Z",
-        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R1",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
-        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 146712049,
-        "secrets_engine_version": "2.159.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 60, "indice_end": 102, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 1, "post_line_end": 1}], "most_sensitive_match_name":
-        "apikey", "insights": [{"name": "test_file", "source": "document", "metadata":
-        null}], "filepath": "test_limits_1_secret.txt", "filename": "test_limits_1_secret.txt",
-        "presence": "visible", "last_presence_seen_at": "2026-03-26T16:10:55.988339Z",
-        "last_presence_check_at": "2026-03-26T16:10:55.988339Z", "first_presence_deleted_at":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
+        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
+        34186239, "account": 8, "criterion": "Generic Password", "date": "2026-06-22T15:14:57Z",
+        "last_trigger_published_at": "2026-06-22T15:14:57Z", "last_triggered_at":
+        "2026-06-22T15:16:49.799821Z", "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z",
+        "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Generic Password", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
+        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
+        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
+        "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
+        "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
+        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 113, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_63.txt", "filename":
+        "configuration_63.txt", "presence": "visible", "last_presence_seen_at": "2026-06-22T15:16:49.824313Z",
+        "last_presence_check_at": "2026-06-22T15:16:49.824313Z", "first_presence_deleted_at":
         null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}, {"type": "DEFAULT_BRANCH", "metadata":
-        null}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG",
-        "TEST_FILE"], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
-        29236130, "account": 8, "criterion": "Slack Bot Token", "date": "2026-03-26T16:10:40Z",
-        "last_trigger_published_at": "2026-03-26T16:10:40Z", "last_triggered_at":
-        "2026-03-26T16:10:55.649133Z", "last_trigger_detected_at": "2026-03-26T16:10:55.649133Z",
-        "hash": "1d291ZrFV0RBbVE8r2t6EFI1jgdXhzZkb4RYrNKH10mjkZ9yOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-03-26T16:10:55.695057Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "pierrelalanne/test_repo", "type": "gh_repository", "path": "pierrelalanne/test_repo",
-        "source_criticality": "critical"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 10, "score": 0, "displayed_occurrence":
-        {"id": 253938082, "issue": 29236130, "account": 8, "kind": "RLTM", "element":
-        "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
-        "value": null, "value_hash": "8CeYKeR2kMER0aBlyGThkdNGWeRYfKFLPj1kOQJO8lH2bXzFs7jhuR1VfR21VK1W",
-        "published_at": "2026-03-26T16:10:40Z", "date": "2026-03-26T16:10:40Z", "detected_at":
-        "2026-03-26T16:10:51.878216Z", "is_vcs_type": true, "last_detected_at": "2026-03-26T16:10:40Z",
-        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R20",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
-        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 146712049,
-        "secrets_engine_version": "2.159.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 896, "indice_end": 938, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 20, "post_line_end": 20}], "most_sensitive_match_name":
-        "apikey", "insights": [{"name": "test_file", "source": "document", "metadata":
-        null}], "filepath": "test_limits_1_secret.txt", "filename": "test_limits_1_secret.txt",
-        "presence": "visible", "last_presence_seen_at": "2026-03-26T16:10:55.988339Z",
-        "last_presence_check_at": "2026-03-26T16:10:55.988339Z", "first_presence_deleted_at":
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 34181686, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-22T11:25:45.739149Z", "last_trigger_published_at": "2026-06-22T11:25:45.739149Z",
+        "last_triggered_at": "2026-06-22T11:25:45.762592Z", "last_trigger_detected_at":
+        "2026-06-22T11:25:45.762592Z", "hash": "gVrL/pjjFLo7sSikPS1pWtPJbr+oWSSVz8IB6+2ViJDSJKiK25LITKmJimoqGr3z",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": true, "resolved_at": "2026-06-22T11:26:52.971214Z", "resolver":
+        1751937, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
+        "none", "ignorer_type": "none", "resolver_display_name": "candidate.playground+eu@gitguardian.com",
+        "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
+        "none", "status": "RESOLVED", "issue_name": "Microsoft Azure Storage Connection
+        String", "severity_rule_config": null, "declarative_secret_status": "revoked",
+        "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "", "name": "Kashyapa P.A. Jayasekera"}],
+        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "GGFRLTA127
+        \u2014 kashyapap.jayasekera", "type": "endpoints", "path": "GGFRLTA127 \u2014
+        kashyapap.jayasekera", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274639444, "issue": 34181686, "account": 8, "kind": "RLTM", "element":
+        "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "AAr6ayAj6Hs2pOICdVUlEyuXlsQ78K3HFGOJgWA/yAiQrRuQH9Kv1GxUH36IT99d",
+        "published_at": "2026-06-22T11:25:45.739149Z", "date": "2026-06-22T11:25:45.739149Z",
+        "detected_at": "2026-06-22T11:25:45.739149Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-22T11:25:45.739149Z", "last_seen_at": "2026-06-22T11:25:45.739149Z",
+        "data": {"line": 20, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-22T11:25:45.739149Z", "last_presence_check_at":
+        "2026-06-22T11:25:45.739149Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 6}, {"id":
+        34122510, "account": 8, "criterion": "Generic Password", "date": "2026-06-19T13:41:03Z",
+        "last_trigger_published_at": "2026-06-19T13:41:03Z", "last_triggered_at":
+        "2026-06-19T13:43:05.020137Z", "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z",
+        "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Generic Password", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
+        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
+        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
+        "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
+        "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 129, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_62.txt", "filename":
+        "configuration_62.txt", "presence": "visible", "last_presence_seen_at": "2026-06-19T13:43:05.062490Z",
+        "last_presence_check_at": "2026-06-19T13:43:05.062490Z", "first_presence_deleted_at":
         null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}, {"type": "DEFAULT_BRANCH", "metadata":
-        null}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG",
-        "TEST_FILE"], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}]}'
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 34038186, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-16T18:55:43.166667Z", "last_trigger_published_at": "2026-06-16T18:55:43.166667Z",
+        "last_triggered_at": "2026-06-16T18:55:43.185061Z", "last_trigger_detected_at":
+        "2026-06-16T18:55:43.185061Z", "hash": "JFTpQX+4P/dEcXJJ2iw+u54JYDsJnqLtrdws1wjFQ8t9LtHh25LITKmJimoqGr3z",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
+        "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
+        "detected_at": "2026-06-16T18:55:43.166667Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
+        "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
+        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}]}'
     headers:
+      CF-RAY:
+      - a103959cbee79e5b-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:30 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '23390'
+      - '22548'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:46 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '147'
+      - '157'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_issue_tracker.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_issue_tracker.yaml
@@ -21,259 +21,254 @@ interactions:
   response:
     body:
       string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?issue_tracker__in=jira_cloud_notifier&page=2&page_size=5",
-        "previous": null, "results": [{"id": 29487335, "account": 8, "criterion":
-        "Stripe Webhook Secret", "date": "2026-04-02T16:22:33.518000Z", "last_trigger_published_at":
-        "2026-04-02T16:22:33.518000Z", "last_triggered_at": "2026-04-02T16:22:34.233032Z",
-        "last_trigger_detected_at": "2026-04-02T16:22:34.233032Z", "hash": "JquJu98wTd0k40t3UsNgP22P+ywFCrsGM1VDRg3oZBdGXhRWbjOMbKAG+JtXZUOK",
+        "previous": null, "results": [{"id": 34186239, "account": 8, "criterion":
+        "Generic Password", "date": "2026-06-22T15:14:57Z", "last_trigger_published_at":
+        "2026-06-22T15:14:57Z", "last_triggered_at": "2026-06-22T15:16:49.799821Z",
+        "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z", "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Stripe Webhook Secret", "severity_rule_config": null, "declarative_secret_status":
+        "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": true,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
+        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
+        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
+        "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
+        "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
+        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 113, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_63.txt", "filename":
+        "configuration_63.txt", "presence": "visible", "last_presence_seen_at": "2026-06-22T15:16:49.824313Z",
+        "last_presence_check_at": "2026-06-22T15:16:49.824313Z", "first_presence_deleted_at":
+        null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 34122510, "account": 8, "criterion": "Generic
+        Password", "date": "2026-06-19T13:41:03Z", "last_trigger_published_at": "2026-06-19T13:41:03Z",
+        "last_triggered_at": "2026-06-19T13:43:05.020137Z", "last_trigger_detected_at":
+        "2026-06-19T13:43:05.020137Z", "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Generic Password", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
+        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
+        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
+        "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
+        "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 129, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_62.txt", "filename":
+        "configuration_62.txt", "presence": "visible", "last_presence_seen_at": "2026-06-19T13:43:05.062490Z",
+        "last_presence_check_at": "2026-06-19T13:43:05.062490Z", "first_presence_deleted_at":
+        null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 33929626, "account": 8, "criterion": "Artifactory
+        Token", "date": "2026-06-12T10:26:58.151000Z", "last_trigger_published_at":
+        "2026-06-12T10:26:58.151000Z", "last_triggered_at": "2026-06-12T11:58:00.658791Z",
+        "last_trigger_detected_at": "2026-06-12T11:58:00.658791Z", "hash": "XoKoErcCGXQNocX6b4MGPd8hwhobdx0SCEYMSWCwKkzVE9LnmfERIIoosvzjJs1k",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": 910203, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "celine.agbo@gitguardian.com", "manual_severity_setter_type": "user", "status":
+        "ASSIGNED", "issue_name": "Artifactory Token", "severity_rule_config": {"id":
+        11895, "gg_created_at": "2026-05-20T08:56:10.055460Z", "gg_updated_at": "2026-05-20T08:56:10.055463Z",
+        "index": 130, "severity": 10, "rule": {"id": 513, "gg_created_at": "2025-03-18T08:57:54.142453Z",
+        "gg_updated_at": "2025-03-18T08:57:54.142456Z", "name": "Package manager related
+        secret", "description": "The detector relates to a package manager", "json_rule":
+        {"operator": "EQ", "arg1": {"path": "issue.secret.detector.metadata.category",
+        "default": null}, "arg2": {"value": "package_registry"}}, "is_global": true,
+        "scope": "private", "author": null}}, "declarative_secret_status": null, "assignee":
+        550880, "last_presence_check_at": null, "secret": "[REDACTED]", "severity":
+        20, "authors": [{"info": "ggtestintegrations@proton.me", "name": "GG Test
+        Integrations"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 62, "displayed_occurrence": {"id": 256867982, "issue": 29487335,
-        "account": 8, "kind": "RLTM", "element": "KAN-8?focusedCommentId=10014", "element_type":
-        "JIRA_COMMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "o40+pCpgMCFgcapQEEdZ3imjEpSONYcgy0J+gLe5ygKDJctj7Ro4REsJrqbUl0yj",
-        "published_at": "2026-04-02T16:22:33.518000Z", "date": "2026-04-02T16:22:33.518000Z",
-        "detected_at": "2026-04-02T16:22:34.031682Z", "is_vcs_type": false, "last_detected_at":
-        "2026-04-02T16:22:33.518000Z", "last_seen_at": "2026-04-02T16:22:33.518000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-8?focusedCommentId=10014",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 148603941, "secrets_engine_version": "2.159.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 25, "indice_end":
-        63, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
-        "2026-04-02T16:22:34.268883Z", "last_presence_check_at": "2026-04-02T16:22:34.268883Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        [{"id": 27177247, "name": "gg-test-integrations / Payment Systems", "type":
+        "jira_cloud_project", "path": "gg-test-integrations / Payment Systems", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 86, "displayed_occurrence": {"id": 272781097, "issue": 33929626,
+        "account": 8, "kind": "RLTM", "element": "PAY-4", "element_type": "JIRA_TICKET",
+        "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
+        "value": null, "value_hash": "T71tr/N63V71e27iMbDQa9L9Oh/xkgVEZdomur2uk2WyqO/9fr4lNYuUjUFpuLDi",
+        "published_at": "2026-06-12T10:26:58.151000Z", "date": "2026-06-12T10:26:58.151000Z",
+        "detected_at": "2026-06-12T11:57:58.655858Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-12T10:26:58.151000Z", "last_seen_at": "2026-06-12T10:26:58.151000Z",
+        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/PAY-4",
+        "source": {"id": 27177247, "url": "https://gg-test-integrations.atlassian.net/browse/PAY",
+        "type": "jira_cloud_project", "display_name": "gg-test-integrations / Payment
+        Systems", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168812050, "secrets_engine_version":
+        "2.165.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
+        "indice_start": 5333, "indice_end": 5406, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
+        "apikey", "insights": [], "filepath": null, "filename": null, "presence":
+        "visible", "last_presence_seen_at": "2026-06-12T18:28:18.251022Z", "last_presence_check_at":
+        "2026-06-12T18:28:18.251022Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
+        33905111, "account": 8, "criterion": "GitLab Deploy Token", "date": "2026-06-11T12:29:43Z",
+        "last_trigger_published_at": "2026-06-11T12:29:43Z", "last_triggered_at":
+        "2026-06-11T12:30:11.342010Z", "last_trigger_detected_at": "2026-06-11T12:30:11.342010Z",
+        "hash": "G0fVu31BJOKtUHJsvHbpcGhXGXhyr2/bQf6zzlhNv+czrK+KrGdxdFLGuJmYhmlq",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "GitLab Deploy Token", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 28664611, "name": "dev / plal_test",
+        "type": "gl_project", "path": "dev/plal_test", "source_criticality": "unknown",
+        "monitoring_status": "active", "deleted_at": null}], "custom_tags": [], "vault_metadata":
+        null, "is_vaulted": false, "similar_issue_count": 0, "score": 85, "displayed_occurrence":
+        {"id": 272645187, "issue": 33905111, "account": 8, "kind": "HIST", "element":
+        "0102329ae146f51358cff771dbdf860acbc78ef6", "element_type": "GIT_COMMIT",
+        "author_name": "dev", "author_info": "gim+dev@gitguardian.com", "value": null,
+        "value_hash": "vKgkDXA4NszdEvKqefnQ7tPG4AsADP5uV3carLt96S2ZoMa7KySfdZ9m9HlrAElh",
+        "published_at": "2026-06-11T12:29:43Z", "date": "2026-06-11T12:29:43Z", "detected_at":
+        "2026-06-11T12:30:10.472937Z", "is_vcs_type": true, "last_detected_at": "2026-06-11T12:37:30.541974Z",
+        "last_seen_at": "2026-06-11T12:37:30.541974Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/dev/plal_test/commit/0102329ae146f51358cff771dbdf860acbc78ef6#5a06a4630a05426a25bc162c233d6cf8ed2462a0_None_5",
+        "source": {"id": 28664611, "url": "https://gitlab-01.aws-qa-gitguardian.com/dev/plal_test",
+        "type": "gl_project", "display_name": "dev / plal_test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 168574637,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "apikey", "string_matched":
+        "[REDACTED]", "indice_start": 65, "indice_end": 90, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 5, "post_line_end": 5}], "most_sensitive_match_name":
+        "apikey", "insights": [], "filepath": "secret_and_pii.txt", "filename": "secret_and_pii.txt",
+        "presence": "visible", "last_presence_seen_at": "2026-06-11T12:37:30.541974Z",
+        "last_presence_check_at": "2026-06-11T12:37:30.541974Z", "first_presence_deleted_at":
+        null, "seen_in_default_branch": null, "change_type": "addition", "full_tags":
+        [{"type": "FROM_HISTORICAL_SCAN", "metadata": null, "field": "content"}]},
+        "has_dropped_occurrences": false, "tags": ["FROM_HISTORICAL_SCAN"], "public_exposure":
         {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 1}, {"id": 29186788, "account": 8, "criterion":
-        "GitLab Token", "date": "2026-03-25T16:53:05.035206Z", "last_trigger_published_at":
-        "2026-03-25T16:53:05.035206Z", "last_triggered_at": "2026-03-25T16:53:05.853859Z",
-        "last_trigger_detected_at": "2026-03-25T16:53:05.853859Z", "hash": "SJOfhHk3hANA5qiK6fypwRpA6pyKIbh2xmK/JYKpXtMCszyZxGkRAPRx8mJAAtol",
+        false}, "occurrences_count": 1}, {"id": 33677678, "account": 8, "criterion":
+        "Slack Bot Token", "date": "2026-06-05T10:30:39Z", "last_trigger_published_at":
+        "2026-06-05T10:30:39Z", "last_triggered_at": "2026-06-05T10:30:41.691996Z",
+        "last_trigger_detected_at": "2026-06-05T10:30:41.691996Z", "hash": "yqtucKpj6ENdYYA0YiXpal4qcQLOZvxb28M4FZHJU90ArWBROMgPzYhV28m6OGG4",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "GitLab Token", "severity_rule_config": {"id": 10877, "gg_created_at": "2026-02-12T15:13:37.684430Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684433Z", "index": 200, "severity":
-        20, "rule": {"id": 520, "gg_created_at": "2025-03-18T08:57:54.142633Z", "gg_updated_at":
-        "2025-03-18T08:57:54.142636Z", "name": "The secret is in a sensitive file",
-        "description": "Secret found in a sensitive file (.env, .pem key, dotfiles)",
-        "json_rule": {"operator": "CONTAINS_ANY", "arg1": {"path": "tag_names", "default":
-        null}, "arg2": {"value": ["SENSITIVE_FILE"]}}, "is_global": true, "scope":
-        "any", "author": null}}, "declarative_secret_status": null, "assignee": null,
-        "last_presence_check_at": null, "secret": "[REDACTED]", "severity": 100, "authors":
-        [{"info": "", "name": "GitGuardian Sandbox [internal]"}], "user_permission":
-        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        3, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "totaaa", "type": "custom_source",
-        "path": "totaaa", "source_criticality": "unknown"}, {"name": "totaaab", "type":
-        "custom_source", "path": "totaaab", "source_criticality": "unknown"}, {"name":
-        "totaaabccb", "type": "custom_source", "path": "totaaabccb", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 0, "score": 9, "displayed_occurrence": {"id": 253371418,
-        "issue": 29186788, "account": 8, "kind": "RLTM", "element": "", "element_type":
-        "CUSTOM_ELEMENT", "author_name": "GitGuardian Sandbox [internal]", "author_info":
-        "", "value": null, "value_hash": "bYdCbHZ101hGcZ6Q6XqcVQkGryoOAuqw4QxVXQLjQfpBf5OllP448kL+4h/ug/8v",
-        "published_at": "2026-03-25T16:53:05.035206Z", "date": "2026-03-25T16:53:05.035206Z",
-        "detected_at": "2026-03-25T16:53:05.737995Z", "is_vcs_type": false, "last_detected_at":
-        "2026-03-25T16:53:05.035206Z", "last_seen_at": "2026-03-25T16:53:05.035206Z",
-        "data": {}, "url": "", "source": {"id": 26968497, "url": "", "type": "custom_source",
-        "display_name": "totaaa", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 146400014, "secrets_engine_version": "2.158.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 123, "indice_end":
-        149, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [{"name": "sensitive_filepath", "source": "document", "metadata": {"sensitive_patterns":
-        [{"tags": [], "comment": "", "pattern": "\\.?env(?![^\\.])", "category": "filename",
-        "description": "Environment configuration file"}]}}], "filepath": "/tmp/tmpvcmhu56nggshield/home/hhubert/.env",
-        "filename": ".env", "presence": "visible", "last_presence_seen_at": "2026-03-25T16:53:05.897743Z",
-        "last_presence_check_at": "2026-03-25T16:53:05.897743Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": [{"type":
-        "SENSITIVE_FILE", "metadata": null}]}, "has_dropped_occurrences": false, "tags":
-        ["REVOCABLE_BY_GG", "SENSITIVE_FILE"], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 3}, {"id": 28905156, "account": 8, "criterion": "GitLab
-        Token", "date": "2026-03-17T14:35:54.643000Z", "last_trigger_published_at":
-        "2026-03-17T14:35:54.643000Z", "last_triggered_at": "2026-03-17T14:36:00.418064Z",
-        "last_trigger_detected_at": "2026-03-17T14:36:00.418064Z", "hash": "kbVfTxt8mubX2vVRQN/wNxpT9vQMThT40ap5w7qZ8b20vI7qxGkRAPRx8mJAAtol",
-        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
-        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
-        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
-        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
-        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "GitLab Token", "severity_rule_config": null, "declarative_secret_status":
+        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "<unknown>", "name": "GG Test Integrations"},
-        {"info": "<unknown>", "name": "Unknown"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 4, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"},
-        {"name": "gitguardian-team-vxrpkdpl / D\u00e9veloppement logiciel", "type":
-        "confluence_cloud_space", "path": "gitguardian-team-vxrpkdpl / D\u00e9veloppement
-        logiciel", "source_criticality": "unknown"}, {"name": "gitguardian-team-vxrpkdpl
-        / Philippe Gablain", "type": "confluence_cloud_space", "path": "gitguardian-team-vxrpkdpl
-        / Philippe Gablain", "source_criticality": "unknown"}], "custom_tags": [],
-        "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0, "score":
-        9, "displayed_occurrence": {"id": 252869959, "issue": 28905156, "account":
-        8, "kind": "HIST", "element": "attachment/att524290", "element_type": "CONFLUENCE_ATTACHMENT",
-        "author_name": "Unknown", "author_info": "<unknown>", "value": null, "value_hash":
-        "YZ0Me0zobvsKpuRIo4KGFLcQhBLa5wXObD6V1J3gm/iC+5COK1fW5YSNIAEU43PK", "published_at":
-        "2026-03-12T17:23:48.915000Z", "date": "2026-03-12T17:23:48.915000Z", "detected_at":
-        "2026-03-24T09:54:31.814599Z", "is_vcs_type": false, "last_detected_at": "2026-03-12T17:23:48.915000Z",
-        "last_seen_at": "2026-03-12T17:23:48.915000Z", "data": {}, "url": "https://gitguardian-team-vxrpkdpl.atlassian.net/wiki/spaces/~62a76a05979e6e00690427b5/pages/262177",
-        "source": {"id": 26936741, "url": "https://gitguardian-team-vxrpkdpl.atlassian.net/wiki/spaces/~62a76a05979e6e00690427b5",
-        "type": "confluence_cloud_space", "display_name": "gitguardian-team-vxrpkdpl
-        / Philippe Gablain", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 144316417, "secrets_engine_version": "2.158.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 106, "indice_end":
-        132, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": "/download/attachments/262177/toto9.txt?version=1&modificationDate=1773336228915&cacheVersion=1&api=v2",
-        "filename": "toto9.txt", "presence": "visible", "last_presence_seen_at": "2026-03-30T08:25:43.285668Z",
-        "last_presence_check_at": "2026-03-30T08:25:43.285668Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": [{"type":
-        "FROM_HISTORICAL_SCAN", "metadata": null}]}, "has_dropped_occurrences": false,
-        "tags": ["FROM_HISTORICAL_SCAN", "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 4}, {"id": 28905136, "account": 8, "criterion": "GitLab
-        Token", "date": "2026-03-17T13:50:21.909000Z", "last_trigger_published_at":
-        "2026-03-17T13:50:21.909000Z", "last_triggered_at": "2026-03-17T14:35:04.182999Z",
-        "last_trigger_detected_at": "2026-03-17T14:35:04.182999Z", "hash": "WK++VMwWOtCgcJLB1bssA+LYOZibFxHq2PD3Gc27zcfd1zd3xGkRAPRx8mJAAtol",
-        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
-        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
-        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
-        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
-        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "GitLab Token", "severity_rule_config": null, "declarative_secret_status":
-        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": false,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 9, "displayed_occurrence": {"id": 251397394, "issue": 28905136,
-        "account": 8, "kind": "HIST", "element": "KAN-1/attachment/10000", "element_type":
-        "JIRA_ATTACHMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "HJeG3nW8vJKcwODm8fthKZ+emBqlOohKRUtdSDefI95yvYyjcl17awQJwJ+R7glD",
-        "published_at": "2026-03-17T13:50:21.909000Z", "date": "2026-03-17T13:50:21.909000Z",
-        "detected_at": "2026-03-17T14:34:59.387226Z", "is_vcs_type": false, "last_detected_at":
-        "2026-03-17T13:50:21.909000Z", "last_seen_at": "2026-03-17T13:50:21.909000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-1",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 144316340, "secrets_engine_version": "2.158.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 107, "indice_end":
-        133, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": "https://api.atlassian.com/ex/jira/239c88bc-2664-4cb9-a422-e59dfaf60bf6/rest/api/3/attachment/content/10000",
-        "filename": "toto.pdf", "presence": "visible", "last_presence_seen_at": "2026-03-17T14:35:04.233212Z",
-        "last_presence_check_at": "2026-03-17T14:35:04.233212Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": [{"type":
-        "FROM_HISTORICAL_SCAN", "metadata": null}]}, "has_dropped_occurrences": false,
-        "tags": ["FROM_HISTORICAL_SCAN", "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 1}, {"id": 27966952, "account": 8, "criterion": "OpenAI
-        API Key", "date": "2026-03-06T06:44:00Z", "last_trigger_published_at": "2026-03-06T06:44:00Z",
-        "last_triggered_at": "2026-03-06T06:46:00.813247Z", "last_trigger_detected_at":
-        "2026-03-06T06:46:00.813247Z", "hash": "qAqxBGe/jVUeo2sH1EACPXT4xKnxJeIOJlp4g3WKNS64WAaZ95GRLqiXIWrK60u6",
-        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
-        "resolved": true, "resolved_at": "2026-03-12T18:05:49.089586Z", "resolver":
-        491414, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "none", "ignorer_type": "none", "resolver_display_name": "8@bot.gitguardian.com",
-        "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
-        "none", "status": "RESOLVED", "issue_name": "OpenAI API Key", "severity_rule_config":
-        {"id": 10876, "gg_created_at": "2026-02-12T15:13:37.684414Z", "gg_updated_at":
-        "2026-02-12T15:13:37.684418Z", "index": 190, "severity": 20, "rule": {"id":
-        519, "gg_created_at": "2025-03-18T08:57:54.142609Z", "gg_updated_at": "2025-03-18T08:57:54.142612Z",
-        "name": "Valid secret", "description": "The secrets were valid when the incident
-        was discovered", "json_rule": {"operator": "EQ", "arg1": {"path": "issue.secret.validity_status",
-        "default": null}, "arg2": {"value": "valid"}}, "is_global": true, "scope":
-        "private", "author": null}}, "declarative_secret_status": "revoked", "assignee":
-        614347, "last_presence_check_at": null, "secret": "[REDACTED]", "severity":
-        100, "authors": [{"info": "romain.jouhannet@gitguardian.com", "name": "Romain
-        Jouhannet"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        "severity": 100, "authors": [{"info": "pierre.lalanne.p@gmail.com", "name":
+        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
         0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "RomainJ / demo", "type": "gl_project", "path": "romain/demo", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 0, "score": 72, "displayed_occurrence": {"id": 248062638,
-        "issue": 27966952, "account": 8, "kind": "RLTM", "element": "ffed371ff171aaf844c433d58ace37f0f7f3aba1",
-        "element_type": "GIT_COMMIT", "author_name": "Romain Jouhannet", "author_info":
-        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "4sooonqBbWJu6Yf7TJItubjzIv+0+o8DtXQyynagLjSNV1GV7JDrI7vPyIRMpjWn",
-        "published_at": "2026-03-06T06:44:00Z", "date": "2026-03-06T06:44:00Z", "detected_at":
-        "2026-03-06T06:45:58.524698Z", "is_vcs_type": true, "last_detected_at": "2026-03-06T06:44:00Z",
-        "last_seen_at": "2026-03-06T06:44:00Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/ffed371ff171aaf844c433d58ace37f0f7f3aba1#057715000d77d4d956b27699e12440e405fb48ed_0_1",
-        "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
-        "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
-        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        "main"}, "regression": false, "content": 138922166, "secrets_engine_version":
-        "2.158.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 33, "indice_end": 84, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 1, "post_line_end": 1}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "local_scanning.txt", "filename": "local_scanning.txt",
-        "presence": "visible", "last_presence_seen_at": "2026-03-06T06:46:00.854986Z",
-        "last_presence_check_at": "2026-03-06T06:46:00.854986Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "DEFAULT_BRANCH", "metadata": null}]}, "has_dropped_occurrences":
-        false, "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible":
+        [{"id": 17188087, "name": "pierrelalanne/test_repo", "type": "gh_repository",
+        "path": "pierrelalanne/test_repo", "source_criticality": "critical", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 12, "displayed_occurrence":
+        {"id": 271584642, "issue": 33677678, "account": 8, "kind": "RLTM", "element":
+        "b355f606d5884cfbe83a19c83e6804c0fc9a95f0", "element_type": "GIT_COMMIT",
+        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne.p@gmail.com",
+        "value": null, "value_hash": "BwX3iCglyVyrnbQJ+uR2bcHgVmnkzFUUxyizOMJrHc3YG8H/gEDCz7InbgSdLTaR",
+        "published_at": "2026-06-05T10:30:39Z", "date": "2026-06-05T10:30:39Z", "detected_at":
+        "2026-06-05T10:30:40.398638Z", "is_vcs_type": true, "last_detected_at": "2026-06-05T10:30:39Z",
+        "last_seen_at": "2026-06-05T10:30:39Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/b355f606d5884cfbe83a19c83e6804c0fc9a95f0#diff-cf36aad2a70418098362b5fbd96a9fbbb199e931ccab1ee9713f5b5eb84eba94R67",
+        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
+        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
+        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
+        null, "default_branch": "main", "monitoring_status": "active"}, "regression":
+        false, "content": 166970520, "secrets_engine_version": "2.164.0", "matches":
+        [{"name": "apikey", "string_matched": "[REDACTED]", "indice_start": 303, "indice_end":
+        345, "pre_line_start": null, "pre_line_end": null, "post_line_start": 67,
+        "post_line_end": 67}], "most_sensitive_match_name": "apikey", "insights":
+        [], "filepath": "pii/first_pii.py", "filename": "first_pii.py", "presence":
+        "visible", "last_presence_seen_at": "2026-06-05T10:30:41.723413Z", "last_presence_check_at":
+        "2026-06-05T10:30:41.723413Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        true, "change_type": "addition", "full_tags": [{"type": "DEFAULT_BRANCH",
+        "metadata": null, "field": "content"}]}, "has_dropped_occurrences": false,
+        "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible":
         false, "public_incident_linked": false, "leaked_outside_perimeter": false},
         "occurrences_count": 1}]}'
     headers:
+      CF-RAY:
+      - a1039598dd829e7e-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:29 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '25599'
+      - '23451'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:45 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '134'
+      - '167'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_ordering.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_ordering.yaml
@@ -21,244 +21,241 @@ interactions:
   response:
     body:
       string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?ordering=-date&page=2&page_size=5",
-        "previous": null, "results": [{"id": 29487335, "account": 8, "criterion":
-        "Stripe Webhook Secret", "date": "2026-04-02T16:22:33.518000Z", "last_trigger_published_at":
-        "2026-04-02T16:22:33.518000Z", "last_triggered_at": "2026-04-02T16:22:34.233032Z",
-        "last_trigger_detected_at": "2026-04-02T16:22:34.233032Z", "hash": "JquJu98wTd0k40t3UsNgP22P+ywFCrsGM1VDRg3oZBdGXhRWbjOMbKAG+JtXZUOK",
+        "previous": null, "results": [{"id": 34205503, "account": 8, "criterion":
+        "microsoft_azure_storage_connection_string", "date": "2026-06-23T11:13:31.325324Z",
+        "last_trigger_published_at": "2026-06-23T11:13:31.325324Z", "last_triggered_at":
+        "2026-06-23T11:13:31.343453Z", "last_trigger_detected_at": "2026-06-23T11:13:31.343453Z",
+        "hash": "HdPZ4cjZuziAqsakdlsUnJDapTz3ns5pX8vPzfhvGQvpWWWX25LITKmJimoqGr3z",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Stripe Webhook Secret", "severity_rule_config": null, "declarative_secret_status":
-        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": true,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 62, "displayed_occurrence": {"id": 256867982, "issue": 29487335,
-        "account": 8, "kind": "RLTM", "element": "KAN-8?focusedCommentId=10014", "element_type":
-        "JIRA_COMMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "o40+pCpgMCFgcapQEEdZ3imjEpSONYcgy0J+gLe5ygKDJctj7Ro4REsJrqbUl0yj",
-        "published_at": "2026-04-02T16:22:33.518000Z", "date": "2026-04-02T16:22:33.518000Z",
-        "detected_at": "2026-04-02T16:22:34.031682Z", "is_vcs_type": false, "last_detected_at":
-        "2026-04-02T16:22:33.518000Z", "last_seen_at": "2026-04-02T16:22:33.518000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-8?focusedCommentId=10014",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 148603941, "secrets_engine_version": "2.159.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 25, "indice_end":
-        63, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
-        "2026-04-02T16:22:34.268883Z", "last_presence_check_at": "2026-04-02T16:22:34.268883Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 1}, {"id": 29487333, "account": 8, "criterion":
-        "Slack Bot Token", "date": "2026-04-02T16:22:26.591000Z", "last_trigger_published_at":
-        "2026-04-02T16:22:26.591000Z", "last_triggered_at": "2026-04-02T16:22:27.578209Z",
-        "last_trigger_detected_at": "2026-04-02T16:22:27.578209Z", "hash": "UeONCI+H/I19fHV7Ge45VQxOI0/YUY6CYZu9psQ6W53s6W+UOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-04-02T16:22:27.592459Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": true,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 11, "displayed_occurrence": {"id": 256867977, "issue": 29487333,
-        "account": 8, "kind": "RLTM", "element": "KAN-4?focusedCommentId=10005", "element_type":
-        "JIRA_COMMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "BBZtIrA/2GAvXPBnlTveHP2iPqy+rHM0BxNchD6gRp+/+mUjQPrqnyjHph0vjkPi",
-        "published_at": "2026-04-02T16:22:26.591000Z", "date": "2026-04-02T16:22:26.591000Z",
-        "detected_at": "2026-04-02T16:22:27.022003Z", "is_vcs_type": false, "last_detected_at":
-        "2026-04-02T16:22:26.591000Z", "last_seen_at": "2026-04-02T16:22:26.591000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-4?focusedCommentId=10005",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 148603933, "secrets_engine_version": "2.159.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 25, "indice_end":
-        81, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
-        "2026-04-02T16:22:27.644022Z", "last_presence_check_at": "2026-04-02T16:22:27.644022Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": ["REVOCABLE_BY_GG"],
-        "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
-        29305270, "account": 8, "criterion": "OpenAI API Key", "date": "2026-03-27T13:47:01Z",
-        "last_trigger_published_at": "2026-03-27T13:47:01Z", "last_triggered_at":
-        "2026-03-28T05:01:36.397561Z", "last_trigger_detected_at": "2026-03-28T05:01:36.397561Z",
-        "hash": "MTJFo5AaJdAJ7giIaJE2+Vn/3hEL1nR7oKsu0ry8AAS38W2S95GRLqiXIWrK60u6",
-        "ignored": true, "ignored_at": "2026-03-28T05:01:36.405919Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "OpenAI API Key", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "name": "gg-tools"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-tools / OneDrive", "type": "microsoft_onedrive", "path": "gg-tools
-        / OneDrive", "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata":
-        null, "is_vaulted": false, "similar_issue_count": 0, "score": 6, "displayed_occurrence":
-        {"id": 255746729, "issue": 29305270, "account": 8, "kind": "RLTM", "element":
-        "{\"drive_id\": \"b!ifwT0vIqDE2MYP5tWpOaVJKsAA38ZA1PqHTPWAaO0Ovk8yFkaTlITKSgS6Y2Zlvu\",
-        \"parent_reference_path\": \"/drives/b!ifwT0vIqDE2MYP5tWpOaVJKsAA38ZA1PqHTPWAaO0Ovk8yFkaTlITKSgS6Y2Zlvu/root:/Recordings\",
-        \"file_id\": \"01ICX32E3NSJA7PEQVFZAKEEXG4DH65RP4\"}", "element_type": "SHAREPOINT_ONEDRIVE_FILE",
-        "author_name": "gg-tools", "author_info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "value": null, "value_hash": "CFPFVOpXX+26OfRN+bRLyvVCXnQmU1Cpu36m73v5F4pgz7WMu+D6UW65wQZMF7kQ",
-        "published_at": "2026-03-27T13:47:01Z", "date": "2026-03-27T13:47:01Z", "detected_at":
-        "2026-03-28T04:58:40.843022Z", "is_vcs_type": false, "last_detected_at": "2026-03-27T13:47:01Z",
-        "last_seen_at": "2026-03-27T13:47:01Z", "data": {}, "url": "https://gitguardianengineering-my.sharepoint.com/personal/gg-tools_gitguardianengineering_onmicrosoft_com/Documents/Recordings/secret.txt",
-        "source": {"id": 19962591, "url": "https://onedrive.com/", "type": "microsoft_onedrive",
-        "display_name": "gg-tools / OneDrive", "visibility": "private", "monitored":
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
+        "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
+        "detected_at": "2026-06-23T11:13:31.325324Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
+        "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
         true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null}, "regression": false, "content": 147214824, "secrets_engine_version":
-        "2.159.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 8, "indice_end": 59, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "Recordings/secret.txt", "filename":
-        "secret.txt", "presence": "visible", "last_presence_seen_at": "2026-03-28T05:01:36.456203Z",
-        "last_presence_check_at": "2026-03-28T05:01:36.456203Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": []},
-        "has_dropped_occurrences": false, "tags": ["REVOCABLE_BY_GG"], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 1}, {"id": 29236129, "account": 8, "criterion":
-        "Slack Bot Token", "date": "2026-03-26T16:10:40Z", "last_trigger_published_at":
-        "2026-03-26T16:10:40Z", "last_triggered_at": "2026-03-26T16:10:55.648969Z",
-        "last_trigger_detected_at": "2026-03-26T16:10:55.648969Z", "hash": "0Y7z2cw2c6cwAdy+TeYUL5BKR7Lb/hDQRLHld5PCWUkg5Q0OOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-03-26T16:10:55.689671Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "pierrelalanne/test_repo", "type": "gh_repository", "path": "pierrelalanne/test_repo",
-        "source_criticality": "critical"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 0, "displayed_occurrence":
-        {"id": 253938087, "issue": 29236129, "account": 8, "kind": "RLTM", "element":
-        "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
-        "value": null, "value_hash": "CEL9N36auQTdl9e+bqgAsGyWN0vVPYlqvHWSQMXxC/1zmdQrKYk359La8N2L+SIi",
-        "published_at": "2026-03-26T16:10:40Z", "date": "2026-03-26T16:10:40Z", "detected_at":
-        "2026-03-26T16:10:51.878216Z", "is_vcs_type": true, "last_detected_at": "2026-03-26T16:10:40Z",
-        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R1",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
-        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 146712049,
-        "secrets_engine_version": "2.159.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 60, "indice_end": 102, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 1, "post_line_end": 1}], "most_sensitive_match_name":
-        "apikey", "insights": [{"name": "test_file", "source": "document", "metadata":
-        null}], "filepath": "test_limits_1_secret.txt", "filename": "test_limits_1_secret.txt",
-        "presence": "visible", "last_presence_seen_at": "2026-03-26T16:10:55.988339Z",
-        "last_presence_check_at": "2026-03-26T16:10:55.988339Z", "first_presence_deleted_at":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
+        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
+        34186239, "account": 8, "criterion": "Generic Password", "date": "2026-06-22T15:14:57Z",
+        "last_trigger_published_at": "2026-06-22T15:14:57Z", "last_triggered_at":
+        "2026-06-22T15:16:49.799821Z", "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z",
+        "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Generic Password", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
+        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
+        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
+        "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
+        "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
+        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 113, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_63.txt", "filename":
+        "configuration_63.txt", "presence": "visible", "last_presence_seen_at": "2026-06-22T15:16:49.824313Z",
+        "last_presence_check_at": "2026-06-22T15:16:49.824313Z", "first_presence_deleted_at":
         null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}, {"type": "DEFAULT_BRANCH", "metadata":
-        null}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG",
-        "TEST_FILE"], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
-        29236130, "account": 8, "criterion": "Slack Bot Token", "date": "2026-03-26T16:10:40Z",
-        "last_trigger_published_at": "2026-03-26T16:10:40Z", "last_triggered_at":
-        "2026-03-26T16:10:55.649133Z", "last_trigger_detected_at": "2026-03-26T16:10:55.649133Z",
-        "hash": "1d291ZrFV0RBbVE8r2t6EFI1jgdXhzZkb4RYrNKH10mjkZ9yOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-03-26T16:10:55.695057Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "pierrelalanne/test_repo", "type": "gh_repository", "path": "pierrelalanne/test_repo",
-        "source_criticality": "critical"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 10, "score": 0, "displayed_occurrence":
-        {"id": 253938082, "issue": 29236130, "account": 8, "kind": "RLTM", "element":
-        "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
-        "value": null, "value_hash": "8CeYKeR2kMER0aBlyGThkdNGWeRYfKFLPj1kOQJO8lH2bXzFs7jhuR1VfR21VK1W",
-        "published_at": "2026-03-26T16:10:40Z", "date": "2026-03-26T16:10:40Z", "detected_at":
-        "2026-03-26T16:10:51.878216Z", "is_vcs_type": true, "last_detected_at": "2026-03-26T16:10:40Z",
-        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R20",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
-        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 146712049,
-        "secrets_engine_version": "2.159.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 896, "indice_end": 938, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 20, "post_line_end": 20}], "most_sensitive_match_name":
-        "apikey", "insights": [{"name": "test_file", "source": "document", "metadata":
-        null}], "filepath": "test_limits_1_secret.txt", "filename": "test_limits_1_secret.txt",
-        "presence": "visible", "last_presence_seen_at": "2026-03-26T16:10:55.988339Z",
-        "last_presence_check_at": "2026-03-26T16:10:55.988339Z", "first_presence_deleted_at":
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 34181686, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-22T11:25:45.739149Z", "last_trigger_published_at": "2026-06-22T11:25:45.739149Z",
+        "last_triggered_at": "2026-06-22T11:25:45.762592Z", "last_trigger_detected_at":
+        "2026-06-22T11:25:45.762592Z", "hash": "gVrL/pjjFLo7sSikPS1pWtPJbr+oWSSVz8IB6+2ViJDSJKiK25LITKmJimoqGr3z",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": true, "resolved_at": "2026-06-22T11:26:52.971214Z", "resolver":
+        1751937, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
+        "none", "ignorer_type": "none", "resolver_display_name": "candidate.playground+eu@gitguardian.com",
+        "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
+        "none", "status": "RESOLVED", "issue_name": "Microsoft Azure Storage Connection
+        String", "severity_rule_config": null, "declarative_secret_status": "revoked",
+        "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "", "name": "Kashyapa P.A. Jayasekera"}],
+        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "GGFRLTA127
+        \u2014 kashyapap.jayasekera", "type": "endpoints", "path": "GGFRLTA127 \u2014
+        kashyapap.jayasekera", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274639444, "issue": 34181686, "account": 8, "kind": "RLTM", "element":
+        "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "AAr6ayAj6Hs2pOICdVUlEyuXlsQ78K3HFGOJgWA/yAiQrRuQH9Kv1GxUH36IT99d",
+        "published_at": "2026-06-22T11:25:45.739149Z", "date": "2026-06-22T11:25:45.739149Z",
+        "detected_at": "2026-06-22T11:25:45.739149Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-22T11:25:45.739149Z", "last_seen_at": "2026-06-22T11:25:45.739149Z",
+        "data": {"line": 20, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-22T11:25:45.739149Z", "last_presence_check_at":
+        "2026-06-22T11:25:45.739149Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 6}, {"id":
+        34122510, "account": 8, "criterion": "Generic Password", "date": "2026-06-19T13:41:03Z",
+        "last_trigger_published_at": "2026-06-19T13:41:03Z", "last_triggered_at":
+        "2026-06-19T13:43:05.020137Z", "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z",
+        "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Generic Password", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
+        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
+        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
+        "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
+        "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 129, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_62.txt", "filename":
+        "configuration_62.txt", "presence": "visible", "last_presence_seen_at": "2026-06-19T13:43:05.062490Z",
+        "last_presence_check_at": "2026-06-19T13:43:05.062490Z", "first_presence_deleted_at":
         null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}, {"type": "DEFAULT_BRANCH", "metadata":
-        null}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG",
-        "TEST_FILE"], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}]}'
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 34038186, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-16T18:55:43.166667Z", "last_trigger_published_at": "2026-06-16T18:55:43.166667Z",
+        "last_triggered_at": "2026-06-16T18:55:43.185061Z", "last_trigger_detected_at":
+        "2026-06-16T18:55:43.185061Z", "hash": "JFTpQX+4P/dEcXJJ2iw+u54JYDsJnqLtrdws1wjFQ8t9LtHh25LITKmJimoqGr3z",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
+        "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
+        "detected_at": "2026-06-16T18:55:43.166667Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
+        "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
+        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}]}'
     headers:
+      CF-RAY:
+      - a10395605e939996-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:20 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '23391'
+      - '22549'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:37 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '171'
+      - '110'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_presence_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_presence_filter.yaml
@@ -21,244 +21,241 @@ interactions:
   response:
     body:
       string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?page=2&page_size=5&presence__in=present",
-        "previous": null, "results": [{"id": 29487335, "account": 8, "criterion":
-        "Stripe Webhook Secret", "date": "2026-04-02T16:22:33.518000Z", "last_trigger_published_at":
-        "2026-04-02T16:22:33.518000Z", "last_triggered_at": "2026-04-02T16:22:34.233032Z",
-        "last_trigger_detected_at": "2026-04-02T16:22:34.233032Z", "hash": "JquJu98wTd0k40t3UsNgP22P+ywFCrsGM1VDRg3oZBdGXhRWbjOMbKAG+JtXZUOK",
+        "previous": null, "results": [{"id": 34205503, "account": 8, "criterion":
+        "microsoft_azure_storage_connection_string", "date": "2026-06-23T11:13:31.325324Z",
+        "last_trigger_published_at": "2026-06-23T11:13:31.325324Z", "last_triggered_at":
+        "2026-06-23T11:13:31.343453Z", "last_trigger_detected_at": "2026-06-23T11:13:31.343453Z",
+        "hash": "HdPZ4cjZuziAqsakdlsUnJDapTz3ns5pX8vPzfhvGQvpWWWX25LITKmJimoqGr3z",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Stripe Webhook Secret", "severity_rule_config": null, "declarative_secret_status":
-        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": true,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 62, "displayed_occurrence": {"id": 256867982, "issue": 29487335,
-        "account": 8, "kind": "RLTM", "element": "KAN-8?focusedCommentId=10014", "element_type":
-        "JIRA_COMMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "o40+pCpgMCFgcapQEEdZ3imjEpSONYcgy0J+gLe5ygKDJctj7Ro4REsJrqbUl0yj",
-        "published_at": "2026-04-02T16:22:33.518000Z", "date": "2026-04-02T16:22:33.518000Z",
-        "detected_at": "2026-04-02T16:22:34.031682Z", "is_vcs_type": false, "last_detected_at":
-        "2026-04-02T16:22:33.518000Z", "last_seen_at": "2026-04-02T16:22:33.518000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-8?focusedCommentId=10014",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 148603941, "secrets_engine_version": "2.159.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 25, "indice_end":
-        63, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
-        "2026-04-02T16:22:34.268883Z", "last_presence_check_at": "2026-04-02T16:22:34.268883Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 1}, {"id": 29487333, "account": 8, "criterion":
-        "Slack Bot Token", "date": "2026-04-02T16:22:26.591000Z", "last_trigger_published_at":
-        "2026-04-02T16:22:26.591000Z", "last_triggered_at": "2026-04-02T16:22:27.578209Z",
-        "last_trigger_detected_at": "2026-04-02T16:22:27.578209Z", "hash": "UeONCI+H/I19fHV7Ge45VQxOI0/YUY6CYZu9psQ6W53s6W+UOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-04-02T16:22:27.592459Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": true,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 11, "displayed_occurrence": {"id": 256867977, "issue": 29487333,
-        "account": 8, "kind": "RLTM", "element": "KAN-4?focusedCommentId=10005", "element_type":
-        "JIRA_COMMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "BBZtIrA/2GAvXPBnlTveHP2iPqy+rHM0BxNchD6gRp+/+mUjQPrqnyjHph0vjkPi",
-        "published_at": "2026-04-02T16:22:26.591000Z", "date": "2026-04-02T16:22:26.591000Z",
-        "detected_at": "2026-04-02T16:22:27.022003Z", "is_vcs_type": false, "last_detected_at":
-        "2026-04-02T16:22:26.591000Z", "last_seen_at": "2026-04-02T16:22:26.591000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-4?focusedCommentId=10005",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 148603933, "secrets_engine_version": "2.159.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 25, "indice_end":
-        81, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
-        "2026-04-02T16:22:27.644022Z", "last_presence_check_at": "2026-04-02T16:22:27.644022Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": ["REVOCABLE_BY_GG"],
-        "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
-        29305270, "account": 8, "criterion": "OpenAI API Key", "date": "2026-03-27T13:47:01Z",
-        "last_trigger_published_at": "2026-03-27T13:47:01Z", "last_triggered_at":
-        "2026-03-28T05:01:36.397561Z", "last_trigger_detected_at": "2026-03-28T05:01:36.397561Z",
-        "hash": "MTJFo5AaJdAJ7giIaJE2+Vn/3hEL1nR7oKsu0ry8AAS38W2S95GRLqiXIWrK60u6",
-        "ignored": true, "ignored_at": "2026-03-28T05:01:36.405919Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "OpenAI API Key", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "name": "gg-tools"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-tools / OneDrive", "type": "microsoft_onedrive", "path": "gg-tools
-        / OneDrive", "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata":
-        null, "is_vaulted": false, "similar_issue_count": 0, "score": 6, "displayed_occurrence":
-        {"id": 255746729, "issue": 29305270, "account": 8, "kind": "RLTM", "element":
-        "{\"drive_id\": \"b!ifwT0vIqDE2MYP5tWpOaVJKsAA38ZA1PqHTPWAaO0Ovk8yFkaTlITKSgS6Y2Zlvu\",
-        \"parent_reference_path\": \"/drives/b!ifwT0vIqDE2MYP5tWpOaVJKsAA38ZA1PqHTPWAaO0Ovk8yFkaTlITKSgS6Y2Zlvu/root:/Recordings\",
-        \"file_id\": \"01ICX32E3NSJA7PEQVFZAKEEXG4DH65RP4\"}", "element_type": "SHAREPOINT_ONEDRIVE_FILE",
-        "author_name": "gg-tools", "author_info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "value": null, "value_hash": "CFPFVOpXX+26OfRN+bRLyvVCXnQmU1Cpu36m73v5F4pgz7WMu+D6UW65wQZMF7kQ",
-        "published_at": "2026-03-27T13:47:01Z", "date": "2026-03-27T13:47:01Z", "detected_at":
-        "2026-03-28T04:58:40.843022Z", "is_vcs_type": false, "last_detected_at": "2026-03-27T13:47:01Z",
-        "last_seen_at": "2026-03-27T13:47:01Z", "data": {}, "url": "https://gitguardianengineering-my.sharepoint.com/personal/gg-tools_gitguardianengineering_onmicrosoft_com/Documents/Recordings/secret.txt",
-        "source": {"id": 19962591, "url": "https://onedrive.com/", "type": "microsoft_onedrive",
-        "display_name": "gg-tools / OneDrive", "visibility": "private", "monitored":
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
+        "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
+        "detected_at": "2026-06-23T11:13:31.325324Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
+        "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
         true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null}, "regression": false, "content": 147214824, "secrets_engine_version":
-        "2.159.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 8, "indice_end": 59, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "Recordings/secret.txt", "filename":
-        "secret.txt", "presence": "visible", "last_presence_seen_at": "2026-03-28T05:01:36.456203Z",
-        "last_presence_check_at": "2026-03-28T05:01:36.456203Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": []},
-        "has_dropped_occurrences": false, "tags": ["REVOCABLE_BY_GG"], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 1}, {"id": 29236129, "account": 8, "criterion":
-        "Slack Bot Token", "date": "2026-03-26T16:10:40Z", "last_trigger_published_at":
-        "2026-03-26T16:10:40Z", "last_triggered_at": "2026-03-26T16:10:55.648969Z",
-        "last_trigger_detected_at": "2026-03-26T16:10:55.648969Z", "hash": "0Y7z2cw2c6cwAdy+TeYUL5BKR7Lb/hDQRLHld5PCWUkg5Q0OOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-03-26T16:10:55.689671Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "pierrelalanne/test_repo", "type": "gh_repository", "path": "pierrelalanne/test_repo",
-        "source_criticality": "critical"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 0, "displayed_occurrence":
-        {"id": 253938087, "issue": 29236129, "account": 8, "kind": "RLTM", "element":
-        "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
-        "value": null, "value_hash": "CEL9N36auQTdl9e+bqgAsGyWN0vVPYlqvHWSQMXxC/1zmdQrKYk359La8N2L+SIi",
-        "published_at": "2026-03-26T16:10:40Z", "date": "2026-03-26T16:10:40Z", "detected_at":
-        "2026-03-26T16:10:51.878216Z", "is_vcs_type": true, "last_detected_at": "2026-03-26T16:10:40Z",
-        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R1",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
-        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 146712049,
-        "secrets_engine_version": "2.159.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 60, "indice_end": 102, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 1, "post_line_end": 1}], "most_sensitive_match_name":
-        "apikey", "insights": [{"name": "test_file", "source": "document", "metadata":
-        null}], "filepath": "test_limits_1_secret.txt", "filename": "test_limits_1_secret.txt",
-        "presence": "visible", "last_presence_seen_at": "2026-03-26T16:10:55.988339Z",
-        "last_presence_check_at": "2026-03-26T16:10:55.988339Z", "first_presence_deleted_at":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
+        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
+        34186239, "account": 8, "criterion": "Generic Password", "date": "2026-06-22T15:14:57Z",
+        "last_trigger_published_at": "2026-06-22T15:14:57Z", "last_triggered_at":
+        "2026-06-22T15:16:49.799821Z", "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z",
+        "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Generic Password", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
+        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
+        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
+        "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
+        "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
+        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 113, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_63.txt", "filename":
+        "configuration_63.txt", "presence": "visible", "last_presence_seen_at": "2026-06-22T15:16:49.824313Z",
+        "last_presence_check_at": "2026-06-22T15:16:49.824313Z", "first_presence_deleted_at":
         null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}, {"type": "DEFAULT_BRANCH", "metadata":
-        null}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG",
-        "TEST_FILE"], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
-        29236130, "account": 8, "criterion": "Slack Bot Token", "date": "2026-03-26T16:10:40Z",
-        "last_trigger_published_at": "2026-03-26T16:10:40Z", "last_triggered_at":
-        "2026-03-26T16:10:55.649133Z", "last_trigger_detected_at": "2026-03-26T16:10:55.649133Z",
-        "hash": "1d291ZrFV0RBbVE8r2t6EFI1jgdXhzZkb4RYrNKH10mjkZ9yOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-03-26T16:10:55.695057Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "pierrelalanne/test_repo", "type": "gh_repository", "path": "pierrelalanne/test_repo",
-        "source_criticality": "critical"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 10, "score": 0, "displayed_occurrence":
-        {"id": 253938082, "issue": 29236130, "account": 8, "kind": "RLTM", "element":
-        "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
-        "value": null, "value_hash": "8CeYKeR2kMER0aBlyGThkdNGWeRYfKFLPj1kOQJO8lH2bXzFs7jhuR1VfR21VK1W",
-        "published_at": "2026-03-26T16:10:40Z", "date": "2026-03-26T16:10:40Z", "detected_at":
-        "2026-03-26T16:10:51.878216Z", "is_vcs_type": true, "last_detected_at": "2026-03-26T16:10:40Z",
-        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R20",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
-        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 146712049,
-        "secrets_engine_version": "2.159.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 896, "indice_end": 938, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 20, "post_line_end": 20}], "most_sensitive_match_name":
-        "apikey", "insights": [{"name": "test_file", "source": "document", "metadata":
-        null}], "filepath": "test_limits_1_secret.txt", "filename": "test_limits_1_secret.txt",
-        "presence": "visible", "last_presence_seen_at": "2026-03-26T16:10:55.988339Z",
-        "last_presence_check_at": "2026-03-26T16:10:55.988339Z", "first_presence_deleted_at":
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 34181686, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-22T11:25:45.739149Z", "last_trigger_published_at": "2026-06-22T11:25:45.739149Z",
+        "last_triggered_at": "2026-06-22T11:25:45.762592Z", "last_trigger_detected_at":
+        "2026-06-22T11:25:45.762592Z", "hash": "gVrL/pjjFLo7sSikPS1pWtPJbr+oWSSVz8IB6+2ViJDSJKiK25LITKmJimoqGr3z",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": true, "resolved_at": "2026-06-22T11:26:52.971214Z", "resolver":
+        1751937, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
+        "none", "ignorer_type": "none", "resolver_display_name": "candidate.playground+eu@gitguardian.com",
+        "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
+        "none", "status": "RESOLVED", "issue_name": "Microsoft Azure Storage Connection
+        String", "severity_rule_config": null, "declarative_secret_status": "revoked",
+        "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "", "name": "Kashyapa P.A. Jayasekera"}],
+        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "GGFRLTA127
+        \u2014 kashyapap.jayasekera", "type": "endpoints", "path": "GGFRLTA127 \u2014
+        kashyapap.jayasekera", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274639444, "issue": 34181686, "account": 8, "kind": "RLTM", "element":
+        "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "AAr6ayAj6Hs2pOICdVUlEyuXlsQ78K3HFGOJgWA/yAiQrRuQH9Kv1GxUH36IT99d",
+        "published_at": "2026-06-22T11:25:45.739149Z", "date": "2026-06-22T11:25:45.739149Z",
+        "detected_at": "2026-06-22T11:25:45.739149Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-22T11:25:45.739149Z", "last_seen_at": "2026-06-22T11:25:45.739149Z",
+        "data": {"line": 20, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-22T11:25:45.739149Z", "last_presence_check_at":
+        "2026-06-22T11:25:45.739149Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 6}, {"id":
+        34122510, "account": 8, "criterion": "Generic Password", "date": "2026-06-19T13:41:03Z",
+        "last_trigger_published_at": "2026-06-19T13:41:03Z", "last_triggered_at":
+        "2026-06-19T13:43:05.020137Z", "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z",
+        "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Generic Password", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
+        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
+        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
+        "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
+        "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 129, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_62.txt", "filename":
+        "configuration_62.txt", "presence": "visible", "last_presence_seen_at": "2026-06-19T13:43:05.062490Z",
+        "last_presence_check_at": "2026-06-19T13:43:05.062490Z", "first_presence_deleted_at":
         null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}, {"type": "DEFAULT_BRANCH", "metadata":
-        null}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG",
-        "TEST_FILE"], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}]}'
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 34038186, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-16T18:55:43.166667Z", "last_trigger_published_at": "2026-06-16T18:55:43.166667Z",
+        "last_triggered_at": "2026-06-16T18:55:43.185061Z", "last_trigger_detected_at":
+        "2026-06-16T18:55:43.185061Z", "hash": "JFTpQX+4P/dEcXJJ2iw+u54JYDsJnqLtrdws1wjFQ8t9LtHh25LITKmJimoqGr3z",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
+        "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
+        "detected_at": "2026-06-16T18:55:43.166667Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
+        "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
+        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}]}'
     headers:
+      CF-RAY:
+      - a103956b384ad08f-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:22 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '23397'
+      - '22555'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:39 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '121'
+      - '180'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_publicly_shared.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_publicly_shared.yaml
@@ -21,244 +21,241 @@ interactions:
   response:
     body:
       string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?page=2&page_size=5&publicly_shared=true",
-        "previous": null, "results": [{"id": 29487335, "account": 8, "criterion":
-        "Stripe Webhook Secret", "date": "2026-04-02T16:22:33.518000Z", "last_trigger_published_at":
-        "2026-04-02T16:22:33.518000Z", "last_triggered_at": "2026-04-02T16:22:34.233032Z",
-        "last_trigger_detected_at": "2026-04-02T16:22:34.233032Z", "hash": "JquJu98wTd0k40t3UsNgP22P+ywFCrsGM1VDRg3oZBdGXhRWbjOMbKAG+JtXZUOK",
+        "previous": null, "results": [{"id": 34205503, "account": 8, "criterion":
+        "microsoft_azure_storage_connection_string", "date": "2026-06-23T11:13:31.325324Z",
+        "last_trigger_published_at": "2026-06-23T11:13:31.325324Z", "last_triggered_at":
+        "2026-06-23T11:13:31.343453Z", "last_trigger_detected_at": "2026-06-23T11:13:31.343453Z",
+        "hash": "HdPZ4cjZuziAqsakdlsUnJDapTz3ns5pX8vPzfhvGQvpWWWX25LITKmJimoqGr3z",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Stripe Webhook Secret", "severity_rule_config": null, "declarative_secret_status":
-        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": true,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 62, "displayed_occurrence": {"id": 256867982, "issue": 29487335,
-        "account": 8, "kind": "RLTM", "element": "KAN-8?focusedCommentId=10014", "element_type":
-        "JIRA_COMMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "o40+pCpgMCFgcapQEEdZ3imjEpSONYcgy0J+gLe5ygKDJctj7Ro4REsJrqbUl0yj",
-        "published_at": "2026-04-02T16:22:33.518000Z", "date": "2026-04-02T16:22:33.518000Z",
-        "detected_at": "2026-04-02T16:22:34.031682Z", "is_vcs_type": false, "last_detected_at":
-        "2026-04-02T16:22:33.518000Z", "last_seen_at": "2026-04-02T16:22:33.518000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-8?focusedCommentId=10014",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 148603941, "secrets_engine_version": "2.159.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 25, "indice_end":
-        63, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
-        "2026-04-02T16:22:34.268883Z", "last_presence_check_at": "2026-04-02T16:22:34.268883Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 1}, {"id": 29487333, "account": 8, "criterion":
-        "Slack Bot Token", "date": "2026-04-02T16:22:26.591000Z", "last_trigger_published_at":
-        "2026-04-02T16:22:26.591000Z", "last_triggered_at": "2026-04-02T16:22:27.578209Z",
-        "last_trigger_detected_at": "2026-04-02T16:22:27.578209Z", "hash": "UeONCI+H/I19fHV7Ge45VQxOI0/YUY6CYZu9psQ6W53s6W+UOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-04-02T16:22:27.592459Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": true,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 11, "displayed_occurrence": {"id": 256867977, "issue": 29487333,
-        "account": 8, "kind": "RLTM", "element": "KAN-4?focusedCommentId=10005", "element_type":
-        "JIRA_COMMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "BBZtIrA/2GAvXPBnlTveHP2iPqy+rHM0BxNchD6gRp+/+mUjQPrqnyjHph0vjkPi",
-        "published_at": "2026-04-02T16:22:26.591000Z", "date": "2026-04-02T16:22:26.591000Z",
-        "detected_at": "2026-04-02T16:22:27.022003Z", "is_vcs_type": false, "last_detected_at":
-        "2026-04-02T16:22:26.591000Z", "last_seen_at": "2026-04-02T16:22:26.591000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-4?focusedCommentId=10005",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 148603933, "secrets_engine_version": "2.159.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 25, "indice_end":
-        81, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
-        "2026-04-02T16:22:27.644022Z", "last_presence_check_at": "2026-04-02T16:22:27.644022Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": ["REVOCABLE_BY_GG"],
-        "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
-        29305270, "account": 8, "criterion": "OpenAI API Key", "date": "2026-03-27T13:47:01Z",
-        "last_trigger_published_at": "2026-03-27T13:47:01Z", "last_triggered_at":
-        "2026-03-28T05:01:36.397561Z", "last_trigger_detected_at": "2026-03-28T05:01:36.397561Z",
-        "hash": "MTJFo5AaJdAJ7giIaJE2+Vn/3hEL1nR7oKsu0ry8AAS38W2S95GRLqiXIWrK60u6",
-        "ignored": true, "ignored_at": "2026-03-28T05:01:36.405919Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "OpenAI API Key", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "name": "gg-tools"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-tools / OneDrive", "type": "microsoft_onedrive", "path": "gg-tools
-        / OneDrive", "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata":
-        null, "is_vaulted": false, "similar_issue_count": 0, "score": 6, "displayed_occurrence":
-        {"id": 255746729, "issue": 29305270, "account": 8, "kind": "RLTM", "element":
-        "{\"drive_id\": \"b!ifwT0vIqDE2MYP5tWpOaVJKsAA38ZA1PqHTPWAaO0Ovk8yFkaTlITKSgS6Y2Zlvu\",
-        \"parent_reference_path\": \"/drives/b!ifwT0vIqDE2MYP5tWpOaVJKsAA38ZA1PqHTPWAaO0Ovk8yFkaTlITKSgS6Y2Zlvu/root:/Recordings\",
-        \"file_id\": \"01ICX32E3NSJA7PEQVFZAKEEXG4DH65RP4\"}", "element_type": "SHAREPOINT_ONEDRIVE_FILE",
-        "author_name": "gg-tools", "author_info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "value": null, "value_hash": "CFPFVOpXX+26OfRN+bRLyvVCXnQmU1Cpu36m73v5F4pgz7WMu+D6UW65wQZMF7kQ",
-        "published_at": "2026-03-27T13:47:01Z", "date": "2026-03-27T13:47:01Z", "detected_at":
-        "2026-03-28T04:58:40.843022Z", "is_vcs_type": false, "last_detected_at": "2026-03-27T13:47:01Z",
-        "last_seen_at": "2026-03-27T13:47:01Z", "data": {}, "url": "https://gitguardianengineering-my.sharepoint.com/personal/gg-tools_gitguardianengineering_onmicrosoft_com/Documents/Recordings/secret.txt",
-        "source": {"id": 19962591, "url": "https://onedrive.com/", "type": "microsoft_onedrive",
-        "display_name": "gg-tools / OneDrive", "visibility": "private", "monitored":
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
+        "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
+        "detected_at": "2026-06-23T11:13:31.325324Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
+        "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
         true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null}, "regression": false, "content": 147214824, "secrets_engine_version":
-        "2.159.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 8, "indice_end": 59, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "Recordings/secret.txt", "filename":
-        "secret.txt", "presence": "visible", "last_presence_seen_at": "2026-03-28T05:01:36.456203Z",
-        "last_presence_check_at": "2026-03-28T05:01:36.456203Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": []},
-        "has_dropped_occurrences": false, "tags": ["REVOCABLE_BY_GG"], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 1}, {"id": 29236129, "account": 8, "criterion":
-        "Slack Bot Token", "date": "2026-03-26T16:10:40Z", "last_trigger_published_at":
-        "2026-03-26T16:10:40Z", "last_triggered_at": "2026-03-26T16:10:55.648969Z",
-        "last_trigger_detected_at": "2026-03-26T16:10:55.648969Z", "hash": "0Y7z2cw2c6cwAdy+TeYUL5BKR7Lb/hDQRLHld5PCWUkg5Q0OOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-03-26T16:10:55.689671Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "pierrelalanne/test_repo", "type": "gh_repository", "path": "pierrelalanne/test_repo",
-        "source_criticality": "critical"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 0, "displayed_occurrence":
-        {"id": 253938087, "issue": 29236129, "account": 8, "kind": "RLTM", "element":
-        "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
-        "value": null, "value_hash": "CEL9N36auQTdl9e+bqgAsGyWN0vVPYlqvHWSQMXxC/1zmdQrKYk359La8N2L+SIi",
-        "published_at": "2026-03-26T16:10:40Z", "date": "2026-03-26T16:10:40Z", "detected_at":
-        "2026-03-26T16:10:51.878216Z", "is_vcs_type": true, "last_detected_at": "2026-03-26T16:10:40Z",
-        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R1",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
-        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 146712049,
-        "secrets_engine_version": "2.159.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 60, "indice_end": 102, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 1, "post_line_end": 1}], "most_sensitive_match_name":
-        "apikey", "insights": [{"name": "test_file", "source": "document", "metadata":
-        null}], "filepath": "test_limits_1_secret.txt", "filename": "test_limits_1_secret.txt",
-        "presence": "visible", "last_presence_seen_at": "2026-03-26T16:10:55.988339Z",
-        "last_presence_check_at": "2026-03-26T16:10:55.988339Z", "first_presence_deleted_at":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
+        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
+        34186239, "account": 8, "criterion": "Generic Password", "date": "2026-06-22T15:14:57Z",
+        "last_trigger_published_at": "2026-06-22T15:14:57Z", "last_triggered_at":
+        "2026-06-22T15:16:49.799821Z", "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z",
+        "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Generic Password", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
+        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
+        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
+        "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
+        "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
+        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 113, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_63.txt", "filename":
+        "configuration_63.txt", "presence": "visible", "last_presence_seen_at": "2026-06-22T15:16:49.824313Z",
+        "last_presence_check_at": "2026-06-22T15:16:49.824313Z", "first_presence_deleted_at":
         null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}, {"type": "DEFAULT_BRANCH", "metadata":
-        null}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG",
-        "TEST_FILE"], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
-        29236130, "account": 8, "criterion": "Slack Bot Token", "date": "2026-03-26T16:10:40Z",
-        "last_trigger_published_at": "2026-03-26T16:10:40Z", "last_triggered_at":
-        "2026-03-26T16:10:55.649133Z", "last_trigger_detected_at": "2026-03-26T16:10:55.649133Z",
-        "hash": "1d291ZrFV0RBbVE8r2t6EFI1jgdXhzZkb4RYrNKH10mjkZ9yOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-03-26T16:10:55.695057Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "pierrelalanne/test_repo", "type": "gh_repository", "path": "pierrelalanne/test_repo",
-        "source_criticality": "critical"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 10, "score": 0, "displayed_occurrence":
-        {"id": 253938082, "issue": 29236130, "account": 8, "kind": "RLTM", "element":
-        "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
-        "value": null, "value_hash": "8CeYKeR2kMER0aBlyGThkdNGWeRYfKFLPj1kOQJO8lH2bXzFs7jhuR1VfR21VK1W",
-        "published_at": "2026-03-26T16:10:40Z", "date": "2026-03-26T16:10:40Z", "detected_at":
-        "2026-03-26T16:10:51.878216Z", "is_vcs_type": true, "last_detected_at": "2026-03-26T16:10:40Z",
-        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R20",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
-        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 146712049,
-        "secrets_engine_version": "2.159.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 896, "indice_end": 938, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 20, "post_line_end": 20}], "most_sensitive_match_name":
-        "apikey", "insights": [{"name": "test_file", "source": "document", "metadata":
-        null}], "filepath": "test_limits_1_secret.txt", "filename": "test_limits_1_secret.txt",
-        "presence": "visible", "last_presence_seen_at": "2026-03-26T16:10:55.988339Z",
-        "last_presence_check_at": "2026-03-26T16:10:55.988339Z", "first_presence_deleted_at":
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 34181686, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-22T11:25:45.739149Z", "last_trigger_published_at": "2026-06-22T11:25:45.739149Z",
+        "last_triggered_at": "2026-06-22T11:25:45.762592Z", "last_trigger_detected_at":
+        "2026-06-22T11:25:45.762592Z", "hash": "gVrL/pjjFLo7sSikPS1pWtPJbr+oWSSVz8IB6+2ViJDSJKiK25LITKmJimoqGr3z",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": true, "resolved_at": "2026-06-22T11:26:52.971214Z", "resolver":
+        1751937, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
+        "none", "ignorer_type": "none", "resolver_display_name": "candidate.playground+eu@gitguardian.com",
+        "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
+        "none", "status": "RESOLVED", "issue_name": "Microsoft Azure Storage Connection
+        String", "severity_rule_config": null, "declarative_secret_status": "revoked",
+        "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "", "name": "Kashyapa P.A. Jayasekera"}],
+        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "GGFRLTA127
+        \u2014 kashyapap.jayasekera", "type": "endpoints", "path": "GGFRLTA127 \u2014
+        kashyapap.jayasekera", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274639444, "issue": 34181686, "account": 8, "kind": "RLTM", "element":
+        "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "AAr6ayAj6Hs2pOICdVUlEyuXlsQ78K3HFGOJgWA/yAiQrRuQH9Kv1GxUH36IT99d",
+        "published_at": "2026-06-22T11:25:45.739149Z", "date": "2026-06-22T11:25:45.739149Z",
+        "detected_at": "2026-06-22T11:25:45.739149Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-22T11:25:45.739149Z", "last_seen_at": "2026-06-22T11:25:45.739149Z",
+        "data": {"line": 20, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-22T11:25:45.739149Z", "last_presence_check_at":
+        "2026-06-22T11:25:45.739149Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 6}, {"id":
+        34122510, "account": 8, "criterion": "Generic Password", "date": "2026-06-19T13:41:03Z",
+        "last_trigger_published_at": "2026-06-19T13:41:03Z", "last_triggered_at":
+        "2026-06-19T13:43:05.020137Z", "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z",
+        "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Generic Password", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
+        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
+        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
+        "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
+        "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 129, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_62.txt", "filename":
+        "configuration_62.txt", "presence": "visible", "last_presence_seen_at": "2026-06-19T13:43:05.062490Z",
+        "last_presence_check_at": "2026-06-19T13:43:05.062490Z", "first_presence_deleted_at":
         null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}, {"type": "DEFAULT_BRANCH", "metadata":
-        null}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG",
-        "TEST_FILE"], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}]}'
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 34038186, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-16T18:55:43.166667Z", "last_trigger_published_at": "2026-06-16T18:55:43.166667Z",
+        "last_triggered_at": "2026-06-16T18:55:43.185061Z", "last_trigger_detected_at":
+        "2026-06-16T18:55:43.185061Z", "hash": "JFTpQX+4P/dEcXJJ2iw+u54JYDsJnqLtrdws1wjFQ8t9LtHh25LITKmJimoqGr3z",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
+        "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
+        "detected_at": "2026-06-16T18:55:43.166667Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
+        "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
+        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}]}'
     headers:
+      CF-RAY:
+      - a10395a078011b44-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:30 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '23397'
+      - '22555'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:47 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '143'
+      - '128'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_score_filter_and_ordering.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_score_filter_and_ordering.yaml
@@ -43,11 +43,12 @@ interactions:
         "name": "Lucius Fox"}], "user_permission": 7, "is_publicly_shared": false,
         "feedbacks_count": 1, "occurrences_presence_seen_count": 0, "occurrences_presence_deleted_count":
         2, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "wayne-enterprises-gg/public-app-gg-bis-2020-10", "type": "gh_repository",
-        "path": "wayne-enterprises-gg/public-app-gg-bis-2020-10", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 48, "score": 100, "displayed_occurrence": {"id": 78198,
-        "issue": 21460, "account": 8, "kind": "RLTM", "element": "998deb2c88b0be31f72d117ac1238114334445e8",
+        [{"id": 12349, "name": "wayne-enterprises-gg/public-app-gg-bis-2020-10", "type":
+        "gh_repository", "path": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "source_criticality": "unknown", "monitoring_status": "deleted_on_remote",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 48, "score": 100, "displayed_occurrence": {"id":
+        78198, "issue": 21460, "account": 8, "kind": "RLTM", "element": "998deb2c88b0be31f72d117ac1238114334445e8",
         "element_type": "GIT_COMMIT", "author_name": "Lucius Fox", "author_info":
         "lucius-fox-gg@protonmail.com", "value": null, "value_hash": "1L9CNiJQrSoUY+DgKJLdtjuqHK0OaVUl1VVX1ysCO/lX8FQi+GgD01C2z8H3+skF",
         "published_at": "2020-10-29T13:19:59.005564Z", "date": "2020-10-29T13:19:59.005564Z",
@@ -57,24 +58,25 @@ interactions:
         "source": {"id": 12349, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
         "type": "gh_repository", "display_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
         "visibility": "public", "monitored": true, "source_criticality": "unknown",
-        "deleted_at": "2021-01-14T00:19:19.349665Z", "default_branch": null}, "regression":
-        false, "content": 468, "secrets_engine_version": "unknown", "matches": [{"name":
-        "client_id", "string_matched": "[REDACTED]", "indice_start": 92, "indice_end":
-        112, "pre_line_start": null, "pre_line_end": null, "post_line_start": 3, "post_line_end":
-        3}, {"name": "client_secret", "string_matched": "[REDACTED]", "indice_start":
-        128, "indice_end": 168, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        4, "post_line_end": 4}], "most_sensitive_match_name": "client_secret", "insights":
-        [], "filepath": "app.py", "filename": "app.py", "presence": "repository_deleted",
-        "last_presence_seen_at": "2020-10-29T13:19:59.005564Z", "last_presence_check_at":
-        "2021-07-24T15:12:47.621455Z", "first_presence_deleted_at": "2021-07-24T15:12:47.621455Z",
-        "seen_in_default_branch": null, "change_type": "addition", "full_tags": [{"type":
-        "PUBLICLY_EXPOSED", "metadata": null}]}, "has_dropped_occurrences": false,
-        "tags": ["PUBLICLY_LEAKED"], "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 2}, {"id": 21464, "account": 8, "criterion": "AWS Keys",
-        "date": "2020-10-29T04:19:56.388169Z", "last_trigger_published_at": "2020-10-29T04:19:56.388169Z",
-        "last_triggered_at": "2021-02-11T14:23:22.947692Z", "last_trigger_detected_at":
-        "2021-02-11T14:23:22.947692Z", "hash": "Vk90LgwiOvekJz1ekAbpTtG//qwTheghhQ6DeOBCFVHzghwkL4Qc71cZRqNcojMG",
+        "deleted_at": null, "default_branch": null, "monitoring_status": "deleted_on_remote"},
+        "regression": false, "content": 468, "secrets_engine_version": "unknown",
+        "matches": [{"name": "client_id", "string_matched": "[REDACTED]", "indice_start":
+        92, "indice_end": 112, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        3, "post_line_end": 3}, {"name": "client_secret", "string_matched": "[REDACTED]",
+        "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 4, "post_line_end": 4}], "most_sensitive_match_name":
+        "client_secret", "insights": [], "filepath": "app.py", "filename": "app.py",
+        "presence": "repository_deleted", "last_presence_seen_at": "2020-10-29T13:19:59.005564Z",
+        "last_presence_check_at": "2021-07-24T15:12:47.621455Z", "first_presence_deleted_at":
+        "2021-07-24T15:12:47.621455Z", "seen_in_default_branch": null, "change_type":
+        "addition", "full_tags": [{"type": "PUBLICLY_EXPOSED", "metadata": null, "field":
+        "content"}]}, "has_dropped_occurrences": false, "tags": ["PUBLICLY_LEAKED",
+        "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 2}, {"id":
+        21464, "account": 8, "criterion": "AWS Keys", "date": "2020-10-29T04:19:56.388169Z",
+        "last_trigger_published_at": "2020-10-29T04:19:56.388169Z", "last_triggered_at":
+        "2021-02-11T14:23:22.947692Z", "last_trigger_detected_at": "2021-02-11T14:23:22.947692Z",
+        "hash": "Vk90LgwiOvekJz1ekAbpTtG//qwTheghhQ6DeOBCFVHzghwkL4Qc71cZRqNcojMG",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2026-03-11T22:41:04.525493Z", "resolver":
         491414, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
@@ -93,11 +95,12 @@ interactions:
         Fox"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
         0, "occurrences_presence_seen_count": 0, "occurrences_presence_deleted_count":
         2, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "wayne-enterprises-gg/public-app-gg-bis-2020-09", "type": "gh_repository",
-        "path": "wayne-enterprises-gg/public-app-gg-bis-2020-09", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 48, "score": 100, "displayed_occurrence": {"id": 78206,
-        "issue": 21464, "account": 8, "kind": "RLTM", "element": "643bdce69ff4517e60c383e1a81d7d74244981a1",
+        [{"id": 12345, "name": "wayne-enterprises-gg/public-app-gg-bis-2020-09", "type":
+        "gh_repository", "path": "wayne-enterprises-gg/public-app-gg-bis-2020-09",
+        "source_criticality": "unknown", "monitoring_status": "deleted_on_remote",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 48, "score": 100, "displayed_occurrence": {"id":
+        78206, "issue": 21464, "account": 8, "kind": "RLTM", "element": "643bdce69ff4517e60c383e1a81d7d74244981a1",
         "element_type": "GIT_COMMIT", "author_name": "Lucius Fox", "author_info":
         "lucius-fox-gg@protonmail.com", "value": null, "value_hash": "5lwvD42Y5SrxcOTVkytIeyBCp9rtT6ukEOtUT6LfHX42Psy7pxjjDYOGpRytJCpz",
         "published_at": "2020-10-29T04:19:56.388169Z", "date": "2020-10-29T04:19:56.388169Z",
@@ -107,24 +110,25 @@ interactions:
         "source": {"id": 12345, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-09",
         "type": "gh_repository", "display_name": "wayne-enterprises-gg/public-app-gg-bis-2020-09",
         "visibility": "public", "monitored": true, "source_criticality": "unknown",
-        "deleted_at": "2020-12-15T00:19:32.297591Z", "default_branch": null}, "regression":
-        false, "content": 476, "secrets_engine_version": "unknown", "matches": [{"name":
-        "client_id", "string_matched": "[REDACTED]", "indice_start": 92, "indice_end":
-        112, "pre_line_start": null, "pre_line_end": null, "post_line_start": 3, "post_line_end":
-        3}, {"name": "client_secret", "string_matched": "[REDACTED]", "indice_start":
-        128, "indice_end": 168, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        4, "post_line_end": 4}], "most_sensitive_match_name": "client_secret", "insights":
-        [], "filepath": "app.py", "filename": "app.py", "presence": "repository_deleted",
-        "last_presence_seen_at": "2020-10-29T04:19:56.388169Z", "last_presence_check_at":
-        "2021-06-02T20:59:20.610413Z", "first_presence_deleted_at": "2021-06-02T20:59:20.610413Z",
-        "seen_in_default_branch": null, "change_type": "addition", "full_tags": [{"type":
-        "PUBLICLY_EXPOSED", "metadata": null}]}, "has_dropped_occurrences": false,
-        "tags": ["PUBLICLY_LEAKED"], "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 2}, {"id": 21468, "account": 8, "criterion": "AWS Keys",
-        "date": "2020-10-26T11:19:37.692890Z", "last_trigger_published_at": "2020-10-26T11:19:37.692890Z",
-        "last_triggered_at": "2021-02-11T14:23:22.947805Z", "last_trigger_detected_at":
-        "2021-02-11T14:23:22.947805Z", "hash": "Ht2AYBgk3PDhYwqAc7LqGbqcKAMllvnJ4JmP4l/oSLsfa769L4Qc71cZRqNcojMG",
+        "deleted_at": null, "default_branch": null, "monitoring_status": "deleted_on_remote"},
+        "regression": false, "content": 476, "secrets_engine_version": "unknown",
+        "matches": [{"name": "client_id", "string_matched": "[REDACTED]", "indice_start":
+        92, "indice_end": 112, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        3, "post_line_end": 3}, {"name": "client_secret", "string_matched": "[REDACTED]",
+        "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 4, "post_line_end": 4}], "most_sensitive_match_name":
+        "client_secret", "insights": [], "filepath": "app.py", "filename": "app.py",
+        "presence": "repository_deleted", "last_presence_seen_at": "2020-10-29T04:19:56.388169Z",
+        "last_presence_check_at": "2021-06-02T20:59:20.610413Z", "first_presence_deleted_at":
+        "2021-06-02T20:59:20.610413Z", "seen_in_default_branch": null, "change_type":
+        "addition", "full_tags": [{"type": "PUBLICLY_EXPOSED", "metadata": null, "field":
+        "content"}]}, "has_dropped_occurrences": false, "tags": ["PUBLICLY_LEAKED",
+        "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 2}, {"id":
+        21468, "account": 8, "criterion": "AWS Keys", "date": "2020-10-26T11:19:37.692890Z",
+        "last_trigger_published_at": "2020-10-26T11:19:37.692890Z", "last_triggered_at":
+        "2021-02-11T14:23:22.947805Z", "last_trigger_detected_at": "2021-02-11T14:23:22.947805Z",
+        "hash": "Ht2AYBgk3PDhYwqAc7LqGbqcKAMllvnJ4JmP4l/oSLsfa769L4Qc71cZRqNcojMG",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2021-10-29T11:30:15.067891Z", "resolver":
         null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
@@ -143,11 +147,12 @@ interactions:
         "Lucius Fox"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
         1, "occurrences_presence_seen_count": 0, "occurrences_presence_deleted_count":
         2, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "wayne-enterprises-gg/private-app-gg-bis-2020-10", "type": "gh_repository",
-        "path": "wayne-enterprises-gg/private-app-gg-bis-2020-10", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 0, "score": 100, "displayed_occurrence": {"id": 78214,
-        "issue": 21468, "account": 8, "kind": "RLTM", "element": "3bc35c67a11f7474629e762f2dce57e91c79e64f",
+        [{"id": 12325, "name": "wayne-enterprises-gg/private-app-gg-bis-2020-10",
+        "type": "gh_repository", "path": "wayne-enterprises-gg/private-app-gg-bis-2020-10",
+        "source_criticality": "unknown", "monitoring_status": "deleted_on_remote",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 0, "score": 100, "displayed_occurrence": {"id":
+        78214, "issue": 21468, "account": 8, "kind": "RLTM", "element": "3bc35c67a11f7474629e762f2dce57e91c79e64f",
         "element_type": "GIT_COMMIT", "author_name": "Lucius Fox", "author_info":
         "lucius-fox-gg@protonmail.com", "value": null, "value_hash": "hG1diU79gB2CHQVjnqOs2/jzPWkypY0MPkfnzVId4etJxn1OKn9nKQTMTumsQ0DJ",
         "published_at": "2020-10-26T11:19:37.692890Z", "date": "2020-10-26T11:19:37.692890Z",
@@ -157,24 +162,25 @@ interactions:
         "source": {"id": 12325, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2020-10",
         "type": "gh_repository", "display_name": "wayne-enterprises-gg/private-app-gg-bis-2020-10",
         "visibility": "public", "monitored": true, "source_criticality": "unknown",
-        "deleted_at": "2021-01-14T00:19:19.859391Z", "default_branch": null}, "regression":
-        false, "content": 484, "secrets_engine_version": "unknown", "matches": [{"name":
-        "client_id", "string_matched": "[REDACTED]", "indice_start": 92, "indice_end":
-        112, "pre_line_start": null, "pre_line_end": null, "post_line_start": 3, "post_line_end":
-        3}, {"name": "client_secret", "string_matched": "[REDACTED]", "indice_start":
-        128, "indice_end": 168, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        4, "post_line_end": 4}], "most_sensitive_match_name": "client_secret", "insights":
-        [], "filepath": "app.py", "filename": "app.py", "presence": "repository_deleted",
-        "last_presence_seen_at": "2020-10-26T11:19:37.692890Z", "last_presence_check_at":
-        "2021-06-18T23:39:09.316482Z", "first_presence_deleted_at": "2021-06-18T23:39:09.316482Z",
-        "seen_in_default_branch": null, "change_type": "addition", "full_tags": [{"type":
-        "PUBLICLY_EXPOSED", "metadata": null}]}, "has_dropped_occurrences": false,
-        "tags": ["PUBLICLY_LEAKED"], "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 2}, {"id": 21471, "account": 8, "criterion": "AWS Keys",
-        "date": "2020-10-25T02:19:49.840699Z", "last_trigger_published_at": "2020-10-25T02:19:49.840699Z",
-        "last_triggered_at": "2021-02-11T14:23:22.947888Z", "last_trigger_detected_at":
-        "2021-02-11T14:23:22.947888Z", "hash": "6FW4RNZbYeOvBd3nNaZZZ/Y4DuSSLxp9xjYf5nfijvq0aJRkL4Qc71cZRqNcojMG",
+        "deleted_at": null, "default_branch": null, "monitoring_status": "deleted_on_remote"},
+        "regression": false, "content": 484, "secrets_engine_version": "unknown",
+        "matches": [{"name": "client_id", "string_matched": "[REDACTED]", "indice_start":
+        92, "indice_end": 112, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        3, "post_line_end": 3}, {"name": "client_secret", "string_matched": "[REDACTED]",
+        "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 4, "post_line_end": 4}], "most_sensitive_match_name":
+        "client_secret", "insights": [], "filepath": "app.py", "filename": "app.py",
+        "presence": "repository_deleted", "last_presence_seen_at": "2020-10-26T11:19:37.692890Z",
+        "last_presence_check_at": "2021-06-18T23:39:09.316482Z", "first_presence_deleted_at":
+        "2021-06-18T23:39:09.316482Z", "seen_in_default_branch": null, "change_type":
+        "addition", "full_tags": [{"type": "PUBLICLY_EXPOSED", "metadata": null, "field":
+        "content"}]}, "has_dropped_occurrences": false, "tags": ["PUBLICLY_LEAKED",
+        "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 2}, {"id":
+        21471, "account": 8, "criterion": "AWS Keys", "date": "2020-10-25T02:19:49.840699Z",
+        "last_trigger_published_at": "2020-10-25T02:19:49.840699Z", "last_triggered_at":
+        "2021-02-11T14:23:22.947888Z", "last_trigger_detected_at": "2021-02-11T14:23:22.947888Z",
+        "hash": "6FW4RNZbYeOvBd3nNaZZZ/Y4DuSSLxp9xjYf5nfijvq0aJRkL4Qc71cZRqNcojMG",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2023-11-06T09:02:20.011118Z", "resolver":
         491414, "regression": false, "manual_severity_setter": 9322, "ignorer_display_name":
@@ -193,11 +199,12 @@ interactions:
         "name": "Lucius Fox"}], "user_permission": 7, "is_publicly_shared": false,
         "feedbacks_count": 2, "occurrences_presence_seen_count": 0, "occurrences_presence_deleted_count":
         2, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "wayne-enterprises-gg/private-app-gg-bis-2020-09", "type": "gh_repository",
-        "path": "wayne-enterprises-gg/private-app-gg-bis-2020-09", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 42, "score": 100, "displayed_occurrence": {"id": 78220,
-        "issue": 21471, "account": 8, "kind": "RLTM", "element": "0899f9d92a22cafba6d00ca1a56f216997c357d4",
+        [{"id": 12357, "name": "wayne-enterprises-gg/private-app-gg-bis-2020-09",
+        "type": "gh_repository", "path": "wayne-enterprises-gg/private-app-gg-bis-2020-09",
+        "source_criticality": "unknown", "monitoring_status": "deleted_on_remote",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 42, "score": 100, "displayed_occurrence": {"id":
+        78220, "issue": 21471, "account": 8, "kind": "RLTM", "element": "0899f9d92a22cafba6d00ca1a56f216997c357d4",
         "element_type": "GIT_COMMIT", "author_name": "Lucius Fox", "author_info":
         "lucius-fox-gg@protonmail.com", "value": null, "value_hash": "ut/784B4BzPAarLlCWhL4l5Nr1lqRpIlJuDcUvTqIuoAXbXeWeDKX6I61HmWOtHD",
         "published_at": "2020-10-25T02:19:49.840699Z", "date": "2020-10-25T02:19:49.840699Z",
@@ -207,24 +214,25 @@ interactions:
         "source": {"id": 12357, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2020-09",
         "type": "gh_repository", "display_name": "wayne-enterprises-gg/private-app-gg-bis-2020-09",
         "visibility": "public", "monitored": true, "source_criticality": "unknown",
-        "deleted_at": "2020-12-15T00:19:32.600910Z", "default_branch": null}, "regression":
-        false, "content": 490, "secrets_engine_version": "unknown", "matches": [{"name":
-        "client_id", "string_matched": "[REDACTED]", "indice_start": 92, "indice_end":
-        112, "pre_line_start": null, "pre_line_end": null, "post_line_start": 3, "post_line_end":
-        3}, {"name": "client_secret", "string_matched": "[REDACTED]", "indice_start":
-        128, "indice_end": 168, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        4, "post_line_end": 4}], "most_sensitive_match_name": "client_secret", "insights":
-        [], "filepath": "app.py", "filename": "app.py", "presence": "repository_deleted",
-        "last_presence_seen_at": "2020-10-25T02:19:49.840699Z", "last_presence_check_at":
-        "2021-03-17T10:21:11.522892Z", "first_presence_deleted_at": "2021-03-17T10:21:11.522892Z",
-        "seen_in_default_branch": null, "change_type": "addition", "full_tags": [{"type":
-        "PUBLICLY_EXPOSED", "metadata": null}]}, "has_dropped_occurrences": false,
-        "tags": ["PUBLICLY_LEAKED"], "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 2}, {"id": 21481, "account": 8, "criterion": "AWS Keys",
-        "date": "2020-10-18T12:19:38.047282Z", "last_trigger_published_at": "2020-10-18T12:19:38.047282Z",
-        "last_triggered_at": "2021-02-11T14:23:22.948176Z", "last_trigger_detected_at":
-        "2021-02-11T14:23:22.948176Z", "hash": "aCi7L0fT+cZPk56I9Btc1CVtZNssJ8H0LhtdRItzdl1KzvxPL4Qc71cZRqNcojMG",
+        "deleted_at": null, "default_branch": null, "monitoring_status": "deleted_on_remote"},
+        "regression": false, "content": 490, "secrets_engine_version": "unknown",
+        "matches": [{"name": "client_id", "string_matched": "[REDACTED]", "indice_start":
+        92, "indice_end": 112, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        3, "post_line_end": 3}, {"name": "client_secret", "string_matched": "[REDACTED]",
+        "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 4, "post_line_end": 4}], "most_sensitive_match_name":
+        "client_secret", "insights": [], "filepath": "app.py", "filename": "app.py",
+        "presence": "repository_deleted", "last_presence_seen_at": "2020-10-25T02:19:49.840699Z",
+        "last_presence_check_at": "2021-03-17T10:21:11.522892Z", "first_presence_deleted_at":
+        "2021-03-17T10:21:11.522892Z", "seen_in_default_branch": null, "change_type":
+        "addition", "full_tags": [{"type": "PUBLICLY_EXPOSED", "metadata": null, "field":
+        "content"}]}, "has_dropped_occurrences": false, "tags": ["PUBLICLY_LEAKED",
+        "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 2}, {"id":
+        21481, "account": 8, "criterion": "AWS Keys", "date": "2020-10-18T12:19:38.047282Z",
+        "last_trigger_published_at": "2020-10-18T12:19:38.047282Z", "last_triggered_at":
+        "2021-02-11T14:23:22.948176Z", "last_trigger_detected_at": "2021-02-11T14:23:22.948176Z",
+        "hash": "aCi7L0fT+cZPk56I9Btc1CVtZNssJ8H0LhtdRItzdl1KzvxPL4Qc71cZRqNcojMG",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2021-10-29T16:04:55.127144Z", "resolver":
         null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
@@ -243,11 +251,12 @@ interactions:
         "Lucius Fox"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
         0, "occurrences_presence_seen_count": 0, "occurrences_presence_deleted_count":
         2, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "wayne-enterprises-gg/private-gg-bis-2020-08", "type": "gh_repository",
-        "path": "wayne-enterprises-gg/private-gg-bis-2020-08", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 64, "score": 100, "displayed_occurrence": {"id": 78239,
-        "issue": 21481, "account": 8, "kind": "RLTM", "element": "6877bb0b4fca9e7f125c027fb3c2254be9cb35b6",
+        [{"id": 12275, "name": "wayne-enterprises-gg/private-gg-bis-2020-08", "type":
+        "gh_repository", "path": "wayne-enterprises-gg/private-gg-bis-2020-08", "source_criticality":
+        "unknown", "monitoring_status": "deleted_on_remote", "deleted_at": null}],
+        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
+        64, "score": 100, "displayed_occurrence": {"id": 78239, "issue": 21481, "account":
+        8, "kind": "RLTM", "element": "6877bb0b4fca9e7f125c027fb3c2254be9cb35b6",
         "element_type": "GIT_COMMIT", "author_name": "Lucius Fox", "author_info":
         "lucius-fox-gg@protonmail.com", "value": null, "value_hash": "U3EYGTDUfl1mGIc+8BYoYEAqXHn8UtjhIVmlMZzpGdk451drrHgmRJdpiGpROYFv",
         "published_at": "2020-10-18T12:19:38.047282Z", "date": "2020-10-18T12:19:38.047282Z",
@@ -257,24 +266,25 @@ interactions:
         "source": {"id": 12275, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-08",
         "type": "gh_repository", "display_name": "wayne-enterprises-gg/private-gg-bis-2020-08",
         "visibility": "public", "monitored": true, "source_criticality": "unknown",
-        "deleted_at": "2020-11-14T00:19:21.111601Z", "default_branch": null}, "regression":
-        false, "content": 509, "secrets_engine_version": "unknown", "matches": [{"name":
-        "client_id", "string_matched": "[REDACTED]", "indice_start": 92, "indice_end":
-        112, "pre_line_start": null, "pre_line_end": null, "post_line_start": 3, "post_line_end":
-        3}, {"name": "client_secret", "string_matched": "[REDACTED]", "indice_start":
-        128, "indice_end": 168, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        4, "post_line_end": 4}], "most_sensitive_match_name": "client_secret", "insights":
-        [], "filepath": "app.py", "filename": "app.py", "presence": "repository_deleted",
-        "last_presence_seen_at": "2020-10-18T12:19:38.047282Z", "last_presence_check_at":
-        "2021-07-12T06:35:52.297763Z", "first_presence_deleted_at": "2021-07-12T06:35:52.297763Z",
-        "seen_in_default_branch": null, "change_type": "addition", "full_tags": [{"type":
-        "PUBLICLY_EXPOSED", "metadata": null}]}, "has_dropped_occurrences": false,
-        "tags": ["PUBLICLY_LEAKED"], "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 2}, {"id": 21483, "account": 8, "criterion": "AWS Keys",
-        "date": "2020-10-16T23:19:38.924991Z", "last_trigger_published_at": "2020-10-16T23:19:38.924991Z",
-        "last_triggered_at": "2021-02-11T14:23:22.948203Z", "last_trigger_detected_at":
-        "2021-02-11T14:23:22.948203Z", "hash": "B0E6crZJCVBow2yPeSnJTAL6Gfs0OPt7FnIY5XogCicHKGSaL4Qc71cZRqNcojMG",
+        "deleted_at": null, "default_branch": null, "monitoring_status": "deleted_on_remote"},
+        "regression": false, "content": 509, "secrets_engine_version": "unknown",
+        "matches": [{"name": "client_id", "string_matched": "[REDACTED]", "indice_start":
+        92, "indice_end": 112, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        3, "post_line_end": 3}, {"name": "client_secret", "string_matched": "[REDACTED]",
+        "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 4, "post_line_end": 4}], "most_sensitive_match_name":
+        "client_secret", "insights": [], "filepath": "app.py", "filename": "app.py",
+        "presence": "repository_deleted", "last_presence_seen_at": "2020-10-18T12:19:38.047282Z",
+        "last_presence_check_at": "2021-07-12T06:35:52.297763Z", "first_presence_deleted_at":
+        "2021-07-12T06:35:52.297763Z", "seen_in_default_branch": null, "change_type":
+        "addition", "full_tags": [{"type": "PUBLICLY_EXPOSED", "metadata": null, "field":
+        "content"}]}, "has_dropped_occurrences": false, "tags": ["PUBLICLY_LEAKED",
+        "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 2}, {"id":
+        21483, "account": 8, "criterion": "AWS Keys", "date": "2020-10-16T23:19:38.924991Z",
+        "last_trigger_published_at": "2020-10-16T23:19:38.924991Z", "last_triggered_at":
+        "2021-02-11T14:23:22.948203Z", "last_trigger_detected_at": "2021-02-11T14:23:22.948203Z",
+        "hash": "B0E6crZJCVBow2yPeSnJTAL6Gfs0OPt7FnIY5XogCicHKGSaL4Qc71cZRqNcojMG",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2022-09-06T09:06:08.295495Z", "resolver":
         null, "regression": false, "manual_severity_setter": 9322, "ignorer_display_name":
@@ -293,11 +303,12 @@ interactions:
         "name": "Lucius Fox"}], "user_permission": 7, "is_publicly_shared": false,
         "feedbacks_count": 2, "occurrences_presence_seen_count": 0, "occurrences_presence_deleted_count":
         2, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "wayne-enterprises-gg/private-app-gg-bis-2020-09", "type": "gh_repository",
-        "path": "wayne-enterprises-gg/private-app-gg-bis-2020-09", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 25, "score": 100, "displayed_occurrence": {"id": 78242,
-        "issue": 21483, "account": 8, "kind": "RLTM", "element": "21dfe9873dee987ce65df7cece464299ec359ded",
+        [{"id": 12357, "name": "wayne-enterprises-gg/private-app-gg-bis-2020-09",
+        "type": "gh_repository", "path": "wayne-enterprises-gg/private-app-gg-bis-2020-09",
+        "source_criticality": "unknown", "monitoring_status": "deleted_on_remote",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 25, "score": 100, "displayed_occurrence": {"id":
+        78242, "issue": 21483, "account": 8, "kind": "RLTM", "element": "21dfe9873dee987ce65df7cece464299ec359ded",
         "element_type": "GIT_COMMIT", "author_name": "Lucius Fox", "author_info":
         "lucius-fox-gg@protonmail.com", "value": null, "value_hash": "SVpvvlAm+mSkBreWHt3M0x1lYBT3+d+xuKt2jG4MHghesISKuoP/qcMyEiXAlxlC",
         "published_at": "2020-10-16T23:19:38.924991Z", "date": "2020-10-16T23:19:38.924991Z",
@@ -307,24 +318,25 @@ interactions:
         "source": {"id": 12357, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2020-09",
         "type": "gh_repository", "display_name": "wayne-enterprises-gg/private-app-gg-bis-2020-09",
         "visibility": "public", "monitored": true, "source_criticality": "unknown",
-        "deleted_at": "2020-12-15T00:19:32.600910Z", "default_branch": null}, "regression":
-        false, "content": 511, "secrets_engine_version": "unknown", "matches": [{"name":
-        "client_id", "string_matched": "[REDACTED]", "indice_start": 92, "indice_end":
-        112, "pre_line_start": null, "pre_line_end": null, "post_line_start": 3, "post_line_end":
-        3}, {"name": "client_secret", "string_matched": "[REDACTED]", "indice_start":
-        128, "indice_end": 168, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        4, "post_line_end": 4}], "most_sensitive_match_name": "client_secret", "insights":
-        [], "filepath": "app.py", "filename": "app.py", "presence": "repository_deleted",
-        "last_presence_seen_at": "2020-10-16T23:19:38.924991Z", "last_presence_check_at":
-        "2021-05-07T20:22:57.204503Z", "first_presence_deleted_at": "2021-05-07T20:22:57.204503Z",
-        "seen_in_default_branch": null, "change_type": "addition", "full_tags": [{"type":
-        "PUBLICLY_EXPOSED", "metadata": null}]}, "has_dropped_occurrences": false,
-        "tags": ["PUBLICLY_LEAKED"], "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 2}, {"id": 21496, "account": 8, "criterion": "AWS Keys",
-        "date": "2020-10-10T01:19:39.990914Z", "last_trigger_published_at": "2020-10-10T01:19:39.990914Z",
-        "last_triggered_at": "2021-02-11T14:23:22.948454Z", "last_trigger_detected_at":
-        "2021-02-11T14:23:22.948454Z", "hash": "VqlDWipUnHkfhGiSijqczvR/JWp1lr1/I+Ra3GXk2MMUQUk6L4Qc71cZRqNcojMG",
+        "deleted_at": null, "default_branch": null, "monitoring_status": "deleted_on_remote"},
+        "regression": false, "content": 511, "secrets_engine_version": "unknown",
+        "matches": [{"name": "client_id", "string_matched": "[REDACTED]", "indice_start":
+        92, "indice_end": 112, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        3, "post_line_end": 3}, {"name": "client_secret", "string_matched": "[REDACTED]",
+        "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 4, "post_line_end": 4}], "most_sensitive_match_name":
+        "client_secret", "insights": [], "filepath": "app.py", "filename": "app.py",
+        "presence": "repository_deleted", "last_presence_seen_at": "2020-10-16T23:19:38.924991Z",
+        "last_presence_check_at": "2021-05-07T20:22:57.204503Z", "first_presence_deleted_at":
+        "2021-05-07T20:22:57.204503Z", "seen_in_default_branch": null, "change_type":
+        "addition", "full_tags": [{"type": "PUBLICLY_EXPOSED", "metadata": null, "field":
+        "content"}]}, "has_dropped_occurrences": false, "tags": ["PUBLICLY_LEAKED",
+        "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 2}, {"id":
+        21496, "account": 8, "criterion": "AWS Keys", "date": "2020-10-10T01:19:39.990914Z",
+        "last_trigger_published_at": "2020-10-10T01:19:39.990914Z", "last_triggered_at":
+        "2021-02-11T14:23:22.948454Z", "last_trigger_detected_at": "2021-02-11T14:23:22.948454Z",
+        "hash": "VqlDWipUnHkfhGiSijqczvR/JWp1lr1/I+Ra3GXk2MMUQUk6L4Qc71cZRqNcojMG",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2022-09-06T09:04:13.473983Z", "resolver":
         null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
@@ -343,11 +355,12 @@ interactions:
         "Lucius Fox"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
         0, "occurrences_presence_seen_count": 0, "occurrences_presence_deleted_count":
         2, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "wayne-enterprises-gg/private-app-gg-bis-2020-09", "type": "gh_repository",
-        "path": "wayne-enterprises-gg/private-app-gg-bis-2020-09", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 1, "score": 100, "displayed_occurrence": {"id": 78265,
-        "issue": 21496, "account": 8, "kind": "RLTM", "element": "503679d2088a4ad0ac8da4f7fa80f2d9dc8b53cb",
+        [{"id": 12357, "name": "wayne-enterprises-gg/private-app-gg-bis-2020-09",
+        "type": "gh_repository", "path": "wayne-enterprises-gg/private-app-gg-bis-2020-09",
+        "source_criticality": "unknown", "monitoring_status": "deleted_on_remote",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 1, "score": 100, "displayed_occurrence": {"id":
+        78265, "issue": 21496, "account": 8, "kind": "RLTM", "element": "503679d2088a4ad0ac8da4f7fa80f2d9dc8b53cb",
         "element_type": "GIT_COMMIT", "author_name": "Lucius Fox", "author_info":
         "lucius-fox-gg@protonmail.com", "value": null, "value_hash": "RaQzNWSHPE9wz4Q3ll9+QP43F7uaBELZtgsEuKU1K8k4T1TAIgmRXj0sSXd5i6Rh",
         "published_at": "2020-10-10T01:19:39.990914Z", "date": "2020-10-10T01:19:39.990914Z",
@@ -357,24 +370,25 @@ interactions:
         "source": {"id": 12357, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2020-09",
         "type": "gh_repository", "display_name": "wayne-enterprises-gg/private-app-gg-bis-2020-09",
         "visibility": "public", "monitored": true, "source_criticality": "unknown",
-        "deleted_at": "2020-12-15T00:19:32.600910Z", "default_branch": null}, "regression":
-        false, "content": 531, "secrets_engine_version": "unknown", "matches": [{"name":
-        "client_id", "string_matched": "[REDACTED]", "indice_start": 92, "indice_end":
-        112, "pre_line_start": null, "pre_line_end": null, "post_line_start": 3, "post_line_end":
-        3}, {"name": "client_secret", "string_matched": "[REDACTED]", "indice_start":
-        128, "indice_end": 168, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        4, "post_line_end": 4}], "most_sensitive_match_name": "client_secret", "insights":
-        [], "filepath": "app.py", "filename": "app.py", "presence": "repository_deleted",
-        "last_presence_seen_at": "2020-10-10T01:19:39.990914Z", "last_presence_check_at":
-        "2021-07-04T06:13:29.280264Z", "first_presence_deleted_at": "2021-07-04T06:13:29.280264Z",
-        "seen_in_default_branch": null, "change_type": "addition", "full_tags": [{"type":
-        "PUBLICLY_EXPOSED", "metadata": null}]}, "has_dropped_occurrences": false,
-        "tags": ["PUBLICLY_LEAKED"], "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 2}, {"id": 21504, "account": 8, "criterion": "AWS Keys",
-        "date": "2020-10-07T22:19:40.847825Z", "last_trigger_published_at": "2020-10-07T22:19:40.847825Z",
-        "last_triggered_at": "2021-02-11T14:23:22.948647Z", "last_trigger_detected_at":
-        "2021-02-11T14:23:22.948647Z", "hash": "U7n6mHuR3NaG1u4+1vpdfRYtpM1dfgYOaENqIicUX3KVRVy6L4Qc71cZRqNcojMG",
+        "deleted_at": null, "default_branch": null, "monitoring_status": "deleted_on_remote"},
+        "regression": false, "content": 531, "secrets_engine_version": "unknown",
+        "matches": [{"name": "client_id", "string_matched": "[REDACTED]", "indice_start":
+        92, "indice_end": 112, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        3, "post_line_end": 3}, {"name": "client_secret", "string_matched": "[REDACTED]",
+        "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 4, "post_line_end": 4}], "most_sensitive_match_name":
+        "client_secret", "insights": [], "filepath": "app.py", "filename": "app.py",
+        "presence": "repository_deleted", "last_presence_seen_at": "2020-10-10T01:19:39.990914Z",
+        "last_presence_check_at": "2021-07-04T06:13:29.280264Z", "first_presence_deleted_at":
+        "2021-07-04T06:13:29.280264Z", "seen_in_default_branch": null, "change_type":
+        "addition", "full_tags": [{"type": "PUBLICLY_EXPOSED", "metadata": null, "field":
+        "content"}]}, "has_dropped_occurrences": false, "tags": ["PUBLICLY_LEAKED",
+        "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 2}, {"id":
+        21504, "account": 8, "criterion": "AWS Keys", "date": "2020-10-07T22:19:40.847825Z",
+        "last_trigger_published_at": "2020-10-07T22:19:40.847825Z", "last_triggered_at":
+        "2021-02-11T14:23:22.948647Z", "last_trigger_detected_at": "2021-02-11T14:23:22.948647Z",
+        "hash": "U7n6mHuR3NaG1u4+1vpdfRYtpM1dfgYOaENqIicUX3KVRVy6L4Qc71cZRqNcojMG",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2022-09-06T09:04:13.473983Z", "resolver":
         null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
@@ -393,11 +407,12 @@ interactions:
         "Lucius Fox"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
         0, "occurrences_presence_seen_count": 0, "occurrences_presence_deleted_count":
         2, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "wayne-enterprises-gg/private-gg-bis-2020-08", "type": "gh_repository",
-        "path": "wayne-enterprises-gg/private-gg-bis-2020-08", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 1, "score": 100, "displayed_occurrence": {"id": 78280,
-        "issue": 21504, "account": 8, "kind": "RLTM", "element": "e3b9ca510380b3b675cf180fa5115b8ba4d310ed",
+        [{"id": 12275, "name": "wayne-enterprises-gg/private-gg-bis-2020-08", "type":
+        "gh_repository", "path": "wayne-enterprises-gg/private-gg-bis-2020-08", "source_criticality":
+        "unknown", "monitoring_status": "deleted_on_remote", "deleted_at": null}],
+        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
+        1, "score": 100, "displayed_occurrence": {"id": 78280, "issue": 21504, "account":
+        8, "kind": "RLTM", "element": "e3b9ca510380b3b675cf180fa5115b8ba4d310ed",
         "element_type": "GIT_COMMIT", "author_name": "Lucius Fox", "author_info":
         "lucius-fox-gg@protonmail.com", "value": null, "value_hash": "Z0Wch+TvRD6TeD9XDcZKPlnZ3Y3JGuxreeOUwDUPu+2UhbRM53Aj3nPUanUM/HIG",
         "published_at": "2020-10-07T22:19:40.847825Z", "date": "2020-10-07T22:19:40.847825Z",
@@ -407,24 +422,25 @@ interactions:
         "source": {"id": 12275, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-08",
         "type": "gh_repository", "display_name": "wayne-enterprises-gg/private-gg-bis-2020-08",
         "visibility": "public", "monitored": true, "source_criticality": "unknown",
-        "deleted_at": "2020-11-14T00:19:21.111601Z", "default_branch": null}, "regression":
-        false, "content": 545, "secrets_engine_version": "unknown", "matches": [{"name":
-        "client_id", "string_matched": "[REDACTED]", "indice_start": 92, "indice_end":
-        112, "pre_line_start": null, "pre_line_end": null, "post_line_start": 3, "post_line_end":
-        3}, {"name": "client_secret", "string_matched": "[REDACTED]", "indice_start":
-        128, "indice_end": 168, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        4, "post_line_end": 4}], "most_sensitive_match_name": "client_secret", "insights":
-        [], "filepath": "app.py", "filename": "app.py", "presence": "repository_deleted",
-        "last_presence_seen_at": "2020-10-07T22:19:40.847825Z", "last_presence_check_at":
-        "2021-06-14T01:35:49.012046Z", "first_presence_deleted_at": "2021-06-14T01:35:49.012046Z",
-        "seen_in_default_branch": null, "change_type": "addition", "full_tags": [{"type":
-        "PUBLICLY_EXPOSED", "metadata": null}]}, "has_dropped_occurrences": false,
-        "tags": ["PUBLICLY_LEAKED"], "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 2}, {"id": 21509, "account": 8, "criterion": "AWS Keys",
-        "date": "2020-10-06T13:20:07.039345Z", "last_trigger_published_at": "2020-10-06T13:20:07.039345Z",
-        "last_triggered_at": "2021-02-11T14:23:22.948789Z", "last_trigger_detected_at":
-        "2021-02-11T14:23:22.948789Z", "hash": "fs8yT4OztZJaGVMlj8QrlGVdOWVFLNRcoHWkLUnTtAIKcORfL4Qc71cZRqNcojMG",
+        "deleted_at": null, "default_branch": null, "monitoring_status": "deleted_on_remote"},
+        "regression": false, "content": 545, "secrets_engine_version": "unknown",
+        "matches": [{"name": "client_id", "string_matched": "[REDACTED]", "indice_start":
+        92, "indice_end": 112, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        3, "post_line_end": 3}, {"name": "client_secret", "string_matched": "[REDACTED]",
+        "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 4, "post_line_end": 4}], "most_sensitive_match_name":
+        "client_secret", "insights": [], "filepath": "app.py", "filename": "app.py",
+        "presence": "repository_deleted", "last_presence_seen_at": "2020-10-07T22:19:40.847825Z",
+        "last_presence_check_at": "2021-06-14T01:35:49.012046Z", "first_presence_deleted_at":
+        "2021-06-14T01:35:49.012046Z", "seen_in_default_branch": null, "change_type":
+        "addition", "full_tags": [{"type": "PUBLICLY_EXPOSED", "metadata": null, "field":
+        "content"}]}, "has_dropped_occurrences": false, "tags": ["PUBLICLY_LEAKED",
+        "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 2}, {"id":
+        21509, "account": 8, "criterion": "AWS Keys", "date": "2020-10-06T13:20:07.039345Z",
+        "last_trigger_published_at": "2020-10-06T13:20:07.039345Z", "last_triggered_at":
+        "2021-02-11T14:23:22.948789Z", "last_trigger_detected_at": "2021-02-11T14:23:22.948789Z",
+        "hash": "fs8yT4OztZJaGVMlj8QrlGVdOWVFLNRcoHWkLUnTtAIKcORfL4Qc71cZRqNcojMG",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2022-09-06T09:04:13.473983Z", "resolver":
         null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
@@ -443,11 +459,12 @@ interactions:
         "Lucius Fox"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
         0, "occurrences_presence_seen_count": 0, "occurrences_presence_deleted_count":
         2, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "wayne-enterprises-gg/private-app-gg-2020-09", "type": "gh_repository",
-        "path": "wayne-enterprises-gg/private-app-gg-2020-09", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 34, "score": 100, "displayed_occurrence": {"id": 78288,
-        "issue": 21509, "account": 8, "kind": "RLTM", "element": "2da0fd3222e537b3cd3c299a05def9aa223fd5b7",
+        [{"id": 12367, "name": "wayne-enterprises-gg/private-app-gg-2020-09", "type":
+        "gh_repository", "path": "wayne-enterprises-gg/private-app-gg-2020-09", "source_criticality":
+        "unknown", "monitoring_status": "deleted_on_remote", "deleted_at": null}],
+        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
+        34, "score": 100, "displayed_occurrence": {"id": 78288, "issue": 21509, "account":
+        8, "kind": "RLTM", "element": "2da0fd3222e537b3cd3c299a05def9aa223fd5b7",
         "element_type": "GIT_COMMIT", "author_name": "Lucius Fox", "author_info":
         "lucius-fox-gg@protonmail.com", "value": null, "value_hash": "WTKEyEsI+qZmED0dwL5+kNWUFgmwPfWsJbdihtDLyNPNCG0ADOQMjLDua944vEw4",
         "published_at": "2020-10-06T13:20:07.039345Z", "date": "2020-10-06T13:20:07.039345Z",
@@ -457,24 +474,25 @@ interactions:
         "source": {"id": 12367, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2020-09",
         "type": "gh_repository", "display_name": "wayne-enterprises-gg/private-app-gg-2020-09",
         "visibility": "public", "monitored": true, "source_criticality": "unknown",
-        "deleted_at": "2020-12-01T00:19:49.015465Z", "default_branch": null}, "regression":
-        false, "content": 553, "secrets_engine_version": "unknown", "matches": [{"name":
-        "client_id", "string_matched": "[REDACTED]", "indice_start": 92, "indice_end":
-        112, "pre_line_start": null, "pre_line_end": null, "post_line_start": 3, "post_line_end":
-        3}, {"name": "client_secret", "string_matched": "[REDACTED]", "indice_start":
-        128, "indice_end": 168, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        4, "post_line_end": 4}], "most_sensitive_match_name": "client_secret", "insights":
-        [], "filepath": "app.py", "filename": "app.py", "presence": "repository_deleted",
-        "last_presence_seen_at": "2020-10-06T13:20:07.039345Z", "last_presence_check_at":
-        "2021-03-25T13:47:56.916118Z", "first_presence_deleted_at": "2021-03-25T13:47:56.916118Z",
-        "seen_in_default_branch": null, "change_type": "addition", "full_tags": [{"type":
-        "PUBLICLY_EXPOSED", "metadata": null}]}, "has_dropped_occurrences": false,
-        "tags": ["PUBLICLY_LEAKED"], "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 2}, {"id": 21536, "account": 8, "criterion": "AWS Keys",
-        "date": "2020-09-22T23:19:43.460578Z", "last_trigger_published_at": "2020-09-22T23:19:43.460578Z",
-        "last_triggered_at": "2021-02-11T14:23:22.949356Z", "last_trigger_detected_at":
-        "2021-02-11T14:23:22.949356Z", "hash": "Aq4rWli5jAnS4ZDwGzLS2h2k3ws6Pie9sxWWvY8sX1wG9HJgL4Qc71cZRqNcojMG",
+        "deleted_at": null, "default_branch": null, "monitoring_status": "deleted_on_remote"},
+        "regression": false, "content": 553, "secrets_engine_version": "unknown",
+        "matches": [{"name": "client_id", "string_matched": "[REDACTED]", "indice_start":
+        92, "indice_end": 112, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        3, "post_line_end": 3}, {"name": "client_secret", "string_matched": "[REDACTED]",
+        "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 4, "post_line_end": 4}], "most_sensitive_match_name":
+        "client_secret", "insights": [], "filepath": "app.py", "filename": "app.py",
+        "presence": "repository_deleted", "last_presence_seen_at": "2020-10-06T13:20:07.039345Z",
+        "last_presence_check_at": "2021-03-25T13:47:56.916118Z", "first_presence_deleted_at":
+        "2021-03-25T13:47:56.916118Z", "seen_in_default_branch": null, "change_type":
+        "addition", "full_tags": [{"type": "PUBLICLY_EXPOSED", "metadata": null, "field":
+        "content"}]}, "has_dropped_occurrences": false, "tags": ["PUBLICLY_LEAKED",
+        "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 2}, {"id":
+        21536, "account": 8, "criterion": "AWS Keys", "date": "2020-09-22T23:19:43.460578Z",
+        "last_trigger_published_at": "2020-09-22T23:19:43.460578Z", "last_triggered_at":
+        "2021-02-11T14:23:22.949356Z", "last_trigger_detected_at": "2021-02-11T14:23:22.949356Z",
+        "hash": "Aq4rWli5jAnS4ZDwGzLS2h2k3ws6Pie9sxWWvY8sX1wG9HJgL4Qc71cZRqNcojMG",
         "ignored": true, "ignored_at": "2020-09-24T09:47:42.196767Z", "ignore_reason":
         null, "ignorer": 2503, "resolved": false, "resolved_at": null, "resolver":
         null, "regression": false, "manual_severity_setter": 9322, "ignorer_display_name":
@@ -493,11 +511,12 @@ interactions:
         "name": "Lucius Fox"}], "user_permission": 7, "is_publicly_shared": false,
         "feedbacks_count": 0, "occurrences_presence_seen_count": 0, "occurrences_presence_deleted_count":
         2, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "wayne-enterprises-gg/public-app-gg-bis-2020-09", "type": "gh_repository",
-        "path": "wayne-enterprises-gg/public-app-gg-bis-2020-09", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 101, "score": 100, "displayed_occurrence": {"id": 78335,
-        "issue": 21536, "account": 8, "kind": "RLTM", "element": "1ccd84be4e607782519936669189dcdd44e95a8c",
+        [{"id": 12345, "name": "wayne-enterprises-gg/public-app-gg-bis-2020-09", "type":
+        "gh_repository", "path": "wayne-enterprises-gg/public-app-gg-bis-2020-09",
+        "source_criticality": "unknown", "monitoring_status": "deleted_on_remote",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 101, "score": 100, "displayed_occurrence": {"id":
+        78335, "issue": 21536, "account": 8, "kind": "RLTM", "element": "1ccd84be4e607782519936669189dcdd44e95a8c",
         "element_type": "GIT_COMMIT", "author_name": "Lucius Fox", "author_info":
         "lucius-fox-gg@protonmail.com", "value": null, "value_hash": "heNxh9k0jTZ05w7q9zGYibOwxsZMOq5rHxDweGWf4HsKPayxymxFnFW0QPDEKh3W",
         "published_at": "2020-09-22T23:19:43.460578Z", "date": "2020-09-22T23:19:43.460578Z",
@@ -507,54 +526,62 @@ interactions:
         "source": {"id": 12345, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-09",
         "type": "gh_repository", "display_name": "wayne-enterprises-gg/public-app-gg-bis-2020-09",
         "visibility": "public", "monitored": true, "source_criticality": "unknown",
-        "deleted_at": "2020-12-15T00:19:32.297591Z", "default_branch": null}, "regression":
-        false, "content": 593, "secrets_engine_version": "unknown", "matches": [{"name":
-        "client_id", "string_matched": "[REDACTED]", "indice_start": 92, "indice_end":
-        112, "pre_line_start": null, "pre_line_end": null, "post_line_start": 3, "post_line_end":
-        3}, {"name": "client_secret", "string_matched": "[REDACTED]", "indice_start":
-        128, "indice_end": 168, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        4, "post_line_end": 4}], "most_sensitive_match_name": "client_secret", "insights":
-        [], "filepath": "app.py", "filename": "app.py", "presence": "repository_deleted",
-        "last_presence_seen_at": "2020-09-22T23:19:43.460578Z", "last_presence_check_at":
-        "2021-07-02T13:08:10.941922Z", "first_presence_deleted_at": "2021-07-02T13:08:10.941922Z",
-        "seen_in_default_branch": null, "change_type": "addition", "full_tags": [{"type":
-        "PUBLICLY_EXPOSED", "metadata": null}]}, "has_dropped_occurrences": false,
-        "tags": ["PUBLICLY_LEAKED"], "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 2}]}'
+        "deleted_at": null, "default_branch": null, "monitoring_status": "deleted_on_remote"},
+        "regression": false, "content": 593, "secrets_engine_version": "unknown",
+        "matches": [{"name": "client_id", "string_matched": "[REDACTED]", "indice_start":
+        92, "indice_end": 112, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        3, "post_line_end": 3}, {"name": "client_secret", "string_matched": "[REDACTED]",
+        "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 4, "post_line_end": 4}], "most_sensitive_match_name":
+        "client_secret", "insights": [], "filepath": "app.py", "filename": "app.py",
+        "presence": "repository_deleted", "last_presence_seen_at": "2020-09-22T23:19:43.460578Z",
+        "last_presence_check_at": "2021-07-02T13:08:10.941922Z", "first_presence_deleted_at":
+        "2021-07-02T13:08:10.941922Z", "seen_in_default_branch": null, "change_type":
+        "addition", "full_tags": [{"type": "PUBLICLY_EXPOSED", "metadata": null, "field":
+        "content"}]}, "has_dropped_occurrences": false, "tags": ["PUBLICLY_LEAKED",
+        "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 2}]}'
     headers:
+      CF-RAY:
+      - a10395e7bb71b831-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:43 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '55194'
+      - '56494'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:51 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '187'
+      - '1719'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_search.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_search.yaml
@@ -21,17 +21,150 @@ interactions:
   response:
     body:
       string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?page=2&page_size=5&search=aws",
-        "previous": null, "results": [{"id": 27395126, "account": 8, "criterion":
-        "AWS Keys", "date": "2026-02-19T14:36:24Z", "last_trigger_published_at": "2026-02-19T14:36:24Z",
-        "last_triggered_at": "2026-02-19T14:40:08.909390Z", "last_trigger_detected_at":
-        "2026-02-19T14:40:08.909390Z", "hash": "ldopSL0HhOyMPVqrCoyqhrM0YiRtyDjCRKal/yZRhL1LxHMKL4Qc71cZRqNcojMG",
+        "previous": null, "results": [{"id": 32828142, "account": 8, "criterion":
+        "AWS Keys", "date": "2026-05-13T15:25:02.693000Z", "last_trigger_published_at":
+        "2026-05-13T15:25:02.693000Z", "last_triggered_at": "2026-05-13T15:25:06.309395Z",
+        "last_trigger_detected_at": "2026-05-13T15:25:06.309395Z", "hash": "t7xQt+ZkSijV750x3druPYHdfKPpK9gQxSJCBfrrfNDrwz31L4Qc71cZRqNcojMG",
+        "ignored": true, "ignored_at": "2026-05-13T15:25:06.323251Z", "ignore_reason":
+        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
+        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
+        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
+        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
+        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
+        "AWS IAM Keys", "severity_rule_config": null, "declarative_secret_status":
+        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
+        "GG Test Integrations"}, {"info": "<unknown>", "name": "GG Test Integrations"}],
+        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        3, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 0, "sources": [{"id": 28093162, "name": "gg-test-integrations
+        / QA SH Jira Space", "type": "jira_cloud_project", "path": "gg-test-integrations
+        / QA SH Jira Space", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 0, "displayed_occurrence":
+        {"id": 269409153, "issue": 32828142, "account": 8, "kind": "HIST", "element":
+        "QJS-2", "element_type": "JIRA_TICKET", "author_name": "GG Test Integrations",
+        "author_info": "ggtestintegrations@proton.me", "value": null, "value_hash":
+        "mnhuCDXkjCXmXE4PfqGTgnchdepV6MVg3j0V4l5lv7W2jUxLFuVgLjxYdCAlSkbB", "published_at":
+        "2026-05-13T13:00:33.511000Z", "date": "2026-05-13T13:00:33.511000Z", "detected_at":
+        "2026-05-26T07:42:57.694929Z", "is_vcs_type": false, "last_detected_at": "2026-05-13T13:00:33.511000Z",
+        "last_seen_at": "2026-05-13T13:00:33.511000Z", "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/QJS-2",
+        "source": {"id": 28093162, "url": "https://gg-test-integrations.atlassian.net/browse/QJS",
+        "type": "jira_cloud_project", "display_name": "gg-test-integrations / QA SH
+        Jira Space", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 164512729, "secrets_engine_version":
+        "2.163.1", "matches": [{"name": "client_id", "string_matched": "[REDACTED]",
+        "indice_start": 1798, "indice_end": 1818, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": null, "post_line_end": null}, {"name": "client_secret",
+        "string_matched": "[REDACTED]", "indice_start": 1853, "indice_end": 1893,
+        "pre_line_start": null, "pre_line_end": null, "post_line_start": null, "post_line_end":
+        null}], "most_sensitive_match_name": "client_secret", "insights": [], "filepath":
+        null, "filename": null, "presence": "visible", "last_presence_seen_at": "2026-06-03T05:57:09.531478Z",
+        "last_presence_check_at": "2026-06-03T05:57:09.531478Z", "first_presence_deleted_at":
+        null, "seen_in_default_branch": null, "change_type": null, "full_tags": [{"type":
+        "FROM_HISTORICAL_SCAN", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["FROM_HISTORICAL_SCAN", "REVOCABLE_BY_GG", "TEST_FILE"], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 3}, {"id": 32567570, "account": 8, "criterion":
+        "AWS Keys", "date": "2026-05-07T18:37:22Z", "last_trigger_published_at": "2026-05-07T18:37:22Z",
+        "last_triggered_at": "2026-05-07T18:37:25.895765Z", "last_trigger_detected_at":
+        "2026-05-07T18:37:25.895765Z", "hash": "kQsp1yOoI1CqpcB6NI828uqR2nHSidAhduiJpl30jfD2dULcL4Qc71cZRqNcojMG",
+        "ignored": true, "ignored_at": "2026-05-07T18:37:25.902297Z", "ignore_reason":
+        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
+        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
+        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
+        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
+        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
+        "AWS IAM Keys", "severity_rule_config": null, "declarative_secret_status":
+        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "gg-tools@gitguardian.com", "name":
+        "gim-dev"}, {"info": "mathieu.bellon@gitguardian.com", "name": "Mathieu Bellon"}],
+        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        7, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 0, "sources": [{"id": 27930579, "name": "gim-dev/snow-repro",
+        "type": "ghe_repository", "path": "gim-dev/snow-repro", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}, {"id": 28076509,
+        "name": "gim-dev/repro-empty-merge-secret", "type": "ghe_repository", "path":
+        "gim-dev/repro-empty-merge-secret", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 27, "displayed_occurrence":
+        {"id": 266172913, "issue": 32567570, "account": 8, "kind": "RLTM", "element":
+        "ee576e5cf318090b01602c5ffb24a9607fdd5be9", "element_type": "GIT_COMMIT",
+        "author_name": "gim-dev", "author_info": "gg-tools@gitguardian.com", "value":
+        null, "value_hash": "Wad93KyrKN6S2e6VpviT0T1KtPxF0Oav6XIf/DktZeaiy4obyw7Ogic3qDwsyV+Z",
+        "published_at": "2026-05-07T18:37:22Z", "date": "2026-05-07T18:37:22Z", "detected_at":
+        "2026-05-07T18:37:24.813406Z", "is_vcs_type": true, "last_detected_at": "2026-05-07T18:37:22Z",
+        "last_seen_at": "2026-05-07T18:37:22Z", "data": {}, "url": "https://ghe-01.aws-qa-gitguardian.com/gim-dev/snow-repro/commit/ee576e5cf318090b01602c5ffb24a9607fdd5be9#diff-b486b0402fa5438817157f04e64a1198fa657f9ce9de837cab3d7e48aaaa0748R7",
+        "source": {"id": 27930579, "url": "https://ghe-01.aws-qa-gitguardian.com/gim-dev/snow-repro",
+        "type": "ghe_repository", "display_name": "gim-dev/snow-repro", "visibility":
+        "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
+        null, "default_branch": "main", "monitoring_status": "active"}, "regression":
+        false, "content": 159099625, "secrets_engine_version": "2.162.0", "matches":
+        [{"name": "client_id", "string_matched": "[REDACTED]", "indice_start": 235,
+        "indice_end": 255, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        6, "post_line_end": 6}, {"name": "client_secret", "string_matched": "[REDACTED]",
+        "indice_start": 273, "indice_end": 313, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 7, "post_line_end": 7}], "most_sensitive_match_name":
+        "client_secret", "insights": [], "filepath": "astro.js", "filename": "astro.js",
+        "presence": "visible", "last_presence_seen_at": "2026-05-07T18:37:25.938999Z",
+        "last_presence_check_at": "2026-05-07T18:37:25.938999Z", "first_presence_deleted_at":
+        null, "seen_in_default_branch": null, "change_type": "addition", "full_tags":
+        []}, "has_dropped_occurrences": false, "tags": ["FROM_HISTORICAL_SCAN", "PUBLICLY_LEAKED",
+        "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible": false,
+        "public_incident_linked": true, "leaked_outside_perimeter": false}, "occurrences_count":
+        7}, {"id": 31368075, "account": 8, "criterion": "Generic High Entropy Secret",
+        "date": "2026-04-07T16:48:04Z", "last_trigger_published_at": "2026-04-07T16:48:04Z",
+        "last_triggered_at": "2026-04-23T11:52:54.519524Z", "last_trigger_detected_at":
+        "2026-04-23T11:52:54.519524Z", "hash": "2v90YpV2qImSoM5ClVzUm9xKEZwBaDj5SN/HbtoJSWNFLFX/p+KkPCNpyNbtXqJM",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "AWS IAM Keys", "severity_rule_config": {"id": 10860, "gg_created_at": "2026-02-12T15:13:37.684167Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684171Z", "index": 30, "severity": 10,
+        "Generic High Entropy Secret", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "admin@example.com", "name": "Administrator"}],
+        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 27593417, "name": "analytics-report",
+        "type": "gerrit_repository", "path": "analytics-report", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 53, "displayed_occurrence": {"id": 262526390, "issue": 31368075,
+        "account": 8, "kind": "HIST", "element": "1caa54a1e78225714d2269cd857fff5401f9f718",
+        "element_type": "GIT_COMMIT", "author_name": "Administrator", "author_info":
+        "admin@example.com", "value": null, "value_hash": "FYHiRGX0rvGi20iMJhP7vx+kXpaXLKdVPvD7ToqYMwB9xo3t1WtnP/iejqFtutNn",
+        "published_at": "2026-04-07T16:48:04Z", "date": "2026-04-07T16:48:04Z", "detected_at":
+        "2026-04-23T11:52:52.138517Z", "is_vcs_type": true, "last_detected_at": "2026-04-07T16:48:04Z",
+        "last_seen_at": "2026-04-07T16:48:04Z", "data": {}, "url": "https://azure-delta.exe.xyz/plugins/gitiles/analytics-report/+/1caa54a1e78225714d2269cd857fff5401f9f718%5E%21/",
+        "source": {"id": 27593417, "url": "https://azure-delta.exe.xyz/admin/repos/analytics-report,general",
+        "type": "gerrit_repository", "display_name": "analytics-report", "visibility":
+        "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
+        null, "default_branch": "master", "monitoring_status": "active"}, "regression":
+        false, "content": 155146807, "secrets_engine_version": "2.161.0", "matches":
+        [{"name": "apikey", "string_matched": "[REDACTED]", "indice_start": 157, "indice_end":
+        189, "pre_line_start": null, "pre_line_end": null, "post_line_start": 6, "post_line_end":
+        6}], "most_sensitive_match_name": "apikey", "insights": [], "filepath": "notification_2aWs.java",
+        "filename": "notification_2aWs.java", "presence": "visible", "last_presence_seen_at":
+        "2026-04-23T11:52:54.573910Z", "last_presence_check_at": "2026-04-23T11:52:54.573910Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": true, "change_type":
+        "addition", "full_tags": [{"type": "FROM_HISTORICAL_SCAN", "metadata": null,
+        "field": "content"}, {"type": "DEFAULT_BRANCH", "metadata": null, "field":
+        "content"}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH",
+        "FROM_HISTORICAL_SCAN"], "public_exposure": {"source_publicly_visible": false,
+        "public_incident_linked": false, "leaked_outside_perimeter": false}, "occurrences_count":
+        1}, {"id": 27395126, "account": 8, "criterion": "AWS Keys", "date": "2026-02-19T14:36:24Z",
+        "last_trigger_published_at": "2026-02-19T14:36:24Z", "last_triggered_at":
+        "2026-02-19T14:40:08.909390Z", "last_trigger_detected_at": "2026-02-19T14:40:08.909390Z",
+        "hash": "ldopSL0HhOyMPVqrCoyqhrM0YiRtyDjCRKal/yZRhL1LxHMKL4Qc71cZRqNcojMG",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "AWS IAM Keys", "severity_rule_config": {"id": 11885, "gg_created_at": "2026-05-20T08:56:10.055362Z",
+        "gg_updated_at": "2026-05-20T08:56:10.055364Z", "index": 30, "severity": 10,
         "rule": {"id": 503, "gg_created_at": "2025-03-18T08:57:54.142008Z", "gg_updated_at":
         "2025-04-02T13:15:43.307296Z", "name": "Valid secrets related to highly sensitive
         detectors", "description": "Secrets related to highly sensitive detectors
@@ -48,11 +181,12 @@ interactions:
         "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
         "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "Martin Faucheux / Repo A",
-        "type": "gl_project", "path": "martin-faucheux/repo-a", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 0, "score": 36, "displayed_occurrence": {"id": 245063312,
-        "issue": 27395126, "account": 8, "kind": "RLTM", "element": "7a6a765a03f640cf002e7d23040dad8a17fe4255",
+        null, "locations_count": 0, "sources": [{"id": 16218988, "name": "Martin Faucheux
+        / Repo A", "type": "gl_project", "path": "martin-faucheux/repo-a", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 36, "displayed_occurrence": {"id": 245063312, "issue": 27395126,
+        "account": 8, "kind": "RLTM", "element": "7a6a765a03f640cf002e7d23040dad8a17fe4255",
         "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
         "value": null, "value_hash": "dLLMC28h0JB8KLz6ViyG9URvAnikbB5BBECedrqc2JmDHqkd2KVpMdI0NbaCVmKj",
         "published_at": "2026-02-19T14:36:24Z", "date": "2026-02-19T14:36:24Z", "detected_at":
@@ -61,31 +195,32 @@ interactions:
         "source": {"id": 16218988, "url": "https://gitlab-01.aws-qa-gitguardian.com/martin-faucheux/repo-a",
         "type": "gl_project", "display_name": "Martin Faucheux / Repo A", "visibility":
         "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 134461307,
-        "secrets_engine_version": "2.156.0", "matches": [{"name": "client_id", "string_matched":
-        "[REDACTED]", "indice_start": 45, "indice_end": 65, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 3, "post_line_end": 3}, {"name":
-        "client_secret", "string_matched": "[REDACTED]", "indice_start": 81, "indice_end":
-        121, "pre_line_start": null, "pre_line_end": null, "post_line_start": 4, "post_line_end":
-        4}], "most_sensitive_match_name": "client_secret", "insights": [{"name": "test_file",
-        "source": "document", "metadata": null}], "filepath": "aws_example.py", "filename":
-        "aws_example.py", "presence": "visible", "last_presence_seen_at": "2026-02-19T14:40:08.948798Z",
+        null, "default_branch": "main", "monitoring_status": "active"}, "regression":
+        false, "content": 134461307, "secrets_engine_version": "2.156.0", "matches":
+        [{"name": "client_id", "string_matched": "[REDACTED]", "indice_start": 45,
+        "indice_end": 65, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        3, "post_line_end": 3}, {"name": "client_secret", "string_matched": "[REDACTED]",
+        "indice_start": 81, "indice_end": 121, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 4, "post_line_end": 4}], "most_sensitive_match_name":
+        "client_secret", "insights": [{"name": "test_file", "source": "document",
+        "metadata": null}], "filepath": "aws_example.py", "filename": "aws_example.py",
+        "presence": "visible", "last_presence_seen_at": "2026-02-19T14:40:08.948798Z",
         "last_presence_check_at": "2026-02-19T14:40:08.948798Z", "first_presence_deleted_at":
         null, "seen_in_default_branch": false, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}]}, "has_dropped_occurrences": false,
-        "tags": ["TEST_FILE"], "public_exposure": {"source_publicly_visible": false,
-        "public_incident_linked": false, "leaked_outside_perimeter": false}, "occurrences_count":
-        1}, {"id": 26879946, "account": 8, "criterion": "AWS Keys", "date": "2026-02-05T16:48:19Z",
-        "last_trigger_published_at": "2026-02-05T16:48:19Z", "last_triggered_at":
-        "2026-02-05T16:51:59.912161Z", "last_trigger_detected_at": "2026-02-05T16:51:59.912161Z",
-        "hash": "BPRo0pF0ZesUJFhK1FAEiWQsj9wNtT2WYZ15WbzmXjC7vE/VL4Qc71cZRqNcojMG",
+        [{"type": "TEST_FILE", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["REVOCABLE_BY_GG", "TEST_FILE"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 26879946, "account": 8, "criterion": "AWS
+        Keys", "date": "2026-02-05T16:48:19Z", "last_trigger_published_at": "2026-02-05T16:48:19Z",
+        "last_triggered_at": "2026-02-05T16:51:59.912161Z", "last_trigger_detected_at":
+        "2026-02-05T16:51:59.912161Z", "hash": "BPRo0pF0ZesUJFhK1FAEiWQsj9wNtT2WYZ15WbzmXjC7vE/VL4Qc71cZRqNcojMG",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "ASSIGNED", "issue_name":
-        "AWS IAM Keys", "severity_rule_config": {"id": 10860, "gg_created_at": "2026-02-12T15:13:37.684167Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684171Z", "index": 30, "severity": 10,
+        "AWS IAM Keys", "severity_rule_config": {"id": 11885, "gg_created_at": "2026-05-20T08:56:10.055362Z",
+        "gg_updated_at": "2026-05-20T08:56:10.055364Z", "index": 30, "severity": 10,
         "rule": {"id": 503, "gg_created_at": "2025-03-18T08:57:54.142008Z", "gg_updated_at":
         "2025-04-02T13:15:43.307296Z", "name": "Valid secrets related to highly sensitive
         detectors", "description": "Secrets related to highly sensitive detectors
@@ -101,213 +236,77 @@ interactions:
         "assignee": 581873, "last_presence_check_at": null, "secret": "[REDACTED]",
         "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
         "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        8, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "gim-qa-gitlabSandbox-auto
+        12, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 0, "sources": [{"id": 16219056, "name": "gim-qa-gitlabSandbox-auto
         / gim-qa-gitlabSandbox-staging", "type": "gl_project", "path": "gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
-        "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
-        {"id": 242021853, "issue": 26879946, "account": 8, "kind": "RLTM", "element":
-        "e2cbc193a76a13b94e135c12a055d2083a233a89", "element_type": "GIT_COMMIT",
-        "author_name": "dev", "author_info": "gim+dev@gitguardian.com", "value": null,
-        "value_hash": "7AkVngiwT5n4ZZihQovCHs2qrlx0MOfD853AYv4HHS0DiM0Vk9YtctC+FFM1Iw+v",
+        "source_criticality": "critical", "monitoring_status": "active", "deleted_at":
+        null}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
+        0, "score": 97, "displayed_occurrence": {"id": 242021853, "issue": 26879946,
+        "account": 8, "kind": "RLTM", "element": "e2cbc193a76a13b94e135c12a055d2083a233a89",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "7AkVngiwT5n4ZZihQovCHs2qrlx0MOfD853AYv4HHS0DiM0Vk9YtctC+FFM1Iw+v",
         "published_at": "2026-02-05T16:48:19Z", "date": "2026-02-05T16:48:19Z", "detected_at":
         "2026-02-05T16:51:53.166126Z", "is_vcs_type": true, "last_detected_at": "2026-02-05T16:48:19Z",
         "last_seen_at": "2026-02-05T16:48:19Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging/commit/e2cbc193a76a13b94e135c12a055d2083a233a89#2dd906314026edd7e5fa25025afd4353424625a7_0_19",
         "source": {"id": 16219056, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
         "type": "gl_project", "display_name": "gim-qa-gitlabSandbox-auto / gim-qa-gitlabSandbox-staging",
-        "visibility": "private", "monitored": true, "source_criticality": "unknown",
-        "deleted_at": null, "default_branch": "main"}, "regression": false, "content":
-        130291193, "secrets_engine_version": "2.156.0", "matches": [{"name": "client_id",
-        "string_matched": "[REDACTED]", "indice_start": 124, "indice_end": 144, "pre_line_start":
-        null, "pre_line_end": null, "post_line_start": 4, "post_line_end": 4}, {"name":
-        "client_secret", "string_matched": "[REDACTED]", "indice_start": 981, "indice_end":
-        1021, "pre_line_start": null, "pre_line_end": null, "post_line_start": 19,
-        "post_line_end": 19}], "most_sensitive_match_name": "client_secret", "insights":
-        [], "filepath": "ec2_instance_management.py", "filename": "ec2_instance_management.py",
-        "presence": "visible", "last_presence_seen_at": "2026-02-18T22:30:08.818671Z",
-        "last_presence_check_at": "2026-02-18T22:30:08.818671Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": false, "change_type": "addition", "full_tags":
-        []}, "has_dropped_occurrences": false, "tags": [], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 8}, {"id": 24590787, "account": 8, "criterion": "AWS
-        Keys", "date": "2026-01-12T15:27:28Z", "last_trigger_published_at": "2026-01-12T15:27:28Z",
-        "last_triggered_at": "2026-01-12T15:33:36.783106Z", "last_trigger_detected_at":
-        "2026-01-12T15:33:36.783106Z", "hash": "S/c7Y0f34gQYCYuTir+9tfWUCHbGG2SB2ejhc2TzrxnJAP7RL4Qc71cZRqNcojMG",
-        "ignored": true, "ignored_at": "2026-01-12T15:33:36.792417Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "AWS IAM Keys", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "name": "gg-tools"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "Alina''s site (document libraries) / Documents", "type": "sharepoint_online_drive",
-        "path": "Alina''s site (document libraries) / Documents", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 0, "score": 9, "displayed_occurrence": {"id": 234815659,
-        "issue": 24590787, "account": 8, "kind": "HIST", "element": "{\"drive_id\":
-        \"b!EFtsUNZdNkyikeU9z6xQzkUMGeBD9bdJo5M6BS3bW67zTZ14Z8npSqr01XpQaXIh\", \"parent_reference_path\":
-        \"/drives/b!EFtsUNZdNkyikeU9z6xQzkUMGeBD9bdJo5M6BS3bW67zTZ14Z8npSqr01XpQaXIh/root:\",
-        \"file_id\": \"01Y5MCAQ3ZR5LIZECX3VCJF4HOR4QQQCUI\"}", "element_type": "SHAREPOINT_ONEDRIVE_FILE",
-        "author_name": "gg-tools", "author_info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "value": null, "value_hash": "IoeO9NqppbMYrBec5EYVeL24YscpUDvxkMRdVgHjHUPSLcps2z4rUV35xgH8mqlo",
-        "published_at": "2026-01-12T15:27:28Z", "date": "2026-01-12T15:27:28Z", "detected_at":
-        "2026-01-12T15:30:00.373322Z", "is_vcs_type": false, "last_detected_at": "2026-01-12T15:27:28Z",
-        "last_seen_at": "2026-01-12T15:27:28Z", "data": {}, "url": "https://gitguardianengineering.sharepoint.com/sites/Alina%27ssite/_layouts/15/Doc.aspx?sourcedoc=%7B8C568F79-5790-44DD-92F0-EE8F21080A88%7D&file=AWS%20secrets.docx&action=default&mobileredirect=true",
-        "source": {"id": 23920761, "url": "https://gitguardianengineering.sharepoint.com/sites/Alina%27ssite/Shared%20Documents",
-        "type": "sharepoint_online_drive", "display_name": "Alina''s site (document
-        libraries) / Documents", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 120431919, "secrets_engine_version": "2.154.3", "matches": [{"name":
-        "client_id", "string_matched": "[REDACTED]", "indice_start": 1128, "indice_end":
-        1148, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}, {"name": "client_secret", "string_matched": "[REDACTED]",
-        "indice_start": 159, "indice_end": 199, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
-        "client_secret", "insights": [], "filepath": "AWS secrets.docx", "filename":
-        "AWS secrets.docx", "presence": "visible", "last_presence_seen_at": "2026-01-13T14:17:47.364898Z",
-        "last_presence_check_at": "2026-01-13T14:17:47.364898Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": [{"type":
-        "FROM_HISTORICAL_SCAN", "metadata": null}]}, "has_dropped_occurrences": false,
-        "tags": ["FROM_HISTORICAL_SCAN"], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 1}, {"id": 23429983, "account": 8, "criterion": "AWS
-        Keys", "date": "2025-12-16T17:22:08Z", "last_trigger_published_at": "2025-12-16T17:22:08Z",
-        "last_triggered_at": "2025-12-16T18:22:25.117146Z", "last_trigger_detected_at":
-        "2025-12-16T18:22:25.117146Z", "hash": "Bxk/2SaXQPI8yl7xAhB3l3Q9xdra8RHtG7PEK3Wc2BUYBzgKL4Qc71cZRqNcojMG",
-        "ignored": true, "ignored_at": "2025-12-16T18:22:25.122585Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "AWS IAM Keys", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "name": "gg-tools"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "Alina''s site (document libraries) / Documents", "type": "sharepoint_online_drive",
-        "path": "Alina''s site (document libraries) / Documents", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 0, "score": 9, "displayed_occurrence": {"id": 230344889,
-        "issue": 23429983, "account": 8, "kind": "RLTM", "element": "{\"drive_id\":
-        \"b!EFtsUNZdNkyikeU9z6xQzkUMGeBD9bdJo5M6BS3bW67zTZ14Z8npSqr01XpQaXIh\", \"parent_reference_path\":
-        \"/drives/b!EFtsUNZdNkyikeU9z6xQzkUMGeBD9bdJo5M6BS3bW67zTZ14Z8npSqr01XpQaXIh/root:\",
-        \"file_id\": \"01Y5MCAQY6HCFEWMVSWZCJJ2PCDHL3I2YO\"}", "element_type": "SHAREPOINT_ONEDRIVE_FILE",
-        "author_name": "gg-tools", "author_info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "value": null, "value_hash": "iPtXjz0IchI3JPXhF9r8blhAWpYqtW42SnmwJ/Qm7urxC80Sii0L/QArnKtol4jI",
-        "published_at": "2025-12-16T17:22:08Z", "date": "2025-12-16T17:22:08Z", "detected_at":
-        "2025-12-16T18:15:30.167037Z", "is_vcs_type": false, "last_detected_at": "2025-12-16T17:22:08Z",
-        "last_seen_at": "2025-12-16T17:22:08Z", "data": {}, "url": "https://gitguardianengineering.sharepoint.com/sites/Alina%27ssite/Shared%20Documents/small_with_secret.csv.gz",
-        "source": {"id": 23920761, "url": "https://gitguardianengineering.sharepoint.com/sites/Alina%27ssite/Shared%20Documents",
-        "type": "sharepoint_online_drive", "display_name": "Alina''s site (document
-        libraries) / Documents", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 112471538, "secrets_engine_version": "2.153.1", "matches": [{"name":
-        "client_id", "string_matched": "[REDACTED]", "indice_start": 500, "indice_end":
-        520, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}, {"name": "client_secret", "string_matched": "[REDACTED]",
-        "indice_start": 546, "indice_end": 586, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
-        "client_secret", "insights": [], "filepath": "small_with_secret.csv.gz", "filename":
-        "small_with_secret.csv.gz", "presence": "visible", "last_presence_seen_at":
-        "2026-01-12T15:33:36.829567Z", "last_presence_check_at": "2026-01-12T15:33:36.829567Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": ["FROM_HISTORICAL_SCAN"],
-        "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 2}, {"id":
-        22515404, "account": 8, "criterion": "AWS Keys", "date": "2025-11-17T17:16:25Z",
-        "last_trigger_published_at": "2025-11-17T17:16:25Z", "last_triggered_at":
-        "2025-11-17T17:18:18.706440Z", "last_trigger_detected_at": "2025-11-17T17:18:18.706440Z",
-        "hash": "6y4trbQi60aNmDEFQe0tJH3jke+8j18I9t2sKfgaunTYEUdZL4Qc71cZRqNcojMG",
-        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
-        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
-        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
-        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
-        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "AWS IAM Keys", "severity_rule_config": {"id": 10860, "gg_created_at": "2026-02-12T15:13:37.684167Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684171Z", "index": 30, "severity": 10,
-        "rule": {"id": 503, "gg_created_at": "2025-03-18T08:57:54.142008Z", "gg_updated_at":
-        "2025-04-02T13:15:43.307296Z", "name": "Valid secrets related to highly sensitive
-        detectors", "description": "Secrets related to highly sensitive detectors
-        were valid when the incident was discovered. You can edit this rule to create
-        your own list of sensitive detectors", "json_rule": {"operator": "AND", "args":
-        [{"operator": "EQ", "arg1": {"path": "issue.secret.validity_status", "default":
-        null}, "arg2": {"value": "valid"}}, {"operator": "IN", "arg1": {"path": "issue.secret.detector.detector_group_name",
-        "default": null}, "arg2": {"value": ["github_app_token", "ldap_credentials",
-        "github_oauth_token", "googlecloud_keys", "jira_basic_auth", "python_package_index_key",
-        "aws_iam_sts", "npm_token", "gitlab_token", "smtp_credentials", "github_fine_grained_pat",
-        "gitlab_enterprise_token", "github_access_token", "aws_iam"]}}]}, "is_global":
-        true, "scope": "any", "author": null}}, "declarative_secret_status": null,
-        "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "gim-qa-gitlabSandbox-auto
-        / gim-qa-gitlabSandbox-staging", "type": "gl_project", "path": "gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
-        "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 1, "score": 97, "displayed_occurrence":
-        {"id": 226113779, "issue": 22515404, "account": 8, "kind": "RLTM", "element":
-        "95c8ae28ae02f1182bfa5ae2f6cabb69fab3ece9", "element_type": "GIT_COMMIT",
-        "author_name": "dev", "author_info": "gim+dev@gitguardian.com", "value": null,
-        "value_hash": "yEDhOhQ6p7D5/7TcJR5YtztO3INO1WgqiWd2qPiA0XRele/bong1Td3XczdQcVM3",
-        "published_at": "2025-11-17T17:16:25Z", "date": "2025-11-17T17:16:25Z", "detected_at":
-        "2025-11-17T17:18:16.645938Z", "is_vcs_type": true, "last_detected_at": "2025-11-17T17:16:25Z",
-        "last_seen_at": "2025-11-17T17:16:25Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging/commit/95c8ae28ae02f1182bfa5ae2f6cabb69fab3ece9#34c8dc1a12161a07003ebd2c3145185257f0cd94_0_3",
-        "source": {"id": 16219056, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
-        "type": "gl_project", "display_name": "gim-qa-gitlabSandbox-auto / gim-qa-gitlabSandbox-staging",
-        "visibility": "private", "monitored": true, "source_criticality": "unknown",
-        "deleted_at": null, "default_branch": "main"}, "regression": false, "content":
-        105863010, "secrets_engine_version": "2.150.0", "matches": [{"name": "client_id",
-        "string_matched": "[REDACTED]", "indice_start": 45, "indice_end": 65, "pre_line_start":
-        null, "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}, {"name":
-        "client_secret", "string_matched": "[REDACTED]", "indice_start": 82, "indice_end":
-        122, "pre_line_start": null, "pre_line_end": null, "post_line_start": 3, "post_line_end":
-        3}], "most_sensitive_match_name": "client_secret", "insights": [], "filepath":
-        "aws_api_access.yml", "filename": "aws_api_access.yml", "presence": "visible",
-        "last_presence_seen_at": "2026-02-18T22:30:08.818671Z", "last_presence_check_at":
-        "2026-02-18T22:30:08.818671Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        false, "change_type": "addition", "full_tags": []}, "has_dropped_occurrences":
-        false, "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}]}'
+        "visibility": "private", "monitored": true, "source_criticality": "critical",
+        "deleted_at": null, "default_branch": "main", "monitoring_status": "active"},
+        "regression": false, "content": 130291193, "secrets_engine_version": "2.156.0",
+        "matches": [{"name": "client_id", "string_matched": "[REDACTED]", "indice_start":
+        124, "indice_end": 144, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        4, "post_line_end": 4}, {"name": "client_secret", "string_matched": "[REDACTED]",
+        "indice_start": 981, "indice_end": 1021, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 19, "post_line_end": 19}], "most_sensitive_match_name":
+        "client_secret", "insights": [], "filepath": "ec2_instance_management.py",
+        "filename": "ec2_instance_management.py", "presence": "visible", "last_presence_seen_at":
+        "2026-02-18T22:30:08.818671Z", "last_presence_check_at": "2026-02-18T22:30:08.818671Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": false, "change_type":
+        "addition", "full_tags": []}, "has_dropped_occurrences": false, "tags": ["FROM_HISTORICAL_SCAN",
+        "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible": false,
+        "public_incident_linked": false, "leaked_outside_perimeter": false}, "occurrences_count":
+        12}]}'
     headers:
+      CF-RAY:
+      - a103958cc95d8f0a-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:27 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '28007'
+      - '26846'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:43 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '206'
+      - '503'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_secret_manager_type.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_secret_manager_type.yaml
@@ -37,45 +37,48 @@ interactions:
         {"info": "xavier.blanchot@gitguardian.com", "name": "Xavier Blanchot"}], "user_permission":
         7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         3, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"name": "Loic / demo-shield", "type":
-        "gl_project", "path": "Loic/demo-shield", "source_criticality": "unknown"},
-        {"name": "Xavier Blanchot / qa-sca", "type": "gl_project", "path": "xblanchot/qa-sca",
-        "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata": [{"source":
-        "awssecretsmanager"}], "is_vaulted": true, "similar_issue_count": 0, "score":
-        45, "displayed_occurrence": {"id": 244951751, "issue": 27376615, "account":
-        8, "kind": "HIST", "element": "7f75f6e85952d5ac1c625bd3fcf40d003b0ba8c4",
-        "element_type": "GIT_COMMIT", "author_name": "Xavier Blanchot", "author_info":
-        "xavier.blanchot@gitguardian.com", "value": null, "value_hash": "CBaS+/d/madbwvs/8T4WdjsExX8NK6aTuQDdGQA1GtNcnCtNB1WaTUij1r/0DT4F",
+        null, "locations_count": 2, "sources": [{"id": 16218909, "name": "Xavier Blanchot
+        / qa-sca", "type": "gl_project", "path": "xblanchot/qa-sca", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}, {"id": 24090906,
+        "name": "Loic / demo-shield", "type": "gl_project", "path": "Loic/demo-shield",
+        "source_criticality": "unknown", "monitoring_status": "active", "deleted_at":
+        null}], "custom_tags": [], "vault_metadata": [{"source": "awssecretsmanager"}],
+        "is_vaulted": true, "similar_issue_count": 0, "score": 45, "displayed_occurrence":
+        {"id": 244951751, "issue": 27376615, "account": 8, "kind": "HIST", "element":
+        "7f75f6e85952d5ac1c625bd3fcf40d003b0ba8c4", "element_type": "GIT_COMMIT",
+        "author_name": "Xavier Blanchot", "author_info": "xavier.blanchot@gitguardian.com",
+        "value": null, "value_hash": "CBaS+/d/madbwvs/8T4WdjsExX8NK6aTuQDdGQA1GtNcnCtNB1WaTUij1r/0DT4F",
         "published_at": "2026-02-03T14:54:25Z", "date": "2026-02-03T14:54:25Z", "detected_at":
         "2026-02-18T22:33:23.391472Z", "is_vcs_type": true, "last_detected_at": "2026-02-03T14:54:25Z",
         "last_seen_at": "2026-02-03T14:54:25Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/Loic/demo-shield/commit/7f75f6e85952d5ac1c625bd3fcf40d003b0ba8c4#06b6a8978505059f2298eeea18b85735506e50b0_None_10",
         "source": {"id": 24090906, "url": "https://gitlab-01.aws-qa-gitguardian.com/Loic/demo-shield",
         "type": "gl_project", "display_name": "Loic / demo-shield", "visibility":
         "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
-        null, "default_branch": "master"}, "regression": false, "content": 134320072,
-        "secrets_engine_version": "2.156.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 152, "indice_end": 316, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 10, "post_line_end": 10}], "most_sensitive_match_name":
-        "apikey", "insights": [{"name": "test_file", "source": "document", "metadata":
-        null}], "filepath": "test_xav.py", "filename": "test_xav.py", "presence":
-        "visible", "last_presence_seen_at": "2026-02-18T22:33:24.059192Z", "last_presence_check_at":
-        "2026-02-18T22:33:24.059192Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": "addition", "full_tags": [{"type": "FROM_HISTORICAL_SCAN",
-        "metadata": null}, {"type": "TEST_FILE", "metadata": null}]}, "has_dropped_occurrences":
-        false, "tags": ["FROM_HISTORICAL_SCAN", "PUBLICLY_LEAKED", "REVOCABLE_BY_GG",
-        "TEST_FILE"], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        true, "leaked_outside_perimeter": false}, "occurrences_count": 3}, {"id":
-        27376617, "account": 8, "criterion": "PostgreSQL URI", "date": "2026-02-03T15:03:39Z",
-        "last_trigger_published_at": "2026-02-03T15:03:39Z", "last_triggered_at":
-        "2026-02-18T22:23:47.640669Z", "last_trigger_detected_at": "2026-02-18T22:23:47.640669Z",
-        "hash": "w8plTKT2Ax3sZ5tlV9qlvmUA0pdIAWVowmytVrQQ4fNGeLrECUnJ9mpXO6ItKClD",
+        null, "default_branch": "master", "monitoring_status": "active"}, "regression":
+        false, "content": 134320072, "secrets_engine_version": "2.156.0", "matches":
+        [{"name": "apikey", "string_matched": "[REDACTED]", "indice_start": 152, "indice_end":
+        316, "pre_line_start": null, "pre_line_end": null, "post_line_start": 10,
+        "post_line_end": 10}], "most_sensitive_match_name": "apikey", "insights":
+        [{"name": "test_file", "source": "document", "metadata": null}], "filepath":
+        "test_xav.py", "filename": "test_xav.py", "presence": "visible", "last_presence_seen_at":
+        "2026-02-18T22:33:24.059192Z", "last_presence_check_at": "2026-02-18T22:33:24.059192Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        "addition", "full_tags": [{"type": "FROM_HISTORICAL_SCAN", "metadata": null,
+        "field": "content"}, {"type": "TEST_FILE", "metadata": null, "field": "content"}]},
+        "has_dropped_occurrences": false, "tags": ["FROM_HISTORICAL_SCAN", "PUBLICLY_LEAKED",
+        "REVOCABLE_BY_GG", "TEST_FILE"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": true, "leaked_outside_perimeter": false},
+        "occurrences_count": 3}, {"id": 27376617, "account": 8, "criterion": "PostgreSQL
+        URI", "date": "2026-02-03T15:03:39Z", "last_trigger_published_at": "2026-02-03T15:03:39Z",
+        "last_triggered_at": "2026-02-18T22:23:47.640669Z", "last_trigger_detected_at":
+        "2026-02-18T22:23:47.640669Z", "hash": "w8plTKT2Ax3sZ5tlV9qlvmUA0pdIAWVowmytVrQQ4fNGeLrECUnJ9mpXO6ItKClD",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "PostgreSQL Credentials", "severity_rule_config": {"id": 10873, "gg_created_at":
-        "2026-02-12T15:13:37.684368Z", "gg_updated_at": "2026-02-12T15:13:37.684372Z",
+        "PostgreSQL Credentials", "severity_rule_config": {"id": 11898, "gg_created_at":
+        "2026-05-20T08:56:10.055489Z", "gg_updated_at": "2026-05-20T08:56:10.055492Z",
         "index": 160, "severity": 20, "rule": {"id": 516, "gg_created_at": "2025-03-18T08:57:54.142529Z",
         "gg_updated_at": "2025-03-18T08:57:54.142532Z", "name": "Specific Database
         Credentials", "description": "Specific Database Credentials", "json_rule":
@@ -88,49 +91,52 @@ interactions:
         {"info": "xavier.blanchot@gitguardian.com", "name": "Xavier Blanchot"}], "user_permission":
         7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         3, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 2, "sources": [{"name": "Loic / demo-shield", "type":
-        "gl_project", "path": "Loic/demo-shield", "source_criticality": "unknown"},
-        {"name": "Xavier Blanchot / qa-sca", "type": "gl_project", "path": "xblanchot/qa-sca",
-        "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata": [{"source":
-        "awssecretsmanager"}], "is_vaulted": true, "similar_issue_count": 0, "score":
-        36, "displayed_occurrence": {"id": 244951754, "issue": 27376617, "account":
-        8, "kind": "HIST", "element": "7f75f6e85952d5ac1c625bd3fcf40d003b0ba8c4",
-        "element_type": "GIT_COMMIT", "author_name": "Xavier Blanchot", "author_info":
-        "xavier.blanchot@gitguardian.com", "value": null, "value_hash": "bkjQSYtajI81lN0vpeFk3i7WIys+D668iT37NvZh1WNr+R2mo0AV7BPnZLC8/g/J",
+        null, "locations_count": 2, "sources": [{"id": 16218909, "name": "Xavier Blanchot
+        / qa-sca", "type": "gl_project", "path": "xblanchot/qa-sca", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}, {"id": 24090906,
+        "name": "Loic / demo-shield", "type": "gl_project", "path": "Loic/demo-shield",
+        "source_criticality": "unknown", "monitoring_status": "active", "deleted_at":
+        null}], "custom_tags": [], "vault_metadata": [{"source": "awssecretsmanager"}],
+        "is_vaulted": true, "similar_issue_count": 0, "score": 36, "displayed_occurrence":
+        {"id": 244951754, "issue": 27376617, "account": 8, "kind": "HIST", "element":
+        "7f75f6e85952d5ac1c625bd3fcf40d003b0ba8c4", "element_type": "GIT_COMMIT",
+        "author_name": "Xavier Blanchot", "author_info": "xavier.blanchot@gitguardian.com",
+        "value": null, "value_hash": "bkjQSYtajI81lN0vpeFk3i7WIys+D668iT37NvZh1WNr+R2mo0AV7BPnZLC8/g/J",
         "published_at": "2026-02-03T14:54:25Z", "date": "2026-02-03T14:54:25Z", "detected_at":
         "2026-02-18T22:33:23.391472Z", "is_vcs_type": true, "last_detected_at": "2026-02-03T14:54:25Z",
         "last_seen_at": "2026-02-03T14:54:25Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/Loic/demo-shield/commit/7f75f6e85952d5ac1c625bd3fcf40d003b0ba8c4#06b6a8978505059f2298eeea18b85735506e50b0_None_25",
         "source": {"id": 24090906, "url": "https://gitlab-01.aws-qa-gitguardian.com/Loic/demo-shield",
         "type": "gl_project", "display_name": "Loic / demo-shield", "visibility":
         "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
-        null, "default_branch": "master"}, "regression": false, "content": 134320072,
-        "secrets_engine_version": "2.156.0", "matches": [{"name": "connection_uri",
-        "string_matched": "[REDACTED]", "indice_start": 593, "indice_end": 700, "pre_line_start":
-        null, "pre_line_end": null, "post_line_start": 25, "post_line_end": 25}, {"name":
-        "scheme", "string_matched": "[REDACTED]", "indice_start": 593, "indice_end":
-        603, "pre_line_start": null, "pre_line_end": null, "post_line_start": 25,
-        "post_line_end": 25}, {"name": "username", "string_matched": "[REDACTED]",
-        "indice_start": 606, "indice_end": 611, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 25, "post_line_end": 25}, {"name": "password", "string_matched":
-        "[REDACTED]", "indice_start": 612, "indice_end": 629, "pre_line_start": null,
+        null, "default_branch": "master", "monitoring_status": "active"}, "regression":
+        false, "content": 134320072, "secrets_engine_version": "2.156.0", "matches":
+        [{"name": "connection_uri", "string_matched": "[REDACTED]", "indice_start":
+        593, "indice_end": 700, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        25, "post_line_end": 25}, {"name": "scheme", "string_matched": "[REDACTED]",
+        "indice_start": 593, "indice_end": 603, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 25, "post_line_end": 25}, {"name": "username", "string_matched":
+        "[REDACTED]", "indice_start": 606, "indice_end": 611, "pre_line_start": null,
         "pre_line_end": null, "post_line_start": 25, "post_line_end": 25}, {"name":
-        "host", "string_matched": "[REDACTED]", "indice_start": 630, "indice_end":
-        679, "pre_line_start": null, "pre_line_end": null, "post_line_start": 25,
-        "post_line_end": 25}, {"name": "port", "string_matched": "[REDACTED]", "indice_start":
-        680, "indice_end": 684, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        25, "post_line_end": 25}, {"name": "database", "string_matched": "[REDACTED]",
-        "indice_start": 685, "indice_end": 700, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 25, "post_line_end": 25}], "most_sensitive_match_name":
+        "password", "string_matched": "[REDACTED]", "indice_start": 612, "indice_end":
+        629, "pre_line_start": null, "pre_line_end": null, "post_line_start": 25,
+        "post_line_end": 25}, {"name": "host", "string_matched": "[REDACTED]", "indice_start":
+        630, "indice_end": 679, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        25, "post_line_end": 25}, {"name": "port", "string_matched": "[REDACTED]",
+        "indice_start": 680, "indice_end": 684, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 25, "post_line_end": 25}, {"name": "database", "string_matched":
+        "[REDACTED]", "indice_start": 685, "indice_end": 700, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 25, "post_line_end": 25}], "most_sensitive_match_name":
         "password", "insights": [{"name": "test_file", "source": "document", "metadata":
         null}], "filepath": "test_xav.py", "filename": "test_xav.py", "presence":
         "visible", "last_presence_seen_at": "2026-02-18T22:33:24.059192Z", "last_presence_check_at":
         "2026-02-18T22:33:24.059192Z", "first_presence_deleted_at": null, "seen_in_default_branch":
         null, "change_type": "addition", "full_tags": [{"type": "FROM_HISTORICAL_SCAN",
-        "metadata": null}, {"type": "TEST_FILE", "metadata": null}]}, "has_dropped_occurrences":
-        false, "tags": ["FROM_HISTORICAL_SCAN", "PUBLICLY_LEAKED", "TEST_FILE"], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": true, "leaked_outside_perimeter":
-        false}, "occurrences_count": 3}, {"id": 27376696, "account": 8, "criterion":
-        "Google Cloud Keys", "date": "2026-01-09T10:56:17Z", "last_trigger_published_at":
+        "metadata": null, "field": "content"}, {"type": "TEST_FILE", "metadata": null,
+        "field": "content"}]}, "has_dropped_occurrences": false, "tags": ["FROM_HISTORICAL_SCAN",
+        "PUBLICLY_LEAKED", "TEST_FILE"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": true, "leaked_outside_perimeter": false},
+        "occurrences_count": 3}, {"id": 27376696, "account": 8, "criterion": "Google
+        Cloud Keys", "date": "2026-01-09T10:56:17Z", "last_trigger_published_at":
         "2026-01-09T10:56:17Z", "last_triggered_at": "2026-02-18T22:29:55.266814Z",
         "last_trigger_detected_at": "2026-02-18T22:29:55.266814Z", "hash": "OLnnXSHSvRVd24+peRNgEbCxgpuqp0wuKa58tXipL9mClBEXbixQnS82X3KKgyls",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
@@ -138,8 +144,8 @@ interactions:
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Google Cloud Keys", "severity_rule_config": {"id": 10875, "gg_created_at":
-        "2026-02-12T15:13:37.684399Z", "gg_updated_at": "2026-02-12T15:13:37.684403Z",
+        "Google Cloud Keys", "severity_rule_config": {"id": 11900, "gg_created_at":
+        "2026-05-20T08:56:10.055509Z", "gg_updated_at": "2026-05-20T08:56:10.055512Z",
         "index": 180, "severity": 20, "rule": {"id": 518, "gg_created_at": "2025-03-18T08:57:54.142586Z",
         "gg_updated_at": "2025-03-18T08:57:54.142589Z", "name": "Cloud providers secrets",
         "description": "Detector is linked to cloud providers", "json_rule": {"operator":
@@ -150,8 +156,9 @@ interactions:
         "name": "Samuel Guillaume"}], "user_permission": 7, "is_publicly_shared":
         false, "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "Samuel Guillaume / test", "type": "gl_project", "path": "sguillaume/test",
-        "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata": [{"source":
+        [{"id": 16219049, "name": "Samuel Guillaume / test", "type": "gl_project",
+        "path": "sguillaume/test", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": [{"source":
         "awssecretsmanager"}], "is_vaulted": true, "similar_issue_count": 0, "score":
         0, "displayed_occurrence": {"id": 244951457, "issue": 27376696, "account":
         8, "kind": "HIST", "element": "f0bc33647a2bf4772705f95900bdd1a92b0234f2",
@@ -163,23 +170,24 @@ interactions:
         "source": {"id": 16219049, "url": "https://gitlab-01.aws-qa-gitguardian.com/sguillaume/test",
         "type": "gl_project", "display_name": "Samuel Guillaume / test", "visibility":
         "internal", "monitored": true, "source_criticality": "unknown", "deleted_at":
-        null, "default_branch": "master"}, "regression": false, "content": 134319779,
-        "secrets_engine_version": "2.156.0", "matches": [{"name": "project_id", "string_matched":
-        "[REDACTED]", "indice_start": 60, "indice_end": 79, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}, {"name":
-        "private_key_id", "string_matched": "[REDACTED]", "indice_start": 101, "indice_end":
-        141, "pre_line_start": null, "pre_line_end": null, "post_line_start": 3, "post_line_end":
-        3}, {"name": "private_key", "string_matched": "[REDACTED]", "indice_start":
-        160, "indice_end": 1890, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        4, "post_line_end": 31}, {"name": "client_id", "string_matched": "[REDACTED]",
-        "indice_start": 1912, "indice_end": 1967, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 33, "post_line_end": 33}], "most_sensitive_match_name":
-        "private_key", "insights": [], "filepath": "multiline.txt", "filename": "multiline.txt",
-        "presence": "visible", "last_presence_seen_at": "2026-02-18T22:29:55.323576Z",
-        "last_presence_check_at": "2026-02-18T22:29:55.323576Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": "addition", "full_tags":
-        [{"type": "FROM_HISTORICAL_SCAN", "metadata": null}]}, "has_dropped_occurrences":
-        false, "tags": ["FROM_HISTORICAL_SCAN"], "public_exposure": {"source_publicly_visible":
+        null, "default_branch": "master", "monitoring_status": "active"}, "regression":
+        false, "content": 134319779, "secrets_engine_version": "2.156.0", "matches":
+        [{"name": "project_id", "string_matched": "[REDACTED]", "indice_start": 60,
+        "indice_end": 79, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        2, "post_line_end": 2}, {"name": "private_key_id", "string_matched": "[REDACTED]",
+        "indice_start": 101, "indice_end": 141, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}, {"name": "private_key", "string_matched":
+        "[REDACTED]", "indice_start": 160, "indice_end": 1890, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 4, "post_line_end": 31}, {"name":
+        "client_id", "string_matched": "[REDACTED]", "indice_start": 1912, "indice_end":
+        1967, "pre_line_start": null, "pre_line_end": null, "post_line_start": 33,
+        "post_line_end": 33}], "most_sensitive_match_name": "private_key", "insights":
+        [], "filepath": "multiline.txt", "filename": "multiline.txt", "presence":
+        "visible", "last_presence_seen_at": "2026-02-18T22:29:55.323576Z", "last_presence_check_at":
+        "2026-02-18T22:29:55.323576Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": "addition", "full_tags": [{"type": "FROM_HISTORICAL_SCAN",
+        "metadata": null, "field": "content"}]}, "has_dropped_occurrences": false,
+        "tags": ["FROM_HISTORICAL_SCAN", "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible":
         false, "public_incident_linked": false, "leaked_outside_perimeter": false},
         "occurrences_count": 1}, {"id": 26805047, "account": 8, "criterion": "Google
         API Key", "date": "2025-12-14T19:04:50Z", "last_trigger_published_at": "2025-12-14T19:04:50Z",
@@ -196,33 +204,38 @@ interactions:
         "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"},
         {"info": "romain.jouhannet@gitguardian.com", "name": "Romain Jouhannet"}],
         "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "RomainJ / demo", "type":
-        "gl_project", "path": "romain/demo", "source_criticality": "unknown"}], "custom_tags":
-        [], "vault_metadata": [{"source": "hashicorpvault"}], "is_vaulted": true,
-        "similar_issue_count": 3, "score": 0, "displayed_occurrence": {"id": 241287716,
-        "issue": 26805047, "account": 8, "kind": "HIST", "element": "fd56543c0a2594907b36ab59c885bd1d536a4957",
-        "element_type": "GIT_COMMIT", "author_name": "Romain Jouhannet", "author_info":
-        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "SJwViF0/DsMYa+t+dBEiZx2csnwTDMqh1ro0cKTbBj5LYGqhjI9qf5LnmIYCvOW2",
+        12, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 0, "sources": [{"id": 23485702, "name": "RomainJ
+        / demo", "type": "gl_project", "path": "romain/demo", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}, {"id": 27769329,
+        "name": "business / demo2", "type": "gl_project", "path": "business/demo-2",
+        "source_criticality": "unknown", "monitoring_status": "active", "deleted_at":
+        null}], "custom_tags": [], "vault_metadata": [{"source": "hashicorpvault"}],
+        "is_vaulted": true, "similar_issue_count": 4, "score": 0, "displayed_occurrence":
+        {"id": 241287716, "issue": 26805047, "account": 8, "kind": "HIST", "element":
+        "fd56543c0a2594907b36ab59c885bd1d536a4957", "element_type": "GIT_COMMIT",
+        "author_name": "Romain Jouhannet", "author_info": "romain.jouhannet@gitguardian.com",
+        "value": null, "value_hash": "SJwViF0/DsMYa+t+dBEiZx2csnwTDMqh1ro0cKTbBj5LYGqhjI9qf5LnmIYCvOW2",
         "published_at": "2025-12-14T19:04:50Z", "date": "2025-12-14T19:04:50Z", "detected_at":
         "2026-02-04T13:38:46.386256Z", "is_vcs_type": true, "last_detected_at": "2025-12-14T19:04:50Z",
         "last_seen_at": "2025-12-14T19:04:50Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/fd56543c0a2594907b36ab59c885bd1d536a4957#2ec5fbc02574c84a8b8e3dcae097ffd0be069994_None_12",
         "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
         "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        "main"}, "regression": false, "content": 129708166, "secrets_engine_version":
-        "2.155.4", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 483, "indice_end": 522, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 12, "post_line_end": 12}], "most_sensitive_match_name":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 129708166,
+        "secrets_engine_version": "2.155.4", "matches": [{"name": "apikey", "string_matched":
+        "[REDACTED]", "indice_start": 483, "indice_end": 522, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 12, "post_line_end": 12}], "most_sensitive_match_name":
         "apikey", "insights": [], "filepath": "spinetail.py", "filename": "spinetail.py",
-        "presence": "visible", "last_presence_seen_at": "2026-02-18T22:33:05.054565Z",
-        "last_presence_check_at": "2026-02-18T22:33:05.054565Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": "addition", "full_tags":
-        [{"type": "FROM_HISTORICAL_SCAN", "metadata": null}]}, "has_dropped_occurrences":
-        false, "tags": ["FROM_HISTORICAL_SCAN"], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 6}, {"id": 23269327, "account": 8, "criterion": "GitLab
-        Token", "date": "2025-12-10T14:19:09.551197Z", "last_trigger_published_at":
+        "presence": "visible", "last_presence_seen_at": "2026-05-27T09:51:39.193873Z",
+        "last_presence_check_at": "2026-05-27T09:51:39.193873Z", "first_presence_deleted_at":
+        null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
+        [{"type": "FROM_HISTORICAL_SCAN", "metadata": null, "field": "content"}, {"type":
+        "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH", "FROM_HISTORICAL_SCAN"], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 12}, {"id": 23269327, "account": 8, "criterion":
+        "GitLab Token", "date": "2025-12-10T14:19:09.551197Z", "last_trigger_published_at":
         "2025-12-10T14:19:09.551197Z", "last_triggered_at": "2025-12-10T14:19:10.639669Z",
         "last_trigger_detected_at": "2025-12-10T14:19:10.639669Z", "hash": "gP6S8nfO7keg7t8MtZ8gJMJ3O6xebhyKTL/TG7LIUP7guMdDxGkRAPRx8mJAAtol",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
@@ -236,66 +249,77 @@ interactions:
         "gg-tools"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
         0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "Achille / sca-on-prem-test", "type": "gl_project", "path": "amascia/sca-on-prem-test",
-        "source_criticality": "unknown"}, {"name": "jira-data-center.do.gitguardian.dev
+        [{"id": 16218911, "name": "Achille / sca-on-prem-test", "type": "gl_project",
+        "path": "amascia/sca-on-prem-test", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}, {"id": 24381556, "name": "jira-data-center.do.gitguardian.dev
         / ChangingGCAM", "type": "jira_data_center_project", "path": "jira-data-center.do.gitguardian.dev
-        / ChangingGCAM", "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata":
-        [{"source": "awssecretsmanager"}], "is_vaulted": true, "similar_issue_count":
-        0, "score": 9, "displayed_occurrence": {"id": 244950136, "issue": 23269327,
-        "account": 8, "kind": "HIST", "element": "061e8042f5c82b5a51cea8e716b8183dca978d21",
-        "element_type": "GIT_COMMIT", "author_name": "gg-tools", "author_info": "gg-tools@gitguardian.com",
-        "value": null, "value_hash": "UAvJFhSJJaQysiJNVZIOK8xzO+87NbZwUxRtCLJ1jFEymRaDnLBWocIwrZ2EgJKH",
+        / ChangingGCAM", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": [{"source": "awssecretsmanager"}],
+        "is_vaulted": true, "similar_issue_count": 0, "score": 9, "displayed_occurrence":
+        {"id": 244950136, "issue": 23269327, "account": 8, "kind": "HIST", "element":
+        "061e8042f5c82b5a51cea8e716b8183dca978d21", "element_type": "GIT_COMMIT",
+        "author_name": "gg-tools", "author_info": "gg-tools@gitguardian.com", "value":
+        null, "value_hash": "UAvJFhSJJaQysiJNVZIOK8xzO+87NbZwUxRtCLJ1jFEymRaDnLBWocIwrZ2EgJKH",
         "published_at": "2025-12-10T14:18:42Z", "date": "2025-12-10T14:18:42Z", "detected_at":
         "2026-02-18T22:23:46.672369Z", "is_vcs_type": true, "last_detected_at": "2025-12-10T14:18:42Z",
         "last_seen_at": "2025-12-10T14:18:42Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/amascia/sca-on-prem-test/commit/061e8042f5c82b5a51cea8e716b8183dca978d21#2b0e2f260b21bb2873e28b33ac4ca7f72da36d5e_None_1",
         "source": {"id": 16218911, "url": "https://gitlab-01.aws-qa-gitguardian.com/amascia/sca-on-prem-test",
         "type": "gl_project", "display_name": "Achille / sca-on-prem-test", "visibility":
         "public", "monitored": true, "source_criticality": "unknown", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 134319294,
-        "secrets_engine_version": "2.156.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 23, "indice_end": 49, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 1, "post_line_end": 1}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "dont_leak_me.py", "filename": "dont_leak_me.py",
-        "presence": "visible", "last_presence_seen_at": "2026-02-18T22:23:48.595737Z",
-        "last_presence_check_at": "2026-02-18T22:23:48.595737Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": "addition", "full_tags":
-        [{"type": "FROM_HISTORICAL_SCAN", "metadata": null}]}, "has_dropped_occurrences":
-        false, "tags": ["FROM_HISTORICAL_SCAN", "REVOCABLE_BY_GG"], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 2}]}'
+        null, "default_branch": "main", "monitoring_status": "active"}, "regression":
+        false, "content": 134319294, "secrets_engine_version": "2.156.0", "matches":
+        [{"name": "apikey", "string_matched": "[REDACTED]", "indice_start": 23, "indice_end":
+        49, "pre_line_start": null, "pre_line_end": null, "post_line_start": 1, "post_line_end":
+        1}], "most_sensitive_match_name": "apikey", "insights": [], "filepath": "dont_leak_me.py",
+        "filename": "dont_leak_me.py", "presence": "visible", "last_presence_seen_at":
+        "2026-02-18T22:23:48.595737Z", "last_presence_check_at": "2026-02-18T22:23:48.595737Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        "addition", "full_tags": [{"type": "FROM_HISTORICAL_SCAN", "metadata": null,
+        "field": "content"}]}, "has_dropped_occurrences": false, "tags": ["FROM_HISTORICAL_SCAN",
+        "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible": false,
+        "public_incident_linked": false, "leaked_outside_perimeter": false}, "occurrences_count":
+        2}]}'
     headers:
+      CF-RAY:
+      - a10395a3ddf100a0-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:31 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '27232'
+      - '28282'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:48 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '233'
+      - '557'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_severity_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_severity_filter.yaml
@@ -21,220 +21,250 @@ interactions:
   response:
     body:
       string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?page=2&page_size=5&severity__in=10%2C20",
-        "previous": null, "results": [{"id": 29186788, "account": 8, "criterion":
-        "GitLab Token", "date": "2026-03-25T16:53:05.035206Z", "last_trigger_published_at":
-        "2026-03-25T16:53:05.035206Z", "last_triggered_at": "2026-03-25T16:53:05.853859Z",
-        "last_trigger_detected_at": "2026-03-25T16:53:05.853859Z", "hash": "SJOfhHk3hANA5qiK6fypwRpA6pyKIbh2xmK/JYKpXtMCszyZxGkRAPRx8mJAAtol",
+        "previous": null, "results": [{"id": 33929626, "account": 8, "criterion":
+        "Artifactory Token", "date": "2026-06-12T10:26:58.151000Z", "last_trigger_published_at":
+        "2026-06-12T10:26:58.151000Z", "last_triggered_at": "2026-06-12T11:58:00.658791Z",
+        "last_trigger_detected_at": "2026-06-12T11:58:00.658791Z", "hash": "XoKoErcCGXQNocX6b4MGPd8hwhobdx0SCEYMSWCwKkzVE9LnmfERIIoosvzjJs1k",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": 910203, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "celine.agbo@gitguardian.com", "manual_severity_setter_type": "user", "status":
+        "ASSIGNED", "issue_name": "Artifactory Token", "severity_rule_config": {"id":
+        11895, "gg_created_at": "2026-05-20T08:56:10.055460Z", "gg_updated_at": "2026-05-20T08:56:10.055463Z",
+        "index": 130, "severity": 10, "rule": {"id": 513, "gg_created_at": "2025-03-18T08:57:54.142453Z",
+        "gg_updated_at": "2025-03-18T08:57:54.142456Z", "name": "Package manager related
+        secret", "description": "The detector relates to a package manager", "json_rule":
+        {"operator": "EQ", "arg1": {"path": "issue.secret.detector.metadata.category",
+        "default": null}, "arg2": {"value": "package_registry"}}, "is_global": true,
+        "scope": "private", "author": null}}, "declarative_secret_status": null, "assignee":
+        550880, "last_presence_check_at": null, "secret": "[REDACTED]", "severity":
+        20, "authors": [{"info": "ggtestintegrations@proton.me", "name": "GG Test
+        Integrations"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
+        [{"id": 27177247, "name": "gg-test-integrations / Payment Systems", "type":
+        "jira_cloud_project", "path": "gg-test-integrations / Payment Systems", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 86, "displayed_occurrence": {"id": 272781097, "issue": 33929626,
+        "account": 8, "kind": "RLTM", "element": "PAY-4", "element_type": "JIRA_TICKET",
+        "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
+        "value": null, "value_hash": "T71tr/N63V71e27iMbDQa9L9Oh/xkgVEZdomur2uk2WyqO/9fr4lNYuUjUFpuLDi",
+        "published_at": "2026-06-12T10:26:58.151000Z", "date": "2026-06-12T10:26:58.151000Z",
+        "detected_at": "2026-06-12T11:57:58.655858Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-12T10:26:58.151000Z", "last_seen_at": "2026-06-12T10:26:58.151000Z",
+        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/PAY-4",
+        "source": {"id": 27177247, "url": "https://gg-test-integrations.atlassian.net/browse/PAY",
+        "type": "jira_cloud_project", "display_name": "gg-test-integrations / Payment
+        Systems", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168812050, "secrets_engine_version":
+        "2.165.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
+        "indice_start": 5333, "indice_end": 5406, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
+        "apikey", "insights": [], "filepath": null, "filename": null, "presence":
+        "visible", "last_presence_seen_at": "2026-06-12T18:28:18.251022Z", "last_presence_check_at":
+        "2026-06-12T18:28:18.251022Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
+        33211589, "account": 8, "criterion": "MongoDB URI", "date": "2026-05-27T09:42:47Z",
+        "last_trigger_published_at": "2026-05-27T09:42:47Z", "last_triggered_at":
+        "2026-05-27T09:51:38.902002Z", "last_trigger_detected_at": "2026-05-27T09:51:38.902002Z",
+        "hash": "dX7xqTqTRiPdxjxHbmvvsqr7fWCc2yGu6359hN8zQhe1adbofeuh40iUuZt2nZY1",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "GitLab Token", "severity_rule_config": {"id": 10877, "gg_created_at": "2026-02-12T15:13:37.684430Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684433Z", "index": 200, "severity":
-        20, "rule": {"id": 520, "gg_created_at": "2025-03-18T08:57:54.142633Z", "gg_updated_at":
-        "2025-03-18T08:57:54.142636Z", "name": "The secret is in a sensitive file",
-        "description": "Secret found in a sensitive file (.env, .pem key, dotfiles)",
-        "json_rule": {"operator": "CONTAINS_ANY", "arg1": {"path": "tag_names", "default":
-        null}, "arg2": {"value": ["SENSITIVE_FILE"]}}, "is_global": true, "scope":
-        "any", "author": null}}, "declarative_secret_status": null, "assignee": null,
-        "last_presence_check_at": null, "secret": "[REDACTED]", "severity": 100, "authors":
-        [{"info": "", "name": "GitGuardian Sandbox [internal]"}], "user_permission":
-        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        3, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "totaaa", "type": "custom_source",
-        "path": "totaaa", "source_criticality": "unknown"}, {"name": "totaaab", "type":
-        "custom_source", "path": "totaaab", "source_criticality": "unknown"}, {"name":
-        "totaaabccb", "type": "custom_source", "path": "totaaabccb", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 0, "score": 9, "displayed_occurrence": {"id": 253371418,
-        "issue": 29186788, "account": 8, "kind": "RLTM", "element": "", "element_type":
-        "CUSTOM_ELEMENT", "author_name": "GitGuardian Sandbox [internal]", "author_info":
-        "", "value": null, "value_hash": "bYdCbHZ101hGcZ6Q6XqcVQkGryoOAuqw4QxVXQLjQfpBf5OllP448kL+4h/ug/8v",
-        "published_at": "2026-03-25T16:53:05.035206Z", "date": "2026-03-25T16:53:05.035206Z",
-        "detected_at": "2026-03-25T16:53:05.737995Z", "is_vcs_type": false, "last_detected_at":
-        "2026-03-25T16:53:05.035206Z", "last_seen_at": "2026-03-25T16:53:05.035206Z",
-        "data": {}, "url": "", "source": {"id": 26968497, "url": "", "type": "custom_source",
-        "display_name": "totaaa", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 146400014, "secrets_engine_version": "2.158.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 123, "indice_end":
-        149, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [{"name": "sensitive_filepath", "source": "document", "metadata": {"sensitive_patterns":
-        [{"tags": [], "comment": "", "pattern": "\\.?env(?![^\\.])", "category": "filename",
-        "description": "Environment configuration file"}]}}], "filepath": "/tmp/tmpvcmhu56nggshield/home/hhubert/.env",
-        "filename": ".env", "presence": "visible", "last_presence_seen_at": "2026-03-25T16:53:05.897743Z",
-        "last_presence_check_at": "2026-03-25T16:53:05.897743Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": [{"type":
-        "SENSITIVE_FILE", "metadata": null}]}, "has_dropped_occurrences": false, "tags":
-        ["REVOCABLE_BY_GG", "SENSITIVE_FILE"], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 3}, {"id": 27966952, "account": 8, "criterion": "OpenAI
-        API Key", "date": "2026-03-06T06:44:00Z", "last_trigger_published_at": "2026-03-06T06:44:00Z",
-        "last_triggered_at": "2026-03-06T06:46:00.813247Z", "last_trigger_detected_at":
-        "2026-03-06T06:46:00.813247Z", "hash": "qAqxBGe/jVUeo2sH1EACPXT4xKnxJeIOJlp4g3WKNS64WAaZ95GRLqiXIWrK60u6",
-        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
-        "resolved": true, "resolved_at": "2026-03-12T18:05:49.089586Z", "resolver":
-        491414, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "none", "ignorer_type": "none", "resolver_display_name": "8@bot.gitguardian.com",
-        "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
-        "none", "status": "RESOLVED", "issue_name": "OpenAI API Key", "severity_rule_config":
-        {"id": 10876, "gg_created_at": "2026-02-12T15:13:37.684414Z", "gg_updated_at":
-        "2026-02-12T15:13:37.684418Z", "index": 190, "severity": 20, "rule": {"id":
-        519, "gg_created_at": "2025-03-18T08:57:54.142609Z", "gg_updated_at": "2025-03-18T08:57:54.142612Z",
-        "name": "Valid secret", "description": "The secrets were valid when the incident
-        was discovered", "json_rule": {"operator": "EQ", "arg1": {"path": "issue.secret.validity_status",
-        "default": null}, "arg2": {"value": "valid"}}, "is_global": true, "scope":
-        "private", "author": null}}, "declarative_secret_status": "revoked", "assignee":
-        614347, "last_presence_check_at": null, "secret": "[REDACTED]", "severity":
-        100, "authors": [{"info": "romain.jouhannet@gitguardian.com", "name": "Romain
-        Jouhannet"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "RomainJ / demo", "type": "gl_project", "path": "romain/demo", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 0, "score": 72, "displayed_occurrence": {"id": 248062638,
-        "issue": 27966952, "account": 8, "kind": "RLTM", "element": "ffed371ff171aaf844c433d58ace37f0f7f3aba1",
+        "MongoDB Credentials", "severity_rule_config": {"id": 11898, "gg_created_at":
+        "2026-05-20T08:56:10.055489Z", "gg_updated_at": "2026-05-20T08:56:10.055492Z",
+        "index": 160, "severity": 20, "rule": {"id": 516, "gg_created_at": "2025-03-18T08:57:54.142529Z",
+        "gg_updated_at": "2025-03-18T08:57:54.142532Z", "name": "Specific Database
+        Credentials", "description": "Specific Database Credentials", "json_rule":
+        {"operator": "AND", "args": [{"operator": "EQ", "arg1": {"path": "issue.secret.detector.metadata.category",
+        "default": null}, "arg2": {"value": "data_storage"}}, {"operator": "EQ", "arg1":
+        {"path": "issue.secret.detector.nature", "default": null}, "arg2": {"value":
+        "specific"}}]}, "is_global": true, "scope": "private", "author": null}}, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "romain.jouhannet@gitguardian.com",
+        "name": "Romain Jouhannet"}], "user_permission": 7, "is_publicly_shared":
+        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
+        [{"id": 23485702, "name": "RomainJ / demo", "type": "gl_project", "path":
+        "romain/demo", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 0, "score": 49, "displayed_occurrence": {"id":
+        269728665, "issue": 33211589, "account": 8, "kind": "HIST", "element": "d189cab00bc31c4bed372402e031de0559fa9d70",
         "element_type": "GIT_COMMIT", "author_name": "Romain Jouhannet", "author_info":
-        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "4sooonqBbWJu6Yf7TJItubjzIv+0+o8DtXQyynagLjSNV1GV7JDrI7vPyIRMpjWn",
-        "published_at": "2026-03-06T06:44:00Z", "date": "2026-03-06T06:44:00Z", "detected_at":
-        "2026-03-06T06:45:58.524698Z", "is_vcs_type": true, "last_detected_at": "2026-03-06T06:44:00Z",
-        "last_seen_at": "2026-03-06T06:44:00Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/ffed371ff171aaf844c433d58ace37f0f7f3aba1#057715000d77d4d956b27699e12440e405fb48ed_0_1",
+        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "4WO+NtMg1huWU4tghYRv7bPopKssi564RukxBZVA2Opur15IVmYm2YNGhd2mwbCp",
+        "published_at": "2026-05-27T09:42:47Z", "date": "2026-05-27T09:42:47Z", "detected_at":
+        "2026-05-27T09:51:34.675578Z", "is_vcs_type": true, "last_detected_at": "2026-05-27T09:42:47Z",
+        "last_seen_at": "2026-05-27T09:42:47Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/d189cab00bc31c4bed372402e031de0559fa9d70#e1755a4a1df75fb12321bae878788f6ca914d373_None_1",
         "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
         "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        "main"}, "regression": false, "content": 138922166, "secrets_engine_version":
-        "2.158.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 33, "indice_end": 84, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 1, "post_line_end": 1}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "local_scanning.txt", "filename": "local_scanning.txt",
-        "presence": "visible", "last_presence_seen_at": "2026-03-06T06:46:00.854986Z",
-        "last_presence_check_at": "2026-03-06T06:46:00.854986Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "DEFAULT_BRANCH", "metadata": null}]}, "has_dropped_occurrences":
-        false, "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 1}, {"id": 27395126, "account": 8, "criterion": "AWS
-        Keys", "date": "2026-02-19T14:36:24Z", "last_trigger_published_at": "2026-02-19T14:36:24Z",
-        "last_triggered_at": "2026-02-19T14:40:08.909390Z", "last_trigger_detected_at":
-        "2026-02-19T14:40:08.909390Z", "hash": "ldopSL0HhOyMPVqrCoyqhrM0YiRtyDjCRKal/yZRhL1LxHMKL4Qc71cZRqNcojMG",
+        "main", "monitoring_status": "active"}, "regression": false, "content": 164835166,
+        "secrets_engine_version": "2.163.1", "matches": [{"name": "connection_uri",
+        "string_matched": "[REDACTED]", "indice_start": 41, "indice_end": 132, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 1, "post_line_end": 1}, {"name":
+        "scheme", "string_matched": "[REDACTED]", "indice_start": 41, "indice_end":
+        52, "pre_line_start": null, "pre_line_end": null, "post_line_start": 1, "post_line_end":
+        1}, {"name": "username", "string_matched": "[REDACTED]", "indice_start": 55,
+        "indice_end": 63, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        1, "post_line_end": 1}, {"name": "password", "string_matched": "[REDACTED]",
+        "indice_start": 64, "indice_end": 76, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 1, "post_line_end": 1}, {"name": "host", "string_matched":
+        "[REDACTED]", "indice_start": 77, "indice_end": 97, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 1, "post_line_end": 1}, {"name":
+        "database", "string_matched": "[REDACTED]", "indice_start": 98, "indice_end":
+        104, "pre_line_start": null, "pre_line_end": null, "post_line_start": 1, "post_line_end":
+        1}, {"name": "query", "string_matched": "[REDACTED]", "indice_start": 105,
+        "indice_end": 132, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        1, "post_line_end": 1}], "most_sensitive_match_name": "password", "insights":
+        [], "filepath": "009396acf5bf911afb1f53bd58573d91e4e2edca", "filename": "009396acf5bf911afb1f53bd58573d91e4e2edca",
+        "presence": "visible", "last_presence_seen_at": "2026-05-27T09:51:39.164163Z",
+        "last_presence_check_at": "2026-05-27T09:51:39.164163Z", "first_presence_deleted_at":
+        null, "seen_in_default_branch": null, "change_type": "addition", "full_tags":
+        [{"type": "FROM_HISTORICAL_SCAN", "metadata": null, "field": "content"}]},
+        "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH", "FROM_HISTORICAL_SCAN"],
+        "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 2}, {"id":
+        33211407, "account": 8, "criterion": "MongoDB URI", "date": "2026-05-27T09:28:55Z",
+        "last_trigger_published_at": "2026-05-27T09:28:55Z", "last_triggered_at":
+        "2026-05-27T09:33:03.018451Z", "last_trigger_detected_at": "2026-05-27T09:33:03.018451Z",
+        "hash": "f3/8VwzVd7DQeZGQ5/KE3RVyckzjIEeBi3597wegzcjbsKhZfeuh40iUuZt2nZY1",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "AWS IAM Keys", "severity_rule_config": {"id": 10860, "gg_created_at": "2026-02-12T15:13:37.684167Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684171Z", "index": 30, "severity": 10,
-        "rule": {"id": 503, "gg_created_at": "2025-03-18T08:57:54.142008Z", "gg_updated_at":
-        "2025-04-02T13:15:43.307296Z", "name": "Valid secrets related to highly sensitive
-        detectors", "description": "Secrets related to highly sensitive detectors
-        were valid when the incident was discovered. You can edit this rule to create
-        your own list of sensitive detectors", "json_rule": {"operator": "AND", "args":
-        [{"operator": "EQ", "arg1": {"path": "issue.secret.validity_status", "default":
-        null}, "arg2": {"value": "valid"}}, {"operator": "IN", "arg1": {"path": "issue.secret.detector.detector_group_name",
-        "default": null}, "arg2": {"value": ["github_app_token", "ldap_credentials",
-        "github_oauth_token", "googlecloud_keys", "jira_basic_auth", "python_package_index_key",
-        "aws_iam_sts", "npm_token", "gitlab_token", "smtp_credentials", "github_fine_grained_pat",
-        "gitlab_enterprise_token", "github_access_token", "aws_iam"]}}]}, "is_global":
-        true, "scope": "any", "author": null}}, "declarative_secret_status": null,
-        "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "Martin Faucheux / Repo A",
-        "type": "gl_project", "path": "martin-faucheux/repo-a", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 0, "score": 36, "displayed_occurrence": {"id": 245063312,
-        "issue": 27395126, "account": 8, "kind": "RLTM", "element": "7a6a765a03f640cf002e7d23040dad8a17fe4255",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
-        "value": null, "value_hash": "dLLMC28h0JB8KLz6ViyG9URvAnikbB5BBECedrqc2JmDHqkd2KVpMdI0NbaCVmKj",
-        "published_at": "2026-02-19T14:36:24Z", "date": "2026-02-19T14:36:24Z", "detected_at":
-        "2026-02-19T14:40:06.772801Z", "is_vcs_type": true, "last_detected_at": "2026-02-19T14:36:24Z",
-        "last_seen_at": "2026-02-19T14:36:24Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/martin-faucheux/repo-a/commit/7a6a765a03f640cf002e7d23040dad8a17fe4255#710a727ecafa5cfe744810c543a838230918ff04_0_4",
-        "source": {"id": 16218988, "url": "https://gitlab-01.aws-qa-gitguardian.com/martin-faucheux/repo-a",
-        "type": "gl_project", "display_name": "Martin Faucheux / Repo A", "visibility":
-        "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 134461307,
-        "secrets_engine_version": "2.156.0", "matches": [{"name": "client_id", "string_matched":
-        "[REDACTED]", "indice_start": 45, "indice_end": 65, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 3, "post_line_end": 3}, {"name":
-        "client_secret", "string_matched": "[REDACTED]", "indice_start": 81, "indice_end":
-        121, "pre_line_start": null, "pre_line_end": null, "post_line_start": 4, "post_line_end":
-        4}], "most_sensitive_match_name": "client_secret", "insights": [{"name": "test_file",
-        "source": "document", "metadata": null}], "filepath": "aws_example.py", "filename":
-        "aws_example.py", "presence": "visible", "last_presence_seen_at": "2026-02-19T14:40:08.948798Z",
-        "last_presence_check_at": "2026-02-19T14:40:08.948798Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": false, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}]}, "has_dropped_occurrences": false,
-        "tags": ["TEST_FILE"], "public_exposure": {"source_publicly_visible": false,
-        "public_incident_linked": false, "leaked_outside_perimeter": false}, "occurrences_count":
-        1}, {"id": 26879946, "account": 8, "criterion": "AWS Keys", "date": "2026-02-05T16:48:19Z",
-        "last_trigger_published_at": "2026-02-05T16:48:19Z", "last_triggered_at":
-        "2026-02-05T16:51:59.912161Z", "last_trigger_detected_at": "2026-02-05T16:51:59.912161Z",
-        "hash": "BPRo0pF0ZesUJFhK1FAEiWQsj9wNtT2WYZ15WbzmXjC7vE/VL4Qc71cZRqNcojMG",
+        "MongoDB Credentials", "severity_rule_config": {"id": 11898, "gg_created_at":
+        "2026-05-20T08:56:10.055489Z", "gg_updated_at": "2026-05-20T08:56:10.055492Z",
+        "index": 160, "severity": 20, "rule": {"id": 516, "gg_created_at": "2025-03-18T08:57:54.142529Z",
+        "gg_updated_at": "2025-03-18T08:57:54.142532Z", "name": "Specific Database
+        Credentials", "description": "Specific Database Credentials", "json_rule":
+        {"operator": "AND", "args": [{"operator": "EQ", "arg1": {"path": "issue.secret.detector.metadata.category",
+        "default": null}, "arg2": {"value": "data_storage"}}, {"operator": "EQ", "arg1":
+        {"path": "issue.secret.detector.nature", "default": null}, "arg2": {"value":
+        "specific"}}]}, "is_global": true, "scope": "private", "author": null}}, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "romain.jouhannet@gitguardian.com",
+        "name": "Romain Jouhannet"}], "user_permission": 7, "is_publicly_shared":
+        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
+        [{"id": 23485702, "name": "RomainJ / demo", "type": "gl_project", "path":
+        "romain/demo", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 1, "score": 49, "displayed_occurrence": {"id":
+        269727691, "issue": 33211407, "account": 8, "kind": "RLTM", "element": "d6361a080aa92dc554cd2b55f6f3a7dcf26d1dcb",
+        "element_type": "GIT_COMMIT", "author_name": "Romain Jouhannet", "author_info":
+        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "YU5lBhVgALxxn8rYMmJe6Uh0y3sUhot77BxviUqvi2cqEVzhNyDcgwtJW6F//p33",
+        "published_at": "2026-05-27T09:28:55Z", "date": "2026-05-27T09:28:55Z", "detected_at":
+        "2026-05-27T09:32:59.686337Z", "is_vcs_type": true, "last_detected_at": "2026-05-27T09:28:55Z",
+        "last_seen_at": "2026-05-27T09:28:55Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/d6361a080aa92dc554cd2b55f6f3a7dcf26d1dcb#3a94abefa57e93ce6945d8a053c37e4e2598dbee_0_7",
+        "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
+        "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 164831857,
+        "secrets_engine_version": "2.163.1", "matches": [{"name": "connection_uri",
+        "string_matched": "[REDACTED]", "indice_start": 159, "indice_end": 250, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 7, "post_line_end": 7}, {"name":
+        "scheme", "string_matched": "[REDACTED]", "indice_start": 159, "indice_end":
+        170, "pre_line_start": null, "pre_line_end": null, "post_line_start": 7, "post_line_end":
+        7}, {"name": "username", "string_matched": "[REDACTED]", "indice_start": 173,
+        "indice_end": 181, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        7, "post_line_end": 7}, {"name": "password", "string_matched": "[REDACTED]",
+        "indice_start": 182, "indice_end": 194, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 7, "post_line_end": 7}, {"name": "host", "string_matched":
+        "[REDACTED]", "indice_start": 195, "indice_end": 215, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 7, "post_line_end": 7}, {"name":
+        "database", "string_matched": "[REDACTED]", "indice_start": 216, "indice_end":
+        222, "pre_line_start": null, "pre_line_end": null, "post_line_start": 7, "post_line_end":
+        7}, {"name": "query", "string_matched": "[REDACTED]", "indice_start": 223,
+        "indice_end": 250, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        7, "post_line_end": 7}], "most_sensitive_match_name": "password", "insights":
+        [], "filepath": "go-away-bird.py", "filename": "go-away-bird.py", "presence":
+        "visible", "last_presence_seen_at": "2026-05-27T09:51:39.193873Z", "last_presence_check_at":
+        "2026-05-27T09:51:39.193873Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        true, "change_type": "addition", "full_tags": [{"type": "DEFAULT_BRANCH",
+        "metadata": null, "field": "content"}]}, "has_dropped_occurrences": false,
+        "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 33211409, "account": 8, "criterion": "MongoDB
+        URI", "date": "2026-05-27T09:28:55Z", "last_trigger_published_at": "2026-05-27T09:28:55Z",
+        "last_triggered_at": "2026-05-27T09:33:03.018587Z", "last_trigger_detected_at":
+        "2026-05-27T09:33:03.018587Z", "hash": "moGvUliRX8qewDsI4A+2brZjdcsh4ZKDzShm/YWXFgktPfL3feuh40iUuZt2nZY1",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
-        "none", "manual_severity_setter_type": "none", "status": "ASSIGNED", "issue_name":
-        "AWS IAM Keys", "severity_rule_config": {"id": 10860, "gg_created_at": "2026-02-12T15:13:37.684167Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684171Z", "index": 30, "severity": 10,
-        "rule": {"id": 503, "gg_created_at": "2025-03-18T08:57:54.142008Z", "gg_updated_at":
-        "2025-04-02T13:15:43.307296Z", "name": "Valid secrets related to highly sensitive
-        detectors", "description": "Secrets related to highly sensitive detectors
-        were valid when the incident was discovered. You can edit this rule to create
-        your own list of sensitive detectors", "json_rule": {"operator": "AND", "args":
-        [{"operator": "EQ", "arg1": {"path": "issue.secret.validity_status", "default":
-        null}, "arg2": {"value": "valid"}}, {"operator": "IN", "arg1": {"path": "issue.secret.detector.detector_group_name",
-        "default": null}, "arg2": {"value": ["github_app_token", "ldap_credentials",
-        "github_oauth_token", "googlecloud_keys", "jira_basic_auth", "python_package_index_key",
-        "aws_iam_sts", "npm_token", "gitlab_token", "smtp_credentials", "github_fine_grained_pat",
-        "gitlab_enterprise_token", "github_access_token", "aws_iam"]}}]}, "is_global":
-        true, "scope": "any", "author": null}}, "declarative_secret_status": null,
-        "assignee": 581873, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        8, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "gim-qa-gitlabSandbox-auto
-        / gim-qa-gitlabSandbox-staging", "type": "gl_project", "path": "gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
-        "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
-        {"id": 242021853, "issue": 26879946, "account": 8, "kind": "RLTM", "element":
-        "e2cbc193a76a13b94e135c12a055d2083a233a89", "element_type": "GIT_COMMIT",
-        "author_name": "dev", "author_info": "gim+dev@gitguardian.com", "value": null,
-        "value_hash": "7AkVngiwT5n4ZZihQovCHs2qrlx0MOfD853AYv4HHS0DiM0Vk9YtctC+FFM1Iw+v",
-        "published_at": "2026-02-05T16:48:19Z", "date": "2026-02-05T16:48:19Z", "detected_at":
-        "2026-02-05T16:51:53.166126Z", "is_vcs_type": true, "last_detected_at": "2026-02-05T16:48:19Z",
-        "last_seen_at": "2026-02-05T16:48:19Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging/commit/e2cbc193a76a13b94e135c12a055d2083a233a89#2dd906314026edd7e5fa25025afd4353424625a7_0_19",
-        "source": {"id": 16219056, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
-        "type": "gl_project", "display_name": "gim-qa-gitlabSandbox-auto / gim-qa-gitlabSandbox-staging",
-        "visibility": "private", "monitored": true, "source_criticality": "unknown",
-        "deleted_at": null, "default_branch": "main"}, "regression": false, "content":
-        130291193, "secrets_engine_version": "2.156.0", "matches": [{"name": "client_id",
-        "string_matched": "[REDACTED]", "indice_start": 124, "indice_end": 144, "pre_line_start":
-        null, "pre_line_end": null, "post_line_start": 4, "post_line_end": 4}, {"name":
-        "client_secret", "string_matched": "[REDACTED]", "indice_start": 981, "indice_end":
-        1021, "pre_line_start": null, "pre_line_end": null, "post_line_start": 19,
-        "post_line_end": 19}], "most_sensitive_match_name": "client_secret", "insights":
-        [], "filepath": "ec2_instance_management.py", "filename": "ec2_instance_management.py",
-        "presence": "visible", "last_presence_seen_at": "2026-02-18T22:30:08.818671Z",
-        "last_presence_check_at": "2026-02-18T22:30:08.818671Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": false, "change_type": "addition", "full_tags":
-        []}, "has_dropped_occurrences": false, "tags": [], "public_exposure": {"source_publicly_visible":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "MongoDB Credentials", "severity_rule_config": {"id": 11898, "gg_created_at":
+        "2026-05-20T08:56:10.055489Z", "gg_updated_at": "2026-05-20T08:56:10.055492Z",
+        "index": 160, "severity": 20, "rule": {"id": 516, "gg_created_at": "2025-03-18T08:57:54.142529Z",
+        "gg_updated_at": "2025-03-18T08:57:54.142532Z", "name": "Specific Database
+        Credentials", "description": "Specific Database Credentials", "json_rule":
+        {"operator": "AND", "args": [{"operator": "EQ", "arg1": {"path": "issue.secret.detector.metadata.category",
+        "default": null}, "arg2": {"value": "data_storage"}}, {"operator": "EQ", "arg1":
+        {"path": "issue.secret.detector.nature", "default": null}, "arg2": {"value":
+        "specific"}}]}, "is_global": true, "scope": "private", "author": null}}, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "romain.jouhannet@gitguardian.com",
+        "name": "Romain Jouhannet"}], "user_permission": 7, "is_publicly_shared":
+        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
+        [{"id": 23485702, "name": "RomainJ / demo", "type": "gl_project", "path":
+        "romain/demo", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 1, "score": 49, "displayed_occurrence": {"id":
+        269727692, "issue": 33211409, "account": 8, "kind": "RLTM", "element": "d6361a080aa92dc554cd2b55f6f3a7dcf26d1dcb",
+        "element_type": "GIT_COMMIT", "author_name": "Romain Jouhannet", "author_info":
+        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "dGSO0UNu3ir5xB1mNC4rhS2IL21oXm+7tSQPn+qUFGZ3HkBlVp3JYrpf4ubmlbDB",
+        "published_at": "2026-05-27T09:28:55Z", "date": "2026-05-27T09:28:55Z", "detected_at":
+        "2026-05-27T09:32:59.686337Z", "is_vcs_type": true, "last_detected_at": "2026-05-27T09:28:55Z",
+        "last_seen_at": "2026-05-27T09:28:55Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/d6361a080aa92dc554cd2b55f6f3a7dcf26d1dcb#7b83dc4c52bef56016855ec981bdf4b8425c6486_0_7",
+        "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
+        "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 164831858,
+        "secrets_engine_version": "2.163.1", "matches": [{"name": "connection_uri",
+        "string_matched": "[REDACTED]", "indice_start": 159, "indice_end": 250, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 7, "post_line_end": 7}, {"name":
+        "scheme", "string_matched": "[REDACTED]", "indice_start": 159, "indice_end":
+        170, "pre_line_start": null, "pre_line_end": null, "post_line_start": 7, "post_line_end":
+        7}, {"name": "username", "string_matched": "[REDACTED]", "indice_start": 173,
+        "indice_end": 181, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        7, "post_line_end": 7}, {"name": "password", "string_matched": "[REDACTED]",
+        "indice_start": 182, "indice_end": 194, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 7, "post_line_end": 7}, {"name": "host", "string_matched":
+        "[REDACTED]", "indice_start": 195, "indice_end": 215, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 7, "post_line_end": 7}, {"name":
+        "database", "string_matched": "[REDACTED]", "indice_start": 216, "indice_end":
+        222, "pre_line_start": null, "pre_line_end": null, "post_line_start": 7, "post_line_end":
+        7}, {"name": "query", "string_matched": "[REDACTED]", "indice_start": 223,
+        "indice_end": 250, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        7, "post_line_end": 7}], "most_sensitive_match_name": "password", "insights":
+        [], "filepath": "palmchat.py", "filename": "palmchat.py", "presence": "visible",
+        "last_presence_seen_at": "2026-05-27T09:51:39.193873Z", "last_presence_check_at":
+        "2026-05-27T09:51:39.193873Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        true, "change_type": "addition", "full_tags": [{"type": "DEFAULT_BRANCH",
+        "metadata": null, "field": "content"}]}, "has_dropped_occurrences": false,
+        "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
         false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 8}, {"id": 26805043, "account": 8, "criterion": "MongoDB
-        URI", "date": "2026-02-04T12:40:14Z", "last_trigger_published_at": "2026-02-04T12:40:14Z",
-        "last_triggered_at": "2026-02-04T13:38:51.987022Z", "last_trigger_detected_at":
-        "2026-02-04T13:38:51.987022Z", "hash": "/7fR6f5kCJxcKOBY7aGaXANERrgmNFFGl2msVGfVPMEzhnM4feuh40iUuZt2nZY1",
+        "occurrences_count": 1}, {"id": 33049834, "account": 8, "criterion": "MongoDB
+        URI", "date": "2026-05-21T12:49:39Z", "last_trigger_published_at": "2026-05-21T12:49:39Z",
+        "last_triggered_at": "2026-05-21T12:51:05.194725Z", "last_trigger_detected_at":
+        "2026-05-21T12:51:05.194725Z", "hash": "DbxT4zPpJzBcaEwkFxemH2PT7pGdQ10v/GPqGgREciXMu4bFfeuh40iUuZt2nZY1",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
-        "resolved": true, "resolved_at": "2026-02-06T14:57:44.199417Z", "resolver":
-        104371, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "none", "ignorer_type": "none", "resolver_display_name": "pierre.lalanne@gitguardian.com",
-        "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
-        "none", "status": "RESOLVED", "issue_name": "MongoDB Credentials", "severity_rule_config":
-        {"id": 7276, "gg_created_at": "2025-03-18T08:57:54.146841Z", "gg_updated_at":
-        "2026-03-10T09:47:04.603115Z", "index": 15, "severity": 20, "rule": {"id":
+        "resolved": false, "resolved_at": null, "resolver": 614347, "regression":
+        true, "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "romain.jouhannet@gitguardian.com", "resolver_type":
+        "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
+        "none", "status": "ASSIGNED", "issue_name": "MongoDB Credentials", "severity_rule_config":
+        {"id": 11898, "gg_created_at": "2026-05-20T08:56:10.055489Z", "gg_updated_at":
+        "2026-05-20T08:56:10.055492Z", "index": 160, "severity": 20, "rule": {"id":
         516, "gg_created_at": "2025-03-18T08:57:54.142529Z", "gg_updated_at": "2025-03-18T08:57:54.142532Z",
         "name": "Specific Database Credentials", "description": "Specific Database
         Credentials", "json_rule": {"operator": "AND", "args": [{"operator": "EQ",
@@ -242,81 +272,91 @@ interactions:
         "arg2": {"value": "data_storage"}}, {"operator": "EQ", "arg1": {"path": "issue.secret.detector.nature",
         "default": null}, "arg2": {"value": "specific"}}]}, "is_global": true, "scope":
         "private", "author": null}}, "declarative_secret_status": "revoked", "assignee":
-        null, "last_presence_check_at": null, "secret": "[REDACTED]", "severity":
+        694621, "last_presence_check_at": null, "secret": "[REDACTED]", "severity":
         100, "authors": [{"info": "romain.jouhannet@gitguardian.com", "name": "Romain
-        Jouhannet"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
+        Jouhannet"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 6, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "RomainJ / demo", "type": "gl_project", "path": "romain/demo", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 0, "score": 49, "displayed_occurrence": {"id": 241287706,
-        "issue": 26805043, "account": 8, "kind": "HIST", "element": "5198e8b1dbfceb42a733e2f96a8c737fa8bc5ee8",
+        [{"id": 23485702, "name": "RomainJ / demo", "type": "gl_project", "path":
+        "romain/demo", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 5, "score": 49, "displayed_occurrence": {"id":
+        268701358, "issue": 33049834, "account": 8, "kind": "RLTM", "element": "f13f8127edb3e5d386cb44679c12e5d6c3ce05be",
         "element_type": "GIT_COMMIT", "author_name": "Romain Jouhannet", "author_info":
-        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "I7HWuf4N7z4BUl5YTbmxXGsCjjQ/IlAjXcso7ELZ+5LYJl5p8C+H70xNQGAF2tHA",
-        "published_at": "2026-02-04T12:40:14Z", "date": "2026-02-04T12:40:14Z", "detected_at":
-        "2026-02-04T13:38:46.386256Z", "is_vcs_type": true, "last_detected_at": "2026-02-04T12:40:14Z",
-        "last_seen_at": "2026-02-04T12:40:14Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/5198e8b1dbfceb42a733e2f96a8c737fa8bc5ee8#8b00584865b28d12f057cc2064a51a05b33603f1_None_8",
+        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "ElUKHxkW6poM78sJZq6fX/NNHh82/5I40MrYWprOWor+UttOwqRf0MFMFvJD2sMv",
+        "published_at": "2026-05-21T12:49:39Z", "date": "2026-05-21T12:49:39Z", "detected_at":
+        "2026-05-21T12:51:02.846566Z", "is_vcs_type": true, "last_detected_at": "2026-05-21T12:51:02.846566Z",
+        "last_seen_at": "2026-05-21T12:51:02.846566Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/f13f8127edb3e5d386cb44679c12e5d6c3ce05be#f9553d98ad319e9f50f10ef0cf086752c16a337b_5_6",
         "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
         "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        "main"}, "regression": false, "content": 129708170, "secrets_engine_version":
-        "2.155.4", "matches": [{"name": "connection_uri", "string_matched": "[REDACTED]",
-        "indice_start": 232, "indice_end": 323, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 8, "post_line_end": 8}, {"name": "scheme", "string_matched":
-        "[REDACTED]", "indice_start": 232, "indice_end": 243, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 8, "post_line_end": 8}, {"name":
-        "username", "string_matched": "[REDACTED]", "indice_start": 246, "indice_end":
-        254, "pre_line_start": null, "pre_line_end": null, "post_line_start": 8, "post_line_end":
-        8}, {"name": "password", "string_matched": "[REDACTED]", "indice_start": 255,
-        "indice_end": 267, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        8, "post_line_end": 8}, {"name": "host", "string_matched": "[REDACTED]", "indice_start":
-        268, "indice_end": 288, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        8, "post_line_end": 8}, {"name": "database", "string_matched": "[REDACTED]",
-        "indice_start": 289, "indice_end": 295, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 8, "post_line_end": 8}, {"name": "query", "string_matched":
-        "[REDACTED]", "indice_start": 296, "indice_end": 323, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 8, "post_line_end": 8}], "most_sensitive_match_name":
-        "password", "insights": [], "filepath": "bluethroat.py", "filename": "bluethroat.py",
-        "presence": "visible", "last_presence_seen_at": "2026-02-18T22:33:05.054565Z",
-        "last_presence_check_at": "2026-02-18T22:33:05.054565Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": "addition", "full_tags":
-        [{"type": "FROM_HISTORICAL_SCAN", "metadata": null}]}, "has_dropped_occurrences":
-        false, "tags": ["DEFAULT_BRANCH", "FROM_HISTORICAL_SCAN"], "public_exposure":
+        "main", "monitoring_status": "active"}, "regression": true, "content": 163473773,
+        "secrets_engine_version": "2.163.0", "matches": [{"name": "connection_uri",
+        "string_matched": "[REDACTED]", "indice_start": 157, "indice_end": 248, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 6, "post_line_end": 6}, {"name":
+        "scheme", "string_matched": "[REDACTED]", "indice_start": 157, "indice_end":
+        168, "pre_line_start": null, "pre_line_end": null, "post_line_start": 6, "post_line_end":
+        6}, {"name": "username", "string_matched": "[REDACTED]", "indice_start": 171,
+        "indice_end": 179, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        6, "post_line_end": 6}, {"name": "password", "string_matched": "[REDACTED]",
+        "indice_start": 180, "indice_end": 192, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 6, "post_line_end": 6}, {"name": "host", "string_matched":
+        "[REDACTED]", "indice_start": 193, "indice_end": 213, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 6, "post_line_end": 6}, {"name":
+        "database", "string_matched": "[REDACTED]", "indice_start": 214, "indice_end":
+        220, "pre_line_start": null, "pre_line_end": null, "post_line_start": 6, "post_line_end":
+        6}, {"name": "query", "string_matched": "[REDACTED]", "indice_start": 221,
+        "indice_end": 248, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        6, "post_line_end": 6}], "most_sensitive_match_name": "password", "insights":
+        [], "filepath": "new_occurence.py", "filename": "new_occurence.py", "presence":
+        "visible", "last_presence_seen_at": "2026-05-27T09:51:39.193873Z", "last_presence_check_at":
+        "2026-05-27T09:51:39.193873Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        true, "change_type": "addition", "full_tags": [{"type": "DEFAULT_BRANCH",
+        "metadata": null, "field": "content"}]}, "has_dropped_occurrences": false,
+        "tags": ["DEFAULT_BRANCH", "FROM_HISTORICAL_SCAN", "REGRESSION"], "public_exposure":
         {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 2}]}'
+        false}, "occurrences_count": 6}]}'
     headers:
+      CF-RAY:
+      - a103955be9242a3b-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:19 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '28837'
+      - '30545'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:36 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '112'
+      - '210'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_source_criticality.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_source_criticality.yaml
@@ -21,10 +21,133 @@ interactions:
   response:
     body:
       string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?page=2&page_size=5&source_criticality__in=critical%2Chigh",
-        "previous": null, "results": [{"id": 29236129, "account": 8, "criterion":
-        "Slack Bot Token", "date": "2026-03-26T16:10:40Z", "last_trigger_published_at":
-        "2026-03-26T16:10:40Z", "last_triggered_at": "2026-03-26T16:10:55.648969Z",
-        "last_trigger_detected_at": "2026-03-26T16:10:55.648969Z", "hash": "0Y7z2cw2c6cwAdy+TeYUL5BKR7Lb/hDQRLHld5PCWUkg5Q0OOMgPzYhV28m6OGG4",
+        "previous": null, "results": [{"id": 33677678, "account": 8, "criterion":
+        "Slack Bot Token", "date": "2026-06-05T10:30:39Z", "last_trigger_published_at":
+        "2026-06-05T10:30:39Z", "last_triggered_at": "2026-06-05T10:30:41.691996Z",
+        "last_trigger_detected_at": "2026-06-05T10:30:41.691996Z", "hash": "yqtucKpj6ENdYYA0YiXpal4qcQLOZvxb28M4FZHJU90ArWBROMgPzYhV28m6OGG4",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "pierre.lalanne.p@gmail.com", "name":
+        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 17188087, "name": "pierrelalanne/test_repo", "type": "gh_repository",
+        "path": "pierrelalanne/test_repo", "source_criticality": "critical", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 12, "displayed_occurrence":
+        {"id": 271584642, "issue": 33677678, "account": 8, "kind": "RLTM", "element":
+        "b355f606d5884cfbe83a19c83e6804c0fc9a95f0", "element_type": "GIT_COMMIT",
+        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne.p@gmail.com",
+        "value": null, "value_hash": "BwX3iCglyVyrnbQJ+uR2bcHgVmnkzFUUxyizOMJrHc3YG8H/gEDCz7InbgSdLTaR",
+        "published_at": "2026-06-05T10:30:39Z", "date": "2026-06-05T10:30:39Z", "detected_at":
+        "2026-06-05T10:30:40.398638Z", "is_vcs_type": true, "last_detected_at": "2026-06-05T10:30:39Z",
+        "last_seen_at": "2026-06-05T10:30:39Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/b355f606d5884cfbe83a19c83e6804c0fc9a95f0#diff-cf36aad2a70418098362b5fbd96a9fbbb199e931ccab1ee9713f5b5eb84eba94R67",
+        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
+        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
+        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
+        null, "default_branch": "main", "monitoring_status": "active"}, "regression":
+        false, "content": 166970520, "secrets_engine_version": "2.164.0", "matches":
+        [{"name": "apikey", "string_matched": "[REDACTED]", "indice_start": 303, "indice_end":
+        345, "pre_line_start": null, "pre_line_end": null, "post_line_start": 67,
+        "post_line_end": 67}], "most_sensitive_match_name": "apikey", "insights":
+        [], "filepath": "pii/first_pii.py", "filename": "first_pii.py", "presence":
+        "visible", "last_presence_seen_at": "2026-06-05T10:30:41.723413Z", "last_presence_check_at":
+        "2026-06-05T10:30:41.723413Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        true, "change_type": "addition", "full_tags": [{"type": "DEFAULT_BRANCH",
+        "metadata": null, "field": "content"}]}, "has_dropped_occurrences": false,
+        "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 33677565, "account": 8, "criterion": "Slack
+        Bot Token", "date": "2026-06-05T10:22:50Z", "last_trigger_published_at": "2026-06-05T10:22:50Z",
+        "last_triggered_at": "2026-06-05T10:22:54.870744Z", "last_trigger_detected_at":
+        "2026-06-05T10:22:54.870744Z", "hash": "E0oFI6V78grKtHh0UZXzEEgK25OJOpHtnKC+t7Dzy0qhfh5lOMgPzYhV28m6OGG4",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "pierre.lalanne.p@gmail.com", "name":
+        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 17188087, "name": "pierrelalanne/test_repo", "type": "gh_repository",
+        "path": "pierrelalanne/test_repo", "source_criticality": "critical", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 8, "score": 44, "displayed_occurrence":
+        {"id": 271584100, "issue": 33677565, "account": 8, "kind": "RLTM", "element":
+        "276bdd24d5b2ea7dd5d24065a874e7b38c4baf02", "element_type": "GIT_COMMIT",
+        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne.p@gmail.com",
+        "value": null, "value_hash": "dghMd9QxxXO40sNOZin7UwNQEofOjVvZPRnc0uuhC5UGTg3dHls6b/A69cLp1JsO",
+        "published_at": "2026-06-05T10:22:50Z", "date": "2026-06-05T10:22:50Z", "detected_at":
+        "2026-06-05T10:22:52.066950Z", "is_vcs_type": true, "last_detected_at": "2026-06-05T10:22:50Z",
+        "last_seen_at": "2026-06-05T10:22:50Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/276bdd24d5b2ea7dd5d24065a874e7b38c4baf02#diff-e6b5ea99d732f641a1ed2ab4a8c2d85f73f418a055112ef514157ff958ba8d09R1",
+        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
+        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
+        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
+        null, "default_branch": "main", "monitoring_status": "active"}, "regression":
+        false, "content": 166969572, "secrets_engine_version": "2.164.0", "matches":
+        [{"name": "apikey", "string_matched": "[REDACTED]", "indice_start": 25, "indice_end":
+        67, "pre_line_start": null, "pre_line_end": null, "post_line_start": 1, "post_line_end":
+        1}], "most_sensitive_match_name": "apikey", "insights": [], "filepath": "some_secret_again.py",
+        "filename": "some_secret_again.py", "presence": "visible", "last_presence_seen_at":
+        "2026-06-05T10:22:54.909510Z", "last_presence_check_at": "2026-06-05T10:22:54.909510Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": true, "change_type":
+        "addition", "full_tags": [{"type": "DEFAULT_BRANCH", "metadata": null, "field":
+        "content"}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH",
+        "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible": false,
+        "public_incident_linked": false, "leaked_outside_perimeter": false}, "occurrences_count":
+        1}, {"id": 31373342, "account": 8, "criterion": "OpenAI Project API Key v2",
+        "date": "2026-04-23T14:12:47Z", "last_trigger_published_at": "2026-04-23T14:12:47Z",
+        "last_triggered_at": "2026-04-23T14:12:58.563281Z", "last_trigger_detected_at":
+        "2026-04-23T14:12:58.563281Z", "hash": "D7PsPi/DU6dj2uNjQnheKv8HIw+N4K+WKjS6csnzZuXS6qjgQvtp9WTZ/kMbY8Dv",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": true, "resolved_at": "2026-04-23T14:21:21.665606Z", "resolver":
+        491414, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
+        "none", "ignorer_type": "none", "resolver_display_name": "8@bot.gitguardian.com",
+        "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
+        "none", "status": "RESOLVED", "issue_name": "OpenAI Project API Key v2", "severity_rule_config":
+        null, "declarative_secret_status": "revoked", "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "pierre.lalanne.p@gmail.com",
+        "name": "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false,
+        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 17188087, "name": "pierrelalanne/test_repo", "type": "gh_repository",
+        "path": "pierrelalanne/test_repo", "source_criticality": "critical", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 72, "displayed_occurrence":
+        {"id": 262554997, "issue": 31373342, "account": 8, "kind": "RLTM", "element":
+        "7a29784f96775c22382dd7597ea6b8eba6b0eb6e", "element_type": "GIT_COMMIT",
+        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne.p@gmail.com",
+        "value": null, "value_hash": "iOpliw67mpaH863gBvLPJI/gDBERPy3H1wOuCOS/FoHFmDU9QVFmWDntVjR7KBsQ",
+        "published_at": "2026-04-23T14:12:47Z", "date": "2026-04-23T14:12:47Z", "detected_at":
+        "2026-04-23T14:12:57.197663Z", "is_vcs_type": true, "last_detected_at": "2026-04-23T14:12:47Z",
+        "last_seen_at": "2026-04-23T14:12:47Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/7a29784f96775c22382dd7597ea6b8eba6b0eb6e#diff-424350c68ff6be273a06da5e45468d69074e9eaa0b0a9b19175a602dbb861531R1",
+        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
+        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
+        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
+        null, "default_branch": "main", "monitoring_status": "active"}, "regression":
+        false, "content": 155179630, "secrets_engine_version": "2.161.0", "matches":
+        [{"name": "apikey", "string_matched": "[REDACTED]", "indice_start": 15, "indice_end":
+        179, "pre_line_start": null, "pre_line_end": null, "post_line_start": 1, "post_line_end":
+        1}], "most_sensitive_match_name": "apikey", "insights": [], "filepath": "openai_revoker.txt",
+        "filename": "openai_revoker.txt", "presence": "visible", "last_presence_seen_at":
+        "2026-05-27T14:39:15.843532Z", "last_presence_check_at": "2026-05-27T14:39:15.843532Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": true, "change_type":
+        "addition", "full_tags": [{"type": "DEFAULT_BRANCH", "metadata": null, "field":
+        "content"}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH",
+        "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible": false,
+        "public_incident_linked": false, "leaked_outside_perimeter": false}, "occurrences_count":
+        1}, {"id": 29236129, "account": 8, "criterion": "Slack Bot Token", "date":
+        "2026-03-26T16:10:40Z", "last_trigger_published_at": "2026-03-26T16:10:40Z",
+        "last_triggered_at": "2026-03-26T16:10:55.648969Z", "last_trigger_detected_at":
+        "2026-03-26T16:10:55.648969Z", "hash": "0Y7z2cw2c6cwAdy+TeYUL5BKR7Lb/hDQRLHld5PCWUkg5Q0OOMgPzYhV28m6OGG4",
         "ignored": true, "ignored_at": "2026-03-26T16:10:55.689671Z", "ignore_reason":
         "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
         null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
@@ -37,9 +160,10 @@ interactions:
         "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
         0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "pierrelalanne/test_repo", "type": "gh_repository", "path": "pierrelalanne/test_repo",
-        "source_criticality": "critical"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 0, "displayed_occurrence":
+        [{"id": 17188087, "name": "pierrelalanne/test_repo", "type": "gh_repository",
+        "path": "pierrelalanne/test_repo", "source_criticality": "critical", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 22, "displayed_occurrence":
         {"id": 253938087, "issue": 29236129, "account": 8, "kind": "RLTM", "element":
         "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
         "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
@@ -50,17 +174,18 @@ interactions:
         "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
         "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
         "private", "monitored": true, "source_criticality": "critical", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 146712049,
-        "secrets_engine_version": "2.159.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 60, "indice_end": 102, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 1, "post_line_end": 1}], "most_sensitive_match_name":
-        "apikey", "insights": [{"name": "test_file", "source": "document", "metadata":
-        null}], "filepath": "test_limits_1_secret.txt", "filename": "test_limits_1_secret.txt",
-        "presence": "visible", "last_presence_seen_at": "2026-03-26T16:10:55.988339Z",
-        "last_presence_check_at": "2026-03-26T16:10:55.988339Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}, {"type": "DEFAULT_BRANCH", "metadata":
-        null}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG",
+        null, "default_branch": "main", "monitoring_status": "active"}, "regression":
+        false, "content": 146712049, "secrets_engine_version": "2.159.0", "matches":
+        [{"name": "apikey", "string_matched": "[REDACTED]", "indice_start": 60, "indice_end":
+        102, "pre_line_start": null, "pre_line_end": null, "post_line_start": 1, "post_line_end":
+        1}], "most_sensitive_match_name": "apikey", "insights": [{"name": "test_file",
+        "source": "document", "metadata": null}], "filepath": "test_limits_1_secret.txt",
+        "filename": "test_limits_1_secret.txt", "presence": "visible", "last_presence_seen_at":
+        "2026-05-27T14:39:15.843532Z", "last_presence_check_at": "2026-05-27T14:39:15.843532Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": true, "change_type":
+        "addition", "full_tags": [{"type": "TEST_FILE", "metadata": null, "field":
+        "content"}, {"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]},
+        "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG",
         "TEST_FILE"], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
         false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
         29236130, "account": 8, "criterion": "Slack Bot Token", "date": "2026-03-26T16:10:40Z",
@@ -79,9 +204,10 @@ interactions:
         "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
         0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "pierrelalanne/test_repo", "type": "gh_repository", "path": "pierrelalanne/test_repo",
-        "source_criticality": "critical"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 10, "score": 0, "displayed_occurrence":
+        [{"id": 17188087, "name": "pierrelalanne/test_repo", "type": "gh_repository",
+        "path": "pierrelalanne/test_repo", "source_criticality": "critical", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 10, "score": 22, "displayed_occurrence":
         {"id": 253938082, "issue": 29236130, "account": 8, "kind": "RLTM", "element":
         "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
         "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
@@ -92,179 +218,62 @@ interactions:
         "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
         "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
         "private", "monitored": true, "source_criticality": "critical", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 146712049,
-        "secrets_engine_version": "2.159.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 896, "indice_end": 938, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 20, "post_line_end": 20}], "most_sensitive_match_name":
-        "apikey", "insights": [{"name": "test_file", "source": "document", "metadata":
-        null}], "filepath": "test_limits_1_secret.txt", "filename": "test_limits_1_secret.txt",
-        "presence": "visible", "last_presence_seen_at": "2026-03-26T16:10:55.988339Z",
-        "last_presence_check_at": "2026-03-26T16:10:55.988339Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}, {"type": "DEFAULT_BRANCH", "metadata":
-        null}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG",
-        "TEST_FILE"], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
-        29236131, "account": 8, "criterion": "Slack Bot Token", "date": "2026-03-26T16:10:40Z",
-        "last_trigger_published_at": "2026-03-26T16:10:40Z", "last_triggered_at":
-        "2026-03-26T16:10:55.649314Z", "last_trigger_detected_at": "2026-03-26T16:10:55.649314Z",
-        "hash": "3hALwOgj5xsGsX7Xr2djpOQfm3fKZyceESwEaAHqV53W4r/4OMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-03-26T16:10:55.698981Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "pierrelalanne/test_repo", "type": "gh_repository", "path": "pierrelalanne/test_repo",
-        "source_criticality": "critical"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 10, "score": 0, "displayed_occurrence":
-        {"id": 253938115, "issue": 29236131, "account": 8, "kind": "RLTM", "element":
-        "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
-        "value": null, "value_hash": "vAvNHLmfGcUlg2u5YpP6HYeqfGfqaoNr6UO/FF+gN5EZS8q/KCEKAv96lVFgc2Gd",
-        "published_at": "2026-03-26T16:10:40Z", "date": "2026-03-26T16:10:40Z", "detected_at":
-        "2026-03-26T16:10:51.878216Z", "is_vcs_type": true, "last_detected_at": "2026-03-26T16:10:40Z",
-        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R33",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
-        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 146712049,
-        "secrets_engine_version": "2.159.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 1468, "indice_end": 1510, "pre_line_start":
-        null, "pre_line_end": null, "post_line_start": 33, "post_line_end": 33}],
-        "most_sensitive_match_name": "apikey", "insights": [{"name": "test_file",
-        "source": "document", "metadata": null}], "filepath": "test_limits_1_secret.txt",
-        "filename": "test_limits_1_secret.txt", "presence": "visible", "last_presence_seen_at":
-        "2026-03-26T16:10:55.988339Z", "last_presence_check_at": "2026-03-26T16:10:55.988339Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": true, "change_type":
-        "addition", "full_tags": [{"type": "TEST_FILE", "metadata": null}, {"type":
-        "DEFAULT_BRANCH", "metadata": null}]}, "has_dropped_occurrences": false, "tags":
-        ["DEFAULT_BRANCH", "REVOCABLE_BY_GG", "TEST_FILE"], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 1}, {"id": 29236132, "account": 8, "criterion": "Slack
-        Bot Token", "date": "2026-03-26T16:10:40Z", "last_trigger_published_at": "2026-03-26T16:10:40Z",
-        "last_triggered_at": "2026-03-26T16:10:55.649399Z", "last_trigger_detected_at":
-        "2026-03-26T16:10:55.649399Z", "hash": "BSCOzBXlG7sdaNBisTtS0YT7n9F4g/RNs99ei6DL/3l0L7tJOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-03-26T16:10:55.703657Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "pierrelalanne/test_repo", "type": "gh_repository", "path": "pierrelalanne/test_repo",
-        "source_criticality": "critical"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 1, "score": 0, "displayed_occurrence":
-        {"id": 253938110, "issue": 29236132, "account": 8, "kind": "RLTM", "element":
-        "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
-        "value": null, "value_hash": "m4GM7BpskXJQUZEOA3E9VwY6driWpYHtGS8tHzbJ0Mwm62Q6W6xgPHGgog/9iUaw",
-        "published_at": "2026-03-26T16:10:40Z", "date": "2026-03-26T16:10:40Z", "detected_at":
-        "2026-03-26T16:10:51.878216Z", "is_vcs_type": true, "last_detected_at": "2026-03-26T16:10:40Z",
-        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R37",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
-        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 146712049,
-        "secrets_engine_version": "2.159.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 1644, "indice_end": 1686, "pre_line_start":
-        null, "pre_line_end": null, "post_line_start": 37, "post_line_end": 37}],
-        "most_sensitive_match_name": "apikey", "insights": [{"name": "test_file",
-        "source": "document", "metadata": null}], "filepath": "test_limits_1_secret.txt",
-        "filename": "test_limits_1_secret.txt", "presence": "visible", "last_presence_seen_at":
-        "2026-03-26T16:10:55.988339Z", "last_presence_check_at": "2026-03-26T16:10:55.988339Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": true, "change_type":
-        "addition", "full_tags": [{"type": "TEST_FILE", "metadata": null}, {"type":
-        "DEFAULT_BRANCH", "metadata": null}]}, "has_dropped_occurrences": false, "tags":
-        ["DEFAULT_BRANCH", "REVOCABLE_BY_GG", "TEST_FILE"], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 1}, {"id": 29236133, "account": 8, "criterion": "Slack
-        Bot Token", "date": "2026-03-26T16:10:40Z", "last_trigger_published_at": "2026-03-26T16:10:40Z",
-        "last_triggered_at": "2026-03-26T16:10:55.649474Z", "last_trigger_detected_at":
-        "2026-03-26T16:10:55.649474Z", "hash": "BoKfyANPT/SBEno+bbQvYgqKzPu5CRTqMv0VHuJzQqDc1ZHSOMgPzYhV28m6OGG4",
-        "ignored": true, "ignored_at": "2026-03-26T16:10:55.707644Z", "ignore_reason":
-        "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
-        null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
-        "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
-        "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
-        "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"name": "pierrelalanne/test_repo", "type": "gh_repository", "path": "pierrelalanne/test_repo",
-        "source_criticality": "critical"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 10, "score": 0, "displayed_occurrence":
-        {"id": 253938084, "issue": 29236133, "account": 8, "kind": "RLTM", "element":
-        "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
-        "value": null, "value_hash": "9rgOz5ciLEquwzvvAdl7t+RxjQwXKUxlHtdF8X+361zOnQ4isQL4MjRjjRKn1C3p",
-        "published_at": "2026-03-26T16:10:40Z", "date": "2026-03-26T16:10:40Z", "detected_at":
-        "2026-03-26T16:10:51.878216Z", "is_vcs_type": true, "last_detected_at": "2026-03-26T16:10:40Z",
-        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R35",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
-        "private", "monitored": true, "source_criticality": "critical", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 146712049,
-        "secrets_engine_version": "2.159.0", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 1556, "indice_end": 1598, "pre_line_start":
-        null, "pre_line_end": null, "post_line_start": 35, "post_line_end": 35}],
-        "most_sensitive_match_name": "apikey", "insights": [{"name": "test_file",
-        "source": "document", "metadata": null}], "filepath": "test_limits_1_secret.txt",
-        "filename": "test_limits_1_secret.txt", "presence": "visible", "last_presence_seen_at":
-        "2026-03-26T16:10:55.988339Z", "last_presence_check_at": "2026-03-26T16:10:55.988339Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": true, "change_type":
-        "addition", "full_tags": [{"type": "TEST_FILE", "metadata": null}, {"type":
-        "DEFAULT_BRANCH", "metadata": null}]}, "has_dropped_occurrences": false, "tags":
-        ["DEFAULT_BRANCH", "REVOCABLE_BY_GG", "TEST_FILE"], "public_exposure": {"source_publicly_visible":
+        null, "default_branch": "main", "monitoring_status": "active"}, "regression":
+        false, "content": 146712049, "secrets_engine_version": "2.159.0", "matches":
+        [{"name": "apikey", "string_matched": "[REDACTED]", "indice_start": 896, "indice_end":
+        938, "pre_line_start": null, "pre_line_end": null, "post_line_start": 20,
+        "post_line_end": 20}], "most_sensitive_match_name": "apikey", "insights":
+        [{"name": "test_file", "source": "document", "metadata": null}], "filepath":
+        "test_limits_1_secret.txt", "filename": "test_limits_1_secret.txt", "presence":
+        "visible", "last_presence_seen_at": "2026-05-27T14:39:15.843532Z", "last_presence_check_at":
+        "2026-05-27T14:39:15.843532Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        true, "change_type": "addition", "full_tags": [{"type": "TEST_FILE", "metadata":
+        null, "field": "content"}, {"type": "DEFAULT_BRANCH", "metadata": null, "field":
+        "content"}]}, "has_dropped_occurrences": false, "tags": ["DEFAULT_BRANCH",
+        "REVOCABLE_BY_GG", "TEST_FILE"], "public_exposure": {"source_publicly_visible":
         false, "public_incident_linked": false, "leaked_outside_perimeter": false},
         "occurrences_count": 1}]}'
     headers:
+      CF-RAY:
+      - a103956398da0365-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:20 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '23880'
+      - '24148'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:38 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '314'
+      - '230'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_status_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_status_filter.yaml
@@ -21,184 +21,49 @@ interactions:
   response:
     body:
       string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?page=2&page_size=5&status__in=TRIGGERED",
-        "previous": null, "results": [{"id": 29487335, "account": 8, "criterion":
-        "Stripe Webhook Secret", "date": "2026-04-02T16:22:33.518000Z", "last_trigger_published_at":
-        "2026-04-02T16:22:33.518000Z", "last_triggered_at": "2026-04-02T16:22:34.233032Z",
-        "last_trigger_detected_at": "2026-04-02T16:22:34.233032Z", "hash": "JquJu98wTd0k40t3UsNgP22P+ywFCrsGM1VDRg3oZBdGXhRWbjOMbKAG+JtXZUOK",
+        "previous": null, "results": [{"id": 34205503, "account": 8, "criterion":
+        "microsoft_azure_storage_connection_string", "date": "2026-06-23T11:13:31.325324Z",
+        "last_trigger_published_at": "2026-06-23T11:13:31.325324Z", "last_triggered_at":
+        "2026-06-23T11:13:31.343453Z", "last_trigger_detected_at": "2026-06-23T11:13:31.343453Z",
+        "hash": "HdPZ4cjZuziAqsakdlsUnJDapTz3ns5pX8vPzfhvGQvpWWWX25LITKmJimoqGr3z",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Stripe Webhook Secret", "severity_rule_config": null, "declarative_secret_status":
-        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": true,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 62, "displayed_occurrence": {"id": 256867982, "issue": 29487335,
-        "account": 8, "kind": "RLTM", "element": "KAN-8?focusedCommentId=10014", "element_type":
-        "JIRA_COMMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "o40+pCpgMCFgcapQEEdZ3imjEpSONYcgy0J+gLe5ygKDJctj7Ro4REsJrqbUl0yj",
-        "published_at": "2026-04-02T16:22:33.518000Z", "date": "2026-04-02T16:22:33.518000Z",
-        "detected_at": "2026-04-02T16:22:34.031682Z", "is_vcs_type": false, "last_detected_at":
-        "2026-04-02T16:22:33.518000Z", "last_seen_at": "2026-04-02T16:22:33.518000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-8?focusedCommentId=10014",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 148603941, "secrets_engine_version": "2.159.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 25, "indice_end":
-        63, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
-        "2026-04-02T16:22:34.268883Z", "last_presence_check_at": "2026-04-02T16:22:34.268883Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 1}, {"id": 29186788, "account": 8, "criterion":
-        "GitLab Token", "date": "2026-03-25T16:53:05.035206Z", "last_trigger_published_at":
-        "2026-03-25T16:53:05.035206Z", "last_triggered_at": "2026-03-25T16:53:05.853859Z",
-        "last_trigger_detected_at": "2026-03-25T16:53:05.853859Z", "hash": "SJOfhHk3hANA5qiK6fypwRpA6pyKIbh2xmK/JYKpXtMCszyZxGkRAPRx8mJAAtol",
-        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
-        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
-        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
-        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
-        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "GitLab Token", "severity_rule_config": {"id": 10877, "gg_created_at": "2026-02-12T15:13:37.684430Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684433Z", "index": 200, "severity":
-        20, "rule": {"id": 520, "gg_created_at": "2025-03-18T08:57:54.142633Z", "gg_updated_at":
-        "2025-03-18T08:57:54.142636Z", "name": "The secret is in a sensitive file",
-        "description": "Secret found in a sensitive file (.env, .pem key, dotfiles)",
-        "json_rule": {"operator": "CONTAINS_ANY", "arg1": {"path": "tag_names", "default":
-        null}, "arg2": {"value": ["SENSITIVE_FILE"]}}, "is_global": true, "scope":
-        "any", "author": null}}, "declarative_secret_status": null, "assignee": null,
-        "last_presence_check_at": null, "secret": "[REDACTED]", "severity": 100, "authors":
-        [{"info": "", "name": "GitGuardian Sandbox [internal]"}], "user_permission":
-        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        3, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "totaaa", "type": "custom_source",
-        "path": "totaaa", "source_criticality": "unknown"}, {"name": "totaaab", "type":
-        "custom_source", "path": "totaaab", "source_criticality": "unknown"}, {"name":
-        "totaaabccb", "type": "custom_source", "path": "totaaabccb", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 0, "score": 9, "displayed_occurrence": {"id": 253371418,
-        "issue": 29186788, "account": 8, "kind": "RLTM", "element": "", "element_type":
-        "CUSTOM_ELEMENT", "author_name": "GitGuardian Sandbox [internal]", "author_info":
-        "", "value": null, "value_hash": "bYdCbHZ101hGcZ6Q6XqcVQkGryoOAuqw4QxVXQLjQfpBf5OllP448kL+4h/ug/8v",
-        "published_at": "2026-03-25T16:53:05.035206Z", "date": "2026-03-25T16:53:05.035206Z",
-        "detected_at": "2026-03-25T16:53:05.737995Z", "is_vcs_type": false, "last_detected_at":
-        "2026-03-25T16:53:05.035206Z", "last_seen_at": "2026-03-25T16:53:05.035206Z",
-        "data": {}, "url": "", "source": {"id": 26968497, "url": "", "type": "custom_source",
-        "display_name": "totaaa", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 146400014, "secrets_engine_version": "2.158.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 123, "indice_end":
-        149, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [{"name": "sensitive_filepath", "source": "document", "metadata": {"sensitive_patterns":
-        [{"tags": [], "comment": "", "pattern": "\\.?env(?![^\\.])", "category": "filename",
-        "description": "Environment configuration file"}]}}], "filepath": "/tmp/tmpvcmhu56nggshield/home/hhubert/.env",
-        "filename": ".env", "presence": "visible", "last_presence_seen_at": "2026-03-25T16:53:05.897743Z",
-        "last_presence_check_at": "2026-03-25T16:53:05.897743Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": [{"type":
-        "SENSITIVE_FILE", "metadata": null}]}, "has_dropped_occurrences": false, "tags":
-        ["REVOCABLE_BY_GG", "SENSITIVE_FILE"], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 3}, {"id": 28905156, "account": 8, "criterion": "GitLab
-        Token", "date": "2026-03-17T14:35:54.643000Z", "last_trigger_published_at":
-        "2026-03-17T14:35:54.643000Z", "last_triggered_at": "2026-03-17T14:36:00.418064Z",
-        "last_trigger_detected_at": "2026-03-17T14:36:00.418064Z", "hash": "kbVfTxt8mubX2vVRQN/wNxpT9vQMThT40ap5w7qZ8b20vI7qxGkRAPRx8mJAAtol",
-        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
-        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
-        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
-        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
-        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "GitLab Token", "severity_rule_config": null, "declarative_secret_status":
-        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "<unknown>", "name": "GG Test Integrations"},
-        {"info": "<unknown>", "name": "Unknown"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 4, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"},
-        {"name": "gitguardian-team-vxrpkdpl / D\u00e9veloppement logiciel", "type":
-        "confluence_cloud_space", "path": "gitguardian-team-vxrpkdpl / D\u00e9veloppement
-        logiciel", "source_criticality": "unknown"}, {"name": "gitguardian-team-vxrpkdpl
-        / Philippe Gablain", "type": "confluence_cloud_space", "path": "gitguardian-team-vxrpkdpl
-        / Philippe Gablain", "source_criticality": "unknown"}], "custom_tags": [],
-        "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0, "score":
-        9, "displayed_occurrence": {"id": 252869959, "issue": 28905156, "account":
-        8, "kind": "HIST", "element": "attachment/att524290", "element_type": "CONFLUENCE_ATTACHMENT",
-        "author_name": "Unknown", "author_info": "<unknown>", "value": null, "value_hash":
-        "YZ0Me0zobvsKpuRIo4KGFLcQhBLa5wXObD6V1J3gm/iC+5COK1fW5YSNIAEU43PK", "published_at":
-        "2026-03-12T17:23:48.915000Z", "date": "2026-03-12T17:23:48.915000Z", "detected_at":
-        "2026-03-24T09:54:31.814599Z", "is_vcs_type": false, "last_detected_at": "2026-03-12T17:23:48.915000Z",
-        "last_seen_at": "2026-03-12T17:23:48.915000Z", "data": {}, "url": "https://gitguardian-team-vxrpkdpl.atlassian.net/wiki/spaces/~62a76a05979e6e00690427b5/pages/262177",
-        "source": {"id": 26936741, "url": "https://gitguardian-team-vxrpkdpl.atlassian.net/wiki/spaces/~62a76a05979e6e00690427b5",
-        "type": "confluence_cloud_space", "display_name": "gitguardian-team-vxrpkdpl
-        / Philippe Gablain", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 144316417, "secrets_engine_version": "2.158.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 106, "indice_end":
-        132, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": "/download/attachments/262177/toto9.txt?version=1&modificationDate=1773336228915&cacheVersion=1&api=v2",
-        "filename": "toto9.txt", "presence": "visible", "last_presence_seen_at": "2026-03-30T08:25:43.285668Z",
-        "last_presence_check_at": "2026-03-30T08:25:43.285668Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": [{"type":
-        "FROM_HISTORICAL_SCAN", "metadata": null}]}, "has_dropped_occurrences": false,
-        "tags": ["FROM_HISTORICAL_SCAN", "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 4}, {"id": 28905136, "account": 8, "criterion": "GitLab
-        Token", "date": "2026-03-17T13:50:21.909000Z", "last_trigger_published_at":
-        "2026-03-17T13:50:21.909000Z", "last_triggered_at": "2026-03-17T14:35:04.182999Z",
-        "last_trigger_detected_at": "2026-03-17T14:35:04.182999Z", "hash": "WK++VMwWOtCgcJLB1bssA+LYOZibFxHq2PD3Gc27zcfd1zd3xGkRAPRx8mJAAtol",
-        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
-        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
-        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
-        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
-        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "GitLab Token", "severity_rule_config": null, "declarative_secret_status":
-        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": false,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 9, "displayed_occurrence": {"id": 251397394, "issue": 28905136,
-        "account": 8, "kind": "HIST", "element": "KAN-1/attachment/10000", "element_type":
-        "JIRA_ATTACHMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "HJeG3nW8vJKcwODm8fthKZ+emBqlOohKRUtdSDefI95yvYyjcl17awQJwJ+R7glD",
-        "published_at": "2026-03-17T13:50:21.909000Z", "date": "2026-03-17T13:50:21.909000Z",
-        "detected_at": "2026-03-17T14:34:59.387226Z", "is_vcs_type": false, "last_detected_at":
-        "2026-03-17T13:50:21.909000Z", "last_seen_at": "2026-03-17T13:50:21.909000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-1",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 144316340, "secrets_engine_version": "2.158.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 107, "indice_end":
-        133, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": "https://api.atlassian.com/ex/jira/239c88bc-2664-4cb9-a422-e59dfaf60bf6/rest/api/3/attachment/content/10000",
-        "filename": "toto.pdf", "presence": "visible", "last_presence_seen_at": "2026-03-17T14:35:04.233212Z",
-        "last_presence_check_at": "2026-03-17T14:35:04.233212Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": [{"type":
-        "FROM_HISTORICAL_SCAN", "metadata": null}]}, "has_dropped_occurrences": false,
-        "tags": ["FROM_HISTORICAL_SCAN", "REVOCABLE_BY_GG"], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 1}, {"id": 27743219, "account": 8, "criterion": "Generic
-        Password", "date": "2026-03-02T08:03:19Z", "last_trigger_published_at": "2026-03-02T08:03:19Z",
-        "last_triggered_at": "2026-03-02T08:04:40.966599Z", "last_trigger_detected_at":
-        "2026-03-02T08:04:40.966599Z", "hash": "DIhTV8EvZb3qiiqNdZxIdx5KXxPM1+opgvbjqYv9ikr7Xshkfma8ieOEhD7igl+v",
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
+        "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
+        "detected_at": "2026-06-23T11:13:31.325324Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
+        "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
+        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
+        34186239, "account": 8, "criterion": "Generic Password", "date": "2026-06-22T15:14:57Z",
+        "last_trigger_published_at": "2026-06-22T15:14:57Z", "last_triggered_at":
+        "2026-06-22T15:16:49.799821Z", "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z",
+        "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -207,67 +72,191 @@ interactions:
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
         "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        2, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"name": "olaugier / test", "type":
-        "gl_project", "path": "olaugier/test", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 63, "displayed_occurrence": {"id": 247153722, "issue": 27743219,
-        "account": 8, "kind": "RLTM", "element": "876b995fcda9f3ebacdde3630fe8521c09e88a50",
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
+        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
+        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
         "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
-        "value": null, "value_hash": "kqtDoOt2gXsDpCN6VFM6vvO0PUTxcS7pA+2Yu2AS9t2s4kcdjypyaVpjw9oi8GAg",
-        "published_at": "2026-03-02T08:03:19Z", "date": "2026-03-02T08:03:19Z", "detected_at":
-        "2026-03-02T08:04:26.107138Z", "is_vcs_type": true, "last_detected_at": "2026-03-02T08:03:19Z",
-        "last_seen_at": "2026-03-02T08:03:19Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/876b995fcda9f3ebacdde3630fe8521c09e88a50#dbdb2e6bfc642ed0d0c5033e50062fe3ede15e4e_0_3",
+        "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
+        "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
+        "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
         "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        "main"}, "regression": false, "content": 137431882, "secrets_engine_version":
-        "2.157.1", "matches": [{"name": "password", "string_matched": "[REDACTED]",
-        "indice_start": 67, "indice_end": 143, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 3, "post_line_end": 3}], "most_sensitive_match_name":
-        "password", "insights": [{"name": "minified", "source": "document", "metadata":
-        {"minified_probability": 0.0}}], "filepath": "configuration_15.txt", "filename":
-        "configuration_15.txt", "presence": "visible", "last_presence_seen_at": "2026-03-02T08:04:41.000526Z",
-        "last_presence_check_at": "2026-03-02T08:04:41.000526Z", "first_presence_deleted_at":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 113, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_63.txt", "filename":
+        "configuration_63.txt", "presence": "visible", "last_presence_seen_at": "2026-06-22T15:16:49.824313Z",
+        "last_presence_check_at": "2026-06-22T15:16:49.824313Z", "first_presence_deleted_at":
         null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "DEFAULT_BRANCH", "metadata": null}]}, "has_dropped_occurrences":
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
         false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
         false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 2}]}'
+        "occurrences_count": 1}, {"id": 34122510, "account": 8, "criterion": "Generic
+        Password", "date": "2026-06-19T13:41:03Z", "last_trigger_published_at": "2026-06-19T13:41:03Z",
+        "last_triggered_at": "2026-06-19T13:43:05.020137Z", "last_trigger_detected_at":
+        "2026-06-19T13:43:05.020137Z", "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Generic Password", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
+        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
+        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
+        "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
+        "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 129, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_62.txt", "filename":
+        "configuration_62.txt", "presence": "visible", "last_presence_seen_at": "2026-06-19T13:43:05.062490Z",
+        "last_presence_check_at": "2026-06-19T13:43:05.062490Z", "first_presence_deleted_at":
+        null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 34038186, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-16T18:55:43.166667Z", "last_trigger_published_at": "2026-06-16T18:55:43.166667Z",
+        "last_triggered_at": "2026-06-16T18:55:43.185061Z", "last_trigger_detected_at":
+        "2026-06-16T18:55:43.185061Z", "hash": "JFTpQX+4P/dEcXJJ2iw+u54JYDsJnqLtrdws1wjFQ8t9LtHh25LITKmJimoqGr3z",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
+        "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
+        "detected_at": "2026-06-16T18:55:43.166667Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
+        "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
+        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
+        33905111, "account": 8, "criterion": "GitLab Deploy Token", "date": "2026-06-11T12:29:43Z",
+        "last_trigger_published_at": "2026-06-11T12:29:43Z", "last_triggered_at":
+        "2026-06-11T12:30:11.342010Z", "last_trigger_detected_at": "2026-06-11T12:30:11.342010Z",
+        "hash": "G0fVu31BJOKtUHJsvHbpcGhXGXhyr2/bQf6zzlhNv+czrK+KrGdxdFLGuJmYhmlq",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "GitLab Deploy Token", "severity_rule_config": null, "declarative_secret_status":
+        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 28664611, "name": "dev / plal_test",
+        "type": "gl_project", "path": "dev/plal_test", "source_criticality": "unknown",
+        "monitoring_status": "active", "deleted_at": null}], "custom_tags": [], "vault_metadata":
+        null, "is_vaulted": false, "similar_issue_count": 0, "score": 85, "displayed_occurrence":
+        {"id": 272645187, "issue": 33905111, "account": 8, "kind": "HIST", "element":
+        "0102329ae146f51358cff771dbdf860acbc78ef6", "element_type": "GIT_COMMIT",
+        "author_name": "dev", "author_info": "gim+dev@gitguardian.com", "value": null,
+        "value_hash": "vKgkDXA4NszdEvKqefnQ7tPG4AsADP5uV3carLt96S2ZoMa7KySfdZ9m9HlrAElh",
+        "published_at": "2026-06-11T12:29:43Z", "date": "2026-06-11T12:29:43Z", "detected_at":
+        "2026-06-11T12:30:10.472937Z", "is_vcs_type": true, "last_detected_at": "2026-06-11T12:37:30.541974Z",
+        "last_seen_at": "2026-06-11T12:37:30.541974Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/dev/plal_test/commit/0102329ae146f51358cff771dbdf860acbc78ef6#5a06a4630a05426a25bc162c233d6cf8ed2462a0_None_5",
+        "source": {"id": 28664611, "url": "https://gitlab-01.aws-qa-gitguardian.com/dev/plal_test",
+        "type": "gl_project", "display_name": "dev / plal_test", "visibility": "private",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 168574637,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "apikey", "string_matched":
+        "[REDACTED]", "indice_start": 65, "indice_end": 90, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 5, "post_line_end": 5}], "most_sensitive_match_name":
+        "apikey", "insights": [], "filepath": "secret_and_pii.txt", "filename": "secret_and_pii.txt",
+        "presence": "visible", "last_presence_seen_at": "2026-06-11T12:37:30.541974Z",
+        "last_presence_check_at": "2026-06-11T12:37:30.541974Z", "first_presence_deleted_at":
+        null, "seen_in_default_branch": null, "change_type": "addition", "full_tags":
+        [{"type": "FROM_HISTORICAL_SCAN", "metadata": null, "field": "content"}]},
+        "has_dropped_occurrences": false, "tags": ["FROM_HISTORICAL_SCAN"], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 1}]}'
     headers:
+      CF-RAY:
+      - a103955788af9952-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:19 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '24879'
+      - '22623'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:35 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '155'
+      - '170'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_teams.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_teams.yaml
@@ -23,38 +23,46 @@ interactions:
       string: '{"count": null, "page": 1, "next": null, "previous": null, "results":
         []}'
     headers:
+      CF-RAY:
+      - a10395afaa59e887-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:32 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '64'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:49 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '63'
+      - '51'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_validity.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_validity.yaml
@@ -21,179 +21,133 @@ interactions:
   response:
     body:
       string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?page=2&page_size=5&validity__in=valid%2Cnot_checked",
-        "previous": null, "results": [{"id": 27395126, "account": 8, "criterion":
-        "AWS Keys", "date": "2026-02-19T14:36:24Z", "last_trigger_published_at": "2026-02-19T14:36:24Z",
-        "last_triggered_at": "2026-02-19T14:40:08.909390Z", "last_trigger_detected_at":
-        "2026-02-19T14:40:08.909390Z", "hash": "ldopSL0HhOyMPVqrCoyqhrM0YiRtyDjCRKal/yZRhL1LxHMKL4Qc71cZRqNcojMG",
+        "previous": null, "results": [{"id": 34205503, "account": 8, "criterion":
+        "microsoft_azure_storage_connection_string", "date": "2026-06-23T11:13:31.325324Z",
+        "last_trigger_published_at": "2026-06-23T11:13:31.325324Z", "last_triggered_at":
+        "2026-06-23T11:13:31.343453Z", "last_trigger_detected_at": "2026-06-23T11:13:31.343453Z",
+        "hash": "HdPZ4cjZuziAqsakdlsUnJDapTz3ns5pX8vPzfhvGQvpWWWX25LITKmJimoqGr3z",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "AWS IAM Keys", "severity_rule_config": {"id": 10860, "gg_created_at": "2026-02-12T15:13:37.684167Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684171Z", "index": 30, "severity": 10,
-        "rule": {"id": 503, "gg_created_at": "2025-03-18T08:57:54.142008Z", "gg_updated_at":
-        "2025-04-02T13:15:43.307296Z", "name": "Valid secrets related to highly sensitive
-        detectors", "description": "Secrets related to highly sensitive detectors
-        were valid when the incident was discovered. You can edit this rule to create
-        your own list of sensitive detectors", "json_rule": {"operator": "AND", "args":
-        [{"operator": "EQ", "arg1": {"path": "issue.secret.validity_status", "default":
-        null}, "arg2": {"value": "valid"}}, {"operator": "IN", "arg1": {"path": "issue.secret.detector.detector_group_name",
-        "default": null}, "arg2": {"value": ["github_app_token", "ldap_credentials",
-        "github_oauth_token", "googlecloud_keys", "jira_basic_auth", "python_package_index_key",
-        "aws_iam_sts", "npm_token", "gitlab_token", "smtp_credentials", "github_fine_grained_pat",
-        "gitlab_enterprise_token", "github_access_token", "aws_iam"]}}]}, "is_global":
-        true, "scope": "any", "author": null}}, "declarative_secret_status": null,
-        "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "Martin Faucheux / Repo A",
-        "type": "gl_project", "path": "martin-faucheux/repo-a", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 0, "score": 36, "displayed_occurrence": {"id": 245063312,
-        "issue": 27395126, "account": 8, "kind": "RLTM", "element": "7a6a765a03f640cf002e7d23040dad8a17fe4255",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
-        "value": null, "value_hash": "dLLMC28h0JB8KLz6ViyG9URvAnikbB5BBECedrqc2JmDHqkd2KVpMdI0NbaCVmKj",
-        "published_at": "2026-02-19T14:36:24Z", "date": "2026-02-19T14:36:24Z", "detected_at":
-        "2026-02-19T14:40:06.772801Z", "is_vcs_type": true, "last_detected_at": "2026-02-19T14:36:24Z",
-        "last_seen_at": "2026-02-19T14:36:24Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/martin-faucheux/repo-a/commit/7a6a765a03f640cf002e7d23040dad8a17fe4255#710a727ecafa5cfe744810c543a838230918ff04_0_4",
-        "source": {"id": 16218988, "url": "https://gitlab-01.aws-qa-gitguardian.com/martin-faucheux/repo-a",
-        "type": "gl_project", "display_name": "Martin Faucheux / Repo A", "visibility":
-        "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
-        null, "default_branch": "main"}, "regression": false, "content": 134461307,
-        "secrets_engine_version": "2.156.0", "matches": [{"name": "client_id", "string_matched":
-        "[REDACTED]", "indice_start": 45, "indice_end": 65, "pre_line_start": null,
-        "pre_line_end": null, "post_line_start": 3, "post_line_end": 3}, {"name":
-        "client_secret", "string_matched": "[REDACTED]", "indice_start": 81, "indice_end":
-        121, "pre_line_start": null, "pre_line_end": null, "post_line_start": 4, "post_line_end":
-        4}], "most_sensitive_match_name": "client_secret", "insights": [{"name": "test_file",
-        "source": "document", "metadata": null}], "filepath": "aws_example.py", "filename":
-        "aws_example.py", "presence": "visible", "last_presence_seen_at": "2026-02-19T14:40:08.948798Z",
-        "last_presence_check_at": "2026-02-19T14:40:08.948798Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": false, "change_type": "addition", "full_tags":
-        [{"type": "TEST_FILE", "metadata": null}]}, "has_dropped_occurrences": false,
-        "tags": ["TEST_FILE"], "public_exposure": {"source_publicly_visible": false,
-        "public_incident_linked": false, "leaked_outside_perimeter": false}, "occurrences_count":
-        1}, {"id": 26879946, "account": 8, "criterion": "AWS Keys", "date": "2026-02-05T16:48:19Z",
-        "last_trigger_published_at": "2026-02-05T16:48:19Z", "last_triggered_at":
-        "2026-02-05T16:51:59.912161Z", "last_trigger_detected_at": "2026-02-05T16:51:59.912161Z",
-        "hash": "BPRo0pF0ZesUJFhK1FAEiWQsj9wNtT2WYZ15WbzmXjC7vE/VL4Qc71cZRqNcojMG",
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
+        "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
+        "detected_at": "2026-06-23T11:13:31.325324Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
+        "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
+        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
+        34181686, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-22T11:25:45.739149Z", "last_trigger_published_at": "2026-06-22T11:25:45.739149Z",
+        "last_triggered_at": "2026-06-22T11:25:45.762592Z", "last_trigger_detected_at":
+        "2026-06-22T11:25:45.762592Z", "hash": "gVrL/pjjFLo7sSikPS1pWtPJbr+oWSSVz8IB6+2ViJDSJKiK25LITKmJimoqGr3z",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
-        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
-        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
-        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
-        "none", "manual_severity_setter_type": "none", "status": "ASSIGNED", "issue_name":
-        "AWS IAM Keys", "severity_rule_config": {"id": 10860, "gg_created_at": "2026-02-12T15:13:37.684167Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684171Z", "index": 30, "severity": 10,
-        "rule": {"id": 503, "gg_created_at": "2025-03-18T08:57:54.142008Z", "gg_updated_at":
-        "2025-04-02T13:15:43.307296Z", "name": "Valid secrets related to highly sensitive
-        detectors", "description": "Secrets related to highly sensitive detectors
-        were valid when the incident was discovered. You can edit this rule to create
-        your own list of sensitive detectors", "json_rule": {"operator": "AND", "args":
-        [{"operator": "EQ", "arg1": {"path": "issue.secret.validity_status", "default":
-        null}, "arg2": {"value": "valid"}}, {"operator": "IN", "arg1": {"path": "issue.secret.detector.detector_group_name",
-        "default": null}, "arg2": {"value": ["github_app_token", "ldap_credentials",
-        "github_oauth_token", "googlecloud_keys", "jira_basic_auth", "python_package_index_key",
-        "aws_iam_sts", "npm_token", "gitlab_token", "smtp_credentials", "github_fine_grained_pat",
-        "gitlab_enterprise_token", "github_access_token", "aws_iam"]}}]}, "is_global":
-        true, "scope": "any", "author": null}}, "declarative_secret_status": null,
-        "assignee": 581873, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "resolved": true, "resolved_at": "2026-06-22T11:26:52.971214Z", "resolver":
+        1751937, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
+        "none", "ignorer_type": "none", "resolver_display_name": "candidate.playground+eu@gitguardian.com",
+        "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
+        "none", "status": "RESOLVED", "issue_name": "Microsoft Azure Storage Connection
+        String", "severity_rule_config": null, "declarative_secret_status": "revoked",
+        "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
+        "severity": 100, "authors": [{"info": "", "name": "Kashyapa P.A. Jayasekera"}],
         "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        8, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "gim-qa-gitlabSandbox-auto
-        / gim-qa-gitlabSandbox-staging", "type": "gl_project", "path": "gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
-        "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata": null,
+        6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "GGFRLTA127
+        \u2014 kashyapap.jayasekera", "type": "endpoints", "path": "GGFRLTA127 \u2014
+        kashyapap.jayasekera", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
         "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
-        {"id": 242021853, "issue": 26879946, "account": 8, "kind": "RLTM", "element":
-        "e2cbc193a76a13b94e135c12a055d2083a233a89", "element_type": "GIT_COMMIT",
-        "author_name": "dev", "author_info": "gim+dev@gitguardian.com", "value": null,
-        "value_hash": "7AkVngiwT5n4ZZihQovCHs2qrlx0MOfD853AYv4HHS0DiM0Vk9YtctC+FFM1Iw+v",
-        "published_at": "2026-02-05T16:48:19Z", "date": "2026-02-05T16:48:19Z", "detected_at":
-        "2026-02-05T16:51:53.166126Z", "is_vcs_type": true, "last_detected_at": "2026-02-05T16:48:19Z",
-        "last_seen_at": "2026-02-05T16:48:19Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging/commit/e2cbc193a76a13b94e135c12a055d2083a233a89#2dd906314026edd7e5fa25025afd4353424625a7_0_19",
-        "source": {"id": 16219056, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
-        "type": "gl_project", "display_name": "gim-qa-gitlabSandbox-auto / gim-qa-gitlabSandbox-staging",
-        "visibility": "private", "monitored": true, "source_criticality": "unknown",
-        "deleted_at": null, "default_branch": "main"}, "regression": false, "content":
-        130291193, "secrets_engine_version": "2.156.0", "matches": [{"name": "client_id",
-        "string_matched": "[REDACTED]", "indice_start": 124, "indice_end": 144, "pre_line_start":
-        null, "pre_line_end": null, "post_line_start": 4, "post_line_end": 4}, {"name":
-        "client_secret", "string_matched": "[REDACTED]", "indice_start": 981, "indice_end":
-        1021, "pre_line_start": null, "pre_line_end": null, "post_line_start": 19,
-        "post_line_end": 19}], "most_sensitive_match_name": "client_secret", "insights":
-        [], "filepath": "ec2_instance_management.py", "filename": "ec2_instance_management.py",
-        "presence": "visible", "last_presence_seen_at": "2026-02-18T22:30:08.818671Z",
-        "last_presence_check_at": "2026-02-18T22:30:08.818671Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": false, "change_type": "addition", "full_tags":
-        []}, "has_dropped_occurrences": false, "tags": [], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 8}, {"id": 22515404, "account": 8, "criterion": "AWS
-        Keys", "date": "2025-11-17T17:16:25Z", "last_trigger_published_at": "2025-11-17T17:16:25Z",
-        "last_triggered_at": "2025-11-17T17:18:18.706440Z", "last_trigger_detected_at":
-        "2025-11-17T17:18:18.706440Z", "hash": "6y4trbQi60aNmDEFQe0tJH3jke+8j18I9t2sKfgaunTYEUdZL4Qc71cZRqNcojMG",
+        {"id": 274639444, "issue": 34181686, "account": 8, "kind": "RLTM", "element":
+        "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "AAr6ayAj6Hs2pOICdVUlEyuXlsQ78K3HFGOJgWA/yAiQrRuQH9Kv1GxUH36IT99d",
+        "published_at": "2026-06-22T11:25:45.739149Z", "date": "2026-06-22T11:25:45.739149Z",
+        "detected_at": "2026-06-22T11:25:45.739149Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-22T11:25:45.739149Z", "last_seen_at": "2026-06-22T11:25:45.739149Z",
+        "data": {"line": 20, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-22T11:25:45.739149Z", "last_presence_check_at":
+        "2026-06-22T11:25:45.739149Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 6}, {"id":
+        34038186, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-16T18:55:43.166667Z", "last_trigger_published_at": "2026-06-16T18:55:43.166667Z",
+        "last_triggered_at": "2026-06-16T18:55:43.185061Z", "last_trigger_detected_at":
+        "2026-06-16T18:55:43.185061Z", "hash": "JFTpQX+4P/dEcXJJ2iw+u54JYDsJnqLtrdws1wjFQ8t9LtHh25LITKmJimoqGr3z",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "AWS IAM Keys", "severity_rule_config": {"id": 10860, "gg_created_at": "2026-02-12T15:13:37.684167Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684171Z", "index": 30, "severity": 10,
-        "rule": {"id": 503, "gg_created_at": "2025-03-18T08:57:54.142008Z", "gg_updated_at":
-        "2025-04-02T13:15:43.307296Z", "name": "Valid secrets related to highly sensitive
-        detectors", "description": "Secrets related to highly sensitive detectors
-        were valid when the incident was discovered. You can edit this rule to create
-        your own list of sensitive detectors", "json_rule": {"operator": "AND", "args":
-        [{"operator": "EQ", "arg1": {"path": "issue.secret.validity_status", "default":
-        null}, "arg2": {"value": "valid"}}, {"operator": "IN", "arg1": {"path": "issue.secret.detector.detector_group_name",
-        "default": null}, "arg2": {"value": ["github_app_token", "ldap_credentials",
-        "github_oauth_token", "googlecloud_keys", "jira_basic_auth", "python_package_index_key",
-        "aws_iam_sts", "npm_token", "gitlab_token", "smtp_credentials", "github_fine_grained_pat",
-        "gitlab_enterprise_token", "github_access_token", "aws_iam"]}}]}, "is_global":
-        true, "scope": "any", "author": null}}, "declarative_secret_status": null,
-        "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "gim-qa-gitlabSandbox-auto
-        / gim-qa-gitlabSandbox-staging", "type": "gl_project", "path": "gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
-        "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 1, "score": 97, "displayed_occurrence":
-        {"id": 226113779, "issue": 22515404, "account": 8, "kind": "RLTM", "element":
-        "95c8ae28ae02f1182bfa5ae2f6cabb69fab3ece9", "element_type": "GIT_COMMIT",
-        "author_name": "dev", "author_info": "gim+dev@gitguardian.com", "value": null,
-        "value_hash": "yEDhOhQ6p7D5/7TcJR5YtztO3INO1WgqiWd2qPiA0XRele/bong1Td3XczdQcVM3",
-        "published_at": "2025-11-17T17:16:25Z", "date": "2025-11-17T17:16:25Z", "detected_at":
-        "2025-11-17T17:18:16.645938Z", "is_vcs_type": true, "last_detected_at": "2025-11-17T17:16:25Z",
-        "last_seen_at": "2025-11-17T17:16:25Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging/commit/95c8ae28ae02f1182bfa5ae2f6cabb69fab3ece9#34c8dc1a12161a07003ebd2c3145185257f0cd94_0_3",
-        "source": {"id": 16219056, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
-        "type": "gl_project", "display_name": "gim-qa-gitlabSandbox-auto / gim-qa-gitlabSandbox-staging",
-        "visibility": "private", "monitored": true, "source_criticality": "unknown",
-        "deleted_at": null, "default_branch": "main"}, "regression": false, "content":
-        105863010, "secrets_engine_version": "2.150.0", "matches": [{"name": "client_id",
-        "string_matched": "[REDACTED]", "indice_start": 45, "indice_end": 65, "pre_line_start":
-        null, "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}, {"name":
-        "client_secret", "string_matched": "[REDACTED]", "indice_start": 82, "indice_end":
-        122, "pre_line_start": null, "pre_line_end": null, "post_line_start": 3, "post_line_end":
-        3}], "most_sensitive_match_name": "client_secret", "insights": [], "filepath":
-        "aws_api_access.yml", "filename": "aws_api_access.yml", "presence": "visible",
-        "last_presence_seen_at": "2026-02-18T22:30:08.818671Z", "last_presence_check_at":
-        "2026-02-18T22:30:08.818671Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        false, "change_type": "addition", "full_tags": []}, "has_dropped_occurrences":
-        false, "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
-        21256874, "account": 8, "criterion": "Google API Key", "date": "2025-09-28T15:22:38.271649Z",
-        "last_trigger_published_at": "2025-09-28T15:22:38.271649Z", "last_triggered_at":
-        "2025-09-28T15:22:38.612424Z", "last_trigger_detected_at": "2025-09-28T15:22:38.612424Z",
-        "hash": "Jxnz5kPob11xLvEtZ86g47aESTtckctpj4bPLy+pvS9PIsSDiwQ5Z8PP16EaJtIX",
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
+        "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
+        "detected_at": "2026-06-16T18:55:43.166667Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
+        "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
+        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
+        32985083, "account": 8, "criterion": "Google API Key", "date": "2026-05-19T09:33:23Z",
+        "last_trigger_published_at": "2026-05-19T09:33:23Z", "last_triggered_at":
+        "2026-05-19T09:36:55.570755Z", "last_trigger_detected_at": "2026-05-19T09:36:55.570755Z",
+        "hash": "pHE0O7zGgt2lhT0TLQzB2cwgMuZgrhqH4vSIGV5fw5ao1EL3iwQ5Z8PP16EaJtIX",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Google API Key", "severity_rule_config": {"id": 10858, "gg_created_at": "2026-02-12T15:13:37.684102Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684119Z", "index": 10, "severity": 10,
+        "Google API Key", "severity_rule_config": {"id": 11883, "gg_created_at": "2026-05-20T08:56:10.055321Z",
+        "gg_updated_at": "2026-05-20T08:56:10.055331Z", "index": 10, "severity": 10,
         "rule": {"id": 745, "gg_created_at": "2026-02-12T15:13:36.079495Z", "gg_updated_at":
         "2026-02-12T15:13:36.079508Z", "name": "Publicly leaked secrets", "description":
         "Publicly leaked secrets outside perimeter", "json_rule": {"operator": "AND",
@@ -201,116 +155,123 @@ interactions:
         "default": null}, "arg2": {"value": "0"}}}, {"operator": "NOT", "arg1": {"operator":
         "EQ", "arg1": {"path": "issue.secret.validity_status", "default": null}, "arg2":
         {"value": "invalid"}}}]}, "is_global": false, "scope": "private", "author":
-        520858}}, "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
-        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "GitGuardian Sandbox [internal]"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 3, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "GitHub Gist Public Testing", "type": "custom_source", "path": "GitHub
-        Gist Public Testing", "source_criticality": "unknown"}], "custom_tags": [],
-        "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0, "score":
-        35, "displayed_occurrence": {"id": 217629888, "issue": 21256874, "account":
-        8, "kind": "RLTM", "element": "", "element_type": "CUSTOM_ELEMENT", "author_name":
-        "GitGuardian Sandbox [internal]", "author_info": "", "value": null, "value_hash":
-        "vaoX27XgrGUFeuRDLf1lGhRHkgfeKQkdi/3qMgXMYvxgUYRCJMTAoAK2DALLNEk3", "published_at":
-        "2025-09-28T15:22:38.271649Z", "date": "2025-09-28T15:22:38.271649Z", "detected_at":
-        "2025-09-28T15:22:38.386090Z", "is_vcs_type": false, "last_detected_at": "2025-09-28T15:22:38.271649Z",
-        "last_seen_at": "2025-09-28T15:22:38.271649Z", "data": {}, "url": "", "source":
-        {"id": 22879703, "url": "", "type": "custom_source", "display_name": "GitHub
-        Gist Public Testing", "visibility": "private", "monitored": false, "source_criticality":
-        "unknown", "deleted_at": "2025-09-30T09:36:56.792947Z", "default_branch":
-        null}, "regression": false, "content": 95760168, "secrets_engine_version":
-        "2.148.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 715525, "indice_end": 715564, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "public_github_sagarchittaragi_75a7ce7770d67624fd77656f0d3ad099",
-        "filename": "public_github_sagarchittaragi_75a7ce7770d67624fd77656f0d3ad099",
-        "presence": "visible", "last_presence_seen_at": "2025-09-28T15:22:38.645860Z",
-        "last_presence_check_at": "2025-09-28T15:22:38.645860Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": []},
-        "has_dropped_occurrences": false, "tags": [], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 3}, {"id": 21251447, "account": 8, "criterion": "Google
-        API Key", "date": "2025-09-28T04:37:26.780820Z", "last_trigger_published_at":
-        "2025-09-28T04:37:26.780820Z", "last_triggered_at": "2025-09-28T04:37:27.086350Z",
-        "last_trigger_detected_at": "2025-09-28T04:37:27.086350Z", "hash": "WalGxMwzVJ87pj8JiS0ZNe3lw3X3qfK3BkEsRZ10l5GkP6wwiwQ5Z8PP16EaJtIX",
+        520858}}, "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com",
+        "name": "dev"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 16218896, "name": "qa / test-nriv", "type": "gl_project", "path":
+        "qa1/test-nriv", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 0, "score": 64, "displayed_occurrence": {"id":
+        268288466, "issue": 32985083, "account": 8, "kind": "RLTM", "element": "9181621d49e910c3d2393f2373e52c04b26c7adb",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "y0o7bgCt8InKo3/G0QE6WaG+gU32WlUdYH0N4oUFXredK2KoKwrhfI+hoCMCs6v6",
+        "published_at": "2026-05-19T09:33:23Z", "date": "2026-05-19T09:33:23Z", "detected_at":
+        "2026-05-19T09:36:53.339083Z", "is_vcs_type": true, "last_detected_at": "2026-05-19T09:33:23Z",
+        "last_seen_at": "2026-05-19T09:33:23Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa1/test-nriv/commit/9181621d49e910c3d2393f2373e52c04b26c7adb#a290632bbcae192e53c54337b3238d835c97e8a9_5_4",
+        "source": {"id": 16218896, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa1/test-nriv",
+        "type": "gl_project", "display_name": "qa / test-nriv", "visibility": "internal",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 162813398,
+        "secrets_engine_version": "2.162.0", "matches": [{"name": "apikey", "string_matched":
+        "[REDACTED]", "indice_start": 307, "indice_end": 346, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 4, "post_line_end": 4}], "most_sensitive_match_name":
+        "apikey", "insights": [], "filepath": ".envrc", "filename": ".envrc", "presence":
+        "visible", "last_presence_seen_at": "2026-05-19T09:36:55.598741Z", "last_presence_check_at":
+        "2026-05-19T09:36:55.598741Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        true, "change_type": "addition", "full_tags": [{"type": "DEFAULT_BRANCH",
+        "metadata": null, "field": "content"}]}, "has_dropped_occurrences": false,
+        "tags": ["DEFAULT_BRANCH", "PUBLICLY_LEAKED"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": true},
+        "occurrences_count": 2}, {"id": 32971986, "account": 8, "criterion": "GitGuardian
+        Test Token Checked", "date": "2026-05-18T16:46:02.652000Z", "last_trigger_published_at":
+        "2026-05-18T16:46:02.652000Z", "last_triggered_at": "2026-05-18T21:54:00.456840Z",
+        "last_trigger_detected_at": "2026-05-18T21:54:00.456840Z", "hash": "H2xlJHEiSoY9Dp4AAvsp9IUC8tJn5VQnVkxnWdAqDESo7y5ACxpDOKaZihAFaYMH",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Google API Key", "severity_rule_config": {"id": 10858, "gg_created_at": "2026-02-12T15:13:37.684102Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684119Z", "index": 10, "severity": 10,
-        "rule": {"id": 745, "gg_created_at": "2026-02-12T15:13:36.079495Z", "gg_updated_at":
-        "2026-02-12T15:13:36.079508Z", "name": "Publicly leaked secrets", "description":
-        "Publicly leaked secrets outside perimeter", "json_rule": {"operator": "AND",
-        "args": [{"operator": "NOT", "arg1": {"operator": "EQ", "arg1": {"path": "issue.public_leak_range",
-        "default": null}, "arg2": {"value": "0"}}}, {"operator": "NOT", "arg1": {"operator":
+        "GitGuardian Test Token Checked", "severity_rule_config": {"id": 11901, "gg_created_at":
+        "2026-05-20T08:56:10.055519Z", "gg_updated_at": "2026-05-20T08:56:10.055521Z",
+        "index": 190, "severity": 20, "rule": {"id": 519, "gg_created_at": "2025-03-18T08:57:54.142609Z",
+        "gg_updated_at": "2025-03-18T08:57:54.142612Z", "name": "Valid secret", "description":
+        "The secrets were valid when the incident was discovered", "json_rule": {"operator":
         "EQ", "arg1": {"path": "issue.secret.validity_status", "default": null}, "arg2":
-        {"value": "invalid"}}}]}, "is_global": false, "scope": "private", "author":
-        520858}}, "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
-        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "GitGuardian Sandbox [internal]"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        {"value": "valid"}}, "is_global": true, "scope": "private", "author": null}},
+        "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "<unknown>",
+        "name": "Guy Le Gardien"}], "user_permission": 7, "is_publicly_shared": false,
+        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "GitHub Gist Public Testing", "type": "custom_source", "path": "GitHub
-        Gist Public Testing", "source_criticality": "unknown"}], "custom_tags": [],
-        "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0, "score":
-        64, "displayed_occurrence": {"id": 217594938, "issue": 21251447, "account":
-        8, "kind": "RLTM", "element": "", "element_type": "CUSTOM_ELEMENT", "author_name":
-        "GitGuardian Sandbox [internal]", "author_info": "", "value": null, "value_hash":
-        "8WalVYdfAy9WWVLzVZBfOXcyF0UCcYGuYQrb3Wdix673pMDZxFC6e51x3UmXyF+6", "published_at":
-        "2025-09-28T04:37:26.780820Z", "date": "2025-09-28T04:37:26.780820Z", "detected_at":
-        "2025-09-28T04:37:26.850787Z", "is_vcs_type": false, "last_detected_at": "2025-09-28T04:37:26.780820Z",
-        "last_seen_at": "2025-09-28T04:37:26.780820Z", "data": {}, "url": "", "source":
-        {"id": 22879703, "url": "", "type": "custom_source", "display_name": "GitHub
-        Gist Public Testing", "visibility": "private", "monitored": false, "source_criticality":
-        "unknown", "deleted_at": "2025-09-30T09:36:56.792947Z", "default_branch":
-        null}, "regression": false, "content": 95670280, "secrets_engine_version":
-        "2.148.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 4660, "indice_end": 4699, "pre_line_start": null, "pre_line_end":
+        [{"id": 26936741, "name": "gitguardian-team-vxrpkdpl / Philippe Gablain",
+        "type": "confluence_cloud_space", "path": "gitguardian-team-vxrpkdpl / Philippe
+        Gablain", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 0, "score": 60, "displayed_occurrence": {"id":
+        268216251, "issue": 32971986, "account": 8, "kind": "RLTM", "element": "14057485",
+        "element_type": "CONFLUENCE_PAGE", "author_name": "Guy Le Gardien", "author_info":
+        "<unknown>", "value": null, "value_hash": "aYVfGM8nV/Ld8zHxuyceM8pdmSDxiNAmP9oGIJun9+NtN/xDdpu8LgTD8V+IJb9L",
+        "published_at": "2026-05-18T16:46:02.652000Z", "date": "2026-05-18T16:46:02.652000Z",
+        "detected_at": "2026-05-18T21:53:58.368709Z", "is_vcs_type": false, "last_detected_at":
+        "2026-05-18T16:46:02.652000Z", "last_seen_at": "2026-05-18T16:46:02.652000Z",
+        "data": {}, "url": "https://gitguardian-team-vxrpkdpl.atlassian.net/wiki/spaces/~62a76a05979e6e00690427b5/pages/14057485/test+gg+token",
+        "source": {"id": 26936741, "url": "https://gitguardian-team-vxrpkdpl.atlassian.net/wiki/spaces/~62a76a05979e6e00690427b5",
+        "type": "confluence_cloud_space", "display_name": "gitguardian-team-vxrpkdpl
+        / Philippe Gablain", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 162682107, "secrets_engine_version":
+        "2.162.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
+        "indice_start": 30, "indice_end": 47, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "public_github_youngbee369_a8de7dcd6c0ff078c7f99a4d1622ad45",
-        "filename": "public_github_youngbee369_a8de7dcd6c0ff078c7f99a4d1622ad45",
-        "presence": "visible", "last_presence_seen_at": "2025-09-28T04:37:27.121112Z",
-        "last_presence_check_at": "2025-09-28T04:37:27.121112Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": []},
-        "has_dropped_occurrences": false, "tags": ["PUBLICLY_LEAKED"], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        true}, "occurrences_count": 1}]}'
+        "apikey", "insights": [], "filepath": null, "filename": null, "presence":
+        "visible", "last_presence_seen_at": "2026-05-18T21:54:00.520852Z", "last_presence_check_at":
+        "2026-05-18T21:54:00.520852Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}]}'
     headers:
+      CF-RAY:
+      - a10395b17f944f05-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:34 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '29121'
+      - '24054'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:50 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '109'
+      - '1206'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_get_all.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_get_all.yaml
@@ -21,36 +21,37 @@ interactions:
   response:
     body:
       string: '[{"id": 21460, "detector": {"name": "aws_iam", "display_name": "AWS
-        IAM Keys", "nature": "specific", "family": "credentials", "detector_group_name":
-        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2020-10-29T13:19:59.005564Z",
-        "secret_id": 70588, "secret_hash": "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG",
-        "hmsl_hash": "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2026-03-11T22:41:04.525493Z", "resolver_id": 492181, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "invalid", "severity": "medium",
-        "assignee_id": null, "assignee_email": "vincent.boyer@gitguardian.com", "share_url":
-        "[REDACTED]", "feedback_list": [{"created_at": "2022-07-20T13:22:52.756189Z",
-        "updated_at": "2022-07-20T13:22:52.756207Z", "email": "stanislas.crepin@gitguardian.com",
-        "member_id": null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
-        "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
-        "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
-        give or has given access to any sensitive information or services?", "boolean":
-        true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
-        this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
-        "remarks_text", "field_label": "Additional remarks", "text": "Hasn''t been
-        revoked yet because X"}]}], "risk_score": 100, "is_vaulted": false, "ignore_reason":
-        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        IAM Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2020-10-29T13:19:59.005564Z", "secret_id": 70588, "secret_hash":
+        "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG", "hmsl_hash":
+        "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
+        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
+        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
+        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
+        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
+        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
+        given access to any sensitive information or services?", "boolean": true},
+        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
+        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
+        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
+        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
+        "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
         0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
         0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["PUBLICLY_LEAKED"],
-        "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["PUBLICLY_LEAKED",
+        "REVOCABLE_BY_GG"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
         "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}, {"id": 21461, "detector": {"name": "private_key_dsa",
         "display_name": "DSA Private Key", "nature": "specific", "family": "cryptographic_key",
-        "detector_group_name": "private_key_dsa", "detector_group_display_name": "DSA
-        Private Key"}, "date": "2020-10-29T09:19:54.249454Z", "secret_id": 70589,
+        "category": "private_key", "detector_group_name": "private_key_dsa", "detector_group_display_name":
+        "DSA Private Key"}, "date": "2020-10-29T09:19:54.249454Z", "secret_id": 70589,
         "secret_hash": "FNJbfEKG/ZXHjBfeEDa+45ryvtA8AC1egwR+QsSqIDlRVNh2Z/McHLTpLI6+WVL/",
         "hmsl_hash": "ae092263bbe1c8bbcc5e8e4dd785681b62e9d48226d66cb28f5d305fa5ef8e68",
         "occurrences_count": 2, "status": "ASSIGNED", "triggered_at": "2021-02-11T14:23:22.947605Z",
@@ -67,108 +68,117 @@ interactions:
         true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
         this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
         "remarks_text", "field_label": "Additional remarks", "text": "important info."}]}],
-        "risk_score": 72, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21461",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "DSA Private Key", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link":
-        "https://sandboxgitguardian.atlassian.net/browse/JB-15"}, {"id": "JB-14",
-        "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-14"}],
+        "risk_score": 72, "severity_rule_id": 11883, "is_vaulted": false, "ignore_reason":
+        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21461", "tags": ["PUBLICLY_LEAKED"],
+        "incident_name": "DSA Private Key", "public_exposure": {"source_publicly_visible":
+        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-15"},
+        {"id": "JB-14", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-14"}],
         "custom_tags": []}, {"id": 21462, "detector": {"name": "salesforce_oauth2",
         "display_name": "Salesforce Oauth2 Keys", "nature": "specific", "family":
-        "credentials", "detector_group_name": "salesforce_oauth2_keys", "detector_group_display_name":
-        "Salesforce Oauth2 Keys"}, "date": "2020-10-29T07:19:30.598398Z", "secret_id":
-        70590, "secret_hash": "c7Kwkwc1D3iO0XnbILGE93uD0GJXOV0CL1t/0icvVnmQUzR2LCAWyy4SR5jhsuGk",
+        "credentials", "category": "crm", "detector_group_name": "salesforce_oauth2_keys",
+        "detector_group_display_name": "Salesforce Oauth2 Keys"}, "date": "2020-10-29T07:19:30.598398Z",
+        "secret_id": 70590, "secret_hash": "c7Kwkwc1D3iO0XnbILGE93uD0GJXOV0CL1t/0icvVnmQUzR2LCAWyy4SR5jhsuGk",
         "hmsl_hash": "e2671771c77564e0f9b6dea27d7b71faa3e9566445b52e7ed403fc8f5e100390",
         "occurrences_count": 2, "status": "IGNORED", "triggered_at": "2021-02-11T14:23:22.947632Z",
         "ignored_at": "2025-07-28T09:27:09.871747Z", "ignorer_id": 492181, "ignorer_api_token_id":
         null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
         "secret_revoked": false, "validity": "invalid", "severity": "high", "assignee_id":
         10, "assignee_email": "bruce-wayne-gg@protonmail.com", "share_url": "[REDACTED]",
-        "feedback_list": [], "risk_score": 23, "is_vaulted": false, "ignore_reason":
-        "invalid", "occurrences": null, "secret_presence": {"files_requiring_code_fix":
-        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
-        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21462", "tags": ["PUBLICLY_LEAKED"],
-        "incident_name": "Salesforce Oauth2 Keys", "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [], "custom_tags": []}, {"id": 21463, "detector": {"name":
-        "private_key_rsa", "display_name": "RSA Private Key", "nature": "specific",
-        "family": "cryptographic_key", "detector_group_name": "private_key_rsa", "detector_group_display_name":
-        "RSA Private Key"}, "date": "2020-10-29T06:20:15.521071Z", "secret_id": 70591,
-        "secret_hash": "rm3JVOM1diLeHDKQaemsg9nNbygNQEAth6YpABj++z5JxBYo7vN5xZFHxYj+duJV",
+        "feedback_list": [], "risk_score": 23, "severity_rule_id": 31, "is_vaulted":
+        false, "ignore_reason": "invalid", "occurrences": null, "secret_presence":
+        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
+        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
+        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21462",
+        "tags": ["PUBLICLY_LEAKED"], "incident_name": "Salesforce Oauth2 Keys", "public_exposure":
+        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "destination_tickets": [], "custom_tags": []}, {"id": 21463, "detector":
+        {"name": "private_key_rsa", "display_name": "RSA Private Key", "nature": "specific",
+        "family": "cryptographic_key", "category": "private_key", "detector_group_name":
+        "private_key_rsa", "detector_group_display_name": "RSA Private Key"}, "date":
+        "2020-10-29T06:20:15.521071Z", "secret_id": 70591, "secret_hash": "rm3JVOM1diLeHDKQaemsg9nNbygNQEAth6YpABj++z5JxBYo7vN5xZFHxYj+duJV",
         "hmsl_hash": "8a0925c807e5f9986368746f18b8cbb748379d31e4187cbb0b1dd0cda8a4a170",
         "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947664Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         "2023-04-21T12:50:04.503620Z", "resolver_id": null, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "no_checker", "severity": "high",
+        null, "secret_revoked": true, "validity": "failed_to_check", "severity": "high",
         "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 72, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21463",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "RSA Private Key", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [], "custom_tags": []}, {"id": 21464, "detector":
-        {"name": "aws_iam", "display_name": "AWS IAM Keys", "nature": "specific",
-        "family": "credentials", "detector_group_name": "aws_iam", "detector_group_display_name":
-        "AWS IAM Keys"}, "date": "2020-10-29T04:19:56.388169Z", "secret_id": 70592,
-        "secret_hash": "Vk90LgwiOvekJz1ekAbpTtG//qwTheghhQ6DeOBCFVHzghwkL4Qc71cZRqNcojMG",
+        [], "risk_score": 57, "severity_rule_id": 31, "is_vaulted": false, "ignore_reason":
+        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21463", "tags": ["PUBLICLY_LEAKED"],
+        "incident_name": "RSA Private Key", "public_exposure": {"source_publicly_visible":
+        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "destination_tickets": [], "custom_tags": []}, {"id": 21464, "detector": {"name":
+        "aws_iam", "display_name": "AWS IAM Keys", "nature": "specific", "family":
+        "credentials", "category": "cloud_provider", "detector_group_name": "aws_iam",
+        "detector_group_display_name": "AWS IAM Keys"}, "date": "2020-10-29T04:19:56.388169Z",
+        "secret_id": 70592, "secret_hash": "Vk90LgwiOvekJz1ekAbpTtG//qwTheghhQ6DeOBCFVHzghwkL4Qc71cZRqNcojMG",
         "hmsl_hash": "ebfb0b865d12332d62237b9893b78ca51e6a14ca773935a4771972074708af4c",
         "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947692Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         "2026-03-11T22:41:04.525493Z", "resolver_id": 492181, "resolver_api_token_id":
         null, "secret_revoked": true, "validity": "invalid", "severity": "high", "assignee_id":
         10, "assignee_email": "bruce-wayne-gg@protonmail.com", "share_url": "[REDACTED]",
-        "feedback_list": [], "risk_score": 100, "is_vaulted": false, "ignore_reason":
-        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        "feedback_list": [], "risk_score": 100, "severity_rule_id": 28, "is_vaulted":
+        false, "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
         0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
         0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21464", "tags": ["PUBLICLY_LEAKED"],
-        "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21464", "tags": ["PUBLICLY_LEAKED",
+        "REVOCABLE_BY_GG"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
         "destination_tickets": [{"id": "AEF-2326", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-2326"}],
         "custom_tags": []}]'
     headers:
+      CF-RAY:
+      - a10395354f42d0b4-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:13 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '8647'
+      - '8926'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:28 GMT
       link:
       - <https://api.gitguardian.com/v1/incidents/secrets?cursor=cD0yMTQ2NA%3D%3D&per_page=5>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '103'
+      - '95'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -196,13 +206,13 @@ interactions:
   response:
     body:
       string: '[{"id": 21465, "detector": {"name": "salesforce_oauth2", "display_name":
-        "Salesforce Oauth2 Keys", "nature": "specific", "family": "credentials", "detector_group_name":
-        "salesforce_oauth2_keys", "detector_group_display_name": "Salesforce Oauth2
-        Keys"}, "date": "2020-10-28T21:20:05.533072Z", "secret_id": 70593, "secret_hash":
-        "H1VHKQe3XFUXs+UkBa4Ml0HurkRRv/Tzd6jP/azd3nBkk9L6LCAWyy4SR5jhsuGk", "hmsl_hash":
-        "2577e326545d8062d43387210736a5f7021208049f1aa92ba1ebdc694fb6ef6c", "occurrences_count":
-        2, "status": "IGNORED", "triggered_at": "2021-02-11T14:23:22.947720Z", "ignored_at":
-        "2025-07-28T09:27:09.871747Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        "Salesforce Oauth2 Keys", "nature": "specific", "family": "credentials", "category":
+        "crm", "detector_group_name": "salesforce_oauth2_keys", "detector_group_display_name":
+        "Salesforce Oauth2 Keys"}, "date": "2020-10-28T21:20:05.533072Z", "secret_id":
+        70593, "secret_hash": "H1VHKQe3XFUXs+UkBa4Ml0HurkRRv/Tzd6jP/azd3nBkk9L6LCAWyy4SR5jhsuGk",
+        "hmsl_hash": "2577e326545d8062d43387210736a5f7021208049f1aa92ba1ebdc694fb6ef6c",
+        "occurrences_count": 2, "status": "IGNORED", "triggered_at": "2021-02-11T14:23:22.947720Z",
+        "ignored_at": "2025-07-28T09:27:09.871747Z", "ignorer_id": 492181, "ignorer_api_token_id":
         null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
         "secret_revoked": false, "validity": "invalid", "severity": "high", "assignee_id":
         null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
@@ -215,32 +225,33 @@ interactions:
         {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
         secret been revoked?", "boolean": true}, {"type": "text", "field_ref": "remarks_text",
         "field_label": "Additional remarks", "text": "my bad"}]}], "risk_score": 23,
-        "is_vaulted": false, "ignore_reason": "invalid", "occurrences": null, "secret_presence":
-        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
-        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
-        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21465",
+        "severity_rule_id": 8220, "is_vaulted": false, "ignore_reason": "invalid",
+        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
+        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
+        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21465",
         "tags": ["PUBLICLY_LEAKED"], "incident_name": "Salesforce Oauth2 Keys", "public_exposure":
         {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
         false}, "destination_tickets": [], "custom_tags": []}, {"id": 21466, "detector":
         {"name": "slackusertoken", "display_name": "Slack User Token", "nature": "specific",
-        "family": "token", "detector_group_name": "slack_user_token", "detector_group_display_name":
-        "Slack User Token"}, "date": "2020-10-26T15:19:37.812603Z", "secret_id": 70594,
-        "secret_hash": "VPFr8rA97mNsCMoQcmSIU5gc39BC8fCQTh1iz+aEuPzDAdqHq3vgT7VWMTb6ax/h",
+        "family": "token", "category": "messaging_system", "detector_group_name":
+        "slack_user_token", "detector_group_display_name": "Slack User Token"}, "date":
+        "2020-10-26T15:19:37.812603Z", "secret_id": 70594, "secret_hash": "VPFr8rA97mNsCMoQcmSIU5gc39BC8fCQTh1iz+aEuPzDAdqHq3vgT7VWMTb6ax/h",
         "hmsl_hash": "d532f2464a9613bab5fbb857f2a94752ecf24d1b19f2b0056df9aa84768f89d8",
         "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947748Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         "2022-09-06T09:04:13.473983Z", "resolver_id": null, "resolver_api_token_id":
         null, "secret_revoked": true, "validity": "invalid", "severity": "high", "assignee_id":
         null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 22, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21466",
-        "tags": ["PUBLICLY_LEAKED", "REVOCABLE_BY_GG"], "incident_name": "Slack User
-        Token", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "destination_tickets": [], "custom_tags":
-        []}, {"id": 21467, "detector": {"name": "newrelic_apm_license_key", "display_name":
-        "New Relic APM License Key", "nature": "specific", "family": "token", "detector_group_name":
+        [], "risk_score": 22, "severity_rule_id": 31, "is_vaulted": false, "ignore_reason":
+        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21466", "tags": ["REVOCABLE_BY_GG",
+        "PUBLICLY_LEAKED"], "incident_name": "Slack User Token", "public_exposure":
+        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "destination_tickets": [], "custom_tags": []}, {"id": 21467, "detector":
+        {"name": "newrelic_apm_license_key", "display_name": "New Relic APM License
+        Key", "nature": "specific", "family": "token", "category": "monitoring", "detector_group_name":
         "newrelic_apm_license_key", "detector_group_display_name": "New Relic APM
         License Key"}, "date": "2020-10-26T14:19:40.469654Z", "secret_id": 70595,
         "secret_hash": "Rkk5oUrdwpPC4VEVfur6poyo2E+7l2kFI6xMeO7sOu2Pz052OuGBsJoc20xNYyU1",
@@ -250,95 +261,105 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "critical", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        72, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
-        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
-        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
-        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21467",
+        72, "severity_rule_id": 11883, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
+        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
+        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21467",
         "tags": ["PUBLICLY_LEAKED"], "incident_name": "New Relic APM License Key",
         "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
         false, "leaked_outside_perimeter": false}, "destination_tickets": [], "custom_tags":
         []}, {"id": 21468, "detector": {"name": "aws_iam", "display_name": "AWS IAM
-        Keys", "nature": "specific", "family": "credentials", "detector_group_name":
-        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2020-10-26T11:19:37.692890Z",
-        "secret_id": 70596, "secret_hash": "Ht2AYBgk3PDhYwqAc7LqGbqcKAMllvnJ4JmP4l/oSLsfa769L4Qc71cZRqNcojMG",
-        "hmsl_hash": "a03837c053290204fd7835e43203df295d71888400741a5c098b51a4199f22e3",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947805Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2021-10-29T11:30:15.067891Z", "resolver_id": null, "resolver_api_token_id":
-        null, "secret_revoked": false, "validity": "invalid", "severity": "high",
-        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2023-03-31T09:17:59.282371Z", "updated_at": "2023-03-31T09:17:59.282384Z",
-        "email": "mackenzie.jackson@gitguardian.com", "member_id": null, "answers":
-        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
-        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
-        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
-        given access to any sensitive information or services?", "boolean": false},
-        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": true}, {"type": "text", "field_ref": "remarks_text",
-        "field_label": "Additional remarks", "text": "fhg"}]}], "risk_score": 100,
-        "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
-        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
-        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
-        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21468",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [], "custom_tags": []}, {"id": 21469, "detector":
-        {"name": "private_key_openssh", "display_name": "OpenSSH Private Key", "nature":
-        "specific", "family": "cryptographic_key", "detector_group_name": "private_key_openssh",
-        "detector_group_display_name": "OpenSSH Private Key"}, "date": "2020-10-25T23:19:57.381648Z",
-        "secret_id": 70597, "secret_hash": "uXOeC9IsaE56xHpyEY+k5ZcR5PdQWRkDlBOWi/I2RwLVwrqVkTr0t/OLrv3FkQLP",
+        Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2020-10-26T11:19:37.692890Z", "secret_id": 70596, "secret_hash":
+        "Ht2AYBgk3PDhYwqAc7LqGbqcKAMllvnJ4JmP4l/oSLsfa769L4Qc71cZRqNcojMG", "hmsl_hash":
+        "a03837c053290204fd7835e43203df295d71888400741a5c098b51a4199f22e3", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947805Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2021-10-29T11:30:15.067891Z",
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [{"created_at": "2023-03-31T09:17:59.282371Z",
+        "updated_at": "2023-03-31T09:17:59.282384Z", "email": "mackenzie.jackson@gitguardian.com",
+        "member_id": null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
+        "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
+        "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
+        give or has given access to any sensitive information or services?", "boolean":
+        false}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label":
+        "Has this secret been revoked?", "boolean": true}, {"type": "text", "field_ref":
+        "remarks_text", "field_label": "Additional remarks", "text": "fhg"}]}], "risk_score":
+        100, "severity_rule_id": 28, "is_vaulted": false, "ignore_reason": null, "occurrences":
+        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
+        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
+        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21468",
+        "tags": ["REVOCABLE_BY_GG", "PUBLICLY_LEAKED"], "incident_name": "AWS IAM
+        Keys", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "destination_tickets": [], "custom_tags":
+        []}, {"id": 21469, "detector": {"name": "private_key_openssh", "display_name":
+        "OpenSSH Private Key", "nature": "specific", "family": "cryptographic_key",
+        "category": "private_key", "detector_group_name": "private_key_openssh", "detector_group_display_name":
+        "OpenSSH Private Key"}, "date": "2020-10-25T23:19:57.381648Z", "secret_id":
+        70597, "secret_hash": "uXOeC9IsaE56xHpyEY+k5ZcR5PdQWRkDlBOWi/I2RwLVwrqVkTr0t/OLrv3FkQLP",
         "hmsl_hash": "cefa1de8f00a3047848849473b2397b231874aa183d4393b9ff8cb3708a99475",
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2021-02-11T14:23:22.947833Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "no_checker", "severity": "critical", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        72, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
-        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
-        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
-        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21469",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "OpenSSH Private Key", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [], "custom_tags": []}]'
+        false, "validity": "failed_to_check", "severity": "critical", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 57, "severity_rule_id": null, "is_vaulted": false, "ignore_reason":
+        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21469", "tags": ["PUBLICLY_LEAKED"],
+        "incident_name": "OpenSSH Private Key", "public_exposure": {"source_publicly_visible":
+        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "destination_tickets": [], "custom_tags": []}]'
     headers:
+      CF-RAY:
+      - a10395377f2071e6-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:13 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '8180'
+      - '8444'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:28 GMT
       link:
       - <https://api.gitguardian.com/v1/incidents/secrets?cursor=cD0yMTQ2OQ%3D%3D&per_page=5>;
         rel="next", <https://api.gitguardian.com/v1/incidents/secrets?cursor=cj0xJnA9MjE0NjU%3D&per_page=5>;
         rel="prev"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '79'
+      - '93'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -367,146 +388,159 @@ interactions:
     body:
       string: '[{"id": 21470, "detector": {"name": "newrelic_insights_query_key",
         "display_name": "New Relic Insights Query Key", "nature": "specific", "family":
-        "token", "detector_group_name": "newrelic_insights_query_key", "detector_group_display_name":
-        "New Relic Insights Query Key"}, "date": "2020-10-25T05:20:21.486451Z", "secret_id":
-        70598, "secret_hash": "9dgBZ54XIWVGlkBHWKH0eYPMN/GVRUWOPaGidbG6b4vl3rWoNibIrsxoDmTHlvoB",
+        "token", "category": "monitoring", "detector_group_name": "newrelic_insights_query_key",
+        "detector_group_display_name": "New Relic Insights Query Key"}, "date": "2020-10-25T05:20:21.486451Z",
+        "secret_id": 70598, "secret_hash": "9dgBZ54XIWVGlkBHWKH0eYPMN/GVRUWOPaGidbG6b4vl3rWoNibIrsxoDmTHlvoB",
         "hmsl_hash": "78c435f66dca1f6d6b92612c38695cd2003e176843d9604a4e4788e5ae2adc5c",
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2021-02-11T14:23:22.947861Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "critical", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        62, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
-        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
-        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
-        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21470",
+        62, "severity_rule_id": 11883, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
+        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
+        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21470",
         "tags": ["PUBLICLY_LEAKED"], "incident_name": "New Relic Insights Query Key",
         "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
         false, "leaked_outside_perimeter": false}, "destination_tickets": [], "custom_tags":
         []}, {"id": 21471, "detector": {"name": "aws_iam", "display_name": "AWS IAM
-        Keys", "nature": "specific", "family": "credentials", "detector_group_name":
-        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2020-10-25T02:19:49.840699Z",
-        "secret_id": 70599, "secret_hash": "6FW4RNZbYeOvBd3nNaZZZ/Y4DuSSLxp9xjYf5nfijvq0aJRkL4Qc71cZRqNcojMG",
-        "hmsl_hash": "997814b6c93e187ad2ace18d1735df1999c761e7e03b441b103c15c88d0e390d",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947888Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2023-11-06T09:02:20.011118Z", "resolver_id": 492181, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "invalid", "severity": "high", "assignee_id":
-        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2022-07-05T18:00:41.598862Z", "updated_at": "2022-07-05T18:00:41.599096Z",
-        "email": "mackenzie.jackson@gitguardian.com", "member_id": null, "answers":
-        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
-        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
-        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
-        given access to any sensitive information or services?", "boolean": true},
-        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
-        "field_label": "Additional remarks", "text": "Notes"}]}, {"created_at": "2023-06-26T12:44:52.641388Z",
-        "updated_at": "2023-06-26T12:44:52.641404Z", "email": "aymeric.sicard@gitguardian.com",
-        "member_id": 13, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
+        Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2020-10-25T02:19:49.840699Z", "secret_id": 70599, "secret_hash":
+        "6FW4RNZbYeOvBd3nNaZZZ/Y4DuSSLxp9xjYf5nfijvq0aJRkL4Qc71cZRqNcojMG", "hmsl_hash":
+        "997814b6c93e187ad2ace18d1735df1999c761e7e03b441b103c15c88d0e390d", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947888Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2023-11-06T09:02:20.011118Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [{"created_at": "2022-07-05T18:00:41.598862Z",
+        "updated_at": "2022-07-05T18:00:41.599096Z", "email": "mackenzie.jackson@gitguardian.com",
+        "member_id": null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
         "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
         "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
         give or has given access to any sensitive information or services?", "boolean":
         true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
         this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
-        "remarks_text", "field_label": "Additional remarks", "text": ""}]}], "risk_score":
-        100, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
+        "remarks_text", "field_label": "Additional remarks", "text": "Notes"}]}, {"created_at":
+        "2023-06-26T12:44:52.641388Z", "updated_at": "2023-06-26T12:44:52.641404Z",
+        "email": "aymeric.sicard@gitguardian.com", "member_id": 13, "answers": [{"type":
+        "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is this an
+        actual secret?", "boolean": true}, {"type": "boolean", "field_ref": "access_to_sensitive_yes_no",
+        "field_label": "Does this secret give or has given access to any sensitive
+        information or services?", "boolean": true}, {"type": "boolean", "field_ref":
+        "revoked_yes_no", "field_label": "Has this secret been revoked?", "boolean":
+        false}, {"type": "text", "field_ref": "remarks_text", "field_label": "Additional
+        remarks", "text": ""}]}], "risk_score": 100, "severity_rule_id": 28, "is_vaulted":
+        false, "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21471", "tags": ["REVOCABLE_BY_GG",
+        "PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
+        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "destination_tickets": [], "custom_tags": []}, {"id": 21472, "detector": {"name":
+        "mailgun_basic_auth", "display_name": "Mailgun Primary Key", "nature": "specific",
+        "family": "token", "category": "messaging_system", "detector_group_name":
+        "mailgun_primary_key", "detector_group_display_name": "Mailgun Primary Key"},
+        "date": "2020-10-24T13:20:01.922433Z", "secret_id": 70600, "secret_hash":
+        "08ojvEC4nIUJUAN4ttWhl3xQ7wpuWfFsb0spGFSBvQk4eUCHYohSEf1f9eeKaOdx", "hmsl_hash":
+        "43bfd7d1df6ba59f374b714be65a7176e3ca7b6613d48a09dc822f96d98d0a01", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947918Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2022-09-06T09:04:13.473983Z",
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 91, "severity_rule_id":
+        31, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
         {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
         "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
-        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21471",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [], "custom_tags": []}, {"id": 21472, "detector":
-        {"name": "mailgun_basic_auth", "display_name": "Mailgun Primary Key", "nature":
-        "specific", "family": "token", "detector_group_name": "mailgun_primary_key",
-        "detector_group_display_name": "Mailgun Primary Key"}, "date": "2020-10-24T13:20:01.922433Z",
-        "secret_id": 70600, "secret_hash": "08ojvEC4nIUJUAN4ttWhl3xQ7wpuWfFsb0spGFSBvQk4eUCHYohSEf1f9eeKaOdx",
-        "hmsl_hash": "43bfd7d1df6ba59f374b714be65a7176e3ca7b6613d48a09dc822f96d98d0a01",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947918Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2022-09-06T09:04:13.473983Z", "resolver_id": null, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "invalid", "severity": "high", "assignee_id":
-        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 91, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21472",
+        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21472",
         "tags": ["PUBLICLY_LEAKED"], "incident_name": "Mailgun Primary Key", "public_exposure":
         {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
         false}, "destination_tickets": [], "custom_tags": []}, {"id": 21473, "detector":
         {"name": "salesforce_oauth2", "display_name": "Salesforce Oauth2 Keys", "nature":
-        "specific", "family": "credentials", "detector_group_name": "salesforce_oauth2_keys",
-        "detector_group_display_name": "Salesforce Oauth2 Keys"}, "date": "2020-10-24T00:19:42.919336Z",
-        "secret_id": 70601, "secret_hash": "sWioKesgGOGrd+XHdi46/EGgFYfr/lh2cpaxYZjxsZlcuoRELCAWyy4SR5jhsuGk",
-        "hmsl_hash": "a69efc4cae224de7fc48506c0726ca5ea943aadbfbfd9e14f52bc528b10a802c",
-        "occurrences_count": 2, "status": "IGNORED", "triggered_at": "2021-02-11T14:23:22.947946Z",
-        "ignored_at": "2025-07-28T09:26:59.237657Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        "specific", "family": "credentials", "category": "crm", "detector_group_name":
+        "salesforce_oauth2_keys", "detector_group_display_name": "Salesforce Oauth2
+        Keys"}, "date": "2020-10-24T00:19:42.919336Z", "secret_id": 70601, "secret_hash":
+        "sWioKesgGOGrd+XHdi46/EGgFYfr/lh2cpaxYZjxsZlcuoRELCAWyy4SR5jhsuGk", "hmsl_hash":
+        "a69efc4cae224de7fc48506c0726ca5ea943aadbfbfd9e14f52bc528b10a802c", "occurrences_count":
+        2, "status": "IGNORED", "triggered_at": "2021-02-11T14:23:22.947946Z", "ignored_at":
+        "2025-07-28T09:26:59.237657Z", "ignorer_id": 492181, "ignorer_api_token_id":
         null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
         "secret_revoked": false, "validity": "invalid", "severity": "medium", "assignee_id":
         null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 23, "is_vaulted": false, "ignore_reason": "invalid", "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21473",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "Salesforce Oauth2 Keys", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [], "custom_tags": []}, {"id": 21474, "detector":
-        {"name": "private_key_openssh", "display_name": "OpenSSH Private Key", "nature":
-        "specific", "family": "cryptographic_key", "detector_group_name": "private_key_openssh",
-        "detector_group_display_name": "OpenSSH Private Key"}, "date": "2020-10-23T04:19:58.086544Z",
-        "secret_id": 70602, "secret_hash": "lz267UbwajGhSFmN5cJA6VwXIHkhpy/ew7Y8tHuS+5x11BplkTr0t/OLrv3FkQLP",
-        "hmsl_hash": "2a37036933c1358322383377b9449b3c4968096ec2d9bbb864118b64293531e6",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947974Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2024-10-29T12:21:43.182834Z", "resolver_id": 582569, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "no_checker", "severity": "critical",
-        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 72, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
+        [], "risk_score": 23, "severity_rule_id": null, "is_vaulted": false, "ignore_reason":
+        "invalid", "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21473", "tags": ["PUBLICLY_LEAKED"],
+        "incident_name": "Salesforce Oauth2 Keys", "public_exposure": {"source_publicly_visible":
+        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "destination_tickets": [], "custom_tags": []}, {"id": 21474, "detector": {"name":
+        "private_key_openssh", "display_name": "OpenSSH Private Key", "nature": "specific",
+        "family": "cryptographic_key", "category": "private_key", "detector_group_name":
+        "private_key_openssh", "detector_group_display_name": "OpenSSH Private Key"},
+        "date": "2020-10-23T04:19:58.086544Z", "secret_id": 70602, "secret_hash":
+        "lz267UbwajGhSFmN5cJA6VwXIHkhpy/ew7Y8tHuS+5x11BplkTr0t/OLrv3FkQLP", "hmsl_hash":
+        "2a37036933c1358322383377b9449b3c4968096ec2d9bbb864118b64293531e6", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947974Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2024-10-29T12:21:43.182834Z",
+        "resolver_id": 582569, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "failed_to_check", "severity": "critical", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        57, "severity_rule_id": 5026, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
         0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
         0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21474",
         "tags": ["PUBLICLY_LEAKED"], "incident_name": "OpenSSH Private Key", "public_exposure":
         {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
         false}, "destination_tickets": [], "custom_tags": []}]'
     headers:
+      CF-RAY:
+      - a1039539da556ec9-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:14 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '8216'
+      - '8480'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:29 GMT
       link:
       - <https://api.gitguardian.com/v1/incidents/secrets?cursor=cD0yMTQ3NA%3D%3D&per_page=5>;
         rel="next", <https://api.gitguardian.com/v1/incidents/secrets?cursor=cj0xJnA9MjE0NzA%3D&per_page=5>;
         rel="prev"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '76'
+      - '100'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_with_date_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_with_date_filter.yaml
@@ -21,36 +21,37 @@ interactions:
   response:
     body:
       string: '[{"id": 21460, "detector": {"name": "aws_iam", "display_name": "AWS
-        IAM Keys", "nature": "specific", "family": "credentials", "detector_group_name":
-        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2020-10-29T13:19:59.005564Z",
-        "secret_id": 70588, "secret_hash": "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG",
-        "hmsl_hash": "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2026-03-11T22:41:04.525493Z", "resolver_id": 492181, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "invalid", "severity": "medium",
-        "assignee_id": null, "assignee_email": "vincent.boyer@gitguardian.com", "share_url":
-        "[REDACTED]", "feedback_list": [{"created_at": "2022-07-20T13:22:52.756189Z",
-        "updated_at": "2022-07-20T13:22:52.756207Z", "email": "stanislas.crepin@gitguardian.com",
-        "member_id": null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
-        "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
-        "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
-        give or has given access to any sensitive information or services?", "boolean":
-        true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
-        this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
-        "remarks_text", "field_label": "Additional remarks", "text": "Hasn''t been
-        revoked yet because X"}]}], "risk_score": 100, "is_vaulted": false, "ignore_reason":
-        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        IAM Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2020-10-29T13:19:59.005564Z", "secret_id": 70588, "secret_hash":
+        "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG", "hmsl_hash":
+        "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
+        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
+        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
+        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
+        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
+        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
+        given access to any sensitive information or services?", "boolean": true},
+        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
+        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
+        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
+        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
+        "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
         0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
         0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["PUBLICLY_LEAKED"],
-        "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["PUBLICLY_LEAKED",
+        "REVOCABLE_BY_GG"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
         "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}, {"id": 21461, "detector": {"name": "private_key_dsa",
         "display_name": "DSA Private Key", "nature": "specific", "family": "cryptographic_key",
-        "detector_group_name": "private_key_dsa", "detector_group_display_name": "DSA
-        Private Key"}, "date": "2020-10-29T09:19:54.249454Z", "secret_id": 70589,
+        "category": "private_key", "detector_group_name": "private_key_dsa", "detector_group_display_name":
+        "DSA Private Key"}, "date": "2020-10-29T09:19:54.249454Z", "secret_id": 70589,
         "secret_hash": "FNJbfEKG/ZXHjBfeEDa+45ryvtA8AC1egwR+QsSqIDlRVNh2Z/McHLTpLI6+WVL/",
         "hmsl_hash": "ae092263bbe1c8bbcc5e8e4dd785681b62e9d48226d66cb28f5d305fa5ef8e68",
         "occurrences_count": 2, "status": "ASSIGNED", "triggered_at": "2021-02-11T14:23:22.947605Z",
@@ -67,108 +68,117 @@ interactions:
         true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
         this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
         "remarks_text", "field_label": "Additional remarks", "text": "important info."}]}],
-        "risk_score": 72, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21461",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "DSA Private Key", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link":
-        "https://sandboxgitguardian.atlassian.net/browse/JB-15"}, {"id": "JB-14",
-        "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-14"}],
+        "risk_score": 72, "severity_rule_id": 11883, "is_vaulted": false, "ignore_reason":
+        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21461", "tags": ["PUBLICLY_LEAKED"],
+        "incident_name": "DSA Private Key", "public_exposure": {"source_publicly_visible":
+        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-15"},
+        {"id": "JB-14", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-14"}],
         "custom_tags": []}, {"id": 21462, "detector": {"name": "salesforce_oauth2",
         "display_name": "Salesforce Oauth2 Keys", "nature": "specific", "family":
-        "credentials", "detector_group_name": "salesforce_oauth2_keys", "detector_group_display_name":
-        "Salesforce Oauth2 Keys"}, "date": "2020-10-29T07:19:30.598398Z", "secret_id":
-        70590, "secret_hash": "c7Kwkwc1D3iO0XnbILGE93uD0GJXOV0CL1t/0icvVnmQUzR2LCAWyy4SR5jhsuGk",
+        "credentials", "category": "crm", "detector_group_name": "salesforce_oauth2_keys",
+        "detector_group_display_name": "Salesforce Oauth2 Keys"}, "date": "2020-10-29T07:19:30.598398Z",
+        "secret_id": 70590, "secret_hash": "c7Kwkwc1D3iO0XnbILGE93uD0GJXOV0CL1t/0icvVnmQUzR2LCAWyy4SR5jhsuGk",
         "hmsl_hash": "e2671771c77564e0f9b6dea27d7b71faa3e9566445b52e7ed403fc8f5e100390",
         "occurrences_count": 2, "status": "IGNORED", "triggered_at": "2021-02-11T14:23:22.947632Z",
         "ignored_at": "2025-07-28T09:27:09.871747Z", "ignorer_id": 492181, "ignorer_api_token_id":
         null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
         "secret_revoked": false, "validity": "invalid", "severity": "high", "assignee_id":
         10, "assignee_email": "bruce-wayne-gg@protonmail.com", "share_url": "[REDACTED]",
-        "feedback_list": [], "risk_score": 23, "is_vaulted": false, "ignore_reason":
-        "invalid", "occurrences": null, "secret_presence": {"files_requiring_code_fix":
-        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
-        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21462", "tags": ["PUBLICLY_LEAKED"],
-        "incident_name": "Salesforce Oauth2 Keys", "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [], "custom_tags": []}, {"id": 21463, "detector": {"name":
-        "private_key_rsa", "display_name": "RSA Private Key", "nature": "specific",
-        "family": "cryptographic_key", "detector_group_name": "private_key_rsa", "detector_group_display_name":
-        "RSA Private Key"}, "date": "2020-10-29T06:20:15.521071Z", "secret_id": 70591,
-        "secret_hash": "rm3JVOM1diLeHDKQaemsg9nNbygNQEAth6YpABj++z5JxBYo7vN5xZFHxYj+duJV",
+        "feedback_list": [], "risk_score": 23, "severity_rule_id": 31, "is_vaulted":
+        false, "ignore_reason": "invalid", "occurrences": null, "secret_presence":
+        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
+        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
+        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21462",
+        "tags": ["PUBLICLY_LEAKED"], "incident_name": "Salesforce Oauth2 Keys", "public_exposure":
+        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "destination_tickets": [], "custom_tags": []}, {"id": 21463, "detector":
+        {"name": "private_key_rsa", "display_name": "RSA Private Key", "nature": "specific",
+        "family": "cryptographic_key", "category": "private_key", "detector_group_name":
+        "private_key_rsa", "detector_group_display_name": "RSA Private Key"}, "date":
+        "2020-10-29T06:20:15.521071Z", "secret_id": 70591, "secret_hash": "rm3JVOM1diLeHDKQaemsg9nNbygNQEAth6YpABj++z5JxBYo7vN5xZFHxYj+duJV",
         "hmsl_hash": "8a0925c807e5f9986368746f18b8cbb748379d31e4187cbb0b1dd0cda8a4a170",
         "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947664Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         "2023-04-21T12:50:04.503620Z", "resolver_id": null, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "no_checker", "severity": "high",
+        null, "secret_revoked": true, "validity": "failed_to_check", "severity": "high",
         "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 72, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21463",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "RSA Private Key", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [], "custom_tags": []}, {"id": 21464, "detector":
-        {"name": "aws_iam", "display_name": "AWS IAM Keys", "nature": "specific",
-        "family": "credentials", "detector_group_name": "aws_iam", "detector_group_display_name":
-        "AWS IAM Keys"}, "date": "2020-10-29T04:19:56.388169Z", "secret_id": 70592,
-        "secret_hash": "Vk90LgwiOvekJz1ekAbpTtG//qwTheghhQ6DeOBCFVHzghwkL4Qc71cZRqNcojMG",
+        [], "risk_score": 57, "severity_rule_id": 31, "is_vaulted": false, "ignore_reason":
+        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21463", "tags": ["PUBLICLY_LEAKED"],
+        "incident_name": "RSA Private Key", "public_exposure": {"source_publicly_visible":
+        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "destination_tickets": [], "custom_tags": []}, {"id": 21464, "detector": {"name":
+        "aws_iam", "display_name": "AWS IAM Keys", "nature": "specific", "family":
+        "credentials", "category": "cloud_provider", "detector_group_name": "aws_iam",
+        "detector_group_display_name": "AWS IAM Keys"}, "date": "2020-10-29T04:19:56.388169Z",
+        "secret_id": 70592, "secret_hash": "Vk90LgwiOvekJz1ekAbpTtG//qwTheghhQ6DeOBCFVHzghwkL4Qc71cZRqNcojMG",
         "hmsl_hash": "ebfb0b865d12332d62237b9893b78ca51e6a14ca773935a4771972074708af4c",
         "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947692Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         "2026-03-11T22:41:04.525493Z", "resolver_id": 492181, "resolver_api_token_id":
         null, "secret_revoked": true, "validity": "invalid", "severity": "high", "assignee_id":
         10, "assignee_email": "bruce-wayne-gg@protonmail.com", "share_url": "[REDACTED]",
-        "feedback_list": [], "risk_score": 100, "is_vaulted": false, "ignore_reason":
-        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        "feedback_list": [], "risk_score": 100, "severity_rule_id": 28, "is_vaulted":
+        false, "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
         0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
         0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21464", "tags": ["PUBLICLY_LEAKED"],
-        "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21464", "tags": ["PUBLICLY_LEAKED",
+        "REVOCABLE_BY_GG"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
         "destination_tickets": [{"id": "AEF-2326", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-2326"}],
         "custom_tags": []}]'
     headers:
+      CF-RAY:
+      - a1039532c9edb7d0-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:12 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '8647'
+      - '8926'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:27 GMT
       link:
       - <https://api.gitguardian.com/v1/incidents/secrets?cursor=cD0yMTQ2NA%3D%3D&from_date=2024-01-01&per_page=5&to_date=2024-12-31>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '88'
+      - '73'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_with_ordering.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_with_ordering.yaml
@@ -20,132 +20,148 @@ interactions:
     uri: https://api.gitguardian.com/v1/incidents/secrets?per_page=5&ordering=-date
   response:
     body:
-      string: '[{"id": 29487335, "detector": {"name": "stripe_webhook_secret", "display_name":
-        "Stripe Webhook Secret", "nature": "specific", "family": "token", "detector_group_name":
-        "stripe_webhook_secret", "detector_group_display_name": "Stripe Webhook Secret"},
-        "date": "2026-04-02T16:22:33.518000Z", "secret_id": 30393936, "secret_hash":
-        "JquJu98wTd0k40t3UsNgP22P+ywFCrsGM1VDRg3oZBdGXhRWbjOMbKAG+JtXZUOK", "hmsl_hash":
-        "2ff36381d6ac8340ab574aee45e128e5f6b983ec78fe761ccc88da5e4a0f8698", "occurrences_count":
-        1, "status": "TRIGGERED", "triggered_at": "2026-04-02T16:22:34.233032Z", "ignored_at":
-        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
-        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
-        "validity": "no_checker", "severity": "unknown", "assignee_id": null, "assignee_email":
-        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 62, "is_vaulted":
-        false, "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
-        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 1, "removed_outside_vcs":
-        0, "in_vcs": 0, "removed_in_vcs": 0}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/29487335", "tags":
-        [], "incident_name": "Stripe Webhook Secret", "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [{"id": "AEF-2330", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-2330"}],
-        "custom_tags": []}, {"id": 29487333, "detector": {"name": "slackbototken",
-        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
-        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
-        Bot Token"}, "date": "2026-04-02T16:22:26.591000Z", "secret_id": 30393934,
-        "secret_hash": "UeONCI+H/I19fHV7Ge45VQxOI0/YUY6CYZu9psQ6W53s6W+UOMgPzYhV28m6OGG4",
-        "hmsl_hash": "ddfd57b5fd9d223785d498b53bc03e096771b6fa3a9b747fea5a065c1f5204a1",
-        "occurrences_count": 1, "status": "IGNORED", "triggered_at": "2026-04-02T16:22:27.578209Z",
-        "ignored_at": "2026-04-02T16:22:27.592459Z", "ignorer_id": 492181, "ignorer_api_token_id":
-        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
-        "secret_revoked": false, "validity": "invalid", "severity": "unknown", "assignee_id":
-        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 11, "is_vaulted": false, "ignore_reason": "invalid", "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 1, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 0}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/29487333",
-        "tags": ["REVOCABLE_BY_GG"], "incident_name": "Slack Bot Token", "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [], "custom_tags": []}, {"id": 29305270, "detector":
-        {"name": "openai_apikey", "display_name": "OpenAI API Key", "nature": "specific",
-        "family": "token", "detector_group_name": "openai_apikey", "detector_group_display_name":
-        "OpenAI API Key"}, "date": "2026-03-27T13:47:01Z", "secret_id": 30183432,
-        "secret_hash": "MTJFo5AaJdAJ7giIaJE2+Vn/3hEL1nR7oKsu0ry8AAS38W2S95GRLqiXIWrK60u6",
-        "hmsl_hash": "1d83cdea747cb8f141183f5453b8a91afc30d8124da43f904a2ff3f4fae18d5a",
-        "occurrences_count": 1, "status": "IGNORED", "triggered_at": "2026-03-28T05:01:36.397561Z",
-        "ignored_at": "2026-03-28T05:01:36.405919Z", "ignorer_id": 492181, "ignorer_api_token_id":
-        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
-        "secret_revoked": false, "validity": "invalid", "severity": "unknown", "assignee_id":
-        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 6, "is_vaulted": false, "ignore_reason": "invalid", "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 1, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 0}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/29305270",
-        "tags": ["REVOCABLE_BY_GG"], "incident_name": "OpenAI API Key", "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [], "custom_tags": []}, {"id": 29236167, "detector":
-        {"name": "slackbototken", "display_name": "Slack Bot Token", "nature": "specific",
-        "family": "token", "detector_group_name": "slackbot_token", "detector_group_display_name":
-        "Slack Bot Token"}, "date": "2026-03-26T16:10:40Z", "secret_id": 30092110,
-        "secret_hash": "zjn71aK7GgaG08kYQpcl/JoZIqGNGCjNlB7jcstxdWYrVg3rOMgPzYhV28m6OGG4",
-        "hmsl_hash": "1b7034015ae219c0f41bf3ba656baac33d29debbde6304c81f1d38a2280a2ac2",
-        "occurrences_count": 1, "status": "IGNORED", "triggered_at": "2026-03-26T16:10:55.651903Z",
-        "ignored_at": "2026-03-26T16:10:55.850365Z", "ignorer_id": 492181, "ignorer_api_token_id":
-        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
-        "secret_revoked": false, "validity": "invalid", "severity": "unknown", "assignee_id":
-        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 0, "is_vaulted": false, "ignore_reason": "invalid", "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 1, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        1, "removed_in_vcs": 0}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/29236167",
-        "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG", "TEST_FILE"], "incident_name":
-        "Slack Bot Token", "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+      string: '[{"id": 34205503, "detector": {"name": "microsoft_azure_storage_connection_string",
+        "display_name": "Microsoft Azure Storage Connection String", "nature": "specific",
+        "family": "credentials", "category": "cloud_provider", "detector_group_name":
+        "microsoft_azure_storage_connection_string", "detector_group_display_name":
+        "Microsoft Azure Storage Connection String"}, "date": "2026-06-23T11:13:31.325324Z",
+        "secret_id": 34903121, "secret_hash": "HdPZ4cjZuziAqsakdlsUnJDapTz3ns5pX8vPzfhvGQvpWWWX25LITKmJimoqGr3z",
+        "hmsl_hash": "fc26291ba9199f678ab0cf82c2e51f33d8edafcb311142da271d4cdc6c2cd305",
+        "occurrences_count": 16, "status": "TRIGGERED", "triggered_at": "2026-06-23T11:13:31.343453Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        null, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
+        {"files_requiring_code_fix": 16, "files_pending_merge": 0, "files_fixed":
+        0, "outside_vcs": 16, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
+        0}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/34205503",
+        "tags": [], "incident_name": "Microsoft Azure Storage Connection String",
+        "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
         false, "leaked_outside_perimeter": false}, "destination_tickets": [], "custom_tags":
-        []}, {"id": 29236166, "detector": {"name": "slackbototken", "display_name":
-        "Slack Bot Token", "nature": "specific", "family": "token", "detector_group_name":
-        "slackbot_token", "detector_group_display_name": "Slack Bot Token"}, "date":
-        "2026-03-26T16:10:40Z", "secret_id": 30092109, "secret_hash": "y6dvop5+MJ/HoYVkecDkMT1SJWrnGVzvlLWZtx5h39virCYOOMgPzYhV28m6OGG4",
-        "hmsl_hash": "48bc6a71c21286f97ee89b9bf21e3e8814bad1ed6cc6dc2671b38b688d1326f4",
-        "occurrences_count": 1, "status": "IGNORED", "triggered_at": "2026-03-26T16:10:55.651856Z",
-        "ignored_at": "2026-03-26T16:10:55.846528Z", "ignorer_id": 492181, "ignorer_api_token_id":
-        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
-        "secret_revoked": false, "validity": "invalid", "severity": "unknown", "assignee_id":
-        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 0, "is_vaulted": false, "ignore_reason": "invalid", "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 1, "files_pending_merge":
+        []}, {"id": 34186239, "detector": {"name": "generic_password", "display_name":
+        "Generic Password", "nature": "generic", "family": "other", "category": "other",
+        "detector_group_name": "generic_password", "detector_group_display_name":
+        "Generic Password"}, "date": "2026-06-22T15:14:57Z", "secret_id": 34876981,
+        "secret_hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
+        "hmsl_hash": "6662d7be52f195e819ae005e22e00568c2e3ce932fd825ed9d2c8a2a8611f2cc",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2026-06-22T15:16:49.799821Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        53, "severity_rule_id": null, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 1, "files_pending_merge":
         0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        1, "removed_in_vcs": 0}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/29236166",
-        "tags": ["DEFAULT_BRANCH", "REVOCABLE_BY_GG", "TEST_FILE"], "incident_name":
-        "Slack Bot Token", "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        1, "removed_in_vcs": 0}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/34186239",
+        "tags": ["DEFAULT_BRANCH"], "incident_name": "Generic Password", "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "destination_tickets": [{"id": "AEF-2792", "type": "jira_cloud", "link":
+        "https://yanne-gg-integration.atlassian.net/browse/AEF-2792"}], "custom_tags":
+        []}, {"id": 34181686, "detector": {"name": "microsoft_azure_storage_connection_string",
+        "display_name": "Microsoft Azure Storage Connection String", "nature": "specific",
+        "family": "credentials", "category": "cloud_provider", "detector_group_name":
+        "microsoft_azure_storage_connection_string", "detector_group_display_name":
+        "Microsoft Azure Storage Connection String"}, "date": "2026-06-22T11:25:45.739149Z",
+        "secret_id": 34872210, "secret_hash": "gVrL/pjjFLo7sSikPS1pWtPJbr+oWSSVz8IB6+2ViJDSJKiK25LITKmJimoqGr3z",
+        "hmsl_hash": "fc86a4bb9428d007e885d680d2858defdad881c9e59824d7e7a2397929d1b097",
+        "occurrences_count": 6, "status": "RESOLVED", "triggered_at": "2026-06-22T11:25:45.762592Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        "2026-06-22T11:26:52.971214Z", "resolver_id": 1754656, "resolver_api_token_id":
+        null, "secret_revoked": true, "validity": "valid", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 97, "severity_rule_id": null, "is_vaulted": false, "ignore_reason":
+        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        6, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 6, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 0}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/34181686", "tags":
+        [], "incident_name": "Microsoft Azure Storage Connection String", "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "destination_tickets": [], "custom_tags": []}, {"id": 34122510, "detector":
+        {"name": "generic_password", "display_name": "Generic Password", "nature":
+        "generic", "family": "other", "category": "other", "detector_group_name":
+        "generic_password", "detector_group_display_name": "Generic Password"}, "date":
+        "2026-06-19T13:41:03Z", "secret_id": 34793369, "secret_hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
+        "hmsl_hash": "82a3eb1bb819a7e984de59d084c034533c5c6534007c583bbcf532452856f6ab",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2026-06-19T13:43:05.020137Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        63, "severity_rule_id": null, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 1, "files_pending_merge":
+        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
+        1, "removed_in_vcs": 0}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/34122510",
+        "tags": ["DEFAULT_BRANCH"], "incident_name": "Generic Password", "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "destination_tickets": [{"id": "AEF-2791", "type": "jira_cloud", "link":
+        "https://yanne-gg-integration.atlassian.net/browse/AEF-2791"}], "custom_tags":
+        []}, {"id": 34038186, "detector": {"name": "microsoft_azure_storage_connection_string",
+        "display_name": "Microsoft Azure Storage Connection String", "nature": "specific",
+        "family": "credentials", "category": "cloud_provider", "detector_group_name":
+        "microsoft_azure_storage_connection_string", "detector_group_display_name":
+        "Microsoft Azure Storage Connection String"}, "date": "2026-06-16T18:55:43.166667Z",
+        "secret_id": 34579611, "secret_hash": "JFTpQX+4P/dEcXJJ2iw+u54JYDsJnqLtrdws1wjFQ8t9LtHh25LITKmJimoqGr3z",
+        "hmsl_hash": "ffe05952664110d9de0ac3d90ced8c4aaacc6210c2a240d363a4caa5e645d0b2",
+        "occurrences_count": 16, "status": "TRIGGERED", "triggered_at": "2026-06-16T18:55:43.185061Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
+        null, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
+        {"files_requiring_code_fix": 16, "files_pending_merge": 0, "files_fixed":
+        0, "outside_vcs": 16, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
+        0}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/34038186",
+        "tags": [], "incident_name": "Microsoft Azure Storage Connection String",
+        "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
         false, "leaked_outside_perimeter": false}, "destination_tickets": [], "custom_tags":
         []}]'
     headers:
+      CF-RAY:
+      - a103952e9931d784-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:12 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '7034'
+      - '7625'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:26 GMT
       link:
-      - <https://api.gitguardian.com/v1/incidents/secrets?cursor=bz0yJnA9MjAyNi0wMy0yNysxMyUzQTQ3JTNBMDElMkIwMCUzQTAw&ordering=-date&per_page=5>;
+      - <https://api.gitguardian.com/v1/incidents/secrets?cursor=cD0yMDI2LTA2LTE2KzE4JTNBNTUlM0E0My4xNjY2NjclMkIwMCUzQTAw&ordering=-date&per_page=5>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '72'
+      - '163'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_with_severity_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_with_severity_filter.yaml
@@ -21,9 +21,10 @@ interactions:
   response:
     body:
       string: '[{"id": 21461, "detector": {"name": "private_key_dsa", "display_name":
-        "DSA Private Key", "nature": "specific", "family": "cryptographic_key", "detector_group_name":
-        "private_key_dsa", "detector_group_display_name": "DSA Private Key"}, "date":
-        "2020-10-29T09:19:54.249454Z", "secret_id": 70589, "secret_hash": "FNJbfEKG/ZXHjBfeEDa+45ryvtA8AC1egwR+QsSqIDlRVNh2Z/McHLTpLI6+WVL/",
+        "DSA Private Key", "nature": "specific", "family": "cryptographic_key", "category":
+        "private_key", "detector_group_name": "private_key_dsa", "detector_group_display_name":
+        "DSA Private Key"}, "date": "2020-10-29T09:19:54.249454Z", "secret_id": 70589,
+        "secret_hash": "FNJbfEKG/ZXHjBfeEDa+45ryvtA8AC1egwR+QsSqIDlRVNh2Z/McHLTpLI6+WVL/",
         "hmsl_hash": "ae092263bbe1c8bbcc5e8e4dd785681b62e9d48226d66cb28f5d305fa5ef8e68",
         "occurrences_count": 2, "status": "ASSIGNED", "triggered_at": "2021-02-11T14:23:22.947605Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
@@ -39,53 +40,54 @@ interactions:
         true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
         this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
         "remarks_text", "field_label": "Additional remarks", "text": "important info."}]}],
-        "risk_score": 72, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21461",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "DSA Private Key", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link":
-        "https://sandboxgitguardian.atlassian.net/browse/JB-15"}, {"id": "JB-14",
-        "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-14"}],
+        "risk_score": 72, "severity_rule_id": 11883, "is_vaulted": false, "ignore_reason":
+        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21461", "tags": ["PUBLICLY_LEAKED"],
+        "incident_name": "DSA Private Key", "public_exposure": {"source_publicly_visible":
+        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-15"},
+        {"id": "JB-14", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-14"}],
         "custom_tags": []}, {"id": 21467, "detector": {"name": "newrelic_apm_license_key",
         "display_name": "New Relic APM License Key", "nature": "specific", "family":
-        "token", "detector_group_name": "newrelic_apm_license_key", "detector_group_display_name":
-        "New Relic APM License Key"}, "date": "2020-10-26T14:19:40.469654Z", "secret_id":
-        70595, "secret_hash": "Rkk5oUrdwpPC4VEVfur6poyo2E+7l2kFI6xMeO7sOu2Pz052OuGBsJoc20xNYyU1",
+        "token", "category": "monitoring", "detector_group_name": "newrelic_apm_license_key",
+        "detector_group_display_name": "New Relic APM License Key"}, "date": "2020-10-26T14:19:40.469654Z",
+        "secret_id": 70595, "secret_hash": "Rkk5oUrdwpPC4VEVfur6poyo2E+7l2kFI6xMeO7sOu2Pz052OuGBsJoc20xNYyU1",
         "hmsl_hash": "beec046bdad5b63f3fcae66e5b5925240bcb0ac0bf68661abb6ed1aaaa954b1c",
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2021-02-11T14:23:22.947776Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "critical", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        72, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
-        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
-        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
-        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21467",
+        72, "severity_rule_id": 11883, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
+        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
+        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21467",
         "tags": ["PUBLICLY_LEAKED"], "incident_name": "New Relic APM License Key",
         "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
         false, "leaked_outside_perimeter": false}, "destination_tickets": [], "custom_tags":
         []}, {"id": 21469, "detector": {"name": "private_key_openssh", "display_name":
         "OpenSSH Private Key", "nature": "specific", "family": "cryptographic_key",
-        "detector_group_name": "private_key_openssh", "detector_group_display_name":
+        "category": "private_key", "detector_group_name": "private_key_openssh", "detector_group_display_name":
         "OpenSSH Private Key"}, "date": "2020-10-25T23:19:57.381648Z", "secret_id":
         70597, "secret_hash": "uXOeC9IsaE56xHpyEY+k5ZcR5PdQWRkDlBOWi/I2RwLVwrqVkTr0t/OLrv3FkQLP",
         "hmsl_hash": "cefa1de8f00a3047848849473b2397b231874aa183d4393b9ff8cb3708a99475",
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2021-02-11T14:23:22.947833Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "no_checker", "severity": "critical", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        72, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
-        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
-        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
-        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21469",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "OpenSSH Private Key", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [], "custom_tags": []}, {"id": 21470, "detector":
-        {"name": "newrelic_insights_query_key", "display_name": "New Relic Insights
-        Query Key", "nature": "specific", "family": "token", "detector_group_name":
+        false, "validity": "failed_to_check", "severity": "critical", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 57, "severity_rule_id": null, "is_vaulted": false, "ignore_reason":
+        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21469", "tags": ["PUBLICLY_LEAKED"],
+        "incident_name": "OpenSSH Private Key", "public_exposure": {"source_publicly_visible":
+        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "destination_tickets": [], "custom_tags": []}, {"id": 21470, "detector": {"name":
+        "newrelic_insights_query_key", "display_name": "New Relic Insights Query Key",
+        "nature": "specific", "family": "token", "category": "monitoring", "detector_group_name":
         "newrelic_insights_query_key", "detector_group_display_name": "New Relic Insights
         Query Key"}, "date": "2020-10-25T05:20:21.486451Z", "secret_id": 70598, "secret_hash":
         "9dgBZ54XIWVGlkBHWKH0eYPMN/GVRUWOPaGidbG6b4vl3rWoNibIrsxoDmTHlvoB", "hmsl_hash":
@@ -94,69 +96,79 @@ interactions:
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "no_checker", "severity": "critical", "assignee_id": null, "assignee_email":
-        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 62, "is_vaulted":
-        false, "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
-        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
-        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21470", "tags": ["PUBLICLY_LEAKED"],
-        "incident_name": "New Relic Insights Query Key", "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [], "custom_tags": []}, {"id": 21474, "detector": {"name":
-        "private_key_openssh", "display_name": "OpenSSH Private Key", "nature": "specific",
-        "family": "cryptographic_key", "detector_group_name": "private_key_openssh",
-        "detector_group_display_name": "OpenSSH Private Key"}, "date": "2020-10-23T04:19:58.086544Z",
-        "secret_id": 70602, "secret_hash": "lz267UbwajGhSFmN5cJA6VwXIHkhpy/ew7Y8tHuS+5x11BplkTr0t/OLrv3FkQLP",
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 62, "severity_rule_id":
+        11883, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
+        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
+        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
+        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21470",
+        "tags": ["PUBLICLY_LEAKED"], "incident_name": "New Relic Insights Query Key",
+        "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "destination_tickets": [], "custom_tags":
+        []}, {"id": 21474, "detector": {"name": "private_key_openssh", "display_name":
+        "OpenSSH Private Key", "nature": "specific", "family": "cryptographic_key",
+        "category": "private_key", "detector_group_name": "private_key_openssh", "detector_group_display_name":
+        "OpenSSH Private Key"}, "date": "2020-10-23T04:19:58.086544Z", "secret_id":
+        70602, "secret_hash": "lz267UbwajGhSFmN5cJA6VwXIHkhpy/ew7Y8tHuS+5x11BplkTr0t/OLrv3FkQLP",
         "hmsl_hash": "2a37036933c1358322383377b9449b3c4968096ec2d9bbb864118b64293531e6",
         "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947974Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         "2024-10-29T12:21:43.182834Z", "resolver_id": 582569, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "no_checker", "severity": "critical",
+        null, "secret_revoked": true, "validity": "failed_to_check", "severity": "critical",
         "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 72, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21474",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "OpenSSH Private Key", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [], "custom_tags": []}]'
+        [], "risk_score": 57, "severity_rule_id": 5026, "is_vaulted": false, "ignore_reason":
+        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21474", "tags": ["PUBLICLY_LEAKED"],
+        "incident_name": "OpenSSH Private Key", "public_exposure": {"source_publicly_visible":
+        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "destination_tickets": [], "custom_tags": []}]'
     headers:
+      CF-RAY:
+      - a103952c59a16f87-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:11 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '7796'
+      - '8052'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:26 GMT
       link:
       - <https://api.gitguardian.com/v1/incidents/secrets?cursor=cD0yMTQ3NA%3D%3D&per_page=5&severity=critical>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '98'
+      - '82'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_incidents_with_status_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_with_status_filter.yaml
@@ -21,43 +21,44 @@ interactions:
   response:
     body:
       string: '[{"id": 21467, "detector": {"name": "newrelic_apm_license_key", "display_name":
-        "New Relic APM License Key", "nature": "specific", "family": "token", "detector_group_name":
-        "newrelic_apm_license_key", "detector_group_display_name": "New Relic APM
-        License Key"}, "date": "2020-10-26T14:19:40.469654Z", "secret_id": 70595,
-        "secret_hash": "Rkk5oUrdwpPC4VEVfur6poyo2E+7l2kFI6xMeO7sOu2Pz052OuGBsJoc20xNYyU1",
+        "New Relic APM License Key", "nature": "specific", "family": "token", "category":
+        "monitoring", "detector_group_name": "newrelic_apm_license_key", "detector_group_display_name":
+        "New Relic APM License Key"}, "date": "2020-10-26T14:19:40.469654Z", "secret_id":
+        70595, "secret_hash": "Rkk5oUrdwpPC4VEVfur6poyo2E+7l2kFI6xMeO7sOu2Pz052OuGBsJoc20xNYyU1",
         "hmsl_hash": "beec046bdad5b63f3fcae66e5b5925240bcb0ac0bf68661abb6ed1aaaa954b1c",
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2021-02-11T14:23:22.947776Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "critical", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        72, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
-        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
-        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
-        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21467",
+        72, "severity_rule_id": 11883, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
+        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
+        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21467",
         "tags": ["PUBLICLY_LEAKED"], "incident_name": "New Relic APM License Key",
         "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
         false, "leaked_outside_perimeter": false}, "destination_tickets": [], "custom_tags":
         []}, {"id": 21469, "detector": {"name": "private_key_openssh", "display_name":
         "OpenSSH Private Key", "nature": "specific", "family": "cryptographic_key",
-        "detector_group_name": "private_key_openssh", "detector_group_display_name":
+        "category": "private_key", "detector_group_name": "private_key_openssh", "detector_group_display_name":
         "OpenSSH Private Key"}, "date": "2020-10-25T23:19:57.381648Z", "secret_id":
         70597, "secret_hash": "uXOeC9IsaE56xHpyEY+k5ZcR5PdQWRkDlBOWi/I2RwLVwrqVkTr0t/OLrv3FkQLP",
         "hmsl_hash": "cefa1de8f00a3047848849473b2397b231874aa183d4393b9ff8cb3708a99475",
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2021-02-11T14:23:22.947833Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "no_checker", "severity": "critical", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        72, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
-        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
-        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
-        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21469",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "OpenSSH Private Key", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [], "custom_tags": []}, {"id": 21470, "detector":
-        {"name": "newrelic_insights_query_key", "display_name": "New Relic Insights
-        Query Key", "nature": "specific", "family": "token", "detector_group_name":
+        false, "validity": "failed_to_check", "severity": "critical", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 57, "severity_rule_id": null, "is_vaulted": false, "ignore_reason":
+        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21469", "tags": ["PUBLICLY_LEAKED"],
+        "incident_name": "OpenSSH Private Key", "public_exposure": {"source_publicly_visible":
+        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "destination_tickets": [], "custom_tags": []}, {"id": 21470, "detector": {"name":
+        "newrelic_insights_query_key", "display_name": "New Relic Insights Query Key",
+        "nature": "specific", "family": "token", "category": "monitoring", "detector_group_name":
         "newrelic_insights_query_key", "detector_group_display_name": "New Relic Insights
         Query Key"}, "date": "2020-10-25T05:20:21.486451Z", "secret_id": 70598, "secret_hash":
         "9dgBZ54XIWVGlkBHWKH0eYPMN/GVRUWOPaGidbG6b4vl3rWoNibIrsxoDmTHlvoB", "hmsl_hash":
@@ -66,43 +67,44 @@ interactions:
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "no_checker", "severity": "critical", "assignee_id": null, "assignee_email":
-        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 62, "is_vaulted":
-        false, "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
-        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
-        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21470", "tags": ["PUBLICLY_LEAKED"],
-        "incident_name": "New Relic Insights Query Key", "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [], "custom_tags": []}, {"id": 21486, "detector": {"name":
-        "newrelic_insights_query_key", "display_name": "New Relic Insights Query Key",
-        "nature": "specific", "family": "token", "detector_group_name": "newrelic_insights_query_key",
-        "detector_group_display_name": "New Relic Insights Query Key"}, "date": "2020-10-15T17:19:30.287430Z",
-        "secret_id": 70612, "secret_hash": "pDlB0biFZioyiEr4RWDIiR1GV/aYyZEF9DTrqRug6PbAvbsnNibIrsxoDmTHlvoB",
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 62, "severity_rule_id":
+        11883, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
+        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
+        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
+        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21470",
+        "tags": ["PUBLICLY_LEAKED"], "incident_name": "New Relic Insights Query Key",
+        "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "destination_tickets": [], "custom_tags":
+        []}, {"id": 21486, "detector": {"name": "newrelic_insights_query_key", "display_name":
+        "New Relic Insights Query Key", "nature": "specific", "family": "token", "category":
+        "monitoring", "detector_group_name": "newrelic_insights_query_key", "detector_group_display_name":
+        "New Relic Insights Query Key"}, "date": "2020-10-15T17:19:30.287430Z", "secret_id":
+        70612, "secret_hash": "pDlB0biFZioyiEr4RWDIiR1GV/aYyZEF9DTrqRug6PbAvbsnNibIrsxoDmTHlvoB",
         "hmsl_hash": "8eae16fdf59e29b980e41ae52972e3143b5b6a6164b126a269e06bf60cc0c388",
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2021-02-11T14:23:22.948259Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "critical", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        20, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
-        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
-        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
-        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21486",
+        20, "severity_rule_id": 11883, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
+        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
+        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21486",
         "tags": ["PUBLICLY_LEAKED"], "incident_name": "New Relic Insights Query Key",
         "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
         false, "leaked_outside_perimeter": false}, "destination_tickets": [], "custom_tags":
         []}, {"id": 21488, "detector": {"name": "private_key_openssh", "display_name":
         "OpenSSH Private Key", "nature": "specific", "family": "cryptographic_key",
-        "detector_group_name": "private_key_openssh", "detector_group_display_name":
+        "category": "private_key", "detector_group_name": "private_key_openssh", "detector_group_display_name":
         "OpenSSH Private Key"}, "date": "2020-10-15T04:19:33Z", "secret_id": 70614,
         "secret_hash": "bjKsVu/CCw3pPxWhqOykLjoGb2OGTgOL7zoDjf/wptWwjdUrkTr0t/OLrv3FkQLP",
         "hmsl_hash": "a8e052b163fe5a4cf89f6e45c9678e6f25df7d4fb7a3dcbf737b32acc2c2686b",
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2021-02-11T14:23:22.948315Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "no_checker", "severity": "critical", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [{"created_at":
-        "2024-10-27T19:07:31.647677Z", "updated_at": "2024-10-27T19:07:31.647687Z",
+        false, "validity": "failed_to_check", "severity": "critical", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [{"created_at": "2024-10-27T19:07:31.647677Z", "updated_at": "2024-10-27T19:07:31.647687Z",
         "email": "candidate.playground+1@gitguardian.com", "member_id": 582569, "answers":
         [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
         this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
@@ -111,53 +113,61 @@ interactions:
         {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
         secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
         "field_label": "Additional remarks", "text": "Please take a look at this."}]}],
-        "risk_score": 72, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21488",
-        "tags": ["FROM_HISTORICAL_SCAN", "PUBLICLY_LEAKED"], "incident_name": "OpenSSH
-        Private Key", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "destination_tickets": [{"id":
-        "KAN-17", "type": "jira_cloud", "link": "https://vboy.atlassian.net/browse/KAN-17"}],
-        "custom_tags": []}]'
+        "risk_score": 57, "severity_rule_id": 11883, "is_vaulted": false, "ignore_reason":
+        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21488", "tags": ["PUBLICLY_LEAKED",
+        "FROM_HISTORICAL_SCAN"], "incident_name": "OpenSSH Private Key", "public_exposure":
+        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "destination_tickets": [{"id": "KAN-17", "type": "jira_cloud", "link":
+        "https://vboy.atlassian.net/browse/KAN-17"}], "custom_tags": []}]'
     headers:
+      CF-RAY:
+      - a10395291e7ecc0a-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:11 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '7728'
+      - '7984'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:25 GMT
       link:
       - <https://api.gitguardian.com/v1/incidents/secrets?cursor=cD0yMTQ4OA%3D%3D&per_page=5&status=TRIGGERED>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '86'
+      - '167'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_member_incidents.yaml
+++ b/tests/cassettes/client/vcr/test_list_member_incidents.yaml
@@ -20,47 +20,58 @@ interactions:
     uri: https://api.gitguardian.com/v1/api_tokens/self
   response:
     body:
-      string: '{"id": "8a262c6a-832d-49e5-8744-23c743ff25ac", "name": "ggmcp CI",
-        "type": "personal_access_token", "scopes": ["scan", "incidents:read", "members:read",
-        "audit_logs:read", "teams:read", "honeytokens:read", "honeytokens:write",
-        "api_tokens:read", "sources:read", "nhi:send-inventory", "nhi:write-vault",
-        "custom_tags:read", "custom_tags:write", "secrets:read", "secrets:write",
-        "scan:create-incidents", "public-perimeter:read"], "member_id": 480870, "workspace_id":
-        8, "created_at": "2025-12-07T14:13:08.044416Z", "last_used_at": "2026-04-03T08:43:00Z",
-        "expire_at": null, "revoked_at": null, "status": "active", "creator_id": 480870}'
+      string: '{"id": "d0ca9877-641f-4c37-8857-c08e0ae148c4", "name": "ggmcp CI (April)",
+        "type": "personal_access_token", "scopes": ["scan", "incidents:read", "incidents:write",
+        "incidents:share", "members:read", "members:write", "audit_logs:read", "teams:read",
+        "teams:write", "honeytokens:read", "honeytokens:write", "api_tokens:read",
+        "api_tokens:write", "ip_allowlist:read", "ip_allowlist:write", "sources:read",
+        "sources:write", "nhi:send-inventory", "nhi:write-vault", "custom_tags:read",
+        "custom_tags:write", "secrets:read", "secrets:write", "scan:create-incidents",
+        "public-perimeter:read", "nhi:ownership:read", "nhi:ownership:write", "sources:scan"],
+        "member_id": 480870, "workspace_id": 8, "created_at": "2026-04-20T13:31:42.422943Z",
+        "last_used_at": "2026-06-23T12:45:00Z", "expire_at": null, "revoked_at": null,
+        "status": "active", "creator_id": 480870}'
     headers:
+      CF-RAY:
+      - a103972dae7d9ed6-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:33 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '594'
+      - '802'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:22 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '35'
+      - '18'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -89,41 +100,49 @@ interactions:
     body:
       string: '{"id": 480870, "role": "manager", "access_level": "manager", "email":
         "timothe.delion@gitguardian.com", "name": "Timoth\u00e9 DELION", "created_at":
-        "2023-06-26T12:41:18.599497Z", "last_login": "2026-04-02T13:15:43.810850Z",
+        "2023-06-26T12:41:18.599497Z", "last_login": "2026-06-23T12:20:54.639679Z",
         "active": true}'
     headers:
+      CF-RAY:
+      - a103972f5db63772-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:34 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '221'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:22 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '51'
+      - '39'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -151,36 +170,37 @@ interactions:
   response:
     body:
       string: '[{"id": 21460, "detector": {"name": "aws_iam", "display_name": "AWS
-        IAM Keys", "nature": "specific", "family": "credentials", "detector_group_name":
-        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2020-10-29T13:19:59.005564Z",
-        "secret_id": 70588, "secret_hash": "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG",
-        "hmsl_hash": "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2026-03-11T22:41:04.525493Z", "resolver_id": 492181, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "invalid", "severity": "medium",
-        "assignee_id": null, "assignee_email": "vincent.boyer@gitguardian.com", "share_url":
-        "[REDACTED]", "feedback_list": [{"created_at": "2022-07-20T13:22:52.756189Z",
-        "updated_at": "2022-07-20T13:22:52.756207Z", "email": "stanislas.crepin@gitguardian.com",
-        "member_id": null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
-        "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
-        "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
-        give or has given access to any sensitive information or services?", "boolean":
-        true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
-        this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
-        "remarks_text", "field_label": "Additional remarks", "text": "Hasn''t been
-        revoked yet because X"}]}], "risk_score": 100, "is_vaulted": false, "ignore_reason":
-        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        IAM Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2020-10-29T13:19:59.005564Z", "secret_id": 70588, "secret_hash":
+        "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG", "hmsl_hash":
+        "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
+        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
+        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
+        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
+        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
+        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
+        given access to any sensitive information or services?", "boolean": true},
+        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
+        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
+        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
+        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
+        "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
         0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
         0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["PUBLICLY_LEAKED"],
-        "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["PUBLICLY_LEAKED",
+        "REVOCABLE_BY_GG"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
         "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}, {"id": 21461, "detector": {"name": "private_key_dsa",
         "display_name": "DSA Private Key", "nature": "specific", "family": "cryptographic_key",
-        "detector_group_name": "private_key_dsa", "detector_group_display_name": "DSA
-        Private Key"}, "date": "2020-10-29T09:19:54.249454Z", "secret_id": 70589,
+        "category": "private_key", "detector_group_name": "private_key_dsa", "detector_group_display_name":
+        "DSA Private Key"}, "date": "2020-10-29T09:19:54.249454Z", "secret_id": 70589,
         "secret_hash": "FNJbfEKG/ZXHjBfeEDa+45ryvtA8AC1egwR+QsSqIDlRVNh2Z/McHLTpLI6+WVL/",
         "hmsl_hash": "ae092263bbe1c8bbcc5e8e4dd785681b62e9d48226d66cb28f5d305fa5ef8e68",
         "occurrences_count": 2, "status": "ASSIGNED", "triggered_at": "2021-02-11T14:23:22.947605Z",
@@ -197,74 +217,75 @@ interactions:
         true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
         this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
         "remarks_text", "field_label": "Additional remarks", "text": "important info."}]}],
-        "risk_score": 72, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21461",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "DSA Private Key", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link":
-        "https://sandboxgitguardian.atlassian.net/browse/JB-15"}, {"id": "JB-14",
-        "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-14"}],
+        "risk_score": 72, "severity_rule_id": 11883, "is_vaulted": false, "ignore_reason":
+        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21461", "tags": ["PUBLICLY_LEAKED"],
+        "incident_name": "DSA Private Key", "public_exposure": {"source_publicly_visible":
+        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "destination_tickets": [{"id": "JB-14", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-14"},
+        {"id": "JB-15", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-15"}],
         "custom_tags": []}, {"id": 21462, "detector": {"name": "salesforce_oauth2",
         "display_name": "Salesforce Oauth2 Keys", "nature": "specific", "family":
-        "credentials", "detector_group_name": "salesforce_oauth2_keys", "detector_group_display_name":
-        "Salesforce Oauth2 Keys"}, "date": "2020-10-29T07:19:30.598398Z", "secret_id":
-        70590, "secret_hash": "c7Kwkwc1D3iO0XnbILGE93uD0GJXOV0CL1t/0icvVnmQUzR2LCAWyy4SR5jhsuGk",
+        "credentials", "category": "crm", "detector_group_name": "salesforce_oauth2_keys",
+        "detector_group_display_name": "Salesforce Oauth2 Keys"}, "date": "2020-10-29T07:19:30.598398Z",
+        "secret_id": 70590, "secret_hash": "c7Kwkwc1D3iO0XnbILGE93uD0GJXOV0CL1t/0icvVnmQUzR2LCAWyy4SR5jhsuGk",
         "hmsl_hash": "e2671771c77564e0f9b6dea27d7b71faa3e9566445b52e7ed403fc8f5e100390",
         "occurrences_count": 2, "status": "IGNORED", "triggered_at": "2021-02-11T14:23:22.947632Z",
         "ignored_at": "2025-07-28T09:27:09.871747Z", "ignorer_id": 492181, "ignorer_api_token_id":
         null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
         "secret_revoked": false, "validity": "invalid", "severity": "high", "assignee_id":
         10, "assignee_email": "bruce-wayne-gg@protonmail.com", "share_url": "[REDACTED]",
-        "feedback_list": [], "risk_score": 23, "is_vaulted": false, "ignore_reason":
-        "invalid", "occurrences": null, "secret_presence": {"files_requiring_code_fix":
-        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
-        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21462", "tags": ["PUBLICLY_LEAKED"],
-        "incident_name": "Salesforce Oauth2 Keys", "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [], "custom_tags": []}, {"id": 21463, "detector": {"name":
-        "private_key_rsa", "display_name": "RSA Private Key", "nature": "specific",
-        "family": "cryptographic_key", "detector_group_name": "private_key_rsa", "detector_group_display_name":
-        "RSA Private Key"}, "date": "2020-10-29T06:20:15.521071Z", "secret_id": 70591,
-        "secret_hash": "rm3JVOM1diLeHDKQaemsg9nNbygNQEAth6YpABj++z5JxBYo7vN5xZFHxYj+duJV",
+        "feedback_list": [], "risk_score": 23, "severity_rule_id": 31, "is_vaulted":
+        false, "ignore_reason": "invalid", "occurrences": null, "secret_presence":
+        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
+        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
+        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21462",
+        "tags": ["PUBLICLY_LEAKED"], "incident_name": "Salesforce Oauth2 Keys", "public_exposure":
+        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "destination_tickets": [], "custom_tags": []}, {"id": 21463, "detector":
+        {"name": "private_key_rsa", "display_name": "RSA Private Key", "nature": "specific",
+        "family": "cryptographic_key", "category": "private_key", "detector_group_name":
+        "private_key_rsa", "detector_group_display_name": "RSA Private Key"}, "date":
+        "2020-10-29T06:20:15.521071Z", "secret_id": 70591, "secret_hash": "rm3JVOM1diLeHDKQaemsg9nNbygNQEAth6YpABj++z5JxBYo7vN5xZFHxYj+duJV",
         "hmsl_hash": "8a0925c807e5f9986368746f18b8cbb748379d31e4187cbb0b1dd0cda8a4a170",
         "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947664Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         "2023-04-21T12:50:04.503620Z", "resolver_id": null, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "no_checker", "severity": "high",
+        null, "secret_revoked": true, "validity": "failed_to_check", "severity": "high",
         "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 72, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21463",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "RSA Private Key", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [], "custom_tags": []}, {"id": 21464, "detector":
-        {"name": "aws_iam", "display_name": "AWS IAM Keys", "nature": "specific",
-        "family": "credentials", "detector_group_name": "aws_iam", "detector_group_display_name":
-        "AWS IAM Keys"}, "date": "2020-10-29T04:19:56.388169Z", "secret_id": 70592,
-        "secret_hash": "Vk90LgwiOvekJz1ekAbpTtG//qwTheghhQ6DeOBCFVHzghwkL4Qc71cZRqNcojMG",
+        [], "risk_score": 57, "severity_rule_id": 31, "is_vaulted": false, "ignore_reason":
+        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21463", "tags": ["PUBLICLY_LEAKED"],
+        "incident_name": "RSA Private Key", "public_exposure": {"source_publicly_visible":
+        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "destination_tickets": [], "custom_tags": []}, {"id": 21464, "detector": {"name":
+        "aws_iam", "display_name": "AWS IAM Keys", "nature": "specific", "family":
+        "credentials", "category": "cloud_provider", "detector_group_name": "aws_iam",
+        "detector_group_display_name": "AWS IAM Keys"}, "date": "2020-10-29T04:19:56.388169Z",
+        "secret_id": 70592, "secret_hash": "Vk90LgwiOvekJz1ekAbpTtG//qwTheghhQ6DeOBCFVHzghwkL4Qc71cZRqNcojMG",
         "hmsl_hash": "ebfb0b865d12332d62237b9893b78ca51e6a14ca773935a4771972074708af4c",
         "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947692Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         "2026-03-11T22:41:04.525493Z", "resolver_id": 492181, "resolver_api_token_id":
         null, "secret_revoked": true, "validity": "invalid", "severity": "high", "assignee_id":
         10, "assignee_email": "bruce-wayne-gg@protonmail.com", "share_url": "[REDACTED]",
-        "feedback_list": [], "risk_score": 100, "is_vaulted": false, "ignore_reason":
-        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        "feedback_list": [], "risk_score": 100, "severity_rule_id": 28, "is_vaulted":
+        false, "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
         0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
         0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21464", "tags": ["PUBLICLY_LEAKED"],
-        "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21464", "tags": ["PUBLICLY_LEAKED",
+        "REVOCABLE_BY_GG"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
         "destination_tickets": [{"id": "AEF-2326", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-2326"}],
         "custom_tags": []}, {"id": 21465, "detector": {"name": "salesforce_oauth2",
         "display_name": "Salesforce Oauth2 Keys", "nature": "specific", "family":
-        "credentials", "detector_group_name": "salesforce_oauth2_keys", "detector_group_display_name":
-        "Salesforce Oauth2 Keys"}, "date": "2020-10-28T21:20:05.533072Z", "secret_id":
-        70593, "secret_hash": "H1VHKQe3XFUXs+UkBa4Ml0HurkRRv/Tzd6jP/azd3nBkk9L6LCAWyy4SR5jhsuGk",
+        "credentials", "category": "crm", "detector_group_name": "salesforce_oauth2_keys",
+        "detector_group_display_name": "Salesforce Oauth2 Keys"}, "date": "2020-10-28T21:20:05.533072Z",
+        "secret_id": 70593, "secret_hash": "H1VHKQe3XFUXs+UkBa4Ml0HurkRRv/Tzd6jP/azd3nBkk9L6LCAWyy4SR5jhsuGk",
         "hmsl_hash": "2577e326545d8062d43387210736a5f7021208049f1aa92ba1ebdc694fb6ef6c",
         "occurrences_count": 2, "status": "IGNORED", "triggered_at": "2021-02-11T14:23:22.947720Z",
         "ignored_at": "2025-07-28T09:27:09.871747Z", "ignorer_id": 492181, "ignorer_api_token_id":
@@ -280,32 +301,33 @@ interactions:
         {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
         secret been revoked?", "boolean": true}, {"type": "text", "field_ref": "remarks_text",
         "field_label": "Additional remarks", "text": "my bad"}]}], "risk_score": 23,
-        "is_vaulted": false, "ignore_reason": "invalid", "occurrences": null, "secret_presence":
-        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
-        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
-        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21465",
+        "severity_rule_id": 8220, "is_vaulted": false, "ignore_reason": "invalid",
+        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
+        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
+        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21465",
         "tags": ["PUBLICLY_LEAKED"], "incident_name": "Salesforce Oauth2 Keys", "public_exposure":
         {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
         false}, "destination_tickets": [], "custom_tags": []}, {"id": 21466, "detector":
         {"name": "slackusertoken", "display_name": "Slack User Token", "nature": "specific",
-        "family": "token", "detector_group_name": "slack_user_token", "detector_group_display_name":
-        "Slack User Token"}, "date": "2020-10-26T15:19:37.812603Z", "secret_id": 70594,
-        "secret_hash": "VPFr8rA97mNsCMoQcmSIU5gc39BC8fCQTh1iz+aEuPzDAdqHq3vgT7VWMTb6ax/h",
+        "family": "token", "category": "messaging_system", "detector_group_name":
+        "slack_user_token", "detector_group_display_name": "Slack User Token"}, "date":
+        "2020-10-26T15:19:37.812603Z", "secret_id": 70594, "secret_hash": "VPFr8rA97mNsCMoQcmSIU5gc39BC8fCQTh1iz+aEuPzDAdqHq3vgT7VWMTb6ax/h",
         "hmsl_hash": "d532f2464a9613bab5fbb857f2a94752ecf24d1b19f2b0056df9aa84768f89d8",
         "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947748Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         "2022-09-06T09:04:13.473983Z", "resolver_id": null, "resolver_api_token_id":
         null, "secret_revoked": true, "validity": "invalid", "severity": "high", "assignee_id":
         null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 22, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21466",
-        "tags": ["PUBLICLY_LEAKED", "REVOCABLE_BY_GG"], "incident_name": "Slack User
-        Token", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "destination_tickets": [], "custom_tags":
-        []}, {"id": 21467, "detector": {"name": "newrelic_apm_license_key", "display_name":
-        "New Relic APM License Key", "nature": "specific", "family": "token", "detector_group_name":
+        [], "risk_score": 22, "severity_rule_id": 31, "is_vaulted": false, "ignore_reason":
+        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21466", "tags": ["PUBLICLY_LEAKED",
+        "REVOCABLE_BY_GG"], "incident_name": "Slack User Token", "public_exposure":
+        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "destination_tickets": [], "custom_tags": []}, {"id": 21467, "detector":
+        {"name": "newrelic_apm_license_key", "display_name": "New Relic APM License
+        Key", "nature": "specific", "family": "token", "category": "monitoring", "detector_group_name":
         "newrelic_apm_license_key", "detector_group_display_name": "New Relic APM
         License Key"}, "date": "2020-10-26T14:19:40.469654Z", "secret_id": 70595,
         "secret_hash": "Rkk5oUrdwpPC4VEVfur6poyo2E+7l2kFI6xMeO7sOu2Pz052OuGBsJoc20xNYyU1",
@@ -315,58 +337,60 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "critical", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        72, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
-        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
-        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
-        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21467",
+        72, "severity_rule_id": 11883, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
+        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
+        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21467",
         "tags": ["PUBLICLY_LEAKED"], "incident_name": "New Relic APM License Key",
         "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
         false, "leaked_outside_perimeter": false}, "destination_tickets": [], "custom_tags":
         []}, {"id": 21468, "detector": {"name": "aws_iam", "display_name": "AWS IAM
-        Keys", "nature": "specific", "family": "credentials", "detector_group_name":
-        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2020-10-26T11:19:37.692890Z",
-        "secret_id": 70596, "secret_hash": "Ht2AYBgk3PDhYwqAc7LqGbqcKAMllvnJ4JmP4l/oSLsfa769L4Qc71cZRqNcojMG",
-        "hmsl_hash": "a03837c053290204fd7835e43203df295d71888400741a5c098b51a4199f22e3",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947805Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2021-10-29T11:30:15.067891Z", "resolver_id": null, "resolver_api_token_id":
-        null, "secret_revoked": false, "validity": "invalid", "severity": "high",
-        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2023-03-31T09:17:59.282371Z", "updated_at": "2023-03-31T09:17:59.282384Z",
-        "email": "mackenzie.jackson@gitguardian.com", "member_id": null, "answers":
-        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
-        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
-        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
-        given access to any sensitive information or services?", "boolean": false},
-        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": true}, {"type": "text", "field_ref": "remarks_text",
-        "field_label": "Additional remarks", "text": "fhg"}]}], "risk_score": 100,
-        "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
-        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
-        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
-        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21468",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [], "custom_tags": []}, {"id": 21469, "detector":
-        {"name": "private_key_openssh", "display_name": "OpenSSH Private Key", "nature":
-        "specific", "family": "cryptographic_key", "detector_group_name": "private_key_openssh",
-        "detector_group_display_name": "OpenSSH Private Key"}, "date": "2020-10-25T23:19:57.381648Z",
-        "secret_id": 70597, "secret_hash": "uXOeC9IsaE56xHpyEY+k5ZcR5PdQWRkDlBOWi/I2RwLVwrqVkTr0t/OLrv3FkQLP",
+        Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2020-10-26T11:19:37.692890Z", "secret_id": 70596, "secret_hash":
+        "Ht2AYBgk3PDhYwqAc7LqGbqcKAMllvnJ4JmP4l/oSLsfa769L4Qc71cZRqNcojMG", "hmsl_hash":
+        "a03837c053290204fd7835e43203df295d71888400741a5c098b51a4199f22e3", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947805Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2021-10-29T11:30:15.067891Z",
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [{"created_at": "2023-03-31T09:17:59.282371Z",
+        "updated_at": "2023-03-31T09:17:59.282384Z", "email": "mackenzie.jackson@gitguardian.com",
+        "member_id": null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
+        "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
+        "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
+        give or has given access to any sensitive information or services?", "boolean":
+        false}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label":
+        "Has this secret been revoked?", "boolean": true}, {"type": "text", "field_ref":
+        "remarks_text", "field_label": "Additional remarks", "text": "fhg"}]}], "risk_score":
+        100, "severity_rule_id": 28, "is_vaulted": false, "ignore_reason": null, "occurrences":
+        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
+        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
+        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21468",
+        "tags": ["PUBLICLY_LEAKED", "REVOCABLE_BY_GG"], "incident_name": "AWS IAM
+        Keys", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "destination_tickets": [], "custom_tags":
+        []}, {"id": 21469, "detector": {"name": "private_key_openssh", "display_name":
+        "OpenSSH Private Key", "nature": "specific", "family": "cryptographic_key",
+        "category": "private_key", "detector_group_name": "private_key_openssh", "detector_group_display_name":
+        "OpenSSH Private Key"}, "date": "2020-10-25T23:19:57.381648Z", "secret_id":
+        70597, "secret_hash": "uXOeC9IsaE56xHpyEY+k5ZcR5PdQWRkDlBOWi/I2RwLVwrqVkTr0t/OLrv3FkQLP",
         "hmsl_hash": "cefa1de8f00a3047848849473b2397b231874aa183d4393b9ff8cb3708a99475",
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2021-02-11T14:23:22.947833Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "no_checker", "severity": "critical", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        72, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
-        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
-        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
-        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21469",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "OpenSSH Private Key", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [], "custom_tags": []}, {"id": 21470, "detector":
-        {"name": "newrelic_insights_query_key", "display_name": "New Relic Insights
-        Query Key", "nature": "specific", "family": "token", "detector_group_name":
+        false, "validity": "failed_to_check", "severity": "critical", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 57, "severity_rule_id": null, "is_vaulted": false, "ignore_reason":
+        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21469", "tags": ["PUBLICLY_LEAKED"],
+        "incident_name": "OpenSSH Private Key", "public_exposure": {"source_publicly_visible":
+        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "destination_tickets": [], "custom_tags": []}, {"id": 21470, "detector": {"name":
+        "newrelic_insights_query_key", "display_name": "New Relic Insights Query Key",
+        "nature": "specific", "family": "token", "category": "monitoring", "detector_group_name":
         "newrelic_insights_query_key", "detector_group_display_name": "New Relic Insights
         Query Key"}, "date": "2020-10-25T05:20:21.486451Z", "secret_id": 70598, "secret_hash":
         "9dgBZ54XIWVGlkBHWKH0eYPMN/GVRUWOPaGidbG6b4vl3rWoNibIrsxoDmTHlvoB", "hmsl_hash":
@@ -375,169 +399,178 @@ interactions:
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "no_checker", "severity": "critical", "assignee_id": null, "assignee_email":
-        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 62, "is_vaulted":
-        false, "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
-        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
-        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21470", "tags": ["PUBLICLY_LEAKED"],
-        "incident_name": "New Relic Insights Query Key", "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [], "custom_tags": []}, {"id": 21471, "detector": {"name":
-        "aws_iam", "display_name": "AWS IAM Keys", "nature": "specific", "family":
-        "credentials", "detector_group_name": "aws_iam", "detector_group_display_name":
-        "AWS IAM Keys"}, "date": "2020-10-25T02:19:49.840699Z", "secret_id": 70599,
-        "secret_hash": "6FW4RNZbYeOvBd3nNaZZZ/Y4DuSSLxp9xjYf5nfijvq0aJRkL4Qc71cZRqNcojMG",
-        "hmsl_hash": "997814b6c93e187ad2ace18d1735df1999c761e7e03b441b103c15c88d0e390d",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947888Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2023-11-06T09:02:20.011118Z", "resolver_id": 492181, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "invalid", "severity": "high", "assignee_id":
-        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2022-07-05T18:00:41.598862Z", "updated_at": "2022-07-05T18:00:41.599096Z",
-        "email": "mackenzie.jackson@gitguardian.com", "member_id": null, "answers":
-        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
-        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
-        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
-        given access to any sensitive information or services?", "boolean": true},
-        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
-        "field_label": "Additional remarks", "text": "Notes"}]}, {"created_at": "2023-06-26T12:44:52.641388Z",
-        "updated_at": "2023-06-26T12:44:52.641404Z", "email": "aymeric.sicard@gitguardian.com",
-        "member_id": 13, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 62, "severity_rule_id":
+        11883, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
+        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
+        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
+        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21470",
+        "tags": ["PUBLICLY_LEAKED"], "incident_name": "New Relic Insights Query Key",
+        "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "destination_tickets": [], "custom_tags":
+        []}, {"id": 21471, "detector": {"name": "aws_iam", "display_name": "AWS IAM
+        Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2020-10-25T02:19:49.840699Z", "secret_id": 70599, "secret_hash":
+        "6FW4RNZbYeOvBd3nNaZZZ/Y4DuSSLxp9xjYf5nfijvq0aJRkL4Qc71cZRqNcojMG", "hmsl_hash":
+        "997814b6c93e187ad2ace18d1735df1999c761e7e03b441b103c15c88d0e390d", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947888Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2023-11-06T09:02:20.011118Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [{"created_at": "2022-07-05T18:00:41.598862Z",
+        "updated_at": "2022-07-05T18:00:41.599096Z", "email": "mackenzie.jackson@gitguardian.com",
+        "member_id": null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
         "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
         "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
         give or has given access to any sensitive information or services?", "boolean":
         true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
         this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
-        "remarks_text", "field_label": "Additional remarks", "text": ""}]}], "risk_score":
-        100, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
+        "remarks_text", "field_label": "Additional remarks", "text": "Notes"}]}, {"created_at":
+        "2023-06-26T12:44:52.641388Z", "updated_at": "2023-06-26T12:44:52.641404Z",
+        "email": "aymeric.sicard@gitguardian.com", "member_id": 13, "answers": [{"type":
+        "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is this an
+        actual secret?", "boolean": true}, {"type": "boolean", "field_ref": "access_to_sensitive_yes_no",
+        "field_label": "Does this secret give or has given access to any sensitive
+        information or services?", "boolean": true}, {"type": "boolean", "field_ref":
+        "revoked_yes_no", "field_label": "Has this secret been revoked?", "boolean":
+        false}, {"type": "text", "field_ref": "remarks_text", "field_label": "Additional
+        remarks", "text": ""}]}], "risk_score": 100, "severity_rule_id": 28, "is_vaulted":
+        false, "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21471", "tags": ["PUBLICLY_LEAKED",
+        "REVOCABLE_BY_GG"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
+        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "destination_tickets": [], "custom_tags": []}, {"id": 21472, "detector": {"name":
+        "mailgun_basic_auth", "display_name": "Mailgun Primary Key", "nature": "specific",
+        "family": "token", "category": "messaging_system", "detector_group_name":
+        "mailgun_primary_key", "detector_group_display_name": "Mailgun Primary Key"},
+        "date": "2020-10-24T13:20:01.922433Z", "secret_id": 70600, "secret_hash":
+        "08ojvEC4nIUJUAN4ttWhl3xQ7wpuWfFsb0spGFSBvQk4eUCHYohSEf1f9eeKaOdx", "hmsl_hash":
+        "43bfd7d1df6ba59f374b714be65a7176e3ca7b6613d48a09dc822f96d98d0a01", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947918Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2022-09-06T09:04:13.473983Z",
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 91, "severity_rule_id":
+        31, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
         {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
         "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
-        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21471",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [], "custom_tags": []}, {"id": 21472, "detector":
-        {"name": "mailgun_basic_auth", "display_name": "Mailgun Primary Key", "nature":
-        "specific", "family": "token", "detector_group_name": "mailgun_primary_key",
-        "detector_group_display_name": "Mailgun Primary Key"}, "date": "2020-10-24T13:20:01.922433Z",
-        "secret_id": 70600, "secret_hash": "08ojvEC4nIUJUAN4ttWhl3xQ7wpuWfFsb0spGFSBvQk4eUCHYohSEf1f9eeKaOdx",
-        "hmsl_hash": "43bfd7d1df6ba59f374b714be65a7176e3ca7b6613d48a09dc822f96d98d0a01",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947918Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2022-09-06T09:04:13.473983Z", "resolver_id": null, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "invalid", "severity": "high", "assignee_id":
-        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 91, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21472",
+        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21472",
         "tags": ["PUBLICLY_LEAKED"], "incident_name": "Mailgun Primary Key", "public_exposure":
         {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
         false}, "destination_tickets": [], "custom_tags": []}, {"id": 21473, "detector":
         {"name": "salesforce_oauth2", "display_name": "Salesforce Oauth2 Keys", "nature":
-        "specific", "family": "credentials", "detector_group_name": "salesforce_oauth2_keys",
-        "detector_group_display_name": "Salesforce Oauth2 Keys"}, "date": "2020-10-24T00:19:42.919336Z",
-        "secret_id": 70601, "secret_hash": "sWioKesgGOGrd+XHdi46/EGgFYfr/lh2cpaxYZjxsZlcuoRELCAWyy4SR5jhsuGk",
-        "hmsl_hash": "a69efc4cae224de7fc48506c0726ca5ea943aadbfbfd9e14f52bc528b10a802c",
-        "occurrences_count": 2, "status": "IGNORED", "triggered_at": "2021-02-11T14:23:22.947946Z",
-        "ignored_at": "2025-07-28T09:26:59.237657Z", "ignorer_id": 492181, "ignorer_api_token_id":
+        "specific", "family": "credentials", "category": "crm", "detector_group_name":
+        "salesforce_oauth2_keys", "detector_group_display_name": "Salesforce Oauth2
+        Keys"}, "date": "2020-10-24T00:19:42.919336Z", "secret_id": 70601, "secret_hash":
+        "sWioKesgGOGrd+XHdi46/EGgFYfr/lh2cpaxYZjxsZlcuoRELCAWyy4SR5jhsuGk", "hmsl_hash":
+        "a69efc4cae224de7fc48506c0726ca5ea943aadbfbfd9e14f52bc528b10a802c", "occurrences_count":
+        2, "status": "IGNORED", "triggered_at": "2021-02-11T14:23:22.947946Z", "ignored_at":
+        "2025-07-28T09:26:59.237657Z", "ignorer_id": 492181, "ignorer_api_token_id":
         null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
         "secret_revoked": false, "validity": "invalid", "severity": "medium", "assignee_id":
         null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 23, "is_vaulted": false, "ignore_reason": "invalid", "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21473",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "Salesforce Oauth2 Keys", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [], "custom_tags": []}, {"id": 21474, "detector":
-        {"name": "private_key_openssh", "display_name": "OpenSSH Private Key", "nature":
-        "specific", "family": "cryptographic_key", "detector_group_name": "private_key_openssh",
-        "detector_group_display_name": "OpenSSH Private Key"}, "date": "2020-10-23T04:19:58.086544Z",
-        "secret_id": 70602, "secret_hash": "lz267UbwajGhSFmN5cJA6VwXIHkhpy/ew7Y8tHuS+5x11BplkTr0t/OLrv3FkQLP",
-        "hmsl_hash": "2a37036933c1358322383377b9449b3c4968096ec2d9bbb864118b64293531e6",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947974Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2024-10-29T12:21:43.182834Z", "resolver_id": 582569, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "no_checker", "severity": "critical",
-        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 72, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
+        [], "risk_score": 23, "severity_rule_id": null, "is_vaulted": false, "ignore_reason":
+        "invalid", "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21473", "tags": ["PUBLICLY_LEAKED"],
+        "incident_name": "Salesforce Oauth2 Keys", "public_exposure": {"source_publicly_visible":
+        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "destination_tickets": [], "custom_tags": []}, {"id": 21474, "detector": {"name":
+        "private_key_openssh", "display_name": "OpenSSH Private Key", "nature": "specific",
+        "family": "cryptographic_key", "category": "private_key", "detector_group_name":
+        "private_key_openssh", "detector_group_display_name": "OpenSSH Private Key"},
+        "date": "2020-10-23T04:19:58.086544Z", "secret_id": 70602, "secret_hash":
+        "lz267UbwajGhSFmN5cJA6VwXIHkhpy/ew7Y8tHuS+5x11BplkTr0t/OLrv3FkQLP", "hmsl_hash":
+        "2a37036933c1358322383377b9449b3c4968096ec2d9bbb864118b64293531e6", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947974Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2024-10-29T12:21:43.182834Z",
+        "resolver_id": 582569, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "failed_to_check", "severity": "critical", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        57, "severity_rule_id": 5026, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
         0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
         0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21474",
         "tags": ["PUBLICLY_LEAKED"], "incident_name": "OpenSSH Private Key", "public_exposure":
         {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
         false}, "destination_tickets": [], "custom_tags": []}, {"id": 21475, "detector":
         {"name": "mailgun_basic_auth", "display_name": "Mailgun Primary Key", "nature":
-        "specific", "family": "token", "detector_group_name": "mailgun_primary_key",
-        "detector_group_display_name": "Mailgun Primary Key"}, "date": "2020-10-22T09:19:49.658472Z",
-        "secret_id": 70603, "secret_hash": "UpqyZnwHMjsb09Yfr9pbSgT/Op4ALdN4Qgcgj8Aet7Sx0T+NYohSEf1f9eeKaOdx",
-        "hmsl_hash": "d0b214d9381ba715d1623ea1f176ee388f216b548062dd766168f91459849af9",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.948001Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2022-09-06T09:04:13.473983Z", "resolver_id": null, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "invalid", "severity": "high", "assignee_id":
-        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 91, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21475",
+        "specific", "family": "token", "category": "messaging_system", "detector_group_name":
+        "mailgun_primary_key", "detector_group_display_name": "Mailgun Primary Key"},
+        "date": "2020-10-22T09:19:49.658472Z", "secret_id": 70603, "secret_hash":
+        "UpqyZnwHMjsb09Yfr9pbSgT/Op4ALdN4Qgcgj8Aet7Sx0T+NYohSEf1f9eeKaOdx", "hmsl_hash":
+        "d0b214d9381ba715d1623ea1f176ee388f216b548062dd766168f91459849af9", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.948001Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2022-09-06T09:04:13.473983Z",
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 91, "severity_rule_id":
+        31, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
+        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
+        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
+        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21475",
         "tags": ["PUBLICLY_LEAKED"], "incident_name": "Mailgun Primary Key", "public_exposure":
         {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
         false}, "destination_tickets": [], "custom_tags": []}, {"id": 21476, "detector":
         {"name": "mailgun_basic_auth", "display_name": "Mailgun Primary Key", "nature":
-        "specific", "family": "token", "detector_group_name": "mailgun_primary_key",
-        "detector_group_display_name": "Mailgun Primary Key"}, "date": "2020-10-22T02:19:40.384662Z",
-        "secret_id": 70604, "secret_hash": "JHNfPBukO5fCqiF4rEfXqWRBWrdu/U2LUZWFqwoSnb2GSccFYohSEf1f9eeKaOdx",
-        "hmsl_hash": "42e099be8c59bf70ebed19de4948058a3001e8b8244faac5f9bd58944b98f0b1",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.948029Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2022-09-06T09:04:13.473983Z", "resolver_id": null, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "invalid", "severity": "high", "assignee_id":
-        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 91, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21476",
+        "specific", "family": "token", "category": "messaging_system", "detector_group_name":
+        "mailgun_primary_key", "detector_group_display_name": "Mailgun Primary Key"},
+        "date": "2020-10-22T02:19:40.384662Z", "secret_id": 70604, "secret_hash":
+        "JHNfPBukO5fCqiF4rEfXqWRBWrdu/U2LUZWFqwoSnb2GSccFYohSEf1f9eeKaOdx", "hmsl_hash":
+        "42e099be8c59bf70ebed19de4948058a3001e8b8244faac5f9bd58944b98f0b1", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.948029Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2022-09-06T09:04:13.473983Z",
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 91, "severity_rule_id":
+        31, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
+        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
+        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
+        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21476",
         "tags": ["PUBLICLY_LEAKED"], "incident_name": "Mailgun Primary Key", "public_exposure":
         {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
         false}, "destination_tickets": [], "custom_tags": []}, {"id": 21477, "detector":
         {"name": "mailgun_basic_auth", "display_name": "Mailgun Primary Key", "nature":
-        "specific", "family": "token", "detector_group_name": "mailgun_primary_key",
-        "detector_group_display_name": "Mailgun Primary Key"}, "date": "2020-10-20T14:19:28.302309Z",
-        "secret_id": 70605, "secret_hash": "qycBEIMe6dCsBwesY0baIUv0jv+sP8oYF3h+IUgtHCDQ3A49YohSEf1f9eeKaOdx",
-        "hmsl_hash": "3bc6e97ac445896a54b196ad72a19ed16a1e519db6ac287bff22ddb948f344f6",
-        "occurrences_count": 1, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.948057Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2025-03-27T19:40:53.923165Z", "resolver_id": 492181, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "invalid", "severity": "high", "assignee_id":
-        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 91, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 1}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21477",
+        "specific", "family": "token", "category": "messaging_system", "detector_group_name":
+        "mailgun_primary_key", "detector_group_display_name": "Mailgun Primary Key"},
+        "date": "2020-10-20T14:19:28.302309Z", "secret_id": 70605, "secret_hash":
+        "qycBEIMe6dCsBwesY0baIUv0jv+sP8oYF3h+IUgtHCDQ3A49YohSEf1f9eeKaOdx", "hmsl_hash":
+        "3bc6e97ac445896a54b196ad72a19ed16a1e519db6ac287bff22ddb948f344f6", "occurrences_count":
+        1, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.948057Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2025-03-27T19:40:53.923165Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 91, "severity_rule_id":
+        6459, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
+        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
+        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
+        1}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21477",
         "tags": ["PUBLICLY_LEAKED"], "incident_name": "Mailgun Primary Key", "public_exposure":
         {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
         false}, "destination_tickets": [], "custom_tags": []}, {"id": 21478, "detector":
         {"name": "newrelic_api_key_prefixed", "display_name": "New Relic API Key",
-        "nature": "specific", "family": "token", "detector_group_name": "newrelic_api_key",
-        "detector_group_display_name": "New Relic API Key"}, "date": "2020-10-20T04:19:45.590720Z",
-        "secret_id": 70606, "secret_hash": "LZ+gBU0jCFMLF4d4hS1a+sP3ue5eLTJCdQj7q+P0ziWxuBH2y5YhXqALAd237nLX",
+        "nature": "specific", "family": "token", "category": "monitoring", "detector_group_name":
+        "newrelic_api_key", "detector_group_display_name": "New Relic API Key"}, "date":
+        "2020-10-20T04:19:45.590720Z", "secret_id": 70606, "secret_hash": "LZ+gBU0jCFMLF4d4hS1a+sP3ue5eLTJCdQj7q+P0ziWxuBH2y5YhXqALAd237nLX",
         "hmsl_hash": "a035b02828f620a75d6aa0c0813edb61eae867bddb5c95c602ee1926efe746a8",
         "occurrences_count": 2, "status": "IGNORED", "triggered_at": "2021-02-11T14:23:22.948085Z",
         "ignored_at": "2020-10-20T15:55:30.046659Z", "ignorer_id": null, "ignorer_api_token_id":
         null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
         "secret_revoked": false, "validity": "invalid", "severity": "high", "assignee_id":
         null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 75, "is_vaulted": false, "ignore_reason": null, "occurrences":
-        null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21478",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "New Relic API Key", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [], "custom_tags": []}, {"id": 21479, "detector":
-        {"name": "salesforce_oauth2", "display_name": "Salesforce Oauth2 Keys", "nature":
-        "specific", "family": "credentials", "detector_group_name": "salesforce_oauth2_keys",
+        [], "risk_score": 75, "severity_rule_id": 31, "is_vaulted": false, "ignore_reason":
+        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21478", "tags": ["PUBLICLY_LEAKED"],
+        "incident_name": "New Relic API Key", "public_exposure": {"source_publicly_visible":
+        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "destination_tickets": [], "custom_tags": []}, {"id": 21479, "detector": {"name":
+        "salesforce_oauth2", "display_name": "Salesforce Oauth2 Keys", "nature": "specific",
+        "family": "credentials", "category": "crm", "detector_group_name": "salesforce_oauth2_keys",
         "detector_group_display_name": "Salesforce Oauth2 Keys"}, "date": "2020-10-19T23:20:02.997966Z",
         "secret_id": 70607, "secret_hash": "5eki7KifArvH8V3+/h6Q64U9+41vavcxUiKG8rBioZwXFMK4LCAWyy4SR5jhsuGk",
         "hmsl_hash": "071afa7de0b95466265eeac3260f13499119e977aae087a4ebd292abc59ed9a0",
@@ -546,51 +579,60 @@ interactions:
         null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
         "secret_revoked": false, "validity": "invalid", "severity": "high", "assignee_id":
         null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 23, "is_vaulted": false, "ignore_reason": "test_credential",
-        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21479",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "Salesforce Oauth2 Keys", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [], "custom_tags": []}]'
+        [], "risk_score": 23, "severity_rule_id": 31, "is_vaulted": false, "ignore_reason":
+        "test_credential", "occurrences": null, "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21479", "tags": ["PUBLICLY_LEAKED"],
+        "incident_name": "Salesforce Oauth2 Keys", "public_exposure": {"source_publicly_visible":
+        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "destination_tickets": [], "custom_tags": []}]'
     headers:
+      CF-RAY:
+      - a10397310bc97e9b-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:34 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '31956'
+      - '33006'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:23 GMT
       link:
       - <https://api.gitguardian.com/v1/members/480870/secret-incidents?cursor=cD0yMTQ3OQ%3D%3D>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '184'
+      - '116'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_members.yaml
+++ b/tests/cassettes/client/vcr/test_list_members.yaml
@@ -25,54 +25,62 @@ interactions:
         "last_login": "2020-09-30T12:21:19.319487Z", "active": true}, {"id": 13, "role":
         "manager", "access_level": "manager", "email": "aymeric.sicard@gitguardian.com",
         "name": "Aymeric SICARD", "created_at": "2020-01-21T09:35:47.907207Z", "last_login":
-        "2026-04-02T08:21:40.877924Z", "active": true}, {"id": 2508, "role": "manager",
+        "2026-06-22T14:20:46.680540Z", "active": true}, {"id": 2508, "role": "manager",
         "access_level": "manager", "email": "guillaume.charpiat@gitguardian.com",
         "name": "Guillaume CHARPIAT", "created_at": "2020-03-23T17:53:57.158457Z",
-        "last_login": "2026-03-25T10:56:33.130265Z", "active": true}, {"id": 37699,
+        "last_login": "2026-06-10T11:29:54.420261Z", "active": true}, {"id": 37699,
         "role": "manager", "access_level": "manager", "email": "alexis.larnaud@gitguardian.com",
         "name": "Alexis LARNAUD", "created_at": "2020-09-03T11:16:05.980606Z", "last_login":
-        "2026-03-31T09:14:08.791897Z", "active": true}, {"id": 63809, "role": "manager",
+        "2026-06-22T09:33:43.124144Z", "active": true}, {"id": 63809, "role": "manager",
         "access_level": "manager", "email": "orian.roturier@gitguardian.com", "name":
         "Orian ROTURIER", "created_at": "2020-11-25T14:01:01.749542Z", "last_login":
         "2025-08-05T08:47:38.723615Z", "active": true}]'
     headers:
+      CF-RAY:
+      - a103973b4e4103f1-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:36 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '1098'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:26 GMT
       link:
       - <https://api.gitguardian.com/v1/members?cursor=cD02MzgwOQ%3D%3D&per_page=5>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '40'
+      - '54'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_occurrences_basic.yaml
+++ b/tests/cassettes/client/vcr/test_list_occurrences_basic.yaml
@@ -26,7 +26,7 @@ interactions:
         3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}, {"name":
         "client_secret", "indice_start": 85, "indice_end": 125, "pre_line_start":
         4, "pre_line_end": 4, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion",
         "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
@@ -34,20 +34,20 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "304477822", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "provider_metadata": {"archived": false}, "deleted": true}}, {"id": 78198,
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "304477822", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78198,
         "incident_id": 21460, "date": "2020-10-29T13:19:59.005564Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
         "indice_start": 92, "indice_end": 112, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 3}, {"name": "client_secret",
         "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
+        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition",
         "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
@@ -55,18 +55,18 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "304477822", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "provider_metadata": {"archived": false}, "deleted": true}}, {"id": 78199,
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "304477822", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78199,
         "incident_id": 21461, "date": "2020-10-29T10:19:39.723768Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
         "indice_start": 48, "indice_end": 726, "pre_line_start": 3, "pre_line_end":
-        14, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        14, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
+        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "333db3e12b3f863ebb02cac6f232fc44e4f46533", "change_type": "deletion",
         "source": {"id": 12320, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-09",
@@ -74,17 +74,18 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 1524, "duration": "4.818047", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "295879950", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        2, "severity_breakdown": {"critical": 2, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 13, "severity_breakdown":
-        {"critical": 1, "high": 12, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09", "provider_metadata":
-        {"archived": false}, "deleted": true}}, {"id": 78200, "incident_id": 21461,
-        "date": "2020-10-29T09:19:54.249454Z", "filepath": "app.py", "kind": "realtime",
-        "presence": "removed", "matches": [{"name": "apikey", "indice_start": 91,
-        "indice_end": 769, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        3, "post_line_end": 14}], "tags": ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "295879950", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78200,
+        "incident_id": 21461, "date": "2020-10-29T09:19:54.249454Z", "filepath": "app.py",
+        "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
+        "indice_start": 91, "indice_end": 769, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 14}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
+        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "76dd4f31a31c78a151723031bfebff4d076751b2", "change_type": "addition",
         "source": {"id": 12320, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-09",
@@ -92,20 +93,20 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 1524, "duration": "4.818047", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "295879950", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        2, "severity_breakdown": {"critical": 2, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 13, "severity_breakdown":
-        {"critical": 1, "high": 12, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09", "provider_metadata":
-        {"archived": false}, "deleted": true}}, {"id": 78201, "incident_id": 21462,
-        "date": "2020-10-29T08:19:34.987039Z", "filepath": "app.py", "kind": "realtime",
-        "presence": "removed", "matches": [{"name": "client_id", "indice_start": 49,
-        "indice_end": 134, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
-        null, "post_line_end": null}, {"name": "client_secret", "indice_start": 150,
-        "indice_end": 169, "pre_line_start": 4, "pre_line_end": 4, "post_line_start":
-        null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED", "PUBLIC"], "url":
-        "https://github.com/wayne-enterprises-gg/private-gg-2020-08/commit/970509ea87f9913d362d727ac4d178ac4332719a#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "295879950", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78201,
+        "incident_id": 21462, "date": "2020-10-29T08:19:34.987039Z", "filepath": "app.py",
+        "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
+        "indice_start": 49, "indice_end": 134, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": null, "post_line_end": null}, {"name": "client_secret",
+        "indice_start": 150, "indice_end": 169, "pre_line_start": 4, "pre_line_end":
+        4, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
+        "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08/commit/970509ea87f9913d362d727ac4d178ac4332719a#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "970509ea87f9913d362d727ac4d178ac4332719a", "change_type": "deletion",
         "source": {"id": 12297, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-08",
@@ -113,51 +114,59 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         11, "last_scan": {"date": "2020-09-24T09:06:39.261262Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 928, "duration": "3.06658", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "284154426", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 11, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08", "provider_metadata":
-        {"archived": false}, "deleted": true}}]'
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "284154426", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 11, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08",
+        "provider_metadata": {"archived": false}, "deleted": false}}]'
     headers:
+      CF-RAY:
+      - a10395f63856d0b7-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:44 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '8107'
+      - '8310'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:52 GMT
       link:
       - <https://api.gitguardian.com/v1/occurrences/secrets?cursor=cD03ODIwMQ%3D%3D&per_page=5>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '48'
+      - '46'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_occurrences_get_all.yaml
+++ b/tests/cassettes/client/vcr/test_list_occurrences_get_all.yaml
@@ -26,7 +26,7 @@ interactions:
         3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}, {"name":
         "client_secret", "indice_start": 85, "indice_end": 125, "pre_line_start":
         4, "pre_line_end": 4, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion",
         "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
@@ -34,20 +34,20 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "304477822", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "provider_metadata": {"archived": false}, "deleted": true}}, {"id": 78198,
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "304477822", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78198,
         "incident_id": 21460, "date": "2020-10-29T13:19:59.005564Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
         "indice_start": 92, "indice_end": 112, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 3}, {"name": "client_secret",
         "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
+        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition",
         "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
@@ -55,18 +55,18 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "304477822", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "provider_metadata": {"archived": false}, "deleted": true}}, {"id": 78199,
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "304477822", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78199,
         "incident_id": 21461, "date": "2020-10-29T10:19:39.723768Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
         "indice_start": 48, "indice_end": 726, "pre_line_start": 3, "pre_line_end":
-        14, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        14, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
+        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "333db3e12b3f863ebb02cac6f232fc44e4f46533", "change_type": "deletion",
         "source": {"id": 12320, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-09",
@@ -74,17 +74,18 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 1524, "duration": "4.818047", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "295879950", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        2, "severity_breakdown": {"critical": 2, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 13, "severity_breakdown":
-        {"critical": 1, "high": 12, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09", "provider_metadata":
-        {"archived": false}, "deleted": true}}, {"id": 78200, "incident_id": 21461,
-        "date": "2020-10-29T09:19:54.249454Z", "filepath": "app.py", "kind": "realtime",
-        "presence": "removed", "matches": [{"name": "apikey", "indice_start": 91,
-        "indice_end": 769, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        3, "post_line_end": 14}], "tags": ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "295879950", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78200,
+        "incident_id": 21461, "date": "2020-10-29T09:19:54.249454Z", "filepath": "app.py",
+        "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
+        "indice_start": 91, "indice_end": 769, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 14}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
+        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "76dd4f31a31c78a151723031bfebff4d076751b2", "change_type": "addition",
         "source": {"id": 12320, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-09",
@@ -92,20 +93,20 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 1524, "duration": "4.818047", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "295879950", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        2, "severity_breakdown": {"critical": 2, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 13, "severity_breakdown":
-        {"critical": 1, "high": 12, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09", "provider_metadata":
-        {"archived": false}, "deleted": true}}, {"id": 78201, "incident_id": 21462,
-        "date": "2020-10-29T08:19:34.987039Z", "filepath": "app.py", "kind": "realtime",
-        "presence": "removed", "matches": [{"name": "client_id", "indice_start": 49,
-        "indice_end": 134, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
-        null, "post_line_end": null}, {"name": "client_secret", "indice_start": 150,
-        "indice_end": 169, "pre_line_start": 4, "pre_line_end": 4, "post_line_start":
-        null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED", "PUBLIC"], "url":
-        "https://github.com/wayne-enterprises-gg/private-gg-2020-08/commit/970509ea87f9913d362d727ac4d178ac4332719a#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "295879950", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78201,
+        "incident_id": 21462, "date": "2020-10-29T08:19:34.987039Z", "filepath": "app.py",
+        "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
+        "indice_start": 49, "indice_end": 134, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": null, "post_line_end": null}, {"name": "client_secret",
+        "indice_start": 150, "indice_end": 169, "pre_line_start": 4, "pre_line_end":
+        4, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
+        "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08/commit/970509ea87f9913d362d727ac4d178ac4332719a#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "970509ea87f9913d362d727ac4d178ac4332719a", "change_type": "deletion",
         "source": {"id": 12297, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-08",
@@ -113,51 +114,59 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         11, "last_scan": {"date": "2020-09-24T09:06:39.261262Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 928, "duration": "3.06658", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "284154426", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 11, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08", "provider_metadata":
-        {"archived": false}, "deleted": true}}]'
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "284154426", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 11, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08",
+        "provider_metadata": {"archived": false}, "deleted": false}}]'
     headers:
+      CF-RAY:
+      - a1039601b841d0aa-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:45 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '8107'
+      - '8310'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:54 GMT
       link:
       - <https://api.gitguardian.com/v1/occurrences/secrets?cursor=cD03ODIwMQ%3D%3D&per_page=5>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '52'
+      - '60'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -198,18 +207,18 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         11, "last_scan": {"date": "2020-09-24T09:06:39.261262Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 928, "duration": "3.06658", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "284154426", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 11, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08", "provider_metadata":
-        {"archived": false}, "deleted": true}}, {"id": 78203, "incident_id": 21463,
-        "date": "2020-10-29T06:20:19.846592Z", "filepath": "app.py", "kind": "realtime",
-        "presence": "removed", "matches": [{"name": "apikey", "indice_start": 48,
-        "indice_end": 1842, "pre_line_start": 3, "pre_line_end": 32, "post_line_start":
-        null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED", "PUBLIC"], "url":
-        "https://github.com/wayne-enterprises-gg/private-gg-2020-10/commit/65563d9586ec109e098c952559204dbb54e88d6f#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "284154426", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 11, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78203,
+        "incident_id": 21463, "date": "2020-10-29T06:20:19.846592Z", "filepath": "app.py",
+        "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
+        "indice_start": 48, "indice_end": 1842, "pre_line_start": 3, "pre_line_end":
+        32, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED",
+        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-10/commit/65563d9586ec109e098c952559204dbb54e88d6f#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "65563d9586ec109e098c952559204dbb54e88d6f", "change_type": "deletion",
         "source": {"id": 12308, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-10",
@@ -217,17 +226,18 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         9, "last_scan": {"date": "2020-12-10T10:45:12.767631Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 1251, "duration": "4.299251", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "300095842", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 9, "severity_breakdown":
-        {"critical": 0, "high": 9, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-10", "provider_metadata":
-        {"archived": false}, "deleted": true}}, {"id": 78204, "incident_id": 21463,
-        "date": "2020-10-29T06:20:15.521071Z", "filepath": "app.py", "kind": "realtime",
-        "presence": "removed", "matches": [{"name": "apikey", "indice_start": 91,
-        "indice_end": 1885, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        3, "post_line_end": 32}], "tags": ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-10/commit/35a6a3b548c4bf220b347f2bcb0be46f3692d35d#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "300095842", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78204,
+        "incident_id": 21463, "date": "2020-10-29T06:20:15.521071Z", "filepath": "app.py",
+        "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
+        "indice_start": 91, "indice_end": 1885, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 32}], "tags": ["PUBLICLY_EXPOSED",
+        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-10/commit/35a6a3b548c4bf220b347f2bcb0be46f3692d35d#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "35a6a3b548c4bf220b347f2bcb0be46f3692d35d", "change_type": "addition",
         "source": {"id": 12308, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-10",
@@ -235,20 +245,20 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         9, "last_scan": {"date": "2020-12-10T10:45:12.767631Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 1251, "duration": "4.299251", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "300095842", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 9, "severity_breakdown":
-        {"critical": 0, "high": 9, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-10", "provider_metadata":
-        {"archived": false}, "deleted": true}}, {"id": 78205, "incident_id": 21464,
-        "date": "2020-10-29T04:20:15.661229Z", "filepath": "app.py", "kind": "realtime",
-        "presence": "removed", "matches": [{"name": "client_id", "indice_start": 49,
-        "indice_end": 69, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
-        null, "post_line_end": null}, {"name": "client_secret", "indice_start": 85,
-        "indice_end": 125, "pre_line_start": 4, "pre_line_end": 4, "post_line_start":
-        null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED", "PUBLIC"], "url":
-        "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-09/commit/793c4aa24d43972b28661fbbb8ce7ad857abd822#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "300095842", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78205,
+        "incident_id": 21464, "date": "2020-10-29T04:20:15.661229Z", "filepath": "app.py",
+        "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
+        "indice_start": 49, "indice_end": 69, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": null, "post_line_end": null}, {"name": "client_secret",
+        "indice_start": 85, "indice_end": 125, "pre_line_start": 4, "pre_line_end":
+        4, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED",
+        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-09/commit/793c4aa24d43972b28661fbbb8ce7ad857abd822#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "793c4aa24d43972b28661fbbb8ce7ad857abd822", "change_type": "deletion",
         "source": {"id": 12345, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-09",
@@ -256,13 +266,13 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         7, "last_scan": {"date": "2020-12-10T10:45:12.792423Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 1519, "duration": "2.843473", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "295879919", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 7, "severity_breakdown":
-        {"critical": 0, "high": 7, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-09",
-        "provider_metadata": {"archived": false}, "deleted": true}}, {"id": 78206,
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "295879919", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 7, "severity_breakdown": {"critical": 0, "high": 7, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-09",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78206,
         "incident_id": 21464, "date": "2020-10-29T04:19:56.388169Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
         "indice_start": 92, "indice_end": 112, "pre_line_start": null, "pre_line_end":
@@ -277,52 +287,60 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         7, "last_scan": {"date": "2020-12-10T10:45:12.792423Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 1519, "duration": "2.843473", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "295879919", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 7, "severity_breakdown":
-        {"critical": 0, "high": 7, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-09",
-        "provider_metadata": {"archived": false}, "deleted": true}}]'
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "295879919", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 7, "severity_breakdown": {"critical": 0, "high": 7, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-09",
+        "provider_metadata": {"archived": false}, "deleted": false}}]'
     headers:
+      CF-RAY:
+      - a10396039c7bd14a-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:46 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '8069'
+      - '8274'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:55 GMT
       link:
       - <https://api.gitguardian.com/v1/occurrences/secrets?cursor=cD03ODIwNg%3D%3D&per_page=5>;
         rel="next", <https://api.gitguardian.com/v1/occurrences/secrets?cursor=cj0xJnA9NzgyMDI%3D&per_page=5>;
         rel="prev"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '55'
+      - '67'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -355,7 +373,7 @@ interactions:
         3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}, {"name":
         "client_secret", "indice_start": 150, "indice_end": 169, "pre_line_start":
         4, "pre_line_end": 4, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-08/commit/ba6dee25b5c0196a9b4f4dc043413cfac77075e1#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-08/commit/ba6dee25b5c0196a9b4f4dc043413cfac77075e1#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "ba6dee25b5c0196a9b4f4dc043413cfac77075e1", "change_type": "deletion",
         "source": {"id": 12275, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-08",
@@ -363,19 +381,20 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
         9, "last_scan": {"date": "2020-09-24T09:06:39.215897Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 656, "duration": "5.5968", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "287845935", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        1, "severity_breakdown": {"critical": 1, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 9, "severity_breakdown":
-        {"critical": 0, "high": 9, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-08", "provider_metadata":
-        {"archived": false}, "deleted": true}}, {"id": 78208, "incident_id": 21465,
-        "date": "2020-10-28T21:20:05.533072Z", "filepath": "app.py", "kind": "realtime",
-        "presence": "removed", "matches": [{"name": "client_id", "indice_start": 92,
-        "indice_end": 177, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        3, "post_line_end": 3}, {"name": "client_secret", "indice_start": 193, "indice_end":
-        212, "pre_line_start": null, "pre_line_end": null, "post_line_start": 4, "post_line_end":
-        4}], "tags": ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-08/commit/2504a69e99e482a8be9ce5afb1328380416a62e4#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "287845935", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
+        1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-08",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78208,
+        "incident_id": 21465, "date": "2020-10-28T21:20:05.533072Z", "filepath": "app.py",
+        "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
+        "indice_start": 92, "indice_end": 177, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}, {"name": "client_secret",
+        "indice_start": 193, "indice_end": 212, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
+        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-08/commit/2504a69e99e482a8be9ce5afb1328380416a62e4#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "2504a69e99e482a8be9ce5afb1328380416a62e4", "change_type": "addition",
         "source": {"id": 12275, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-08",
@@ -383,18 +402,18 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
         9, "last_scan": {"date": "2020-09-24T09:06:39.215897Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 656, "duration": "5.5968", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "287845935", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        1, "severity_breakdown": {"critical": 1, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 9, "severity_breakdown":
-        {"critical": 0, "high": 9, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-08", "provider_metadata":
-        {"archived": false}, "deleted": true}}, {"id": 78209, "incident_id": 21466,
-        "date": "2020-10-26T16:19:46.771637Z", "filepath": "app.py", "kind": "realtime",
-        "presence": "removed", "matches": [{"name": "apikey", "indice_start": 46,
-        "indice_end": 93, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
-        null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED", "PUBLIC"], "url":
-        "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/da411b85bedcf9e3e3b5ade00f14649a449f2618#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "287845935", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
+        1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-08",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78209,
+        "incident_id": 21466, "date": "2020-10-26T16:19:46.771637Z", "filepath": "app.py",
+        "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
+        "indice_start": 46, "indice_end": 93, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
+        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/da411b85bedcf9e3e3b5ade00f14649a449f2618#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "da411b85bedcf9e3e3b5ade00f14649a449f2618", "change_type": "deletion",
         "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
@@ -402,18 +421,18 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "304477822", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "provider_metadata": {"archived": false}, "deleted": true}}, {"id": 78210,
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "304477822", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78210,
         "incident_id": 21467, "date": "2020-10-26T16:19:44.303499Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
         "indice_start": 46, "indice_end": 86, "pre_line_start": 3, "pre_line_end":
-        3, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-10/commit/a18096b36e00c74db6878ad3acb9221e27539b14#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        3, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
+        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-10/commit/a18096b36e00c74db6878ad3acb9221e27539b14#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "a18096b36e00c74db6878ad3acb9221e27539b14", "change_type": "deletion",
         "source": {"id": 12350, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-2020-10",
@@ -421,17 +440,18 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         8, "last_scan": {"date": "2020-12-29T16:39:57.616455Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 1592, "duration": "4.392921", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "300095824", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 8, "severity_breakdown":
-        {"critical": 0, "high": 8, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-10", "provider_metadata":
-        {"archived": false}, "deleted": true}}, {"id": 78211, "incident_id": 21466,
-        "date": "2020-10-26T15:19:37.812603Z", "filepath": "app.py", "kind": "realtime",
-        "presence": "removed", "matches": [{"name": "apikey", "indice_start": 89,
-        "indice_end": 136, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        3, "post_line_end": 3}], "tags": ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/003d71fe8b183c4038bd1666cf30fd16c2f57dc5#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "300095824", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 8, "severity_breakdown": {"critical": 0, "high": 8, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78211,
+        "incident_id": 21466, "date": "2020-10-26T15:19:37.812603Z", "filepath": "app.py",
+        "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
+        "indice_start": 89, "indice_end": 136, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
+        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/003d71fe8b183c4038bd1666cf30fd16c2f57dc5#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "003d71fe8b183c4038bd1666cf30fd16c2f57dc5", "change_type": "addition",
         "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
@@ -439,52 +459,60 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "304477822", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "provider_metadata": {"archived": false}, "deleted": true}}]'
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "304477822", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}]'
     headers:
+      CF-RAY:
+      - a10396056a63a9b8-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:46 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '7960'
+      - '8163'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:55 GMT
       link:
       - <https://api.gitguardian.com/v1/occurrences/secrets?cursor=cD03ODIxMQ%3D%3D&per_page=5>;
         rel="next", <https://api.gitguardian.com/v1/occurrences/secrets?cursor=cj0xJnA9NzgyMDc%3D&per_page=5>;
         rel="prev"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '46'
+      - '45'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_occurrences_with_date_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_occurrences_with_date_filter.yaml
@@ -26,7 +26,7 @@ interactions:
         3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}, {"name":
         "client_secret", "indice_start": 85, "indice_end": 125, "pre_line_start":
         4, "pre_line_end": 4, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion",
         "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
@@ -34,20 +34,20 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "304477822", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "provider_metadata": {"archived": false}, "deleted": true}}, {"id": 78198,
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "304477822", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78198,
         "incident_id": 21460, "date": "2020-10-29T13:19:59.005564Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
         "indice_start": 92, "indice_end": 112, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 3}, {"name": "client_secret",
         "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLICLY_EXPOSED",
+        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition",
         "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
@@ -55,18 +55,18 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "304477822", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "provider_metadata": {"archived": false}, "deleted": true}}, {"id": 78199,
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "304477822", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78199,
         "incident_id": 21461, "date": "2020-10-29T10:19:39.723768Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
         "indice_start": 48, "indice_end": 726, "pre_line_start": 3, "pre_line_end":
-        14, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        14, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED",
+        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "333db3e12b3f863ebb02cac6f232fc44e4f46533", "change_type": "deletion",
         "source": {"id": 12320, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-09",
@@ -74,17 +74,18 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 1524, "duration": "4.818047", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "295879950", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        2, "severity_breakdown": {"critical": 2, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 13, "severity_breakdown":
-        {"critical": 1, "high": 12, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09", "provider_metadata":
-        {"archived": false}, "deleted": true}}, {"id": 78200, "incident_id": 21461,
-        "date": "2020-10-29T09:19:54.249454Z", "filepath": "app.py", "kind": "realtime",
-        "presence": "removed", "matches": [{"name": "apikey", "indice_start": 91,
-        "indice_end": 769, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        3, "post_line_end": 14}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "295879950", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78200,
+        "incident_id": 21461, "date": "2020-10-29T09:19:54.249454Z", "filepath": "app.py",
+        "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
+        "indice_start": 91, "indice_end": 769, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 14}], "tags": ["PUBLICLY_EXPOSED",
+        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "76dd4f31a31c78a151723031bfebff4d076751b2", "change_type": "addition",
         "source": {"id": 12320, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-09",
@@ -92,20 +93,20 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 1524, "duration": "4.818047", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "295879950", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        2, "severity_breakdown": {"critical": 2, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 13, "severity_breakdown":
-        {"critical": 1, "high": 12, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09", "provider_metadata":
-        {"archived": false}, "deleted": true}}, {"id": 78201, "incident_id": 21462,
-        "date": "2020-10-29T08:19:34.987039Z", "filepath": "app.py", "kind": "realtime",
-        "presence": "removed", "matches": [{"name": "client_id", "indice_start": 49,
-        "indice_end": 134, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
-        null, "post_line_end": null}, {"name": "client_secret", "indice_start": 150,
-        "indice_end": 169, "pre_line_start": 4, "pre_line_end": 4, "post_line_start":
-        null, "post_line_end": null}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"], "url":
-        "https://github.com/wayne-enterprises-gg/private-gg-2020-08/commit/970509ea87f9913d362d727ac4d178ac4332719a#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "295879950", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78201,
+        "incident_id": 21462, "date": "2020-10-29T08:19:34.987039Z", "filepath": "app.py",
+        "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
+        "indice_start": 49, "indice_end": 134, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": null, "post_line_end": null}, {"name": "client_secret",
+        "indice_start": 150, "indice_end": 169, "pre_line_start": 4, "pre_line_end":
+        4, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED",
+        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08/commit/970509ea87f9913d362d727ac4d178ac4332719a#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "970509ea87f9913d362d727ac4d178ac4332719a", "change_type": "deletion",
         "source": {"id": 12297, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-08",
@@ -113,51 +114,59 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         11, "last_scan": {"date": "2020-09-24T09:06:39.261262Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 928, "duration": "3.06658", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "284154426", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 11, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08", "provider_metadata":
-        {"archived": false}, "deleted": true}}]'
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "284154426", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 11, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08",
+        "provider_metadata": {"archived": false}, "deleted": false}}]'
     headers:
+      CF-RAY:
+      - a10395fa9e86ca0e-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:44 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '8107'
+      - '8310'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:52 GMT
       link:
       - <https://api.gitguardian.com/v1/occurrences/secrets?cursor=cD03ODIwMQ%3D%3D&from_date=2024-01-01&per_page=5&to_date=2024-12-31>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '44'
+      - '43'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_occurrences_with_member_assignee_id.yaml
+++ b/tests/cassettes/client/vcr/test_list_occurrences_with_member_assignee_id.yaml
@@ -20,39 +20,50 @@ interactions:
     uri: https://api.gitguardian.com/v1/api_tokens/self
   response:
     body:
-      string: '{"id": "8a262c6a-832d-49e5-8744-23c743ff25ac", "name": "ggmcp CI",
-        "type": "personal_access_token", "scopes": ["scan", "incidents:read", "members:read",
-        "audit_logs:read", "teams:read", "honeytokens:read", "honeytokens:write",
-        "api_tokens:read", "sources:read", "nhi:send-inventory", "nhi:write-vault",
-        "custom_tags:read", "custom_tags:write", "secrets:read", "secrets:write",
-        "scan:create-incidents", "public-perimeter:read"], "member_id": 480870, "workspace_id":
-        8, "created_at": "2025-12-07T14:13:08.044416Z", "last_used_at": "2026-04-03T08:42:00Z",
-        "expire_at": null, "revoked_at": null, "status": "active", "creator_id": 480870}'
+      string: '{"id": "d0ca9877-641f-4c37-8857-c08e0ae148c4", "name": "ggmcp CI (April)",
+        "type": "personal_access_token", "scopes": ["scan", "incidents:read", "incidents:write",
+        "incidents:share", "members:read", "members:write", "audit_logs:read", "teams:read",
+        "teams:write", "honeytokens:read", "honeytokens:write", "api_tokens:read",
+        "api_tokens:write", "ip_allowlist:read", "ip_allowlist:write", "sources:read",
+        "sources:write", "nhi:send-inventory", "nhi:write-vault", "custom_tags:read",
+        "custom_tags:write", "secrets:read", "secrets:write", "scan:create-incidents",
+        "public-perimeter:read", "nhi:ownership:read", "nhi:ownership:write", "sources:scan"],
+        "member_id": 480870, "workspace_id": 8, "created_at": "2026-04-20T13:31:42.422943Z",
+        "last_used_at": "2026-06-23T12:44:00Z", "expire_at": null, "revoked_at": null,
+        "status": "active", "creator_id": 480870}'
     headers:
+      CF-RAY:
+      - a10396072c1baea3-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:46 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '594'
+      - '802'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:56 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
@@ -60,7 +71,7 @@ interactions:
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -89,41 +100,49 @@ interactions:
     body:
       string: '{"id": 480870, "role": "manager", "access_level": "manager", "email":
         "timothe.delion@gitguardian.com", "name": "Timoth\u00e9 DELION", "created_at":
-        "2023-06-26T12:41:18.599497Z", "last_login": "2026-04-02T13:15:43.810850Z",
+        "2023-06-26T12:41:18.599497Z", "last_login": "2026-06-23T12:20:54.639679Z",
         "active": true}'
     headers:
+      CF-RAY:
+      - a1039608bfbd11f4-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:47 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '221'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:56 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '29'
+      - '44'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -164,13 +183,13 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "304477822", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "provider_metadata": {"archived": false}, "deleted": true}}, {"id": 78198,
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "304477822", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78198,
         "incident_id": 21460, "date": "2020-10-29T13:19:59.005564Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
         "indice_start": 92, "indice_end": 112, "pre_line_start": null, "pre_line_end":
@@ -185,13 +204,13 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "304477822", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "provider_metadata": {"archived": false}, "deleted": true}}, {"id": 78199,
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "304477822", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78199,
         "incident_id": 21461, "date": "2020-10-29T10:19:39.723768Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
         "indice_start": 48, "indice_end": 726, "pre_line_start": 3, "pre_line_end":
@@ -204,17 +223,18 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 1524, "duration": "4.818047", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "295879950", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        2, "severity_breakdown": {"critical": 2, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 13, "severity_breakdown":
-        {"critical": 1, "high": 12, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09", "provider_metadata":
-        {"archived": false}, "deleted": true}}, {"id": 78200, "incident_id": 21461,
-        "date": "2020-10-29T09:19:54.249454Z", "filepath": "app.py", "kind": "realtime",
-        "presence": "removed", "matches": [{"name": "apikey", "indice_start": 91,
-        "indice_end": 769, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        3, "post_line_end": 14}], "tags": ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "295879950", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78200,
+        "incident_id": 21461, "date": "2020-10-29T09:19:54.249454Z", "filepath": "app.py",
+        "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
+        "indice_start": 91, "indice_end": 769, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 14}], "tags": ["PUBLICLY_EXPOSED",
+        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "76dd4f31a31c78a151723031bfebff4d076751b2", "change_type": "addition",
         "source": {"id": 12320, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-09",
@@ -222,20 +242,20 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 1524, "duration": "4.818047", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "295879950", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        2, "severity_breakdown": {"critical": 2, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 13, "severity_breakdown":
-        {"critical": 1, "high": 12, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09", "provider_metadata":
-        {"archived": false}, "deleted": true}}, {"id": 78201, "incident_id": 21462,
-        "date": "2020-10-29T08:19:34.987039Z", "filepath": "app.py", "kind": "realtime",
-        "presence": "removed", "matches": [{"name": "client_id", "indice_start": 49,
-        "indice_end": 134, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
-        null, "post_line_end": null}, {"name": "client_secret", "indice_start": 150,
-        "indice_end": 169, "pre_line_start": 4, "pre_line_end": 4, "post_line_start":
-        null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED", "PUBLIC"], "url":
-        "https://github.com/wayne-enterprises-gg/private-gg-2020-08/commit/970509ea87f9913d362d727ac4d178ac4332719a#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "295879950", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78201,
+        "incident_id": 21462, "date": "2020-10-29T08:19:34.987039Z", "filepath": "app.py",
+        "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
+        "indice_start": 49, "indice_end": 134, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": null, "post_line_end": null}, {"name": "client_secret",
+        "indice_start": 150, "indice_end": 169, "pre_line_start": 4, "pre_line_end":
+        4, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED",
+        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08/commit/970509ea87f9913d362d727ac4d178ac4332719a#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "970509ea87f9913d362d727ac4d178ac4332719a", "change_type": "deletion",
         "source": {"id": 12297, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-08",
@@ -243,51 +263,59 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         11, "last_scan": {"date": "2020-09-24T09:06:39.261262Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 928, "duration": "3.06658", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "284154426", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 11, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08", "provider_metadata":
-        {"archived": false}, "deleted": true}}]'
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "284154426", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 11, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08",
+        "provider_metadata": {"archived": false}, "deleted": false}}]'
     headers:
+      CF-RAY:
+      - a103960a6f79f590-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:47 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '8107'
+      - '8310'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:57 GMT
       link:
       - <https://api.gitguardian.com/v1/occurrences/secrets?cursor=cD03ODIwMQ%3D%3D&member_assignee_id=480870&per_page=5>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '44'
+      - '69'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_occurrences_with_presence_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_occurrences_with_presence_filter.yaml
@@ -32,18 +32,18 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         1, "last_scan": {"date": "2020-06-04T09:06:33.833273Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 2, "duration": "2.830578", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "30", "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0,
-        "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0, "info":
-        0, "unknown": 0}}, "closed_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 1}}},
-        "url": "https://ghe.dev.gitguardian.com/my-testing-org/armani_code", "provider_metadata":
-        {"archived": false}, "deleted": true}}, {"id": 79389, "incident_id": 21985,
-        "date": "2020-01-16T13:19:57Z", "filepath": "app.py", "kind": "historical",
-        "presence": "present", "matches": [{"name": "apikey", "indice_start": 46,
-        "indice_end": 93, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
-        null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN", "DEFAULT_BRANCH",
-        "PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/business-app/commit/ceb205b6eb487342c3a5fa931d480cbef12efeb2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "30", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/armani_code",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 79389,
+        "incident_id": 21985, "date": "2020-01-16T13:19:57Z", "filepath": "app.py",
+        "kind": "historical", "presence": "present", "matches": [{"name": "apikey",
+        "indice_start": 46, "indice_end": 93, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLIC", "FROM_HISTORICAL_SCAN",
+        "PUBLICLY_EXPOSED", "DEFAULT_BRANCH"], "url": "https://github.com/wayne-enterprises-gg/business-app/commit/ceb205b6eb487342c3a5fa931d480cbef12efeb2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "change_type": "deletion",
         "source": {"id": 12364, "type": "github", "full_name": "wayne-enterprises-gg/business-app",
@@ -51,18 +51,18 @@ interactions:
         "default_branch_head": "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count":
         0, "closed_incidents_count": 76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z",
         "status": "finished", "failing_reason": "", "commits_scanned": 1242, "duration":
-        "9.779904", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "217533545", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        76, "severity_breakdown": {"critical": 3, "high": 73, "medium": 0, "low":
-        0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/business-app",
+        "9.779904", "branches_scanned": 1, "progress": 100}, "monitored": true, "monitoring_status":
+        "active", "visibility": "public", "external_id": "217533545", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 76, "severity_breakdown": {"critical": 3, "high": 73, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/business-app",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 79390,
         "incident_id": 21986, "date": "2020-01-16T12:19:38Z", "filepath": "app.py",
         "kind": "historical", "presence": "present", "matches": [{"name": "apikey",
         "indice_start": 46, "indice_end": 83, "pre_line_start": 3, "pre_line_end":
-        3, "post_line_start": null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN",
-        "DEFAULT_BRANCH", "PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/business-app/commit/6e2c8fceda3f185139cd95d0d6e9d71faf529048#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        3, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLIC", "FROM_HISTORICAL_SCAN",
+        "PUBLICLY_EXPOSED", "DEFAULT_BRANCH"], "url": "https://github.com/wayne-enterprises-gg/business-app/commit/6e2c8fceda3f185139cd95d0d6e9d71faf529048#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "6e2c8fceda3f185139cd95d0d6e9d71faf529048", "change_type": "deletion",
         "source": {"id": 12364, "type": "github", "full_name": "wayne-enterprises-gg/business-app",
@@ -70,18 +70,18 @@ interactions:
         "default_branch_head": "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count":
         0, "closed_incidents_count": 76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z",
         "status": "finished", "failing_reason": "", "commits_scanned": 1242, "duration":
-        "9.779904", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "217533545", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        76, "severity_breakdown": {"critical": 3, "high": 73, "medium": 0, "low":
-        0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/business-app",
+        "9.779904", "branches_scanned": 1, "progress": 100}, "monitored": true, "monitoring_status":
+        "active", "visibility": "public", "external_id": "217533545", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 76, "severity_breakdown": {"critical": 3, "high": 73, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/business-app",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 79391,
         "incident_id": 21985, "date": "2020-01-16T12:19:38Z", "filepath": "app.py",
         "kind": "historical", "presence": "present", "matches": [{"name": "apikey",
         "indice_start": 92, "indice_end": 139, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "DEFAULT_BRANCH", "PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/business-app/commit/6e2c8fceda3f185139cd95d0d6e9d71faf529048#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["PUBLIC", "FROM_HISTORICAL_SCAN",
+        "PUBLICLY_EXPOSED", "DEFAULT_BRANCH"], "url": "https://github.com/wayne-enterprises-gg/business-app/commit/6e2c8fceda3f185139cd95d0d6e9d71faf529048#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "6e2c8fceda3f185139cd95d0d6e9d71faf529048", "change_type": "addition",
         "source": {"id": 12364, "type": "github", "full_name": "wayne-enterprises-gg/business-app",
@@ -89,18 +89,18 @@ interactions:
         "default_branch_head": "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count":
         0, "closed_incidents_count": 76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z",
         "status": "finished", "failing_reason": "", "commits_scanned": 1242, "duration":
-        "9.779904", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "217533545", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        76, "severity_breakdown": {"critical": 3, "high": 73, "medium": 0, "low":
-        0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/business-app",
+        "9.779904", "branches_scanned": 1, "progress": 100}, "monitored": true, "monitoring_status":
+        "active", "visibility": "public", "external_id": "217533545", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 76, "severity_breakdown": {"critical": 3, "high": 73, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/business-app",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 79392,
         "incident_id": 21986, "date": "2020-01-16T11:19:36Z", "filepath": "app.py",
         "kind": "historical", "presence": "present", "matches": [{"name": "apikey",
         "indice_start": 89, "indice_end": 126, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "DEFAULT_BRANCH", "PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/business-app/commit/c2f01354e84ba1f5a88a2feb9d2a09be28451316#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["PUBLIC", "FROM_HISTORICAL_SCAN",
+        "PUBLICLY_EXPOSED", "DEFAULT_BRANCH"], "url": "https://github.com/wayne-enterprises-gg/business-app/commit/c2f01354e84ba1f5a88a2feb9d2a09be28451316#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "c2f01354e84ba1f5a88a2feb9d2a09be28451316", "change_type": "addition",
         "source": {"id": 12364, "type": "github", "full_name": "wayne-enterprises-gg/business-app",
@@ -108,51 +108,59 @@ interactions:
         "default_branch_head": "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count":
         0, "closed_incidents_count": 76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z",
         "status": "finished", "failing_reason": "", "commits_scanned": 1242, "duration":
-        "9.779904", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "217533545", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        76, "severity_breakdown": {"critical": 3, "high": 73, "medium": 0, "low":
-        0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/business-app",
+        "9.779904", "branches_scanned": 1, "progress": 100}, "monitored": true, "monitoring_status":
+        "active", "visibility": "public", "external_id": "217533545", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 76, "severity_breakdown": {"critical": 3, "high": 73, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/business-app",
         "provider_metadata": {"archived": false}, "deleted": false}}]'
     headers:
+      CF-RAY:
+      - a10395fc9d00d08a-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:45 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '7796'
+      - '7953'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:53 GMT
       link:
       - <https://api.gitguardian.com/v1/occurrences/secrets?cursor=cD03OTM5Mg%3D%3D&per_page=5&presence=present>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '119'
+      - '222'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_occurrences_with_sources.yaml
+++ b/tests/cassettes/client/vcr/test_list_occurrences_with_sources.yaml
@@ -26,7 +26,7 @@ interactions:
         3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}, {"name":
         "client_secret", "indice_start": 85, "indice_end": 125, "pre_line_start":
         4, "pre_line_end": 4, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion",
         "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
@@ -34,20 +34,20 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "304477822", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "provider_metadata": {"archived": false}, "deleted": true}}, {"id": 78198,
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "304477822", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78198,
         "incident_id": 21460, "date": "2020-10-29T13:19:59.005564Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
         "indice_start": 92, "indice_end": 112, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 3}, {"name": "client_secret",
         "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLICLY_EXPOSED",
+        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition",
         "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
@@ -55,18 +55,18 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "304477822", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "provider_metadata": {"archived": false}, "deleted": true}}, {"id": 78199,
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "304477822", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78199,
         "incident_id": 21461, "date": "2020-10-29T10:19:39.723768Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
         "indice_start": 48, "indice_end": 726, "pre_line_start": 3, "pre_line_end":
-        14, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        14, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED",
+        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "333db3e12b3f863ebb02cac6f232fc44e4f46533", "change_type": "deletion",
         "source": {"id": 12320, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-09",
@@ -74,17 +74,18 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 1524, "duration": "4.818047", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "295879950", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        2, "severity_breakdown": {"critical": 2, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 13, "severity_breakdown":
-        {"critical": 1, "high": 12, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09", "provider_metadata":
-        {"archived": false}, "deleted": true}}, {"id": 78200, "incident_id": 21461,
-        "date": "2020-10-29T09:19:54.249454Z", "filepath": "app.py", "kind": "realtime",
-        "presence": "removed", "matches": [{"name": "apikey", "indice_start": 91,
-        "indice_end": 769, "pre_line_start": null, "pre_line_end": null, "post_line_start":
-        3, "post_line_end": 14}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "295879950", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78200,
+        "incident_id": 21461, "date": "2020-10-29T09:19:54.249454Z", "filepath": "app.py",
+        "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
+        "indice_start": 91, "indice_end": 769, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 14}], "tags": ["PUBLICLY_EXPOSED",
+        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "76dd4f31a31c78a151723031bfebff4d076751b2", "change_type": "addition",
         "source": {"id": 12320, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-09",
@@ -92,20 +93,20 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 1524, "duration": "4.818047", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "295879950", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        2, "severity_breakdown": {"critical": 2, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 13, "severity_breakdown":
-        {"critical": 1, "high": 12, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09", "provider_metadata":
-        {"archived": false}, "deleted": true}}, {"id": 78201, "incident_id": 21462,
-        "date": "2020-10-29T08:19:34.987039Z", "filepath": "app.py", "kind": "realtime",
-        "presence": "removed", "matches": [{"name": "client_id", "indice_start": 49,
-        "indice_end": 134, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
-        null, "post_line_end": null}, {"name": "client_secret", "indice_start": 150,
-        "indice_end": 169, "pre_line_start": 4, "pre_line_end": 4, "post_line_start":
-        null, "post_line_end": null}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"], "url":
-        "https://github.com/wayne-enterprises-gg/private-gg-2020-08/commit/970509ea87f9913d362d727ac4d178ac4332719a#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "295879950", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78201,
+        "incident_id": 21462, "date": "2020-10-29T08:19:34.987039Z", "filepath": "app.py",
+        "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
+        "indice_start": 49, "indice_end": 134, "pre_line_start": 3, "pre_line_end":
+        3, "post_line_start": null, "post_line_end": null}, {"name": "client_secret",
+        "indice_start": 150, "indice_end": 169, "pre_line_start": 4, "pre_line_end":
+        4, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED",
+        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08/commit/970509ea87f9913d362d727ac4d178ac4332719a#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "970509ea87f9913d362d727ac4d178ac4332719a", "change_type": "deletion",
         "source": {"id": 12297, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-08",
@@ -113,51 +114,59 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         11, "last_scan": {"date": "2020-09-24T09:06:39.261262Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 928, "duration": "3.06658", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "284154426", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 11, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08", "provider_metadata":
-        {"archived": false}, "deleted": true}}]'
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "284154426", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 11, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08",
+        "provider_metadata": {"archived": false}, "deleted": false}}]'
     headers:
+      CF-RAY:
+      - a10395ffad1f9ef3-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:45 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '8107'
+      - '8310'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:53 GMT
       link:
       - <https://api.gitguardian.com/v1/occurrences/secrets?cursor=cD03ODIwMQ%3D%3D&per_page=5&with_sources=true>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '41'
+      - '54'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_incidents_basic.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_basic.yaml
@@ -43,9 +43,9 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -88,22 +88,22 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
         "Slack Bot Token"}]'
     headers:
       CF-RAY:
-      - 9ef486f099e2d09b-CDG
+      - a1039610dd09d16e-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:33 GMT
+      - Tue, 23 Jun 2026 12:44:48 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -115,7 +115,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '5855'
+      - '5871'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -130,17 +130,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '112'
+      - '79'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_incidents_get_all.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_get_all.yaml
@@ -43,9 +43,9 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -88,22 +88,22 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
         "Slack Bot Token"}]'
     headers:
       CF-RAY:
-      - 9ef487188cf60f1e-CDG
+      - a103964fdcac3cc1-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:39 GMT
+      - Tue, 23 Jun 2026 12:44:58 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -115,7 +115,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '5855'
+      - '5871'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -130,17 +130,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '77'
+      - '70'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -190,9 +190,9 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.747147Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/9", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -242,13 +242,13 @@ interactions:
         [], "incident_name": "SendGrid Key"}]'
     headers:
       CF-RAY:
-      - 9ef4871afe6ad886-CDG
+      - a1039651bb64d476-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:40 GMT
+      - Tue, 23 Jun 2026 12:44:58 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -260,7 +260,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '5638'
+      - '5646'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -276,17 +276,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '63'
+      - '126'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -366,7 +366,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 0, "severity_rule_id":
-        10872, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11897, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/23",
         "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
         "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -381,7 +381,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "high", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        14, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        14, "severity_rule_id": 11897, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/24", "tags":
         ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
@@ -389,13 +389,13 @@ interactions:
         "GitGuardian Development Secret"}]'
     headers:
       CF-RAY:
-      - 9ef4871d0ea06ef7-CDG
+      - a10396540be645f1-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:40 GMT
+      - Tue, 23 Jun 2026 12:44:59 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -423,17 +423,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '77'
+      - '81'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -533,13 +533,13 @@ interactions:
         [], "incident_name": "Stripe Keys"}]'
     headers:
       CF-RAY:
-      - 9ef4871f39ded124-CDG
+      - a1039655f9846cc8-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:40 GMT
+      - Tue, 23 Jun 2026 12:44:59 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -567,17 +567,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '108'
+      - '64'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_incidents_multi_value_severity.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_multi_value_severity.yaml
@@ -31,7 +31,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 0, "severity_rule_id":
-        10872, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11897, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/23",
         "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
         "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -46,7 +46,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "high", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        14, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        14, "severity_rule_id": 11897, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/24", "tags":
         ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
@@ -62,7 +62,7 @@ interactions:
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
-        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11885, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/52",
         "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
         [], "incident_name": "AWS IAM Keys"}, {"id": 57, "detector": {"name": "gitguardian_test_token_checked",
@@ -71,12 +71,17 @@ interactions:
         "detector_group_display_name": "GitGuardian Test Token Checked"}, "date":
         "2021-12-10T10:36:08Z", "secret_id": 7970357, "secret_hash": "cfDzN5RpdE7fN0bd474gxh8fBT9kKunY+sHOlD+OeXGzGAkSCxpDOKaZihAFaYMH",
         "hmsl_hash": "49b26d210036e493d068e32207ab35c98242c41d82db746b1342ef497560195e",
-        "occurrences_count": 187, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.015423Z",
+        "occurrences_count": 187, "status": "ASSIGNED", "triggered_at": "2025-01-07T18:06:03.015423Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
-        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 27, "severity_rule_id":
-        10866, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        false, "validity": "valid", "severity": "critical", "assignee_id": 1778296,
+        "assignee_email": "zeke@binion.io", "share_url": "[REDACTED]", "feedback_list":
+        [{"created_at": "2026-04-23T00:37:26.701645Z", "updated_at": "2026-04-23T00:37:26.701660Z",
+        "email": "zeke@binion.io", "member_id": 1778296, "answers": [{"type": "boolean",
+        "field_ref": "revoked_yes_no", "field_label": "Has this secret been revoked?",
+        "boolean": true}, {"type": "text", "field_ref": "remarks_text", "field_label":
+        "Additional remarks", "text": ""}]}], "risk_score": 27, "severity_rule_id":
+        11891, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/57",
         "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
         "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -91,7 +96,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "failed_to_check", "severity": "critical", "assignee_id":
         null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 45, "severity_rule_id": 10868, "is_vaulted": false, "declarative_secret_status":
+        [], "risk_score": 45, "severity_rule_id": 11893, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/59", "tags":
         ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
@@ -107,7 +112,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "high", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        0, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        0, "severity_rule_id": 11897, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/64", "tags":
         ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "IS_COMPANY_CONTEXT",
@@ -138,7 +143,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "high", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        9, "severity_rule_id": 10877, "is_vaulted": true, "declarative_secret_status":
+        9, "severity_rule_id": 11902, "is_vaulted": true, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/122", "tags":
         ["FROM_HISTORICAL_SCAN", "SENSITIVE_FILE", "INTERNALLY_LEAKED"], "custom_tags":
@@ -154,7 +159,7 @@ interactions:
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
-        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11885, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/123",
         "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
         [], "incident_name": "AWS IAM Keys"}, {"id": 133, "detector": {"name": "aws_iam",
@@ -168,7 +173,7 @@ interactions:
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
-        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11885, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/133",
         "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
         [], "incident_name": "AWS IAM Keys"}, {"id": 160, "detector": {"name": "username_password",
@@ -182,7 +187,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "high", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        24, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        24, "severity_rule_id": 11897, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/160", "tags":
         ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE"],
@@ -198,7 +203,7 @@ interactions:
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
-        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11885, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/223",
         "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
         [], "incident_name": "AWS IAM Keys"}, {"id": 227, "detector": {"name": "generic_high_entropy_secret",
@@ -228,7 +233,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
-        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11885, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/245",
         "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
         [], "incident_name": "AWS IAM Keys"}, {"id": 252, "detector": {"name": "aws_iam",
@@ -242,7 +247,7 @@ interactions:
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
-        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11885, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/252",
         "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
         [], "incident_name": "AWS IAM Keys"}, {"id": 258, "detector": {"name": "aws_iam",
@@ -256,7 +261,7 @@ interactions:
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
-        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11885, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/258",
         "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
         [], "incident_name": "AWS IAM Keys"}, {"id": 381, "detector": {"name": "aws_iam",
@@ -270,7 +275,7 @@ interactions:
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
-        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11885, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/381",
         "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
         [], "incident_name": "AWS IAM Keys"}, {"id": 441, "detector": {"name": "basic_auth_string",
@@ -284,7 +289,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "high", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        20, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        20, "severity_rule_id": 11897, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/441", "tags":
         ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
@@ -300,7 +305,7 @@ interactions:
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
-        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11885, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/465",
         "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
         "destination_tickets": [], "incident_name": "AWS IAM Keys"}, {"id": 472, "detector":
@@ -314,19 +319,19 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
-        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11885, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/472",
         "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
         [], "incident_name": "AWS IAM Keys"}]'
     headers:
       CF-RAY:
-      - 9efb60b2daa42298-CDG
+      - a103961f7ac3a0cb-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:31:47 GMT
+      - Tue, 23 Jun 2026 12:44:51 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -338,7 +343,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '23510'
+      - '23865'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -353,17 +358,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '221'
+      - '230'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_incidents_multi_value_status.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_multi_value_status.yaml
@@ -29,12 +29,13 @@ interactions:
         2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z", "ignored_at":
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
-        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
-        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
-        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/2",
-        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
-        [], "incident_name": "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
         "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
         "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
         "detector_group_display_name": "GitGuardian Development Secret"}, "date":
@@ -73,9 +74,9 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -102,9 +103,9 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.747147Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/9", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -204,7 +205,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 0, "severity_rule_id":
-        10872, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11897, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/23",
         "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
         "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -219,7 +220,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "high", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        14, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        14, "severity_rule_id": 11897, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/24", "tags":
         ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
@@ -303,22 +304,22 @@ interactions:
         "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.766850Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/30", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
         "Slack Bot Token"}]'
     headers:
       CF-RAY:
-      - 9efb60ae1abb0283-CDG
+      - a103961bbdbde8ce-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:31:46 GMT
+      - Tue, 23 Jun 2026 12:44:50 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -330,7 +331,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '22810'
+      - '22842'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -345,17 +346,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '346'
+      - '92'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_incidents_multi_value_validity.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_multi_value_validity.yaml
@@ -20,10 +20,70 @@ interactions:
     uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=20&validity=valid%2Cfailed_to_check
   response:
     body:
-      string: '[{"id": 52, "detector": {"name": "aws_iam", "display_name": "AWS IAM
-        Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
-        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
-        Keys"}, "date": "2024-12-17T10:19:33Z", "secret_id": 14592883, "secret_hash":
+      string: '[{"id": 2, "detector": {"name": "slackbototken", "display_name": "Slack
+        Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash":
+        "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4", "hmsl_hash":
+        "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3", "occurrences_count":
+        2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 5, "detector": {"name": "slackbototken", "display_name":
+        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2024-05-24T12:18:15Z", "secret_id": 14592838, "secret_hash":
+        "Z5EChCcGXgX/eXhBjNhs4sGINbMdnzWjcD4m3l7naZmf7qCBOMgPzYhV28m6OGG4", "hmsl_hash":
+        "dc66b2a9c718f0d32581426943c736bfed9bcfd865c77712ca43d96faf97f731", "occurrences_count":
+        2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 9, "detector": {"name": "slackbototken", "display_name":
+        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2024-10-17T13:35:42Z", "secret_id": 14592842, "secret_hash":
+        "iPhCz0hiEKKcYiKnWwMgF+iE0K4tHJTBECUI1m+w7wJpZCyyOMgPzYhV28m6OGG4", "hmsl_hash":
+        "35764f7687c768b9e42ce14f6b7f4eece8d1cd71d4c63c8fd614b23a8e8c1c7d", "occurrences_count":
+        2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.747147Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/9", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 30, "detector": {"name": "slackbototken", "display_name":
+        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2022-09-01T12:15:30Z", "secret_id": 14592861, "secret_hash":
+        "UcHRteKCwroK47xMicSu6b7x3bMi6jvwgYV4DzuatWRC3HXYOMgPzYhV28m6OGG4", "hmsl_hash":
+        "6e9d452d4b21ac2c8f0cbefb99199985801619e77ad5e35f65d651320d9450a5", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.766850Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/30", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 52, "detector": {"name": "aws_iam", "display_name":
+        "AWS IAM Keys", "nature": "specific", "family": "credentials", "category":
+        "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2024-12-17T10:19:33Z", "secret_id": 14592883, "secret_hash":
         "jfpGRuRzwwkh+0rO1sdbA98K4zuSMBfQHlBIXMm5dQVFAmmDL4Qc71cZRqNcojMG", "hmsl_hash":
         "e50cad6b8e0ca71b4e13b0091d440308990047320f621fadabfb37916010e8ad", "occurrences_count":
         1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.777462Z", "ignored_at":
@@ -31,7 +91,7 @@ interactions:
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
-        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11885, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/52",
         "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
         [], "incident_name": "AWS IAM Keys"}, {"id": 57, "detector": {"name": "gitguardian_test_token_checked",
@@ -40,12 +100,17 @@ interactions:
         "detector_group_display_name": "GitGuardian Test Token Checked"}, "date":
         "2021-12-10T10:36:08Z", "secret_id": 7970357, "secret_hash": "cfDzN5RpdE7fN0bd474gxh8fBT9kKunY+sHOlD+OeXGzGAkSCxpDOKaZihAFaYMH",
         "hmsl_hash": "49b26d210036e493d068e32207ab35c98242c41d82db746b1342ef497560195e",
-        "occurrences_count": 187, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.015423Z",
+        "occurrences_count": 187, "status": "ASSIGNED", "triggered_at": "2025-01-07T18:06:03.015423Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
-        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 27, "severity_rule_id":
-        10866, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        false, "validity": "valid", "severity": "critical", "assignee_id": 1778296,
+        "assignee_email": "zeke@binion.io", "share_url": "[REDACTED]", "feedback_list":
+        [{"created_at": "2026-04-23T00:37:26.701645Z", "updated_at": "2026-04-23T00:37:26.701660Z",
+        "email": "zeke@binion.io", "member_id": 1778296, "answers": [{"type": "boolean",
+        "field_ref": "revoked_yes_no", "field_label": "Has this secret been revoked?",
+        "boolean": true}, {"type": "text", "field_ref": "remarks_text", "field_label":
+        "Additional remarks", "text": ""}]}], "risk_score": 27, "severity_rule_id":
+        11891, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/57",
         "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
         "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -60,7 +125,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "failed_to_check", "severity": "critical", "assignee_id":
         null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 45, "severity_rule_id": 10868, "is_vaulted": false, "declarative_secret_status":
+        [], "risk_score": 45, "severity_rule_id": 11893, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/59", "tags":
         ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
@@ -95,11 +160,26 @@ interactions:
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/65", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "OpenSSH Private Key"}, {"id": 68, "detector": {"name": "postgres_uri", "display_name":
-        "PostgreSQL Credentials", "nature": "specific", "family": "identifiers", "category":
-        "data_storage", "detector_group_name": "postgresql_credentials", "detector_group_display_name":
-        "PostgreSQL Credentials"}, "date": "2024-08-28T12:15:48Z", "secret_id": 14592891,
-        "secret_hash": "lF+MxnMY2/ZkB4HO/TO6YHoHoGaOW/4i4lKmY1kaxc7XeNG3CUnJ9mpXO6ItKClD",
+        "OpenSSH Private Key"}, {"id": 67, "detector": {"name": "slackbototken", "display_name":
+        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2024-08-28T12:15:48Z", "secret_id": 14592890, "secret_hash":
+        "ub2H92Ccdz63MpsMW90kDPr40He50n9puzfVShHqGtnRS9ENOMgPzYhV28m6OGG4", "hmsl_hash":
+        "6b7c037129d2a275d59205af0ef44d56947eb6005afa998ab013bf62eaf2f888", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.251954Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/67", "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Slack Bot Token"}, {"id": 68, "detector": {"name": "postgres_uri",
+        "display_name": "PostgreSQL Credentials", "nature": "specific", "family":
+        "identifiers", "category": "data_storage", "detector_group_name": "postgresql_credentials",
+        "detector_group_display_name": "PostgreSQL Credentials"}, "date": "2024-08-28T12:15:48Z",
+        "secret_id": 14592891, "secret_hash": "lF+MxnMY2/ZkB4HO/TO6YHoHoGaOW/4i4lKmY1kaxc7XeNG3CUnJ9mpXO6ItKClD",
         "hmsl_hash": "48b6704e05b6ac160f89d32be5951a29c8d6e08162853e0841313b16d446e308",
         "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.251954Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
@@ -140,193 +220,120 @@ interactions:
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/88", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "MongoDB Credentials"}, {"id": 123, "detector": {"name": "aws_iam", "display_name":
-        "AWS IAM Keys", "nature": "specific", "family": "credentials", "category":
-        "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
-        "AWS IAM Keys"}, "date": "2024-10-08T08:06:58Z", "secret_id": 14592939, "secret_hash":
-        "Ic0b2F+nC6t10UFsL2q4RoCOnxbICIPG8le5eLah1r7yCUW4L4Qc71cZRqNcojMG", "hmsl_hash":
-        "79daedb7dbd145002662f320d5b3497fe9f99eee48534675db9f85425e87c90f", "occurrences_count":
-        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.922766Z", "ignored_at":
+        "MongoDB Credentials"}, {"id": 89, "detector": {"name": "slackbototken", "display_name":
+        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2020-04-22T09:49:57Z", "secret_id": 14592913, "secret_hash":
+        "fWnrWNk4MmBtU1FQenCZOJqXnRUCgaH3noOJ6IKRWRqqL14LOMgPzYhV28m6OGG4", "hmsl_hash":
+        "fbd39b90cc537de83f12e4a637c72634127ac00086fd953d80c6d7f7ba7e6db1", "occurrences_count":
+        2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.373422Z", "ignored_at":
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
-        "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/89", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 90, "detector": {"name": "slackbototken", "display_name":
+        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2020-04-22T09:49:57Z", "secret_id": 14592914, "secret_hash":
+        "cQe8ajEoMuMfBIvITCxkMxKjZlGGi5TZjjVCiYgXOEKhxosXOMgPzYhV28m6OGG4", "hmsl_hash":
+        "43e3c03bbb89b7cb9fac180d8c56215f8b33c1d34a2d93ce964d91b60448ceb9", "occurrences_count":
+        5, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.373422Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/90", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 91, "detector": {"name": "slackbototken", "display_name":
+        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2022-09-01T09:21:38Z", "secret_id": 14592915, "secret_hash":
+        "BOFY0QrvRV889uyFw32tIB5xsd2svOAbx3n36ijPIB+tXe4LOMgPzYhV28m6OGG4", "hmsl_hash":
+        "3109d75522e3e8ce4b71decbad5f8ea95855da2ecf7bd5472013a97185e60ba2", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.402379Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/91", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 103, "detector": {"name": "slackbototken", "display_name":
+        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2021-10-28T09:38:30Z", "secret_id": 14592925, "secret_hash":
+        "CJlS8pKbJBiPiKwpp+xKyLtFdK2Bkp+eppiBFkGRHShCXw+FOMgPzYhV28m6OGG4", "hmsl_hash":
+        "4d4dd54195afc57be39d4c0a32e18d220ccac7afc075b94e4be20bd27248b8be", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.611201Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/103", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 111, "detector": {"name": "slackbototken", "display_name":
+        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2024-10-10T16:10:59Z", "secret_id": 14592930, "secret_hash":
+        "4nN6N5cCGTlASVI7ZOawD1YGFMmNAqq+SHiOkuAfwbqoAZW+OMgPzYhV28m6OGG4", "hmsl_hash":
+        "fff8332bae120ad18feb3048f99bdd814ab7b4499fc0e94c4f929febcdefa2fe", "occurrences_count":
+        4, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.702962Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/111", "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Slack Bot Token"}, {"id": 123, "detector": {"name":
+        "aws_iam", "display_name": "AWS IAM Keys", "nature": "specific", "family":
+        "credentials", "category": "cloud_provider", "detector_group_name": "aws_iam",
+        "detector_group_display_name": "AWS IAM Keys"}, "date": "2024-10-08T08:06:58Z",
+        "secret_id": 14592939, "secret_hash": "Ic0b2F+nC6t10UFsL2q4RoCOnxbICIPG8le5eLah1r7yCUW4L4Qc71cZRqNcojMG",
+        "hmsl_hash": "79daedb7dbd145002662f320d5b3497fe9f99eee48534675db9f85425e87c90f",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.922766Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
-        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11885, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/123",
         "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
-        [], "incident_name": "AWS IAM Keys"}, {"id": 133, "detector": {"name": "aws_iam",
-        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
-        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
-        "AWS IAM Keys"}, "date": "2023-06-20T17:37:11Z", "secret_id": 14592949, "secret_hash":
-        "xREUeCg4rijhFTi2xfwsH3UKQ1nmE772jLaXnIwSSQX13b29L4Qc71cZRqNcojMG", "hmsl_hash":
-        "cf6f1f93b8a8c05eaec32d63ea56648a7f72805a9cbb9250ba543bcf32e25685", "occurrences_count":
-        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.018836Z", "ignored_at":
-        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
-        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
-        "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
-        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
-        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/133",
-        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
-        [], "incident_name": "AWS IAM Keys"}, {"id": 142, "detector": {"name": "gitguardian_test_token_checked",
-        "display_name": "GitGuardian Test Token Checked", "nature": "specific", "family":
-        "token", "category": "internal", "detector_group_name": "gitguardian_test_token_checked",
-        "detector_group_display_name": "GitGuardian Test Token Checked"}, "date":
-        "2024-08-20T12:45:39Z", "secret_id": 14592957, "secret_hash": "F0v+rUbWNYEaACUQ7e+WD6aGK44ETtBdLu7hJcwYHwAmM46HCxpDOKaZihAFaYMH",
-        "hmsl_hash": "4a715e13b9ac2f1822fa5e59bb2b74ed57214806134df7b76b86e13f2b525b03",
-        "occurrences_count": 6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.191605Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "valid", "severity": "unknown", "assignee_id": null, "assignee_email":
-        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 60, "severity_rule_id":
-        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/142",
-        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
-        [], "incident_name": "GitGuardian Test Token Checked"}, {"id": 143, "detector":
-        {"name": "mssql_uri", "display_name": "MSSQL Credentials", "nature": "specific",
-        "family": "identifiers", "category": "data_storage", "detector_group_name":
-        "mssql_credentials", "detector_group_display_name": "MSSQL Credentials"},
-        "date": "2023-02-07T09:10:20Z", "secret_id": 14592958, "secret_hash": "rbZDKn/4BlHueVX5rt4aqKdBNU4Imx3PEoAYOYPW7ez+6oD5SOKbj7dSz86r4tjg",
-        "hmsl_hash": "42073f1dd8515706fa82e308821ce6041bb54867e08637073188a0ab58e3a0ed",
-        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.197186Z",
+        [], "incident_name": "AWS IAM Keys"}, {"id": 130, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2021-01-07T09:37:17Z", "secret_id": 14592946,
+        "secret_hash": "2llc7lT0uacTL5lboK6wSTNgM0yF6J/JLmUoCAZAzHa3wojsOMgPzYhV28m6OGG4",
+        "hmsl_hash": "a4639c0a9019c85261f442cb4f15e7e665926d96d137753eb41b72adcbea0cee",
+        "occurrences_count": 5, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.957411Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
         null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 84, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/143", "tags":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/130", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "MSSQL Credentials"}, {"id": 144, "detector": {"name": "private_key_rsa",
-        "display_name": "RSA Private Key", "nature": "specific", "family": "cryptographic_key",
-        "category": "private_key", "detector_group_name": "private_key_rsa", "detector_group_display_name":
-        "RSA Private Key"}, "date": "2019-08-27T13:49:27Z", "secret_id": 14592959,
-        "secret_hash": "Asl87g6YNF0Eg9O5vuHiufJwUcx3N8BLJwdgXTqNbsTgRNRP7vN5xZFHxYj+duJV",
-        "hmsl_hash": "082e33472a66c8f92ad328cec850af560b4151e9279c023eae97fed0fbec9ef7",
-        "occurrences_count": 23, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.198512Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
-        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 40, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
-        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/144", "tags":
-        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "RSA Private Key"}, {"id": 150, "detector": {"name": "private_key_rsa", "display_name":
-        "RSA Private Key", "nature": "specific", "family": "cryptographic_key", "category":
-        "private_key", "detector_group_name": "private_key_rsa", "detector_group_display_name":
-        "RSA Private Key"}, "date": "2023-03-03T12:22:41Z", "secret_id": 14592965,
-        "secret_hash": "CuE9V4B3m6qXIGeiHuGTt4ArL0YZ8/zhxBtyQ5BxbACxYtV77vN5xZFHxYj+duJV",
-        "hmsl_hash": "6ceb5f733b0d2ac2f5ad791774a394506e711c4a87cc3e4db4d4fac7cdf02e39",
-        "occurrences_count": 6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.228591Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
-        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 40, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
-        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/150", "tags":
-        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "RSA Private Key"}, {"id": 151, "detector": {"name": "private_key_rsa", "display_name":
-        "RSA Private Key", "nature": "specific", "family": "cryptographic_key", "category":
-        "private_key", "detector_group_name": "private_key_rsa", "detector_group_display_name":
-        "RSA Private Key"}, "date": "2023-03-03T12:22:41Z", "secret_id": 14592966,
-        "secret_hash": "OgPnWBLzMtToimbkAVK+rQANyGlRbK/HfJ2SljRmtAJzIUDV7vN5xZFHxYj+duJV",
-        "hmsl_hash": "3676511484824d2ac6eb79564d520de56a8096f3d5a82538c3bf19d4da28070b",
-        "occurrences_count": 6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.228591Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
-        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 40, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
-        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/151", "tags":
-        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "RSA Private Key"}, {"id": 152, "detector": {"name": "private_key_rsa", "display_name":
-        "RSA Private Key", "nature": "specific", "family": "cryptographic_key", "category":
-        "private_key", "detector_group_name": "private_key_rsa", "detector_group_display_name":
-        "RSA Private Key"}, "date": "2023-03-03T12:22:41Z", "secret_id": 14592967,
-        "secret_hash": "CGOhyo4C8c3ez6u83GtxIGKtTL2S0qXMEYWqB85KUQrSEK2S7vN5xZFHxYj+duJV",
-        "hmsl_hash": "681241c9b9a3c912fbb646c364c3581b9b4f60c3b6072ddb858d80dc077c3fbd",
-        "occurrences_count": 6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.228591Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
-        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 40, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
-        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/152", "tags":
-        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "RSA Private Key"}, {"id": 153, "detector": {"name": "private_key_rsa", "display_name":
-        "RSA Private Key", "nature": "specific", "family": "cryptographic_key", "category":
-        "private_key", "detector_group_name": "private_key_rsa", "detector_group_display_name":
-        "RSA Private Key"}, "date": "2023-03-03T12:22:41Z", "secret_id": 14592968,
-        "secret_hash": "sSRGBc0f6EmyrCha1/ZancNIk/PktDGcSR6pMNjUvcmTi00b7vN5xZFHxYj+duJV",
-        "hmsl_hash": "d52a4a1cf8ff25f8db4b179bff876c5af86763b5404a1acf9abdc4a0e5601ae5",
-        "occurrences_count": 6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.228591Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
-        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 40, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
-        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/153", "tags":
-        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "RSA Private Key"}, {"id": 154, "detector": {"name": "private_key_rsa", "display_name":
-        "RSA Private Key", "nature": "specific", "family": "cryptographic_key", "category":
-        "private_key", "detector_group_name": "private_key_rsa", "detector_group_display_name":
-        "RSA Private Key"}, "date": "2023-03-03T12:22:41Z", "secret_id": 14592969,
-        "secret_hash": "Dprh43QI8+tyHgURzFexd4Y1VF7zxneSq3RoNHlqctHC8L8d7vN5xZFHxYj+duJV",
-        "hmsl_hash": "24c1586f483de5bb60d7d3a84e40946caf6bd1fafd02e5404da21e05b51a0ddc",
-        "occurrences_count": 6, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.228591Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
-        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 40, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
-        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/154", "tags":
-        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "RSA Private Key"}, {"id": 163, "detector": {"name": "mongo_assignment", "display_name":
-        "MongoDB Credentials", "nature": "specific", "family": "identifiers", "category":
-        "data_storage", "detector_group_name": "mongodb_credentials", "detector_group_display_name":
-        "MongoDB Credentials"}, "date": "2019-02-08T16:07:48Z", "secret_id": 14592978,
-        "secret_hash": "C3gnyszrLlSvO/OeLPO+jKK3YINX0nxmhewzX/eAFEnZ7EUqMHFU8eOMXjXgylmC",
-        "hmsl_hash": "c13f266a750e709a57596c9bda6ea8b0e9dc9357e5a069935095c36980b2e0fd",
-        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.301115Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
-        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 84, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
-        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/163", "tags":
-        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "MongoDB Credentials"}, {"id": 164, "detector": {"name": "gitguardian_prm_key",
-        "display_name": "GitGuardian Internal Monitoring Key", "nature": "specific",
-        "family": "token", "category": "monitoring", "detector_group_name": "gitguardian_prm_key",
-        "detector_group_display_name": "GitGuardian Internal Monitoring Key"}, "date":
-        "2020-07-13T14:36:30Z", "secret_id": 14592979, "secret_hash": "tMxCCJ2Jw+yHkTkj+mV6Q4KRx/JwlWQCqcUrP27AkuioOTkXhDo2sD+4lbVkOcLB",
-        "hmsl_hash": "f27dd7388c3b707115128aa98efabb86d5fa7c2ed789fd7c123c66fc7021c6ed",
-        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:04.359134Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
-        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 42, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
-        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/164", "tags":
-        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "GitGuardian Internal Monitoring Key"}]'
+        "Slack Bot Token"}]'
     headers:
       CF-RAY:
-      - 9efb60b7092f2c0b-CDG
+      - a10396234ffb9e91-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:31:48 GMT
+      - Tue, 23 Jun 2026 12:44:51 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -338,13 +345,13 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '23448'
+      - '23632'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
       - same-origin
       link:
-      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0xNjQ%3D&per_page=20&validity=valid%2Cfailed_to_check>;
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0xMzA%3D&per_page=20&validity=valid%2Cfailed_to_check>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
@@ -353,17 +360,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '100'
+      - '99'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_assignee_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_assignee_filter.yaml
@@ -20,26 +20,108 @@ interactions:
     uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=20&status=ASSIGNED
   response:
     body:
-      string: '[]'
+      string: '[{"id": 57, "detector": {"name": "gitguardian_test_token_checked",
+        "display_name": "GitGuardian Test Token Checked", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token_checked",
+        "detector_group_display_name": "GitGuardian Test Token Checked"}, "date":
+        "2021-12-10T10:36:08Z", "secret_id": 7970357, "secret_hash": "cfDzN5RpdE7fN0bd474gxh8fBT9kKunY+sHOlD+OeXGzGAkSCxpDOKaZihAFaYMH",
+        "hmsl_hash": "49b26d210036e493d068e32207ab35c98242c41d82db746b1342ef497560195e",
+        "occurrences_count": 187, "status": "ASSIGNED", "triggered_at": "2025-01-07T18:06:03.015423Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "critical", "assignee_id": 1778296,
+        "assignee_email": "zeke@binion.io", "share_url": "[REDACTED]", "feedback_list":
+        [{"created_at": "2026-04-23T00:37:26.701645Z", "updated_at": "2026-04-23T00:37:26.701660Z",
+        "email": "zeke@binion.io", "member_id": 1778296, "answers": [{"type": "boolean",
+        "field_ref": "revoked_yes_no", "field_label": "Has this secret been revoked?",
+        "boolean": true}, {"type": "text", "field_ref": "remarks_text", "field_label":
+        "Additional remarks", "text": ""}]}], "risk_score": 27, "severity_rule_id":
+        11891, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/57",
+        "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Test Token Checked"}, {"id": 2816, "detector": {"name": "postgres_assignment_attached_port",
+        "display_name": "PostgreSQL Credentials", "nature": "specific", "family":
+        "identifiers", "category": "data_storage", "detector_group_name": "postgresql_credentials",
+        "detector_group_display_name": "PostgreSQL Credentials"}, "date": "2023-02-15T14:47:35Z",
+        "secret_id": 6608759, "secret_hash": "i/hwSGTtVTth0XrZbsg40m1CTTZOW/mZhf2/9VbpC/6mLCFlkwaXJ+SYISDbzGjw",
+        "hmsl_hash": "a70052862d08d1c087c292e91f422614c69c90daf6f177af4f7b3b1cb325d702",
+        "occurrences_count": 1, "status": "ASSIGNED", "triggered_at": "2025-01-07T18:07:49.067090Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        269050, "assignee_email": "achille.mascia@gitguardian.com", "share_url": "[REDACTED]",
+        "feedback_list": [], "risk_score": 84, "severity_rule_id": null, "is_vaulted":
+        false, "declarative_secret_status": "active", "resolve_reason": null, "ignore_reason":
+        null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/2816",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "PostgreSQL Credentials"}, {"id":
+        1965689, "detector": {"name": "username_password", "display_name": "Username
+        Password", "nature": "generic", "family": "other", "category": "other", "detector_group_name":
+        "username_password", "detector_group_display_name": "Username Password"},
+        "date": "2026-05-14T12:25:53Z", "secret_id": 32601569, "secret_hash": "Prcd+9rYpuYBxwJxBt+E++RO850oPMI2m+mgPT4dAzzUAyoGP4G6lsSULyTx/pbN",
+        "hmsl_hash": "af45447beb31cca5cced133291285ff868da14ecb05c8a888e9712cca475928b",
+        "occurrences_count": 1, "status": "ASSIGNED", "triggered_at": "2026-05-14T12:31:54.372745Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "no_checker", "severity": "unknown", "assignee_id": 795293,
+        "assignee_email": "yanne.bensafia@gitguardian.com", "share_url": "[REDACTED]",
+        "feedback_list": [], "risk_score": 53, "severity_rule_id": null, "is_vaulted":
+        false, "declarative_secret_status": "active", "resolve_reason": null, "ignore_reason":
+        null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1965689",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Username Password"}, {"id": 2171929, "detector": {"name": "asana_access_token",
+        "display_name": "Asana Key", "nature": "specific", "family": "token", "category":
+        "collaboration_tool", "detector_group_name": "asana_access_token", "detector_group_display_name":
+        "Asana Key"}, "date": "2026-05-20T08:15:06Z", "secret_id": 32960996, "secret_hash":
+        "x5jLcns+8oqLHpL6OVrtwqAva3HriqHxbBPogO1PCY64ynpb/5YCUcBVz6EmTEcj", "hmsl_hash":
+        "6db8a453c7b1f9c86f2399e2bc96ea617749b94855dbd14f739aa767fc5f3e01", "occurrences_count":
+        2, "status": "ASSIGNED", "triggered_at": "2026-05-20T08:20:12.896567Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": 795293, "assignee_email":
+        "yanne.bensafia@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2171929",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Asana Key"}, {"id": 2174697, "detector": {"name": "asana_access_token", "display_name":
+        "Asana Key", "nature": "specific", "family": "token", "category": "collaboration_tool",
+        "detector_group_name": "asana_access_token", "detector_group_display_name":
+        "Asana Key"}, "date": "2026-05-20T08:24:40Z", "secret_id": 32964274, "secret_hash":
+        "efDFonOFCBMZ0ZwcL4L0xi1Kbwnf3ld2M23i7vqPOwUAGXjo/5YCUcBVz6EmTEcj", "hmsl_hash":
+        "eb0b76a61746c5f8981c7782b90bffa8afd1a1f032fb67cf032f27691e46f685", "occurrences_count":
+        2, "status": "ASSIGNED", "triggered_at": "2026-05-20T08:30:46.126558Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": 795293, "assignee_email":
+        "yanne.bensafia@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2174697",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Asana Key"}]'
     headers:
       CF-RAY:
-      - 9efb6ddf5ff5d125-CDG
+      - a103962bba7d7015-CDG
       Connection:
       - keep-alive
-      Content-Length:
-      - '2'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:46 GMT
+      - Tue, 23 Jun 2026 12:44:52 GMT
       Server:
       - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
       cf-cache-status:
       - DYNAMIC
+      content-length:
+      - '6333'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -53,17 +135,109 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '151'
+      - '102'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=5&assignee_id=1778296
+  response:
+    body:
+      string: '[{"id": 57, "detector": {"name": "gitguardian_test_token_checked",
+        "display_name": "GitGuardian Test Token Checked", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token_checked",
+        "detector_group_display_name": "GitGuardian Test Token Checked"}, "date":
+        "2021-12-10T10:36:08Z", "secret_id": 7970357, "secret_hash": "cfDzN5RpdE7fN0bd474gxh8fBT9kKunY+sHOlD+OeXGzGAkSCxpDOKaZihAFaYMH",
+        "hmsl_hash": "49b26d210036e493d068e32207ab35c98242c41d82db746b1342ef497560195e",
+        "occurrences_count": 187, "status": "ASSIGNED", "triggered_at": "2025-01-07T18:06:03.015423Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "critical", "assignee_id": 1778296,
+        "assignee_email": "zeke@binion.io", "share_url": "[REDACTED]", "feedback_list":
+        [{"created_at": "2026-04-23T00:37:26.701645Z", "updated_at": "2026-04-23T00:37:26.701660Z",
+        "email": "zeke@binion.io", "member_id": 1778296, "answers": [{"type": "boolean",
+        "field_ref": "revoked_yes_no", "field_label": "Has this secret been revoked?",
+        "boolean": true}, {"type": "text", "field_ref": "remarks_text", "field_label":
+        "Additional remarks", "text": ""}]}], "risk_score": 27, "severity_rule_id":
+        11891, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/57",
+        "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Test Token Checked"}]'
+    headers:
+      CF-RAY:
+      - a103962de928d62e-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:44:53 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1631'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '63'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_cursor.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_cursor.yaml
@@ -37,13 +37,13 @@ interactions:
         "destination_tickets": [], "incident_name": "Stripe Keys"}]'
     headers:
       CF-RAY:
-      - 9ef488d96c25d877-CDG
+      - a103964beaf12a76-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:35:51 GMT
+      - Tue, 23 Jun 2026 12:44:57 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -70,17 +70,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '68'
+      - '54'
       x-frame-options:
       - DENY
       x-per-page:
       - '1'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -116,21 +116,22 @@ interactions:
         2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z", "ignored_at":
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
-        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
-        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
-        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/2",
-        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
-        [], "incident_name": "Slack Bot Token"}]'
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}]'
     headers:
       CF-RAY:
-      - 9ef488dbae346fbe-CDG
+      - a103964dddffbb60-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:35:51 GMT
+      - Tue, 23 Jun 2026 12:44:58 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -142,7 +143,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '1137'
+      - '1145'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -158,17 +159,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '72'
+      - '69'
       x-frame-options:
       - DENY
       x-per-page:
       - '1'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_date_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_date_filter.yaml
@@ -29,23 +29,24 @@ interactions:
         2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z", "ignored_at":
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
-        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
-        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
-        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/2",
-        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
-        [], "incident_name": "Slack Bot Token"}, {"id": 5, "detector": {"name": "slackbototken",
-        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
-        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
-        "Slack Bot Token"}, "date": "2024-05-24T12:18:15Z", "secret_id": 14592838,
-        "secret_hash": "Z5EChCcGXgX/eXhBjNhs4sGINbMdnzWjcD4m3l7naZmf7qCBOMgPzYhV28m6OGG4",
-        "hmsl_hash": "dc66b2a9c718f0d32581426943c736bfed9bcfd865c77712ca43d96faf97f731",
-        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 5, "detector": {"name": "slackbototken", "display_name":
+        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2024-05-24T12:18:15Z", "secret_id": 14592838, "secret_hash":
+        "Z5EChCcGXgX/eXhBjNhs4sGINbMdnzWjcD4m3l7naZmf7qCBOMgPzYhV28m6OGG4", "hmsl_hash":
+        "dc66b2a9c718f0d32581426943c736bfed9bcfd865c77712ca43d96faf97f731", "occurrences_count":
+        2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -58,14 +59,15 @@ interactions:
         2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.747147Z", "ignored_at":
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
-        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
-        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
-        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/9",
-        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
-        [], "incident_name": "Slack Bot Token"}, {"id": 31, "detector": {"name": "aws_iam",
-        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
-        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/9", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 31, "detector": {"name": "aws_iam", "display_name":
+        "AWS IAM Keys", "nature": "specific", "family": "credentials", "category":
+        "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
         "AWS IAM Keys"}, "date": "2024-02-19T18:20:22Z", "secret_id": 14592862, "secret_hash":
         "MTwOa4AC8TReqOFMxheHde6NFJU3x7jjFIVroYu+vnbjFmSaL4Qc71cZRqNcojMG", "hmsl_hash":
         "1ad609288e2035eaeb06724530512ceb58d201cb452c0c17ab21a87a0517eed6", "occurrences_count":
@@ -94,13 +96,13 @@ interactions:
         [], "incident_name": "AWS IAM Keys"}]'
     headers:
       CF-RAY:
-      - 9ef486fae97a8156-CDG
+      - a103962699d94742-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:34 GMT
+      - Tue, 23 Jun 2026 12:44:51 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -112,7 +114,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '5647'
+      - '5671'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -127,17 +129,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '68'
+      - '60'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_declarative_secret_status.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_declarative_secret_status.yaml
@@ -94,13 +94,13 @@ interactions:
         "destination_tickets": [], "incident_name": "AWS IAM Keys"}]'
     headers:
       CF-RAY:
-      - 9ef4870c583499dc-CDG
+      - a10396448c3702c7-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:37 GMT
+      - Tue, 23 Jun 2026 12:44:56 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -127,17 +127,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '146'
+      - '79'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_detector_group_name.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_detector_group_name.yaml
@@ -29,23 +29,24 @@ interactions:
         2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z", "ignored_at":
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
-        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
-        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
-        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/2",
-        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
-        [], "incident_name": "Slack Bot Token"}, {"id": 5, "detector": {"name": "slackbototken",
-        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
-        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
-        "Slack Bot Token"}, "date": "2024-05-24T12:18:15Z", "secret_id": 14592838,
-        "secret_hash": "Z5EChCcGXgX/eXhBjNhs4sGINbMdnzWjcD4m3l7naZmf7qCBOMgPzYhV28m6OGG4",
-        "hmsl_hash": "dc66b2a9c718f0d32581426943c736bfed9bcfd865c77712ca43d96faf97f731",
-        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 5, "detector": {"name": "slackbototken", "display_name":
+        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2024-05-24T12:18:15Z", "secret_id": 14592838, "secret_hash":
+        "Z5EChCcGXgX/eXhBjNhs4sGINbMdnzWjcD4m3l7naZmf7qCBOMgPzYhV28m6OGG4", "hmsl_hash":
+        "dc66b2a9c718f0d32581426943c736bfed9bcfd865c77712ca43d96faf97f731", "occurrences_count":
+        2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -58,23 +59,24 @@ interactions:
         2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.747147Z", "ignored_at":
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
-        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
-        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
-        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/9",
-        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
-        [], "incident_name": "Slack Bot Token"}, {"id": 30, "detector": {"name": "slackbototken",
-        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
-        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
-        "Slack Bot Token"}, "date": "2022-09-01T12:15:30Z", "secret_id": 14592861,
-        "secret_hash": "UcHRteKCwroK47xMicSu6b7x3bMi6jvwgYV4DzuatWRC3HXYOMgPzYhV28m6OGG4",
-        "hmsl_hash": "6e9d452d4b21ac2c8f0cbefb99199985801619e77ad5e35f65d651320d9450a5",
-        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.766850Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/9", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 30, "detector": {"name": "slackbototken", "display_name":
+        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2022-09-01T12:15:30Z", "secret_id": 14592861, "secret_hash":
+        "UcHRteKCwroK47xMicSu6b7x3bMi6jvwgYV4DzuatWRC3HXYOMgPzYhV28m6OGG4", "hmsl_hash":
+        "6e9d452d4b21ac2c8f0cbefb99199985801619e77ad5e35f65d651320d9450a5", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.766850Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/30", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -96,13 +98,13 @@ interactions:
         [], "incident_name": "Slack Bot Token"}]'
     headers:
       CF-RAY:
-      - 9ef48703ee6f701a-CDG
+      - a1039635cea7ff34-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:36 GMT
+      - Tue, 23 Jun 2026 12:44:54 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -114,7 +116,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '5748'
+      - '5780'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -129,17 +131,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '111'
+      - '76'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_feedback.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_feedback.yaml
@@ -20,10 +20,30 @@ interactions:
     uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=5&feedback=true
   response:
     body:
-      string: '[{"id": 6987, "detector": {"name": "aws_iam", "display_name": "AWS
-        IAM Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
-        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
-        Keys"}, "date": "2025-02-06T13:11:21Z", "secret_id": 14955862, "secret_hash":
+      string: '[{"id": 57, "detector": {"name": "gitguardian_test_token_checked",
+        "display_name": "GitGuardian Test Token Checked", "nature": "specific", "family":
+        "token", "category": "internal", "detector_group_name": "gitguardian_test_token_checked",
+        "detector_group_display_name": "GitGuardian Test Token Checked"}, "date":
+        "2021-12-10T10:36:08Z", "secret_id": 7970357, "secret_hash": "cfDzN5RpdE7fN0bd474gxh8fBT9kKunY+sHOlD+OeXGzGAkSCxpDOKaZihAFaYMH",
+        "hmsl_hash": "49b26d210036e493d068e32207ab35c98242c41d82db746b1342ef497560195e",
+        "occurrences_count": 187, "status": "ASSIGNED", "triggered_at": "2025-01-07T18:06:03.015423Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "critical", "assignee_id": 1778296,
+        "assignee_email": "zeke@binion.io", "share_url": "[REDACTED]", "feedback_list":
+        [{"created_at": "2026-04-23T00:37:26.701645Z", "updated_at": "2026-04-23T00:37:26.701660Z",
+        "email": "zeke@binion.io", "member_id": 1778296, "answers": [{"type": "boolean",
+        "field_ref": "revoked_yes_no", "field_label": "Has this secret been revoked?",
+        "boolean": true}, {"type": "text", "field_ref": "remarks_text", "field_label":
+        "Additional remarks", "text": ""}]}], "risk_score": 27, "severity_rule_id":
+        11891, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/57",
+        "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "GitGuardian Test Token Checked"}, {"id": 6987, "detector": {"name": "aws_iam",
+        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
+        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2025-02-06T13:11:21Z", "secret_id": 14955862, "secret_hash":
         "kk/auvq83sqNMAD36RivDckUaWd4ApXgmnqrw+x7idvGjJAzL4Qc71cZRqNcojMG", "hmsl_hash":
         "4ff38bc8f1670f5a260989ea723e576278bafa82a2524902093bddbf3b8c054e", "occurrences_count":
         5, "status": "TRIGGERED", "triggered_at": "2025-02-06T13:16:24.742696Z", "ignored_at":
@@ -35,7 +55,7 @@ interactions:
         "member_id": 937472, "answers": [{"type": "boolean", "field_ref": "revoked_yes_no",
         "field_label": "Has this secret been revoked?", "boolean": true}, {"type":
         "text", "field_ref": "remarks_text", "field_label": "Additional remarks",
-        "text": ""}]}], "risk_score": 97, "severity_rule_id": 10860, "is_vaulted":
+        "text": ""}]}], "risk_score": 97, "severity_rule_id": 11885, "is_vaulted":
         false, "declarative_secret_status": "active", "resolve_reason": null, "ignore_reason":
         null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/6987",
         "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -59,16 +79,56 @@ interactions:
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/286920", "tags":
         [], "custom_tags": [], "destination_tickets": [], "incident_name": "Amazon
-        AWS Credentials"}]'
+        AWS Credentials"}, {"id": 1554830, "detector": {"name": "generic_high_entropy_secret",
+        "display_name": "Generic High Entropy Secret", "nature": "generic", "family":
+        "other", "category": "other", "detector_group_name": "generic_high_entropy_secret",
+        "detector_group_display_name": "Generic High Entropy Secret"}, "date": "2026-03-27T18:11:26Z",
+        "secret_id": 30166297, "secret_hash": "PGGOlbTiQZGqXXA3Vj88RduN0f+72Aha3hUU4MwsiKW7Qj8dp+KkPCNpyNbtXqJM",
+        "hmsl_hash": "e2d81242e3b11cd65b823f92e2dde252dadd99821d401c06f00a8b08994d6e54",
+        "occurrences_count": 18, "status": "IGNORED", "triggered_at": "2026-03-27T18:16:57.754167Z",
+        "ignored_at": "2026-04-27T11:43:00.636684Z", "ignorer_id": 790733, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "low", "assignee_id":
+        790733, "assignee_email": "romain.jouhannet@gitguardian.com", "share_url":
+        "[REDACTED]", "feedback_list": [{"created_at": "2026-04-27T11:34:43.510449Z",
+        "updated_at": "2026-04-27T11:34:43.510469Z", "email": "romain.jouhannet@gitguardian.com",
+        "member_id": 790733, "answers": [{"type": "boolean", "field_ref": "revoked_yes_no",
+        "field_label": "Has this secret been revoked?", "boolean": false}, {"type":
+        "text", "field_ref": "remarks_text", "field_label": "Additional remarks",
+        "text": "hello world 2"}]}], "risk_score": 9, "severity_rule_id": null, "is_vaulted":
+        false, "declarative_secret_status": "fp", "resolve_reason": null, "ignore_reason":
+        "false_positive", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1554830",
+        "tags": ["FALSE_POSITIVE"], "custom_tags": [], "destination_tickets": [],
+        "incident_name": "Generic High Entropy Secret"}, {"id": 2268786, "detector":
+        {"name": "openai_apikey", "display_name": "OpenAI API Key", "nature": "specific",
+        "family": "token", "category": "ai", "detector_group_name": "openai_apikey",
+        "detector_group_display_name": "OpenAI API Key"}, "date": "2026-05-29T05:03:46Z",
+        "secret_id": 33497976, "secret_hash": "+clEGvuyd9XKpD04OzDCWviJivsV0XKnMcYyUenUhZm+Db3Q95GRLqiXIWrK60u6",
+        "hmsl_hash": "dd49b2d58b151dc16df4c6b7905178d2c3825001b80641310d3f2695222c80c6",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2026-05-29T05:10:28.967226Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [{"created_at":
+        "2026-06-03T08:25:41.332652Z", "updated_at": "2026-06-03T08:25:41.332665Z",
+        "email": "romain.jouhannet@gitguardian.com", "member_id": 790733, "answers":
+        [{"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
+        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
+        "field_label": "Additional remarks", "text": "Hello <@M319222>"}]}], "risk_score":
+        6, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2268786",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "OpenAI API Key"}]'
     headers:
       CF-RAY:
-      - 9ef48709df860b18-CDG
+      - a10396425cf50080-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:37 GMT
+      - Tue, 23 Jun 2026 12:44:56 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -80,13 +140,14 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '3020'
+      - '7761'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
       - same-origin
       link:
-      - ''
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0yMjY4Nzg2&feedback=true&per_page=5>;
+        rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -94,17 +155,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '79'
+      - '101'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_ignorer_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_ignorer_filter.yaml
@@ -327,13 +327,13 @@ interactions:
         [], "incident_name": "Authentication Tuple"}]'
     headers:
       CF-RAY:
-      - 9efb6de7dd36d6e2-CDG
+      - a1039637cf7f9ef5-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:48 GMT
+      - Tue, 23 Jun 2026 12:44:54 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -360,17 +360,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '233'
+      - '93'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -478,13 +478,13 @@ interactions:
         "destination_tickets": [], "incident_name": "SendGrid Token"}]'
     headers:
       CF-RAY:
-      - 9efb6dec3987d155-CDG
+      - a103963abb72d5d1-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:49 GMT
+      - Tue, 23 Jun 2026 12:44:55 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -511,17 +511,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '149'
+      - '101'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_ordering.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_ordering.yaml
@@ -31,7 +31,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 100, "severity_rule_id":
-        10861, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11886, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/5208",
         "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
         [], "incident_name": "DigitalOcean Token"}, {"id": 5207, "detector": {"name":
@@ -45,10 +45,39 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 100, "severity_rule_id":
-        10861, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11886, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/5207",
         "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
-        [], "incident_name": "DigitalOcean Token"}, {"id": 1142573, "detector": {"name":
+        [], "incident_name": "DigitalOcean Token"}, {"id": 6431, "detector": {"name":
+        "github_oauth_app_keys", "display_name": "GitHub OAuth App Keys", "nature":
+        "specific", "family": "credentials", "category": "version_control_platform",
+        "detector_group_name": "github_oauth_app_keys", "detector_group_display_name":
+        "GitHub OAuth App Keys"}, "date": "2023-03-06T02:22:30Z", "secret_id": 14598994,
+        "secret_hash": "rguvfdbCkXIEiTcPcvvaKSTDL7C5GooKsnQSRXZ2KYadm7wi26bvJ9LImJ7n1yqO",
+        "hmsl_hash": "984f3c5814706bf57aad59c4a55aa353b4f87e111faf7d8262d6452445f5528c",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:12:04.175957Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 99, "severity_rule_id":
+        11887, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/6431",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "GitHub OAuth App Keys"}, {"id": 6430, "detector": {"name":
+        "bitbucket_keys", "display_name": "Bitbucket Keys", "nature": "specific",
+        "family": "credentials", "category": "version_control_platform", "detector_group_name":
+        "bitbucket_keys", "detector_group_display_name": "Bitbucket Keys"}, "date":
+        "2023-03-06T02:22:30Z", "secret_id": 14598993, "secret_hash": "yVPk7/jXGjdN/GD51ZJVnAQGVLZp9OYkO5cNnoGIrw5N2hr6zxp9ieZfVrZIohiA",
+        "hmsl_hash": "be8bf8e2501a998c2910851ea4aa8dd70fafb9fdb942bdff1c168fab708c0596",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:12:04.175957Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 99, "severity_rule_id":
+        11887, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/6430",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Bitbucket Keys"}, {"id": 1142573, "detector": {"name":
         "gitlab_personal_token_v2", "display_name": "GitLab Token", "nature": "specific",
         "family": "token", "category": "version_control_platform", "detector_group_name":
         "gitlab_token", "detector_group_display_name": "GitLab Token"}, "date": "2026-01-20T12:25:14Z",
@@ -63,44 +92,16 @@ interactions:
         "revoked", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/1142573",
         "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "GitLab Token"}, {"id": 6431, "detector": {"name": "github_oauth_app_keys",
-        "display_name": "GitHub OAuth App Keys", "nature": "specific", "family": "credentials",
-        "category": "version_control_platform", "detector_group_name": "github_oauth_app_keys",
-        "detector_group_display_name": "GitHub OAuth App Keys"}, "date": "2023-03-06T02:22:30Z",
-        "secret_id": 14598994, "secret_hash": "rguvfdbCkXIEiTcPcvvaKSTDL7C5GooKsnQSRXZ2KYadm7wi26bvJ9LImJ7n1yqO",
-        "hmsl_hash": "984f3c5814706bf57aad59c4a55aa353b4f87e111faf7d8262d6452445f5528c",
-        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:12:04.175957Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
-        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 99, "severity_rule_id":
-        10862, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/6431",
-        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
-        [], "incident_name": "GitHub OAuth App Keys"}, {"id": 6430, "detector": {"name":
-        "bitbucket_keys", "display_name": "Bitbucket Keys", "nature": "specific",
-        "family": "credentials", "category": "version_control_platform", "detector_group_name":
-        "bitbucket_keys", "detector_group_display_name": "Bitbucket Keys"}, "date":
-        "2023-03-06T02:22:30Z", "secret_id": 14598993, "secret_hash": "yVPk7/jXGjdN/GD51ZJVnAQGVLZp9OYkO5cNnoGIrw5N2hr6zxp9ieZfVrZIohiA",
-        "hmsl_hash": "be8bf8e2501a998c2910851ea4aa8dd70fafb9fdb942bdff1c168fab708c0596",
-        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:12:04.175957Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
-        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 99, "severity_rule_id":
-        10862, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/6430",
-        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
-        [], "incident_name": "Bitbucket Keys"}]'
+        "GitLab Token"}]'
     headers:
       CF-RAY:
-      - 9ef487113db5023e-CDG
+      - a10396487fe7a289-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:38 GMT
+      - Tue, 23 Jun 2026 12:44:57 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -112,7 +113,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '5823'
+      - '5840'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -127,17 +128,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '399'
+      - '270'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_resolver_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_resolver_filter.yaml
@@ -315,13 +315,13 @@ interactions:
         "incident_name": "PostgreSQL Credentials"}]'
     headers:
       CF-RAY:
-      - 9efb6deeca6501cc-CDG
+      - a103963cf850ebb1-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:49 GMT
+      - Tue, 23 Jun 2026 12:44:55 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -348,17 +348,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '148'
+      - '120'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -459,13 +459,13 @@ interactions:
         "destination_tickets": [], "incident_name": "AWS IAM Keys"}]'
     headers:
       CF-RAY:
-      - 9efb6df26ef1f170-CDG
+      - a10396404d63c46a-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:49 GMT
+      - Tue, 23 Jun 2026 12:44:55 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -492,17 +492,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '91'
+      - '79'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_risk_score.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_risk_score.yaml
@@ -76,7 +76,7 @@ interactions:
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
-        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11885, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/52",
         "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
         [], "incident_name": "AWS IAM Keys"}, {"id": 63, "detector": {"name": "generic_high_entropy_secret",
@@ -97,13 +97,13 @@ interactions:
         "Generic High Entropy Secret"}]'
     headers:
       CF-RAY:
-      - 9ef4870efd38bb22-CDG
+      - a1039646894ed140-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:38 GMT
+      - Tue, 23 Jun 2026 12:44:56 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -130,17 +130,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '91'
+      - '84'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_severity_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_severity_filter.yaml
@@ -31,7 +31,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 0, "severity_rule_id":
-        10872, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11897, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/23",
         "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
         "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -46,7 +46,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "high", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        14, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        14, "severity_rule_id": 11897, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/24", "tags":
         ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
@@ -62,7 +62,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "high", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        0, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        0, "severity_rule_id": 11897, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/64", "tags":
         ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "IS_COMPANY_CONTEXT",
@@ -78,7 +78,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "high", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        9, "severity_rule_id": 10877, "is_vaulted": true, "declarative_secret_status":
+        9, "severity_rule_id": 11902, "is_vaulted": true, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/122", "tags":
         ["FROM_HISTORICAL_SCAN", "SENSITIVE_FILE", "INTERNALLY_LEAKED"], "custom_tags":
@@ -93,20 +93,20 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "high", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        24, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        24, "severity_rule_id": 11897, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/160", "tags":
         ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE"],
         "custom_tags": [], "destination_tickets": [], "incident_name": "Username Password"}]'
     headers:
       CF-RAY:
-      - 9ef486f5290f0207-CDG
+      - a10396160ae33c77-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:34 GMT
+      - Tue, 23 Jun 2026 12:44:49 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -133,17 +133,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '282'
+      - '302'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_status_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_status_filter.yaml
@@ -29,12 +29,13 @@ interactions:
         2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z", "ignored_at":
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
-        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
-        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 11, "severity_rule_id":
-        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/2",
-        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
-        [], "incident_name": "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
         "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
         "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
         "detector_group_display_name": "GitGuardian Development Secret"}, "date":
@@ -73,9 +74,9 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -96,13 +97,13 @@ interactions:
         [], "incident_name": "SendGrid Key"}]'
     headers:
       CF-RAY:
-      - 9ef486f2ebd57026-CDG
+      - a10396134f24d10f-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:33 GMT
+      - Tue, 23 Jun 2026 12:44:48 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -114,7 +115,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '5781'
+      - '5797'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -129,17 +130,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '96'
+      - '88'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_tags_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_tags_filter.yaml
@@ -43,9 +43,9 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -88,9 +88,9 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -117,9 +117,9 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.747147Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/9", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -219,7 +219,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 0, "severity_rule_id":
-        10872, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11897, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/23",
         "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
         "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -234,7 +234,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "high", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        14, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        14, "severity_rule_id": 11897, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/24", "tags":
         ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
@@ -312,13 +312,13 @@ interactions:
         [], "incident_name": "Stripe Keys"}]'
     headers:
       CF-RAY:
-      - 9efb6de20fdbeba6-CDG
+      - a10396305fe585fe-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:47 GMT
+      - Tue, 23 Jun 2026 12:44:53 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -330,7 +330,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '22866'
+      - '22890'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -345,17 +345,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '110'
+      - '79'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -405,9 +405,9 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -450,22 +450,22 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
         "Slack Bot Token"}]'
     headers:
       CF-RAY:
-      - 9efb6de55e9a7026-CDG
+      - a10396336c75da68-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:47 GMT
+      - Tue, 23 Jun 2026 12:44:53 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -477,7 +477,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '5855'
+      - '5871'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -492,17 +492,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '88'
+      - '138'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_triggered_at_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_triggered_at_filter.yaml
@@ -43,9 +43,9 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -88,22 +88,22 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
         "Slack Bot Token"}]'
     headers:
       CF-RAY:
-      - 9ef486fd2861d4f2-CDG
+      - a10396293ff19e85-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:35 GMT
+      - Tue, 23 Jun 2026 12:44:52 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -115,7 +115,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '5855'
+      - '5871'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -130,17 +130,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '82'
+      - '74'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_validity_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_validity_filter.yaml
@@ -31,7 +31,7 @@ interactions:
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
-        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11885, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/52",
         "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
         [], "incident_name": "AWS IAM Keys"}, {"id": 57, "detector": {"name": "gitguardian_test_token_checked",
@@ -40,12 +40,17 @@ interactions:
         "detector_group_display_name": "GitGuardian Test Token Checked"}, "date":
         "2021-12-10T10:36:08Z", "secret_id": 7970357, "secret_hash": "cfDzN5RpdE7fN0bd474gxh8fBT9kKunY+sHOlD+OeXGzGAkSCxpDOKaZihAFaYMH",
         "hmsl_hash": "49b26d210036e493d068e32207ab35c98242c41d82db746b1342ef497560195e",
-        "occurrences_count": 187, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:03.015423Z",
+        "occurrences_count": 187, "status": "ASSIGNED", "triggered_at": "2025-01-07T18:06:03.015423Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
-        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 27, "severity_rule_id":
-        10866, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        false, "validity": "valid", "severity": "critical", "assignee_id": 1778296,
+        "assignee_email": "zeke@binion.io", "share_url": "[REDACTED]", "feedback_list":
+        [{"created_at": "2026-04-23T00:37:26.701645Z", "updated_at": "2026-04-23T00:37:26.701660Z",
+        "email": "zeke@binion.io", "member_id": 1778296, "answers": [{"type": "boolean",
+        "field_ref": "revoked_yes_no", "field_label": "Has this secret been revoked?",
+        "boolean": true}, {"type": "text", "field_ref": "remarks_text", "field_label":
+        "Additional remarks", "text": ""}]}], "risk_score": 27, "severity_rule_id":
+        11891, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/57",
         "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
         "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -60,7 +65,7 @@ interactions:
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
-        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11885, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/123",
         "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
         [], "incident_name": "AWS IAM Keys"}, {"id": 133, "detector": {"name": "aws_iam",
@@ -74,7 +79,7 @@ interactions:
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
-        10860, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11885, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/133",
         "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
         [], "incident_name": "AWS IAM Keys"}, {"id": 142, "detector": {"name": "gitguardian_test_token_checked",
@@ -94,13 +99,13 @@ interactions:
         [], "incident_name": "GitGuardian Test Token Checked"}]'
     headers:
       CF-RAY:
-      - 9ef486f8a860034a-CDG
+      - a103961988e4d886-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:34 GMT
+      - Tue, 23 Jun 2026 12:44:49 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -112,7 +117,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '5848'
+      - '6203'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -127,17 +132,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '91'
+      - '89'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_basic.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_basic.yaml
@@ -32,13 +32,13 @@ interactions:
         "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
-      - 9ef487219adb341e-CDG
+      - a10396814911b1ea-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:41 GMT
+      - Tue, 23 Jun 2026 12:45:06 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -64,17 +64,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '81'
+      - '43'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_get_all.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_get_all.yaml
@@ -32,13 +32,13 @@ interactions:
         "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
-      - 9ef4873d9aeb6fa5-CDG
+      - a10396b41ffa2a7f-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:45 GMT
+      - Tue, 23 Jun 2026 12:45:14 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -64,17 +64,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '49'
+      - '77'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_attachment_reason.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_attachment_reason.yaml
@@ -32,13 +32,13 @@ interactions:
         "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
-      - 9ef4872e2f98d30d-CDG
+      - a10396a20944d136-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:43 GMT
+      - Tue, 23 Jun 2026 12:45:11 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -64,17 +64,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '96'
+      - '42'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_cursor.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_cursor.yaml
@@ -25,50 +25,51 @@ interactions:
         "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
         "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
         "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
-        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
-        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
-        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
-        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
-        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
-        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
-        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
-        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
-        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
-        "destination_tickets": [], "incident_name": "Stripe Keys"}, {"id": 2, "detector":
-        {"name": "slackbototken", "display_name": "Slack Bot Token", "nature": "specific",
-        "family": "token", "category": "messaging_system", "detector_group_name":
-        "slackbot_token", "detector_group_display_name": "Slack Bot Token"}, "date":
-        "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash": "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4",
-        "hmsl_hash": "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3",
-        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z",
+        "occurrences_count": 5, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.721195Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
-        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1", "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 2, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-05-14T08:57:46Z", "secret_id": 14592835,
+        "secret_hash": "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4",
+        "hmsl_hash": "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3",
+        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:02.737359Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        "2026-06-23T12:45:04.459053Z", "resolver_id": 480870, "resolver_api_token_id":
+        "d0ca9877-641f-4c37-8857-c08e0ae148c4", "secret_revoked": true, "validity":
+        "failed_to_check", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 44, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        "revoked", "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/2",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
         "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
         "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
         "detector_group_display_name": "GitGuardian Development Secret"}, "date":
         "2019-11-19T14:11:01Z", "secret_id": 14592836, "secret_hash": "UkaGM2d1NaALSIkUqCBkEgY+xnpQYM3vPZeWQp9v/O680MxYd9tR0/CjGaYu0TLp",
         "hmsl_hash": "2cc5873afae5ee7747e26e2d73f7b8abe0ac63e7971442ceb50be7c4bf5c77c9",
-        "occurrences_count": 13, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
-        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/3", "tags":
-        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "GitGuardian Development Secret"}, {"id": 4, "detector": {"name": "gitguardian_test_token",
-        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
-        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
-        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
-        "2019-11-19T14:11:01Z", "secret_id": 14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
+        "occurrences_count": 13, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": "2026-06-23T12:45:05.272899Z", "ignorer_id": 480870, "ignorer_api_token_id":
+        "d0ca9877-641f-4c37-8857-c08e0ae148c4", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "no_checker", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 44, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "test_cred", "resolve_reason":
+        null, "ignore_reason": "test_credential", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/3",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "GitGuardian Development Secret"}, {"id": 4, "detector":
+        {"name": "gitguardian_test_token", "display_name": "GitGuardian Development
+        Secret", "nature": "specific", "family": "token", "category": "internal",
+        "detector_group_name": "gitguardian_test_token", "detector_group_display_name":
+        "GitGuardian Development Secret"}, "date": "2019-11-19T14:11:01Z", "secret_id":
+        14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
         "hmsl_hash": "8d750888a3f74d018e742b42dfb51c60907b26c49fdad4ebdabe1350eedfe0fb",
         "occurrences_count": 10, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
@@ -88,9 +89,9 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -117,9 +118,9 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.747147Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/9", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -219,7 +220,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 0, "severity_rule_id":
-        10872, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11897, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/23",
         "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
         "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -234,7 +235,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "high", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        14, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        14, "severity_rule_id": 11897, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/24", "tags":
         ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
@@ -312,13 +313,13 @@ interactions:
         [], "incident_name": "Stripe Keys"}]'
     headers:
       CF-RAY:
-      - 9ef488dddb962a43-CDG
+      - a10396ad1c220031-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:35:52 GMT
+      - Tue, 23 Jun 2026 12:45:13 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -330,7 +331,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '22866'
+      - '22967'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -345,17 +346,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '103'
+      - '62'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -394,13 +395,13 @@ interactions:
         "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
-      - 9ef488e15b2a7909-CDG
+      - a10396b02b9c99c8-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:35:52 GMT
+      - Tue, 23 Jun 2026 12:45:13 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -427,17 +428,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '67'
+      - '48'
       x-frame-options:
       - DENY
       x-per-page:
       - '1'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -476,13 +477,13 @@ interactions:
         "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
-      - 9ef488e36af2bb60-CDG
+      - a10396b20a0f8825-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:35:53 GMT
+      - Tue, 23 Jun 2026 12:45:14 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -510,17 +511,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '91'
+      - '36'
       x-frame-options:
       - DENY
       x-per-page:
       - '1'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_date_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_date_filter.yaml
@@ -32,13 +32,13 @@ interactions:
         "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
-      - 9efb6df54f6f0159-CDG
+      - a1039683083eb6b4-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:50 GMT
+      - Tue, 23 Jun 2026 12:45:06 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -64,17 +64,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '60'
+      - '49'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_filepath.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_filepath.yaml
@@ -25,50 +25,51 @@ interactions:
         "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
         "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
         "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
-        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
-        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
-        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
-        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
-        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
-        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
-        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
-        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
-        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
-        "destination_tickets": [], "incident_name": "Stripe Keys"}, {"id": 2, "detector":
-        {"name": "slackbototken", "display_name": "Slack Bot Token", "nature": "specific",
-        "family": "token", "category": "messaging_system", "detector_group_name":
-        "slackbot_token", "detector_group_display_name": "Slack Bot Token"}, "date":
-        "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash": "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4",
-        "hmsl_hash": "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3",
-        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z",
+        "occurrences_count": 5, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.721195Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
-        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1", "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 2, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-05-14T08:57:46Z", "secret_id": 14592835,
+        "secret_hash": "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4",
+        "hmsl_hash": "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3",
+        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:02.737359Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        "2026-06-23T12:45:04.459053Z", "resolver_id": 480870, "resolver_api_token_id":
+        "d0ca9877-641f-4c37-8857-c08e0ae148c4", "secret_revoked": true, "validity":
+        "failed_to_check", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 44, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        "revoked", "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/2",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
         "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
         "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
         "detector_group_display_name": "GitGuardian Development Secret"}, "date":
         "2019-11-19T14:11:01Z", "secret_id": 14592836, "secret_hash": "UkaGM2d1NaALSIkUqCBkEgY+xnpQYM3vPZeWQp9v/O680MxYd9tR0/CjGaYu0TLp",
         "hmsl_hash": "2cc5873afae5ee7747e26e2d73f7b8abe0ac63e7971442ceb50be7c4bf5c77c9",
-        "occurrences_count": 13, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
-        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/3", "tags":
-        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "GitGuardian Development Secret"}, {"id": 4, "detector": {"name": "gitguardian_test_token",
-        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
-        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
-        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
-        "2019-11-19T14:11:01Z", "secret_id": 14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
+        "occurrences_count": 13, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": "2026-06-23T12:45:05.272899Z", "ignorer_id": 480870, "ignorer_api_token_id":
+        "d0ca9877-641f-4c37-8857-c08e0ae148c4", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "no_checker", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 44, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "test_cred", "resolve_reason":
+        null, "ignore_reason": "test_credential", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/3",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "GitGuardian Development Secret"}, {"id": 4, "detector":
+        {"name": "gitguardian_test_token", "display_name": "GitGuardian Development
+        Secret", "nature": "specific", "family": "token", "category": "internal",
+        "detector_group_name": "gitguardian_test_token", "detector_group_display_name":
+        "GitGuardian Development Secret"}, "date": "2019-11-19T14:11:01Z", "secret_id":
+        14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
         "hmsl_hash": "8d750888a3f74d018e742b42dfb51c60907b26c49fdad4ebdabe1350eedfe0fb",
         "occurrences_count": 10, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
@@ -88,9 +89,9 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -117,9 +118,9 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.747147Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/9", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -219,7 +220,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 0, "severity_rule_id":
-        10872, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11897, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/23",
         "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
         "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -234,7 +235,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "high", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        14, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        14, "severity_rule_id": 11897, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/24", "tags":
         ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
@@ -312,13 +313,13 @@ interactions:
         [], "incident_name": "Stripe Keys"}]'
     headers:
       CF-RAY:
-      - 9efb6e106b682a7d-CDG
+      - a103969a0a17b6e3-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:54 GMT
+      - Tue, 23 Jun 2026 12:45:10 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -330,7 +331,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '22866'
+      - '22967'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -345,17 +346,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '82'
+      - '121'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -433,13 +434,13 @@ interactions:
         "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
-      - 9efb6e140fce03f3-CDG
+      - a103969d59f77854-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:55 GMT
+      - Tue, 23 Jun 2026 12:45:10 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -465,17 +466,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '66'
+      - '67'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -544,13 +545,13 @@ interactions:
         "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
-      - 9efb6e161dbbd13b-CDG
+      - a103969f4ba0468e-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:55 GMT
+      - Tue, 23 Jun 2026 12:45:11 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -576,17 +577,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '47'
+      - '38'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_ordering.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_ordering.yaml
@@ -32,13 +32,13 @@ interactions:
         "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
-      - 9ef487393de6bb46-CDG
+      - a10396aaeeddd141-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:44 GMT
+      - Tue, 23 Jun 2026 12:45:13 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -64,17 +64,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '49'
+      - '44'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_presence.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_presence.yaml
@@ -25,50 +25,51 @@ interactions:
         "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
         "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
         "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
-        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
-        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
-        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
-        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
-        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
-        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
-        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
-        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
-        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
-        "destination_tickets": [], "incident_name": "Stripe Keys"}, {"id": 2, "detector":
-        {"name": "slackbototken", "display_name": "Slack Bot Token", "nature": "specific",
-        "family": "token", "category": "messaging_system", "detector_group_name":
-        "slackbot_token", "detector_group_display_name": "Slack Bot Token"}, "date":
-        "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash": "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4",
-        "hmsl_hash": "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3",
-        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z",
+        "occurrences_count": 5, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.721195Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
-        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1", "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 2, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-05-14T08:57:46Z", "secret_id": 14592835,
+        "secret_hash": "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4",
+        "hmsl_hash": "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3",
+        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:02.737359Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        "2026-06-23T12:45:04.459053Z", "resolver_id": 480870, "resolver_api_token_id":
+        "d0ca9877-641f-4c37-8857-c08e0ae148c4", "secret_revoked": true, "validity":
+        "failed_to_check", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 44, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        "revoked", "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/2",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
         "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
         "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
         "detector_group_display_name": "GitGuardian Development Secret"}, "date":
         "2019-11-19T14:11:01Z", "secret_id": 14592836, "secret_hash": "UkaGM2d1NaALSIkUqCBkEgY+xnpQYM3vPZeWQp9v/O680MxYd9tR0/CjGaYu0TLp",
         "hmsl_hash": "2cc5873afae5ee7747e26e2d73f7b8abe0ac63e7971442ceb50be7c4bf5c77c9",
-        "occurrences_count": 13, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
-        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/3", "tags":
-        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "GitGuardian Development Secret"}, {"id": 4, "detector": {"name": "gitguardian_test_token",
-        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
-        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
-        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
-        "2019-11-19T14:11:01Z", "secret_id": 14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
+        "occurrences_count": 13, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": "2026-06-23T12:45:05.272899Z", "ignorer_id": 480870, "ignorer_api_token_id":
+        "d0ca9877-641f-4c37-8857-c08e0ae148c4", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "no_checker", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 44, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "test_cred", "resolve_reason":
+        null, "ignore_reason": "test_credential", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/3",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "GitGuardian Development Secret"}, {"id": 4, "detector":
+        {"name": "gitguardian_test_token", "display_name": "GitGuardian Development
+        Secret", "nature": "specific", "family": "token", "category": "internal",
+        "detector_group_name": "gitguardian_test_token", "detector_group_display_name":
+        "GitGuardian Development Secret"}, "date": "2019-11-19T14:11:01Z", "secret_id":
+        14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
         "hmsl_hash": "8d750888a3f74d018e742b42dfb51c60907b26c49fdad4ebdabe1350eedfe0fb",
         "occurrences_count": 10, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
@@ -88,9 +89,9 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -117,9 +118,9 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.747147Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/9", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -219,7 +220,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 0, "severity_rule_id":
-        10872, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11897, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/23",
         "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
         "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -234,7 +235,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "high", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        14, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        14, "severity_rule_id": 11897, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/24", "tags":
         ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
@@ -312,13 +313,13 @@ interactions:
         [], "incident_name": "Stripe Keys"}]'
     headers:
       CF-RAY:
-      - 9efb6e012ff30350-CDG
+      - a103968b8d052a14-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:52 GMT
+      - Tue, 23 Jun 2026 12:45:08 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -330,7 +331,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '22866'
+      - '22967'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -345,17 +346,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '88'
+      - '91'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -433,13 +434,13 @@ interactions:
         "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
-      - 9efb6e046bcd71e6-CDG
+      - a103968e9e878c76-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:52 GMT
+      - Tue, 23 Jun 2026 12:45:08 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -465,17 +466,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '86'
+      - '82'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -553,13 +554,13 @@ interactions:
         "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
-      - 9efb6e069af66f5d-CDG
+      - a1039690899a9ede-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:53 GMT
+      - Tue, 23 Jun 2026 12:45:08 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -585,17 +586,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '78'
+      - '49'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_severity.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_severity.yaml
@@ -32,13 +32,13 @@ interactions:
         "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
-      - 9ef48730bf7fd171-CDG
+      - a10396a3b825d121-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:43 GMT
+      - Tue, 23 Jun 2026 12:45:11 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -64,17 +64,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '61'
+      - '37'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_sha.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_sha.yaml
@@ -25,50 +25,51 @@ interactions:
         "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
         "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
         "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
-        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
-        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
-        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
-        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
-        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
-        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
-        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
-        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
-        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
-        "destination_tickets": [], "incident_name": "Stripe Keys"}, {"id": 2, "detector":
-        {"name": "slackbototken", "display_name": "Slack Bot Token", "nature": "specific",
-        "family": "token", "category": "messaging_system", "detector_group_name":
-        "slackbot_token", "detector_group_display_name": "Slack Bot Token"}, "date":
-        "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash": "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4",
-        "hmsl_hash": "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3",
-        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z",
+        "occurrences_count": 5, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.721195Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
-        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1", "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 2, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-05-14T08:57:46Z", "secret_id": 14592835,
+        "secret_hash": "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4",
+        "hmsl_hash": "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3",
+        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:02.737359Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        "2026-06-23T12:45:04.459053Z", "resolver_id": 480870, "resolver_api_token_id":
+        "d0ca9877-641f-4c37-8857-c08e0ae148c4", "secret_revoked": true, "validity":
+        "failed_to_check", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 44, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        "revoked", "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/2",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
         "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
         "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
         "detector_group_display_name": "GitGuardian Development Secret"}, "date":
         "2019-11-19T14:11:01Z", "secret_id": 14592836, "secret_hash": "UkaGM2d1NaALSIkUqCBkEgY+xnpQYM3vPZeWQp9v/O680MxYd9tR0/CjGaYu0TLp",
         "hmsl_hash": "2cc5873afae5ee7747e26e2d73f7b8abe0ac63e7971442ceb50be7c4bf5c77c9",
-        "occurrences_count": 13, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
-        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/3", "tags":
-        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "GitGuardian Development Secret"}, {"id": 4, "detector": {"name": "gitguardian_test_token",
-        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
-        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
-        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
-        "2019-11-19T14:11:01Z", "secret_id": 14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
+        "occurrences_count": 13, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": "2026-06-23T12:45:05.272899Z", "ignorer_id": 480870, "ignorer_api_token_id":
+        "d0ca9877-641f-4c37-8857-c08e0ae148c4", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "no_checker", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 44, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "test_cred", "resolve_reason":
+        null, "ignore_reason": "test_credential", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/3",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "GitGuardian Development Secret"}, {"id": 4, "detector":
+        {"name": "gitguardian_test_token", "display_name": "GitGuardian Development
+        Secret", "nature": "specific", "family": "token", "category": "internal",
+        "detector_group_name": "gitguardian_test_token", "detector_group_display_name":
+        "GitGuardian Development Secret"}, "date": "2019-11-19T14:11:01Z", "secret_id":
+        14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
         "hmsl_hash": "8d750888a3f74d018e742b42dfb51c60907b26c49fdad4ebdabe1350eedfe0fb",
         "occurrences_count": 10, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
@@ -88,9 +89,9 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -117,9 +118,9 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.747147Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/9", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -219,7 +220,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 0, "severity_rule_id":
-        10872, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11897, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/23",
         "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
         "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -234,7 +235,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "high", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        14, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        14, "severity_rule_id": 11897, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/24", "tags":
         ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
@@ -312,13 +313,13 @@ interactions:
         [], "incident_name": "Stripe Keys"}]'
     headers:
       CF-RAY:
-      - 9efb6e08dafef864-CDG
+      - a1039692cd3febad-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:53 GMT
+      - Tue, 23 Jun 2026 12:45:09 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -330,7 +331,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '22866'
+      - '22967'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -345,17 +346,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '98'
+      - '66'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -433,13 +434,13 @@ interactions:
         "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
-      - 9efb6e0c7c0a9ebc-CDG
+      - a1039695c9450168-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:54 GMT
+      - Tue, 23 Jun 2026 12:45:09 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -465,17 +466,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '56'
+      - '35'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -514,13 +515,13 @@ interactions:
         "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
-      - 9efb6e0e79b64bb5-CDG
+      - a1039697aa85f4e7-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:54 GMT
+      - Tue, 23 Jun 2026 12:45:09 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -546,17 +547,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '52'
+      - '36'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_source_id.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_source_id.yaml
@@ -25,50 +25,51 @@ interactions:
         "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
         "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
         "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
-        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
-        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
-        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
-        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
-        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
-        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
-        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
-        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
-        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
-        "destination_tickets": [], "incident_name": "Stripe Keys"}, {"id": 2, "detector":
-        {"name": "slackbototken", "display_name": "Slack Bot Token", "nature": "specific",
-        "family": "token", "category": "messaging_system", "detector_group_name":
-        "slackbot_token", "detector_group_display_name": "Slack Bot Token"}, "date":
-        "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash": "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4",
-        "hmsl_hash": "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3",
-        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z",
+        "occurrences_count": 5, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.721195Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
-        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1", "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}, {"id": 2, "detector": {"name": "slackbototken",
+        "display_name": "Slack Bot Token", "nature": "specific", "family": "token",
+        "category": "messaging_system", "detector_group_name": "slackbot_token", "detector_group_display_name":
+        "Slack Bot Token"}, "date": "2024-05-14T08:57:46Z", "secret_id": 14592835,
+        "secret_hash": "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4",
+        "hmsl_hash": "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3",
+        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:02.737359Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        "2026-06-23T12:45:04.459053Z", "resolver_id": 480870, "resolver_api_token_id":
+        "d0ca9877-641f-4c37-8857-c08e0ae148c4", "secret_revoked": true, "validity":
+        "failed_to_check", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 44, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
+        "revoked", "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/2",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Slack Bot Token"}, {"id": 3, "detector": {"name": "gitguardian_test_token",
         "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
         "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
         "detector_group_display_name": "GitGuardian Development Secret"}, "date":
         "2019-11-19T14:11:01Z", "secret_id": 14592836, "secret_hash": "UkaGM2d1NaALSIkUqCBkEgY+xnpQYM3vPZeWQp9v/O680MxYd9tR0/CjGaYu0TLp",
         "hmsl_hash": "2cc5873afae5ee7747e26e2d73f7b8abe0ac63e7971442ceb50be7c4bf5c77c9",
-        "occurrences_count": 13, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
-        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/3", "tags":
-        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "GitGuardian Development Secret"}, {"id": 4, "detector": {"name": "gitguardian_test_token",
-        "display_name": "GitGuardian Development Secret", "nature": "specific", "family":
-        "token", "category": "internal", "detector_group_name": "gitguardian_test_token",
-        "detector_group_display_name": "GitGuardian Development Secret"}, "date":
-        "2019-11-19T14:11:01Z", "secret_id": 14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
+        "occurrences_count": 13, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.737783Z",
+        "ignored_at": "2026-06-23T12:45:05.272899Z", "ignorer_id": 480870, "ignorer_api_token_id":
+        "d0ca9877-641f-4c37-8857-c08e0ae148c4", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "no_checker", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 44, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "test_cred", "resolve_reason":
+        null, "ignore_reason": "test_credential", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/3",
+        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "GitGuardian Development Secret"}, {"id": 4, "detector":
+        {"name": "gitguardian_test_token", "display_name": "GitGuardian Development
+        Secret", "nature": "specific", "family": "token", "category": "internal",
+        "detector_group_name": "gitguardian_test_token", "detector_group_display_name":
+        "GitGuardian Development Secret"}, "date": "2019-11-19T14:11:01Z", "secret_id":
+        14592837, "secret_hash": "QFGnJCVo4W6AJ4o0xMe5qNi3TJmztqPMnHaoV0BUE6USNFd+d9tR0/CjGaYu0TLp",
         "hmsl_hash": "8d750888a3f74d018e742b42dfb51c60907b26c49fdad4ebdabe1350eedfe0fb",
         "occurrences_count": 10, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737783Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
@@ -88,9 +89,9 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.739857Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/5", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -117,9 +118,9 @@ interactions:
         "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.747147Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/9", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -219,7 +220,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 0, "severity_rule_id":
-        10872, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11897, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/23",
         "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
         "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -234,7 +235,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "high", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        14, "severity_rule_id": 10872, "is_vaulted": false, "declarative_secret_status":
+        14, "severity_rule_id": 11897, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/24", "tags":
         ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
@@ -312,13 +313,13 @@ interactions:
         [], "incident_name": "Stripe Keys"}]'
     headers:
       CF-RAY:
-      - 9efb6df75827ce93-CDG
+      - a1039684ee48d540-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:51 GMT
+      - Tue, 23 Jun 2026 12:45:07 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -330,7 +331,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '22866'
+      - '22967'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -345,17 +346,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '387'
+      - '70'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -433,13 +434,13 @@ interactions:
         "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
-      - 9efb6dfc981e7018-CDG
+      - a10396881edfc702-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:51 GMT
+      - Tue, 23 Jun 2026 12:45:07 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -465,17 +466,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '87'
+      - '52'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -544,13 +545,13 @@ interactions:
         "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
-      - 9efb6dfecbd77808-CDG
+      - a1039689ca58f6a9-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:51 GMT
+      - Tue, 23 Jun 2026 12:45:07 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -576,17 +577,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '71'
+      - '49'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_status.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_status.yaml
@@ -32,13 +32,13 @@ interactions:
         "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
-      - 9ef48732c9be702e-CDG
+      - a10396a57fe16ed2-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:43 GMT
+      - Tue, 23 Jun 2026 12:45:12 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -64,17 +64,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '42'
+      - '38'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_tags.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_tags.yaml
@@ -32,13 +32,13 @@ interactions:
         "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
-      - 9ef48736dad4d121-CDG
+      - a10396a91d162a11-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:44 GMT
+      - Tue, 23 Jun 2026 12:45:12 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -64,17 +64,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '95'
+      - '42'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_validity.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_validity.yaml
@@ -32,13 +32,13 @@ interactions:
         "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
-      - 9ef48734ad29d477-CDG
+      - a10396a73cc0022d-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:34:44 GMT
+      - Tue, 23 Jun 2026 12:45:12 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -64,17 +64,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '80'
+      - '48'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_source_incidents.yaml
+++ b/tests/cassettes/client/vcr/test_list_source_incidents.yaml
@@ -20,56 +20,62 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?per_page=1
   response:
     body:
-      string: '[{"id": 12338, "type": "github", "full_name": "wayne-enterprises-gg/shared-app",
-        "health": "safe", "source_criticality": "low", "default_branch": "master",
-        "default_branch_head": "a219c18ff8e913427c38fc7d90756d6bb1bb5b43", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2026-02-02T10:49:30.905195Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 544, "duration":
-        "0.0", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "218964926", "secret_incidents_breakdown": {"open_secret_incidents":
+      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/shared-app",
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a1039726ec0700d0-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:33 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '882'
+      - '709'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:20 GMT
       link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjMzOA%3D%3D&per_page=1>;
+      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjI1OQ%3D%3D&per_page=1>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '205'
+      - '516'
       x-frame-options:
       - DENY
       x-per-page:
       - '1'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -93,47 +99,53 @@ interactions:
       X-Privacy-Mode:
       - 'true'
     method: GET
-    uri: https://api.gitguardian.com/v1/sources/12338/incidents/secrets
+    uri: https://api.gitguardian.com/v1/sources/12259/incidents/secrets
   response:
     body:
       string: '[]'
     headers:
+      CF-RAY:
+      - a103972bce471310-CDG
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:33 GMT
+      Server:
+      - cloudflare
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
-      content-length:
-      - '2'
+      cf-cache-status:
+      - DYNAMIC
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:21 GMT
       link:
       - ''
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '77'
+      - '65'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_sources_basic.yaml
+++ b/tests/cassettes/client/vcr/test_list_sources_basic.yaml
@@ -20,102 +20,101 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?per_page=5
   response:
     body:
-      string: '[{"id": 12338, "type": "github", "full_name": "wayne-enterprises-gg/shared-app",
-        "health": "safe", "source_criticality": "low", "default_branch": "master",
-        "default_branch_head": "a219c18ff8e913427c38fc7d90756d6bb1bb5b43", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2026-02-02T10:49:30.905195Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 544, "duration":
-        "0.0", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "218964926", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/shared-app",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12356,
-        "type": "github", "full_name": "wayne-enterprises-gg/with-readme-repo-gg",
-        "health": "safe", "source_criticality": "medium", "default_branch": "master",
-        "default_branch_head": "21ca725ac5028cf45975b49f7b48928f34f73117", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:45:43.352734Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 1, "duration":
-        "3.265244", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "234115319", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/with-readme-repo-gg",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12364,
-        "type": "github", "full_name": "wayne-enterprises-gg/business-app", "health":
-        "safe", "source_criticality": "medium", "default_branch": "master", "default_branch_head":
-        "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count": 0, "closed_incidents_count":
-        76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1242, "duration": "9.779904", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "217533545", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 76, "severity_breakdown":
-        {"critical": 3, "high": 73, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/business-app", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 12369, "type": "github", "full_name":
-        "aymericGG/hello-world", "health": "safe", "source_criticality": "high", "default_branch":
-        "master", "default_branch_head": "665b4e495aef1d7b6737a503209407a297d37772",
-        "open_incidents_count": 0, "closed_incidents_count": 3, "last_scan": {"date":
-        "2025-10-09T16:45:43.352983Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 10, "duration": "0.84662", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "175174005",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
-        0, "high": 3, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/hello-world",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12370,
-        "type": "github", "full_name": "aymericGG/Project-back", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "", "default_branch_head":
+      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:45:43.353058Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.01237", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "253745397",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/Project-back",
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
+        "type": "github", "full_name": "lonely/hunter", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "22", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/hunter",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12261,
+        "type": "github", "full_name": "lonely/time", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "25", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/time",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12262,
+        "type": "github", "full_name": "lonely/tower", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "24", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/tower",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12263,
+        "type": "github", "full_name": "my-testing-org/christian_dior", "health":
+        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:39.211442Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1, "duration": "1.218169", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "12", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a10396b6882f0c47-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:15 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '4374'
+      - '3712'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:58 GMT
       link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjM3MA%3D%3D&per_page=5>;
+      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjI2Mw%3D%3D&per_page=5>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '246'
+      - '622'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_sources_get_all.yaml
+++ b/tests/cassettes/client/vcr/test_list_sources_get_all.yaml
@@ -20,102 +20,101 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?per_page=5
   response:
     body:
-      string: '[{"id": 12338, "type": "github", "full_name": "wayne-enterprises-gg/shared-app",
-        "health": "safe", "source_criticality": "low", "default_branch": "master",
-        "default_branch_head": "a219c18ff8e913427c38fc7d90756d6bb1bb5b43", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2026-02-02T10:49:30.905195Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 544, "duration":
-        "0.0", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "218964926", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/shared-app",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12356,
-        "type": "github", "full_name": "wayne-enterprises-gg/with-readme-repo-gg",
-        "health": "safe", "source_criticality": "medium", "default_branch": "master",
-        "default_branch_head": "21ca725ac5028cf45975b49f7b48928f34f73117", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:45:43.352734Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 1, "duration":
-        "3.265244", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "234115319", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/with-readme-repo-gg",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12364,
-        "type": "github", "full_name": "wayne-enterprises-gg/business-app", "health":
-        "safe", "source_criticality": "medium", "default_branch": "master", "default_branch_head":
-        "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count": 0, "closed_incidents_count":
-        76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1242, "duration": "9.779904", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "217533545", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 76, "severity_breakdown":
-        {"critical": 3, "high": 73, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/business-app", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 12369, "type": "github", "full_name":
-        "aymericGG/hello-world", "health": "safe", "source_criticality": "high", "default_branch":
-        "master", "default_branch_head": "665b4e495aef1d7b6737a503209407a297d37772",
-        "open_incidents_count": 0, "closed_incidents_count": 3, "last_scan": {"date":
-        "2025-10-09T16:45:43.352983Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 10, "duration": "0.84662", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "175174005",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
-        0, "high": 3, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/hello-world",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12370,
-        "type": "github", "full_name": "aymericGG/Project-back", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "", "default_branch_head":
+      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:45:43.353058Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.01237", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "253745397",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/Project-back",
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
+        "type": "github", "full_name": "lonely/hunter", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "22", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/hunter",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12261,
+        "type": "github", "full_name": "lonely/time", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "25", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/time",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12262,
+        "type": "github", "full_name": "lonely/tower", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "24", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/tower",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12263,
+        "type": "github", "full_name": "my-testing-org/christian_dior", "health":
+        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:39.211442Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1, "duration": "1.218169", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "12", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a10396f76d5fed85-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:25 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '4374'
+      - '3712'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:01 GMT
       link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjM3MA%3D%3D&per_page=5>;
+      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjI2Mw%3D%3D&per_page=5>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '208'
+      - '660'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -139,472 +138,513 @@ interactions:
       X-Privacy-Mode:
       - 'true'
     method: GET
-    uri: https://api.gitguardian.com/v1/sources?per_page=5&cursor=cD0xMjM3MA%3D%3D
+    uri: https://api.gitguardian.com/v1/sources?per_page=5&cursor=cD0xMjI2Mw%3D%3D
   response:
     body:
-      string: '[{"id": 12371, "type": "github", "full_name": "aymericGG/Project-Front",
-        "health": "safe", "source_criticality": "high", "default_branch": "", "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:45:43.353136Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.012344", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "253745330",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/Project-Front",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 9123340,
-        "type": "github", "full_name": "orga-083643/solid-octo", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "1218ef7297f84f36297c0111ea88b54b9befd365", "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": {"date": "2025-10-09T16:45:43.351408Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 7, "duration": "1.120819", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "630519649", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/orga-083643/solid-octo", "provider_metadata": {"archived":
-        false}, "deleted": false}, {"id": 9123465, "type": "github", "full_name":
-        "orga-083643/expert-train", "health": "safe", "source_criticality": "unknown",
-        "default_branch": "main", "default_branch_head": "1e3f25567a57f788700cbe9b21a05fb2a3dd23f9",
-        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
-        "2025-10-09T16:45:43.353647Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 4, "duration": "4.092814", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "630525080",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/expert-train",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 9123810,
-        "type": "github", "full_name": "orga-083643/ideal-journey", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "ab24e2860796dff2a67c4915b1a6d745b13bdd76", "open_incidents_count": 0, "closed_incidents_count":
-        1, "last_scan": {"date": "2025-10-09T16:45:43.354999Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 3, "duration": "0.866616", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "630531940", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/orga-083643/ideal-journey", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 9123882, "type": "github",
-        "full_name": "orga-083643/analytics-test", "health": "safe", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": "f19d79466ce40e0bb69c9ee0ea08787ead9b5845",
-        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
-        "2025-10-09T16:45:43.352186Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 7, "duration": "0.942938", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "630536182",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/analytics-test",
-        "provider_metadata": {"archived": false}, "deleted": false}]'
-    headers:
-      access-control-expose-headers:
-      - X-App-Version
-      allow:
-      - GET, HEAD, OPTIONS
-      content-length:
-      - '4327'
-      content-security-policy:
-      - frame-ancestors 'none'
-      content-type:
-      - application/json
-      cross-origin-opener-policy:
-      - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:12 GMT
-      link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD05MTIzODgy&per_page=5>; rel="next",
-        <https://api.gitguardian.com/v1/sources?cursor=cj0xJnA9MTIzNzE%3D&per_page=5>;
-        rel="prev"
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Cookie
-      x-app-version:
-      - v2.426.0
-      x-content-type-options:
-      - nosniff
-      x-envoy-upstream-service-time:
-      - '9744'
-      x-frame-options:
-      - DENY
-      x-per-page:
-      - '5'
-      x-secrets-engine-version:
-      - 2.159.0
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: ''
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Host:
-      - api.gitguardian.com
-      User-Agent:
-      - GitGuardian-MCP-Server/0.5.0
-      X-Privacy-Mode:
-      - 'true'
-    method: GET
-    uri: https://api.gitguardian.com/v1/sources?per_page=5&cursor=cD05MTIzODgy
-  response:
-    body:
-      string: '[{"id": 9124147, "type": "github", "full_name": "orga-083643/improved-carnival",
-        "health": "safe", "source_criticality": "unknown", "default_branch": "main",
-        "default_branch_head": "cdaa5dd8497a52a75702879823adc18141ad88b4", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:45:43.354520Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 4, "duration":
-        "3.881061", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "private", "external_id": "630548292", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/improved-carnival",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 10294451,
-        "type": "github", "full_name": "babassov/PrivateVB", "health": "safe", "source_criticality":
-        "critical", "default_branch": "main", "default_branch_head": "346eeb121643aa8ab28828719d94d33664a55839",
-        "open_incidents_count": 0, "closed_incidents_count": 12, "last_scan": {"date":
-        "2025-10-09T16:45:43.353950Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 14, "duration": "1.396871", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "614802635",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 12, "severity_breakdown": {"critical":
-        0, "high": 12, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/babassov/PrivateVB",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 10836673,
-        "type": "github", "full_name": "leakymcgee/secretproject", "health": "at_risk",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "6fa238be5c8773d3560627df4597c1b0cddc708d", "open_incidents_count": 6, "closed_incidents_count":
-        2, "last_scan": {"date": "2025-10-09T16:45:43.354139Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 9, "duration": "0.0", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "684998195", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        6, "severity_breakdown": {"critical": 5, "high": 1, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 2, "severity_breakdown":
-        {"critical": 0, "high": 2, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/leakymcgee/secretproject", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 11018378, "type": "github",
-        "full_name": "leakymcgee/ggshield", "health": "at_risk", "source_criticality":
-        "high", "default_branch": "main", "default_branch_head": "261ad38336f401683315c9dd30d792d3043f1751",
-        "open_incidents_count": 13, "closed_incidents_count": 5, "last_scan": {"date":
-        "2025-10-09T16:45:43.353684Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 1515, "duration": "12.404975", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "691584428",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 13, "severity_breakdown":
-        {"critical": 12, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 5, "severity_breakdown": {"critical":
-        4, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/leakymcgee/ggshield",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11260258,
-        "type": "github", "full_name": "gitjez/git_playground", "health": "at_risk",
-        "source_criticality": "high", "default_branch": "main", "default_branch_head":
-        "21de97f3a7ab7346d33f92479c6266ed29086642", "open_incidents_count": 11, "closed_incidents_count":
-        13, "last_scan": {"date": "2025-10-09T16:45:43.354669Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 104, "duration": "5.271635", "branches_scanned":
-        15, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "602034939", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        11, "severity_breakdown": {"critical": 2, "high": 9, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 13, "severity_breakdown":
-        {"critical": 1, "high": 12, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/gitjez/git_playground", "provider_metadata": {"archived":
-        false}, "deleted": false}]'
-    headers:
-      access-control-expose-headers:
-      - X-App-Version
-      allow:
-      - GET, HEAD, OPTIONS
-      content-length:
-      - '4378'
-      content-security-policy:
-      - frame-ancestors 'none'
-      content-type:
-      - application/json
-      cross-origin-opener-policy:
-      - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:15 GMT
-      link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMTI2MDI1OA%3D%3D&per_page=5>;
-        rel="next", <https://api.gitguardian.com/v1/sources?cursor=cj0xJnA9OTEyNDE0Nw%3D%3D&per_page=5>;
-        rel="prev"
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Cookie
-      x-app-version:
-      - v2.426.0
-      x-content-type-options:
-      - nosniff
-      x-envoy-upstream-service-time:
-      - '2099'
-      x-frame-options:
-      - DENY
-      x-per-page:
-      - '5'
-      x-secrets-engine-version:
-      - 2.159.0
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: ''
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Host:
-      - api.gitguardian.com
-      User-Agent:
-      - GitGuardian-MCP-Server/0.5.0
-      X-Privacy-Mode:
-      - 'true'
-    method: GET
-    uri: https://api.gitguardian.com/v1/sources?per_page=5&cursor=cD0xMTI2MDI1OA%3D%3D
-  response:
-    body:
-      string: '[{"id": 11260259, "type": "github", "full_name": "gitjez/private_repo",
-        "health": "safe", "source_criticality": "high", "default_branch": "main",
-        "default_branch_head": "a8102e99d82504517c016fd20aa499209c65e41d", "open_incidents_count":
-        0, "closed_incidents_count": 19, "last_scan": {"date": "2025-10-09T16:45:43.354706Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 10, "duration":
-        "3.11961", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "private", "external_id": "699836994", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        19, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 1, "unknown": 18}}}, "url": "https://github.com/gitjez/private_repo",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11270152,
-        "type": "slack", "full_name": "Demo Slack Integration / #general", "health":
-        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 4, "closed_incidents_count": 6, "last_scan":
-        {"date": "2025-10-09T16:44:19.448855Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "2.282765", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "C05V11N7B1T",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 4, "severity_breakdown":
-        {"critical": 2, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 1}},
-        "closed_secret_incidents": {"total": 6, "severity_breakdown": {"critical":
-        3, "high": 1, "medium": 0, "low": 0, "info": 2, "unknown": 0}}}, "url": "https://demoslackinte-0vf1761.slack.com/archives/C05V11N7B1T",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11270153,
-        "type": "slack", "full_name": "Demo Slack Integration / #random", "health":
-        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:44:19.448890Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.215615", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "C0602J433A5",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://demoslackinte-0vf1761.slack.com/archives/C0602J433A5",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11328061,
-        "type": "slack", "full_name": "Demo Slack Integration / #demo-231009", "health":
-        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 2, "closed_incidents_count": 4, "last_scan":
-        {"date": "2025-10-09T16:44:19.448925Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.206472", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "C05VBD2TDST",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 2, "severity_breakdown":
-        {"critical": 0, "high": 2, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
-        1, "high": 1, "medium": 0, "low": 0, "info": 1, "unknown": 1}}}, "url": "https://demoslackinte-0vf1761.slack.com/archives/C05VBD2TDST",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11348776,
-        "type": "slack", "full_name": "Demo Slack Integration / #demo-231011", "health":
-        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 1, "last_scan":
-        {"date": "2025-10-09T16:44:19.448960Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.22554", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "C061AL994KS",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
-        0, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://demoslackinte-0vf1761.slack.com/archives/C061AL994KS",
-        "provider_metadata": {"archived": false}, "deleted": false}]'
-    headers:
-      access-control-expose-headers:
-      - X-App-Version
-      allow:
-      - GET, HEAD, OPTIONS
-      content-length:
-      - '4327'
-      content-security-policy:
-      - frame-ancestors 'none'
-      content-type:
-      - application/json
-      cross-origin-opener-policy:
-      - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:15 GMT
-      link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMTM0ODc3Ng%3D%3D&per_page=5>;
-        rel="next", <https://api.gitguardian.com/v1/sources?cursor=cj0xJnA9MTEyNjAyNTk%3D&per_page=5>;
-        rel="prev"
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Cookie
-      x-app-version:
-      - v2.426.0
-      x-content-type-options:
-      - nosniff
-      x-envoy-upstream-service-time:
-      - '297'
-      x-frame-options:
-      - DENY
-      x-per-page:
-      - '5'
-      x-secrets-engine-version:
-      - 2.159.0
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: ''
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Host:
-      - api.gitguardian.com
-      User-Agent:
-      - GitGuardian-MCP-Server/0.5.0
-      X-Privacy-Mode:
-      - 'true'
-    method: GET
-    uri: https://api.gitguardian.com/v1/sources?per_page=5&cursor=cD0xMTM0ODc3Ng%3D%3D
-  response:
-    body:
-      string: '[{"id": 11363204, "type": "github", "full_name": "amascia-gg/ftn-test-circleci",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": "main",
-        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
-        1, "last_scan": {"date": "2025-10-09T16:45:43.354963Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 3121, "duration": "95.292729", "branches_scanned":
-        2, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "704004504", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        2, "severity_breakdown": {"critical": 1, "high": 1, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/amascia-gg/ftn-test-circleci", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 11379320, "type": "slack",
-        "full_name": "Demo Slack Integration / #public-channel", "health": "safe",
-        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 3, "last_scan":
-        {"date": "2025-10-09T16:44:19.448995Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.221121", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "C0610066CUD",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
-        0, "high": 1, "medium": 0, "low": 0, "info": 2, "unknown": 0}}}, "url": "https://demoslackinte-0vf1761.slack.com/archives/C0610066CUD",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11411960,
-        "type": "github", "full_name": "leakymcgee/nodejs-goof", "health": "at_risk",
-        "source_criticality": "critical", "default_branch": "main", "default_branch_head":
-        "8cacb884e328f0f883b934d427122e8fe8ad8b1c", "open_incidents_count": 3, "closed_incidents_count":
-        0, "last_scan": {"date": "2025-10-09T16:45:43.354368Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 113, "duration": "3.560034", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "705767874", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        3, "severity_breakdown": {"critical": 3, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/leakymcgee/nodejs-goof", "provider_metadata": {"archived":
-        false}, "deleted": false}, {"id": 11454870, "type": "slack", "full_name":
-        "Demo Slack Integration / #demo-231020", "health": "at_risk", "source_criticality":
-        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
-        1, "closed_incidents_count": 3, "last_scan": {"date": "2025-10-09T16:44:19.449030Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 0, "duration":
-        "0.218781", "branches_scanned": 0, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "C062255B9R8", "secret_incidents_breakdown": {"open_secret_incidents":
+      string: '[{"id": 12264, "type": "github", "full_name": "my-testing-org/armani_code",
+        "health": "safe", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        1, "last_scan": {"date": "2020-06-04T09:06:33.833273Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 2, "duration": "2.830578", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "30", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 1}}, "closed_secret_incidents": {"total":
-        3, "severity_breakdown": {"critical": 0, "high": 2, "medium": 0, "low": 0,
-        "info": 0, "unknown": 1}}}, "url": "https://demoslackinte-0vf1761.slack.com/archives/C062255B9R8",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11600587,
-        "type": "github", "full_name": "peterringball/terragoatGGDemoProd", "health":
-        "at_risk", "source_criticality": "medium", "default_branch": "master", "default_branch_head":
-        "d1138f0813f335cd09babbc2863e84ea8d462468", "open_incidents_count": 1, "closed_incidents_count":
-        0, "last_scan": {"date": "2025-10-09T16:45:43.354179Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 18, "duration": "3.934015", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "713321698", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        1, "severity_breakdown": {"critical": 1, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/peterringball/terragoatGGDemoProd", "provider_metadata":
-        {"archived": false}, "deleted": false}]'
+        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/armani_code",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12265,
+        "type": "github", "full_name": "my-testing-org/louis_vuitton", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:32.770273Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 0, "duration": "1.141495", "branches_scanned": 0, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "13", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/louis_vuitton",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12266,
+        "type": "github", "full_name": "my-testing-org/lagarfeld", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:33.598712Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1, "duration": "1.253906", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "29", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/lagarfeld",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12267,
+        "type": "github", "full_name": "my-testing-org/saint_laurent", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-10-09T12:55:14.542227Z", "status": "canceled", "failing_reason":
+        "", "commits_scanned": 0, "duration": "1.684644", "branches_scanned": 0, "progress":
+        0}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "28", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/saint_laurent",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12268,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2021-04",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
+        3, "last_scan": {"date": "2021-05-12T13:40:00.812612Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 686, "duration": "2.80448", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "353525015", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        1, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 3, "severity_breakdown": {"critical": 0, "high": 3, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2021-04",
+        "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a10396fcece4f124-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:26 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '4367'
+      - '4439'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:16 GMT
       link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMTYwMDU4Nw%3D%3D&per_page=5>;
-        rel="next", <https://api.gitguardian.com/v1/sources?cursor=cj0xJnA9MTEzNjMyMDQ%3D&per_page=5>;
+      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjI2OA%3D%3D&per_page=5>;
+        rel="next", <https://api.gitguardian.com/v1/sources?cursor=cj0xJnA9MTIyNjQ%3D&per_page=5>;
         rel="prev"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '542'
+      - '505'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/sources?per_page=5&cursor=cD0xMjI2OA%3D%3D
+  response:
+    body:
+      string: '[{"id": 12269, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2021-02",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
+        9, "last_scan": {"date": "2021-05-12T13:40:00.842952Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1474, "duration": "4.569221", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "339243552", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
+        2, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2021-02",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12270,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2021-04",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
+        4, "last_scan": {"date": "2021-05-12T13:40:00.804955Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 419, "duration": "2.634533", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "358427683", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 1}}, "closed_secret_incidents":
+        {"total": 4, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0,
+        "low": 0, "info": 1, "unknown": 2}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2021-04",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12271,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2021-03",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
+        7, "last_scan": {"date": "2021-05-12T13:40:00.809898Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1216, "duration": "8.598146", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "343245836", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 2}}, "closed_secret_incidents":
+        {"total": 7, "severity_breakdown": {"critical": 0, "high": 2, "medium": 0,
+        "low": 0, "info": 4, "unknown": 1}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2021-03",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12272,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2021-03",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
+        1, "last_scan": {"date": "2021-05-12T13:40:00.801498Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 940, "duration": "6.936519", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "348161051", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 1}}, "closed_secret_incidents":
+        {"total": 1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2021-03",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12273,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2021-03",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
+        6, "last_scan": {"date": "2021-05-12T13:40:00.818740Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 990, "duration": "6.295876", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "348161060", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
+        3, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 6, "severity_breakdown": {"critical": 0, "high": 6, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2021-03",
+        "provider_metadata": {"archived": false}, "deleted": false}]'
+    headers:
+      CF-RAY:
+      - a1039701daf3d093-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:27 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '4597'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjI3Mw%3D%3D&per_page=5>;
+        rel="next", <https://api.gitguardian.com/v1/sources?cursor=cj0xJnA9MTIyNjk%3D&per_page=5>;
+        rel="prev"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '486'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/sources?per_page=5&cursor=cD0xMjI3Mw%3D%3D
+  response:
+    body:
+      string: '[{"id": 12274, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-07",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
+        6, "last_scan": {"date": "2020-09-24T09:06:39.253667Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1408, "duration": "4.083977", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "276237250", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
+        3, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 6, "severity_breakdown": {"critical": 0, "high": 6, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-07",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12275,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-08",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
+        9, "last_scan": {"date": "2020-09-24T09:06:39.215897Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 656, "duration": "5.5968", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "287845935", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
+        1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-08",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12276,
+        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-2020-12",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
+        6, "last_scan": {"date": "2021-02-01T15:38:48.535700Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1040, "duration": "2.651208", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "317380020", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
+        1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 6, "severity_breakdown": {"critical": 0, "high": 6, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-12",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12277,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2020-08",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
+        4, "last_scan": {"date": "2020-09-24T09:06:39.225976Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 913, "duration": "2.608482", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "284154416", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
+        1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 4, "severity_breakdown": {"critical": 0, "high": 4, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2020-08",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12278,
+        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-11",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
+        7, "last_scan": {"date": "2021-02-01T15:38:48.535276Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1282, "duration": "3.557603", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "313150729", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
+        3, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 7, "severity_breakdown": {"critical": 0, "high": 7, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-11",
+        "provider_metadata": {"archived": false}, "deleted": false}]'
+    headers:
+      CF-RAY:
+      - a10397066cff803e-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:28 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '4573'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjI3OA%3D%3D&per_page=5>;
+        rel="next", <https://api.gitguardian.com/v1/sources?cursor=cj0xJnA9MTIyNzQ%3D&per_page=5>;
+        rel="prev"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '516'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/sources?per_page=5&cursor=cD0xMjI3OA%3D%3D
+  response:
+    body:
+      string: '[{"id": 12279, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-01",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
+        3, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "234319360", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
+        1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 3, "severity_breakdown": {"critical": 0, "high": 3, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-01",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12280,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2020-12",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
+        7, "last_scan": {"date": "2021-03-05T16:32:08.931273Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1343, "duration": "3.700622", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "321822525", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
+        1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 7, "severity_breakdown": {"critical": 0, "high": 7, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2020-12",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12281,
+        "type": "github", "full_name": "wayne-enterprises-gg/empty-repo", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-01-27T09:14:01.990109Z", "status": "failed", "failing_reason":
+        "Unknown error", "commits_scanned": 0, "duration": "0.0", "branches_scanned":
+        0, "progress": 0}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "236453863", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/empty-repo",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12282,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-07",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
+        9, "last_scan": {"date": "2020-09-24T09:06:39.281285Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1146, "duration": "5.695658", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "280012005", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-07",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12283,
+        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-2020-09",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
+        5, "last_scan": {"date": "2020-09-24T09:06:39.249695Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 405, "duration": "4.641103", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "291853911", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 5, "severity_breakdown": {"critical": 0, "high": 5, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-09",
+        "provider_metadata": {"archived": false}, "deleted": false}]'
+    headers:
+      CF-RAY:
+      - a103970b1d5ed0aa-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:28 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '4408'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjI4Mw%3D%3D&per_page=5>;
+        rel="next", <https://api.gitguardian.com/v1/sources?cursor=cj0xJnA9MTIyNzk%3D&per_page=5>;
+        rel="prev"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '457'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '5'
+      x-secrets-engine-version:
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_sources_monitored_only.yaml
+++ b/tests/cassettes/client/vcr/test_list_sources_monitored_only.yaml
@@ -20,102 +20,101 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?monitored=true&per_page=5
   response:
     body:
-      string: '[{"id": 12338, "type": "github", "full_name": "wayne-enterprises-gg/shared-app",
-        "health": "safe", "source_criticality": "low", "default_branch": "master",
-        "default_branch_head": "a219c18ff8e913427c38fc7d90756d6bb1bb5b43", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2026-02-02T10:49:30.905195Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 544, "duration":
-        "0.0", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "218964926", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/shared-app",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12356,
-        "type": "github", "full_name": "wayne-enterprises-gg/with-readme-repo-gg",
-        "health": "safe", "source_criticality": "medium", "default_branch": "master",
-        "default_branch_head": "21ca725ac5028cf45975b49f7b48928f34f73117", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:45:43.352734Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 1, "duration":
-        "3.265244", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "234115319", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/with-readme-repo-gg",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12364,
-        "type": "github", "full_name": "wayne-enterprises-gg/business-app", "health":
-        "safe", "source_criticality": "medium", "default_branch": "master", "default_branch_head":
-        "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count": 0, "closed_incidents_count":
-        76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1242, "duration": "9.779904", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "217533545", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 76, "severity_breakdown":
-        {"critical": 3, "high": 73, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/business-app", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 12369, "type": "github", "full_name":
-        "aymericGG/hello-world", "health": "safe", "source_criticality": "high", "default_branch":
-        "master", "default_branch_head": "665b4e495aef1d7b6737a503209407a297d37772",
-        "open_incidents_count": 0, "closed_incidents_count": 3, "last_scan": {"date":
-        "2025-10-09T16:45:43.352983Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 10, "duration": "0.84662", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "175174005",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
-        0, "high": 3, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/hello-world",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12370,
-        "type": "github", "full_name": "aymericGG/Project-back", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "", "default_branch_head":
+      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:45:43.353058Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.01237", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "253745397",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/Project-back",
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
+        "type": "github", "full_name": "lonely/hunter", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "22", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/hunter",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12261,
+        "type": "github", "full_name": "lonely/time", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "25", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/time",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12262,
+        "type": "github", "full_name": "lonely/tower", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "24", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/tower",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12263,
+        "type": "github", "full_name": "my-testing-org/christian_dior", "health":
+        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:39.211442Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1, "duration": "1.218169", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "12", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a10396f289f82a12-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:24 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '4374'
+      - '3712'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:01 GMT
       link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjM3MA%3D%3D&monitored=true&per_page=5>;
+      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjI2Mw%3D%3D&monitored=true&per_page=5>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '200'
+      - '461'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_sources_with_ordering.yaml
+++ b/tests/cassettes/client/vcr/test_list_sources_with_ordering.yaml
@@ -20,91 +20,108 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?ordering=-last_scan_date&per_page=5
   response:
     body:
-      string: '[{"id": 26694167, "type": "slack", "full_name": "Testing Slack / #social",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "visibility": "public", "external_id":
-        "C0ADVSNQBAN", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://11deletetestingslack.slack.com/archives/C0ADVSNQBAN", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 26694166, "type": "slack",
-        "full_name": "Testing Slack / #nouveau-canal", "health": "unknown", "source_criticality":
-        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "visibility":
-        "public", "external_id": "C0ADSEJ45RT", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://11deletetestingslack.slack.com/archives/C0ADSEJ45RT",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 26694165,
-        "type": "slack", "full_name": "Testing Slack / #tous-testing-slack", "health":
+      string: '[{"id": 17543488, "type": "microsoft_teams", "full_name": "GitGuardian
+        Engineering / Team 10 / 227 - a5c6943a5f124a5c96fe5b6c390a6f73", "health":
         "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        null, "monitored": true, "visibility": "public", "external_id": "C0ADEDK2DN3",
+        null, "monitored": false, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "19:a31d8cc11fcd40b983dbbb907c92e054@thread.tacv2",
         "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
         {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
         "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://11deletetestingslack.slack.com/archives/C0ADEDK2DN3",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 22877000,
-        "type": "custom_source", "full_name": "GitHub Gist", "health": "at_risk",
-        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 4, "closed_incidents_count": 20, "last_scan":
-        null, "monitored": true, "visibility": "private", "external_id": "6345947b-7ae5-406e-8655-6ea41785dba1",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 4, "severity_breakdown":
-        {"critical": 3, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 20, "severity_breakdown": {"critical":
-        0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 9}}}, "url": "",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 26301895,
-        "type": "sharepoint_online_drive", "full_name": "Olivier Local testing (document
-        libraries) / Documents", "health": "unknown", "source_criticality": "unknown",
-        "default_branch": null, "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": false, "visibility":
-        "private", "external_id": "b!228zEW-fFkq1-2oX01HbwHGZCWcIaVdMoP3Smh_fYPO2jtDlq8vWRaNE2VXTEJXs",
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://teams.microsoft.com/l/channel/19:a31d8cc11fcd40b983dbbb907c92e054@thread.tacv2/227
+        - a5c6943a5f124a5c96fe5b6c390a6f73?groupId=3246a4a0-4abf-453d-a53a-f4d4f8b3cbf5&tenantId=1eb62cd2-9303-4be2-8187-2404c20ba039",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 17535269,
+        "type": "microsoft_teams", "full_name": "GitGuardian Engineering / team 12
+        / 177 - 522d63b20b20462fa75d3914f8ca2b12", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": false, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "19:7257a9a9f2574b82b07f0871fe665290@thread.tacv2",
         "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
         {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
         "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitguardianengineering.sharepoint.com/sites/OlivierLocaltesting/Shared%20Documents",
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://teams.microsoft.com/l/channel/19:7257a9a9f2574b82b07f0871fe665290@thread.tacv2/177
+        - 522d63b20b20462fa75d3914f8ca2b12?groupId=5dd00fc6-e9f1-40f6-994f-f8dca95b85bd&tenantId=1eb62cd2-9303-4be2-8187-2404c20ba039",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 17535276,
+        "type": "microsoft_teams", "full_name": "GitGuardian Engineering / team 12
+        / 959 - 522d63b20b20462fa75d3914f8ca2b12", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": false, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "19:75394b5732b24ce59ddebea2a98e5df0@thread.tacv2",
+        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
+        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
+        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://teams.microsoft.com/l/channel/19:75394b5732b24ce59ddebea2a98e5df0@thread.tacv2/959
+        - 522d63b20b20462fa75d3914f8ca2b12?groupId=5dd00fc6-e9f1-40f6-994f-f8dca95b85bd&tenantId=1eb62cd2-9303-4be2-8187-2404c20ba039",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 17535268,
+        "type": "microsoft_teams", "full_name": "GitGuardian Engineering / team 12
+        / 239 - 522d63b20b20462fa75d3914f8ca2b12", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": false, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "19:72068fa0511d42e7990d567928a8d00d@thread.tacv2",
+        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
+        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
+        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://teams.microsoft.com/l/channel/19:72068fa0511d42e7990d567928a8d00d@thread.tacv2/239
+        - 522d63b20b20462fa75d3914f8ca2b12?groupId=5dd00fc6-e9f1-40f6-994f-f8dca95b85bd&tenantId=1eb62cd2-9303-4be2-8187-2404c20ba039",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 17535267,
+        "type": "microsoft_teams", "full_name": "GitGuardian Engineering / team 12
+        / 569 - 522d63b20b20462fa75d3914f8ca2b12", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": false, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "19:7203d468f9a941d795344dfb9d260039@thread.tacv2",
+        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
+        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
+        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://teams.microsoft.com/l/channel/19:7203d468f9a941d795344dfb9d260039@thread.tacv2/569
+        - 522d63b20b20462fa75d3914f8ca2b12?groupId=5dd00fc6-e9f1-40f6-994f-f8dca95b85bd&tenantId=1eb62cd2-9303-4be2-8187-2404c20ba039",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a10396e558a67031-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:24 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '3633'
+      - '4991'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:00 GMT
       link:
       - <https://api.gitguardian.com/v1/sources?cursor=bz01&ordering=-last_scan_date&per_page=5>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '393'
+      - '1805'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_sources_with_search.yaml
+++ b/tests/cassettes/client/vcr/test_list_sources_with_search.yaml
@@ -20,99 +20,112 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?search=test&per_page=5
   response:
     body:
-      string: '[{"id": 9123882, "type": "github", "full_name": "orga-083643/analytics-test",
-        "health": "safe", "source_criticality": "unknown", "default_branch": "main",
-        "default_branch_head": "f19d79466ce40e0bb69c9ee0ea08787ead9b5845", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:45:43.352186Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 7, "duration":
-        "0.942938", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "private", "external_id": "630536182", "secret_incidents_breakdown": {"open_secret_incidents":
+      string: '[{"id": 12263, "type": "github", "full_name": "my-testing-org/christian_dior",
+        "health": "safe", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": {"date": "2020-09-24T09:06:39.211442Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1, "duration": "1.218169", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "12", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12264,
+        "type": "github", "full_name": "my-testing-org/armani_code", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 1, "last_scan":
+        {"date": "2020-06-04T09:06:33.833273Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 2, "duration": "2.830578", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "30", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 1}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/armani_code",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12265,
+        "type": "github", "full_name": "my-testing-org/louis_vuitton", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:32.770273Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 0, "duration": "1.141495", "branches_scanned": 0, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "13", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/analytics-test",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11363204,
-        "type": "github", "full_name": "amascia-gg/ftn-test-circleci", "health": "at_risk",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 2, "closed_incidents_count": 1, "last_scan":
-        {"date": "2025-10-09T16:45:43.354963Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 3121, "duration": "95.292729", "branches_scanned":
-        2, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "704004504", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        2, "severity_breakdown": {"critical": 1, "high": 1, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/amascia-gg/ftn-test-circleci", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 11677085, "type": "github",
-        "full_name": "peterringball/test", "health": "unknown", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": false, "visibility":
-        "private", "external_id": "673461264", "secret_incidents_breakdown": {"open_secret_incidents":
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/louis_vuitton",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12266,
+        "type": "github", "full_name": "my-testing-org/lagarfeld", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:33.598712Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1, "duration": "1.253906", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "29", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/peterringball/test",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11678252,
-        "type": "github", "full_name": "tuches/Test", "health": "safe", "source_criticality":
-        "low", "default_branch": "master", "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 1, "last_scan": {"date": "2025-10-09T16:45:43.352050Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 5, "duration":
-        "0.68205", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "291043633", "secret_incidents_breakdown": {"open_secret_incidents":
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/lagarfeld",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12267,
+        "type": "github", "full_name": "my-testing-org/saint_laurent", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-10-09T12:55:14.542227Z", "status": "canceled", "failing_reason":
+        "", "commits_scanned": 0, "duration": "1.684644", "branches_scanned": 0, "progress":
+        0}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "28", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        1, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/tuches/Test", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 11756704, "type": "github",
-        "full_name": "peterringball/test4", "health": "safe", "source_criticality":
-        "low", "default_branch": "main", "default_branch_head": "d7d00895483d9e6fd62acf72594199ee5cabf7c7",
-        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
-        "2025-10-09T16:45:43.353873Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 32, "duration": "3.878778", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "684649378",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/peterringball/test4",
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/saint_laurent",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a10396bbfac2f6b5-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:21 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '4081'
+      - '4421'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:58 GMT
       link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMTc1NjcwNA%3D%3D&per_page=5&search=test>;
+      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjI2Nw%3D%3D&per_page=5&search=test>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '187'
+      - '5654'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_sources_with_visibility_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_sources_with_visibility_filter.yaml
@@ -20,102 +20,110 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?visibility=private&per_page=5
   response:
     body:
-      string: '[{"id": 9123340, "type": "github", "full_name": "orga-083643/solid-octo",
-        "health": "safe", "source_criticality": "unknown", "default_branch": "main",
-        "default_branch_head": "1218ef7297f84f36297c0111ea88b54b9befd365", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:45:43.351408Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 7, "duration":
-        "1.120819", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "private", "external_id": "630519649", "secret_incidents_breakdown": {"open_secret_incidents":
+      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/solid-octo",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 9123810,
-        "type": "github", "full_name": "orga-083643/ideal-journey", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "ab24e2860796dff2a67c4915b1a6d745b13bdd76", "open_incidents_count": 0, "closed_incidents_count":
-        1, "last_scan": {"date": "2025-10-09T16:45:43.354999Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 3, "duration": "0.866616", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "630531940", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12265,
+        "type": "github", "full_name": "my-testing-org/louis_vuitton", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:32.770273Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 0, "duration": "1.141495", "branches_scanned": 0, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "13", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/orga-083643/ideal-journey", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 9123882, "type": "github",
-        "full_name": "orga-083643/analytics-test", "health": "safe", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": "f19d79466ce40e0bb69c9ee0ea08787ead9b5845",
-        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
-        "2025-10-09T16:45:43.352186Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 7, "duration": "0.942938", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "630536182",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/analytics-test",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 9124147,
-        "type": "github", "full_name": "orga-083643/improved-carnival", "health":
-        "safe", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "cdaa5dd8497a52a75702879823adc18141ad88b4", "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": {"date": "2025-10-09T16:45:43.354520Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 4, "duration": "3.881061", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "630548292", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/louis_vuitton",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12266,
+        "type": "github", "full_name": "my-testing-org/lagarfeld", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:33.598712Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1, "duration": "1.253906", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "29", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/orga-083643/improved-carnival", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 10294451, "type": "github",
-        "full_name": "babassov/PrivateVB", "health": "safe", "source_criticality":
-        "critical", "default_branch": "main", "default_branch_head": "346eeb121643aa8ab28828719d94d33664a55839",
-        "open_incidents_count": 0, "closed_incidents_count": 12, "last_scan": {"date":
-        "2025-10-09T16:45:43.353950Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 14, "duration": "1.396871", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "614802635",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 12, "severity_breakdown": {"critical":
-        0, "high": 12, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/babassov/PrivateVB",
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/lagarfeld",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12270,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2021-04",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
+        4, "last_scan": {"date": "2021-05-12T13:40:00.804955Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 419, "duration": "2.634533", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "358427683", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 1}}, "closed_secret_incidents":
+        {"total": 4, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0,
+        "low": 0, "info": 1, "unknown": 2}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2021-04",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12271,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2021-03",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
+        7, "last_scan": {"date": "2021-05-12T13:40:00.809898Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1216, "duration": "8.598146", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "343245836", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 2}}, "closed_secret_incidents":
+        {"total": 7, "severity_breakdown": {"critical": 0, "high": 2, "medium": 0,
+        "low": 0, "info": 4, "unknown": 1}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2021-03",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a10396e0fda4d477-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:22 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '4382'
+      - '4316'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:42:59 GMT
       link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMDI5NDQ1MQ%3D%3D&per_page=5&visibility=private>;
+      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjI3MQ%3D%3D&per_page=5&visibility=private>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '215'
+      - '473'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_reopen_public_incident.yaml
+++ b/tests/cassettes/client/vcr/test_reopen_public_incident.yaml
@@ -20,17 +20,69 @@ interactions:
     uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=1&status=RESOLVED%2CIGNORED
   response:
     body:
-      string: '[{"id": 3760, "detector": {"name": "slack_bot_token", "display_name":
-        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
-        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
-        Bot Token"}, "date": "2024-08-22T14:15:22Z", "occurrences_count": 4, "status":
-        "RESOLVED", "validity": "valid", "severity": "high", "assignee_id": 480870,
-        "assignee_email": "ci@gitguardian.com", "resolved_at": "2026-04-20T10:00:00Z",
-        "resolver_id": 480870, "resolve_reason": "revoked", "tags": ["FROM_HISTORICAL_SCAN"],
-        "risk_score": 80, "share_url": "[REDACTED]", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/3760"}]'
+      string: '[{"id": 1, "detector": {"name": "stripe", "display_name": "Stripe Keys",
+        "nature": "specific", "family": "token", "category": "payment_system", "detector_group_name":
+        "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
+        "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
+        "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
+        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
+        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
+        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
+        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
+        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
+        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "Stripe Keys"}]'
     headers:
-      content-type:
+      CF-RAY:
+      - a103967d4a558a38-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
       - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:05 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1195'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0x&per_page=1&status=RESOLVED%2CIGNORED>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '64'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '1'
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
@@ -43,6 +95,8 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '0'
       Content-Type:
       - application/json
       Host:
@@ -52,20 +106,67 @@ interactions:
       X-Privacy-Mode:
       - 'true'
     method: POST
-    uri: https://api.gitguardian.com/v1/public-incidents/secrets/3760/reopen
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/1/reopen
   response:
     body:
-      string: '{"id": 3760, "detector": {"name": "slack_bot_token", "display_name":
-        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
-        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
-        Bot Token"}, "date": "2024-08-22T14:15:22Z", "occurrences_count": 4, "status":
-        "TRIGGERED", "validity": "valid", "severity": "high", "assignee_id": null,
-        "assignee_email": null, "resolved_at": null, "resolver_id": null, "tags":
-        ["FROM_HISTORICAL_SCAN"], "risk_score": 80, "share_url": "[REDACTED]", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/3760"}'
+      string: '{"id": 1, "detector": {"name": "stripe", "display_name": "Stripe Keys",
+        "nature": "specific", "family": "token", "category": "payment_system", "detector_group_name":
+        "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
+        "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
+        "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
+        "occurrences_count": 5, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1", "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}'
     headers:
-      content-type:
+      CF-RAY:
+      - a103967f2da4468e-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
       - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:06 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - POST, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1130'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '101'
+      x-frame-options:
+      - DENY
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK

--- a/tests/cassettes/client/vcr/test_resolve_public_incident_with_revoked.yaml
+++ b/tests/cassettes/client/vcr/test_resolve_public_incident_with_revoked.yaml
@@ -20,16 +20,70 @@ interactions:
     uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=1&status=TRIGGERED
   response:
     body:
-      string: '[{"id": 3759, "detector": {"name": "slack_bot_token", "display_name":
-        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+      string: '[{"id": 2, "detector": {"name": "slackbototken", "display_name": "Slack
+        Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
         "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
-        Bot Token"}, "date": "2024-08-22T14:15:22Z", "occurrences_count": 4, "status":
-        "TRIGGERED", "validity": "valid", "severity": "high", "assignee_id": null,
-        "assignee_email": null, "tags": ["FROM_HISTORICAL_SCAN"], "risk_score": 80,
-        "share_url": "[REDACTED]", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/3759"}]'
+        Bot Token"}, "date": "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash":
+        "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4", "hmsl_hash":
+        "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3", "occurrences_count":
+        2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.737359Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}]'
     headers:
-      content-type:
+      CF-RAY:
+      - a10396719a12d0bc-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
       - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:03 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1145'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0y&per_page=1&status=TRIGGERED>;
+        rel="next"
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '62'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '1'
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
@@ -43,7 +97,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '29'
+      - '28'
       Content-Type:
       - application/json
       Host:
@@ -53,21 +107,68 @@ interactions:
       X-Privacy-Mode:
       - 'true'
     method: POST
-    uri: https://api.gitguardian.com/v1/public-incidents/secrets/3759/resolve
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/2/resolve
   response:
     body:
-      string: '{"id": 3759, "detector": {"name": "slack_bot_token", "display_name":
-        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+      string: '{"id": 2, "detector": {"name": "slackbototken", "display_name": "Slack
+        Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
         "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
-        Bot Token"}, "date": "2024-08-22T14:15:22Z", "occurrences_count": 4, "status":
-        "RESOLVED", "validity": "valid", "severity": "high", "assignee_id": 480870,
-        "assignee_email": "ci@gitguardian.com", "resolved_at": "2026-04-28T12:00:00Z",
-        "resolver_id": 480870, "resolver_api_token_id": "8a262c6a-832d-49e5-8744-23c743ff25ac",
-        "secret_revoked": true, "resolve_reason": "revoked", "tags": ["FROM_HISTORICAL_SCAN"],
-        "risk_score": 80, "share_url": "[REDACTED]", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/3759"}'
+        Bot Token"}, "date": "2024-05-14T08:57:46Z", "secret_id": 14592835, "secret_hash":
+        "X/Zvbsaxe42JEhaT3zKDBzG7y7ttdN2JNe4t5HOXYxsmOaHROMgPzYhV28m6OGG4", "hmsl_hash":
+        "d2fe5a505156deed0d96e6ee0731deef2d459e652b237c25a72ceb67d0abe1c3", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:02.737359Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-06-23T12:45:04.459053Z",
+        "resolver_id": 480870, "resolver_api_token_id": "d0ca9877-641f-4c37-8857-c08e0ae148c4",
+        "secret_revoked": true, "validity": "failed_to_check", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 44, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "revoked", "resolve_reason": "revoked", "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Slack Bot Token"}'
     headers:
-      content-type:
+      CF-RAY:
+      - a10396738e206cbe-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
       - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:04 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - POST, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1208'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '700'
+      x-frame-options:
+      - DENY
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK

--- a/tests/cassettes/tools/vcr/test_count_incidents_basic.yaml
+++ b/tests/cassettes/tools/vcr/test_count_incidents_basic.yaml
@@ -20,40 +20,46 @@ interactions:
     uri: https://api.gitguardian.com/v1/incidents-for-mcp/count?status__in=TRIGGERED%2CASSIGNED%2CRESOLVED&severity__in=10%2C20%2C30%2C100&validity__in=valid%2Cfailed_to_check%2Cno_checker%2Cnot_checked&tags__nin=TEST_FILE%2CFALSE_POSITIVE%2CCHECK_RUN_SKIP_FALSE_POSITIVE%2CCHECK_RUN_SKIP_LOW_RISK%2CCHECK_RUN_SKIP_TEST_CRED
   response:
     body:
-      string: '{"count": 4033}'
+      string: '{"count": 4387}'
     headers:
+      CF-RAY:
+      - a1039742de9f0173-CDG
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:37 GMT
+      Server:
+      - cloudflare
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
-      content-length:
-      - '14'
+      cf-cache-status:
+      - DYNAMIC
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:28 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '98'
+      - '585'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_count_incidents_coerce_single_values.yaml
+++ b/tests/cassettes/tools/vcr/test_count_incidents_coerce_single_values.yaml
@@ -20,40 +20,46 @@ interactions:
     uri: https://api.gitguardian.com/v1/incidents-for-mcp/count?status__in=TRIGGERED&severity__in=10&validity__in=valid&tags__nin=TEST_FILE%2CFALSE_POSITIVE%2CCHECK_RUN_SKIP_FALSE_POSITIVE%2CCHECK_RUN_SKIP_LOW_RISK%2CCHECK_RUN_SKIP_TEST_CRED
   response:
     body:
-      string: '{"count": 102}'
+      string: '{"count": 108}'
     headers:
+      CF-RAY:
+      - a103974e3bde735b-CDG
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '13'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:39 GMT
+      Server:
+      - cloudflare
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
-      content-length:
-      - '13'
+      cf-cache-status:
+      - DYNAMIC
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:30 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '76'
+      - '169'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_count_incidents_with_combined_filters.yaml
+++ b/tests/cassettes/tools/vcr/test_count_incidents_with_combined_filters.yaml
@@ -20,40 +20,46 @@ interactions:
     uri: https://api.gitguardian.com/v1/incidents-for-mcp/count?status__in=TRIGGERED%2CASSIGNED&severity__in=10%2C20&validity__in=valid
   response:
     body:
-      string: '{"count": 143}'
+      string: '{"count": 150}'
     headers:
+      CF-RAY:
+      - a103974c5ade9cbe-CDG
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '13'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:38 GMT
+      Server:
+      - cloudflare
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
-      content-length:
-      - '13'
+      cf-cache-status:
+      - DYNAMIC
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:30 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '52'
+      - '55'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_count_incidents_with_severity_filter.yaml
+++ b/tests/cassettes/tools/vcr/test_count_incidents_with_severity_filter.yaml
@@ -20,40 +20,46 @@ interactions:
     uri: https://api.gitguardian.com/v1/incidents-for-mcp/count?status__in=TRIGGERED%2CASSIGNED%2CRESOLVED&severity__in=10&validity__in=valid%2Cfailed_to_check%2Cno_checker%2Cnot_checked&tags__nin=TEST_FILE%2CFALSE_POSITIVE%2CCHECK_RUN_SKIP_FALSE_POSITIVE%2CCHECK_RUN_SKIP_LOW_RISK%2CCHECK_RUN_SKIP_TEST_CRED
   response:
     body:
-      string: '{"count": 1288}'
+      string: '{"count": 1330}'
     headers:
+      CF-RAY:
+      - a103974a3d2abb1c-CDG
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:38 GMT
+      Server:
+      - cloudflare
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
-      content-length:
-      - '14'
+      cf-cache-status:
+      - DYNAMIC
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:29 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '81'
+      - '78'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_count_incidents_with_status_filter.yaml
+++ b/tests/cassettes/tools/vcr/test_count_incidents_with_status_filter.yaml
@@ -20,40 +20,46 @@ interactions:
     uri: https://api.gitguardian.com/v1/incidents-for-mcp/count?status__in=TRIGGERED&severity__in=10%2C20%2C30%2C100&validity__in=valid%2Cfailed_to_check%2Cno_checker%2Cnot_checked&tags__nin=TEST_FILE%2CFALSE_POSITIVE%2CCHECK_RUN_SKIP_FALSE_POSITIVE%2CCHECK_RUN_SKIP_LOW_RISK%2CCHECK_RUN_SKIP_TEST_CRED
   response:
     body:
-      string: '{"count": 3955}'
+      string: '{"count": 4301}'
     headers:
+      CF-RAY:
+      - a1039748091a1545-CDG
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:38 GMT
+      Server:
+      - cloudflare
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
-      content-length:
-      - '14'
+      cf-cache-status:
+      - DYNAMIC
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:29 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '73'
+      - '99'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_get_custom_tag.yaml
+++ b/tests/cassettes/tools/vcr/test_get_custom_tag.yaml
@@ -23,38 +23,46 @@ interactions:
       string: '{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key": "commiter", "value":
         "leaky mcgee"}'
     headers:
+      CF-RAY:
+      - a10398d41a79343a-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:46:41 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '84'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:44:56 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '26'
+      - '18'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_get_incident_basic.yaml
+++ b/tests/cassettes/tools/vcr/test_get_incident_basic.yaml
@@ -21,32 +21,34 @@ interactions:
   response:
     body:
       string: '{"id": 21460, "detector": {"name": "aws_iam", "display_name": "AWS
-        IAM Keys", "nature": "specific", "family": "credentials", "detector_group_name":
-        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2020-10-29T13:19:59.005564Z",
-        "secret_id": 70588, "secret_hash": "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG",
-        "hmsl_hash": "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2026-03-11T22:41:04.525493Z", "resolver_id": 492181, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "invalid", "severity": "medium",
-        "assignee_id": null, "assignee_email": "vincent.boyer@gitguardian.com", "share_url":
-        "[REDACTED]", "feedback_list": [{"created_at": "2022-07-20T13:22:52.756189Z",
-        "updated_at": "2022-07-20T13:22:52.756207Z", "email": "stanislas.crepin@gitguardian.com",
-        "member_id": null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
-        "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
-        "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
-        give or has given access to any sensitive information or services?", "boolean":
-        true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
-        this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
-        "remarks_text", "field_label": "Additional remarks", "text": "Hasn''t been
-        revoked yet because X"}]}], "risk_score": 100, "is_vaulted": false, "ignore_reason":
-        null, "occurrences": [{"id": 78197, "incident_id": 21460, "date": "2020-10-29T13:20:05.797462Z",
-        "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
-        [{"name": "client_id", "indice_start": 49, "indice_end": 69, "pre_line_start":
-        3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}, {"name":
-        "client_secret", "indice_start": 85, "indice_end": 125, "pre_line_start":
-        4, "pre_line_end": 4, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        IAM Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2020-10-29T13:19:59.005564Z", "secret_id": 70588, "secret_hash":
+        "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG", "hmsl_hash":
+        "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
+        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
+        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
+        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
+        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
+        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
+        given access to any sensitive information or services?", "boolean": true},
+        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
+        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
+        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
+        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
+        "ignore_reason": null, "occurrences": [{"id": 78197, "incident_id": 21460,
+        "date": "2020-10-29T13:20:05.797462Z", "filepath": "app.py", "kind": "realtime",
+        "presence": "removed", "matches": [{"name": "client_id", "indice_start": 49,
+        "indice_end": 69, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
+        null, "post_line_end": null}, {"name": "client_secret", "indice_start": 85,
+        "indice_end": 125, "pre_line_start": 4, "pre_line_end": 4, "post_line_start":
+        null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED", "PUBLIC"], "url":
+        "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion",
         "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
@@ -54,13 +56,13 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "304477822", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "provider_metadata": {"archived": false}, "deleted": true}}, {"id": 78198,
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "304477822", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78198,
         "incident_id": 21460, "date": "2020-10-29T13:19:59.005564Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
         "indice_start": 92, "indice_end": 112, "pre_line_start": null, "pre_line_end":
@@ -75,54 +77,62 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "304477822", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "provider_metadata": {"archived": false}, "deleted": true}}], "secret_presence":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "304477822", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}], "secret_presence":
         {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
         "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
         2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21460",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link":
-        "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}], "custom_tags":
-        []}'
+        "tags": ["REVOCABLE_BY_GG", "PUBLICLY_LEAKED"], "incident_name": "AWS IAM
+        Keys", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "destination_tickets": [{"id":
+        "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
+        "custom_tags": []}'
     headers:
+      CF-RAY:
+      - a1039750bf76f3b3-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:39 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, PUT, PATCH, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '5516'
+      - '5666'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:31 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '81'
+      - '73'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_get_incident_has_detector_info.yaml
+++ b/tests/cassettes/tools/vcr/test_get_incident_has_detector_info.yaml
@@ -21,32 +21,34 @@ interactions:
   response:
     body:
       string: '{"id": 21460, "detector": {"name": "aws_iam", "display_name": "AWS
-        IAM Keys", "nature": "specific", "family": "credentials", "detector_group_name":
-        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2020-10-29T13:19:59.005564Z",
-        "secret_id": 70588, "secret_hash": "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG",
-        "hmsl_hash": "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2026-03-11T22:41:04.525493Z", "resolver_id": 492181, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "invalid", "severity": "medium",
-        "assignee_id": null, "assignee_email": "vincent.boyer@gitguardian.com", "share_url":
-        "[REDACTED]", "feedback_list": [{"created_at": "2022-07-20T13:22:52.756189Z",
-        "updated_at": "2022-07-20T13:22:52.756207Z", "email": "stanislas.crepin@gitguardian.com",
-        "member_id": null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
-        "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
-        "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
-        give or has given access to any sensitive information or services?", "boolean":
-        true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
-        this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
-        "remarks_text", "field_label": "Additional remarks", "text": "Hasn''t been
-        revoked yet because X"}]}], "risk_score": 100, "is_vaulted": false, "ignore_reason":
-        null, "occurrences": [{"id": 78197, "incident_id": 21460, "date": "2020-10-29T13:20:05.797462Z",
-        "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
-        [{"name": "client_id", "indice_start": 49, "indice_end": 69, "pre_line_start":
-        3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}, {"name":
-        "client_secret", "indice_start": 85, "indice_end": 125, "pre_line_start":
-        4, "pre_line_end": 4, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        IAM Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2020-10-29T13:19:59.005564Z", "secret_id": 70588, "secret_hash":
+        "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG", "hmsl_hash":
+        "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
+        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
+        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
+        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
+        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
+        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
+        given access to any sensitive information or services?", "boolean": true},
+        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
+        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
+        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
+        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
+        "ignore_reason": null, "occurrences": [{"id": 78197, "incident_id": 21460,
+        "date": "2020-10-29T13:20:05.797462Z", "filepath": "app.py", "kind": "realtime",
+        "presence": "removed", "matches": [{"name": "client_id", "indice_start": 49,
+        "indice_end": 69, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
+        null, "post_line_end": null}, {"name": "client_secret", "indice_start": 85,
+        "indice_end": 125, "pre_line_start": 4, "pre_line_end": 4, "post_line_start":
+        null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED", "PUBLIC"], "url":
+        "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion",
         "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
@@ -54,20 +56,20 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "304477822", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "provider_metadata": {"archived": false}, "deleted": true}}, {"id": 78198,
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "304477822", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78198,
         "incident_id": 21460, "date": "2020-10-29T13:19:59.005564Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
         "indice_start": 92, "indice_end": 112, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 3}, {"name": "client_secret",
         "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLICLY_EXPOSED",
+        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition",
         "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
@@ -75,54 +77,62 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "304477822", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "provider_metadata": {"archived": false}, "deleted": true}}], "secret_presence":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "304477822", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}], "secret_presence":
         {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
         "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
         2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21460",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link":
-        "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}], "custom_tags":
-        []}'
+        "tags": ["REVOCABLE_BY_GG", "PUBLICLY_LEAKED"], "incident_name": "AWS IAM
+        Keys", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "destination_tickets": [{"id":
+        "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
+        "custom_tags": []}'
     headers:
+      CF-RAY:
+      - a1039756cbc15903-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:40 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, PUT, PATCH, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '5516'
+      - '5666'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:33 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '74'
+      - '72'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_get_incident_no_occurrences.yaml
+++ b/tests/cassettes/tools/vcr/test_get_incident_no_occurrences.yaml
@@ -21,66 +21,75 @@ interactions:
   response:
     body:
       string: '{"id": 21460, "detector": {"name": "aws_iam", "display_name": "AWS
-        IAM Keys", "nature": "specific", "family": "credentials", "detector_group_name":
-        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2020-10-29T13:19:59.005564Z",
-        "secret_id": 70588, "secret_hash": "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG",
-        "hmsl_hash": "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2026-03-11T22:41:04.525493Z", "resolver_id": 492181, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "invalid", "severity": "medium",
-        "assignee_id": null, "assignee_email": "vincent.boyer@gitguardian.com", "share_url":
-        "[REDACTED]", "feedback_list": [{"created_at": "2022-07-20T13:22:52.756189Z",
-        "updated_at": "2022-07-20T13:22:52.756207Z", "email": "stanislas.crepin@gitguardian.com",
-        "member_id": null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
-        "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
-        "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
-        give or has given access to any sensitive information or services?", "boolean":
-        true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
-        this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
-        "remarks_text", "field_label": "Additional remarks", "text": "Hasn''t been
-        revoked yet because X"}]}], "risk_score": 100, "is_vaulted": false, "ignore_reason":
-        null, "occurrences": [], "secret_presence": {"files_requiring_code_fix": 0,
-        "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
+        IAM Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2020-10-29T13:19:59.005564Z", "secret_id": 70588, "secret_hash":
+        "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG", "hmsl_hash":
+        "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
+        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
+        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
+        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
+        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
+        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
+        given access to any sensitive information or services?", "boolean": true},
+        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
+        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
+        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
+        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
+        "ignore_reason": null, "occurrences": [], "secret_presence": {"files_requiring_code_fix":
+        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
         0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["PUBLICLY_LEAKED"],
-        "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
+        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["REVOCABLE_BY_GG",
+        "PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
         "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}'
     headers:
+      CF-RAY:
+      - a1039754cb79017b-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:40 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, PUT, PATCH, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '2145'
+      - '2215'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:32 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '91'
+      - '75'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_get_incident_with_occurrences.yaml
+++ b/tests/cassettes/tools/vcr/test_get_incident_with_occurrences.yaml
@@ -21,32 +21,34 @@ interactions:
   response:
     body:
       string: '{"id": 21460, "detector": {"name": "aws_iam", "display_name": "AWS
-        IAM Keys", "nature": "specific", "family": "credentials", "detector_group_name":
-        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2020-10-29T13:19:59.005564Z",
-        "secret_id": 70588, "secret_hash": "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG",
-        "hmsl_hash": "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7",
-        "occurrences_count": 2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        "2026-03-11T22:41:04.525493Z", "resolver_id": 492181, "resolver_api_token_id":
-        null, "secret_revoked": true, "validity": "invalid", "severity": "medium",
-        "assignee_id": null, "assignee_email": "vincent.boyer@gitguardian.com", "share_url":
-        "[REDACTED]", "feedback_list": [{"created_at": "2022-07-20T13:22:52.756189Z",
-        "updated_at": "2022-07-20T13:22:52.756207Z", "email": "stanislas.crepin@gitguardian.com",
-        "member_id": null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
-        "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
-        "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
-        give or has given access to any sensitive information or services?", "boolean":
-        true}, {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has
-        this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
-        "remarks_text", "field_label": "Additional remarks", "text": "Hasn''t been
-        revoked yet because X"}]}], "risk_score": 100, "is_vaulted": false, "ignore_reason":
-        null, "occurrences": [{"id": 78197, "incident_id": 21460, "date": "2020-10-29T13:20:05.797462Z",
-        "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
-        [{"name": "client_id", "indice_start": 49, "indice_end": 69, "pre_line_start":
-        3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}, {"name":
-        "client_secret", "indice_start": 85, "indice_end": 125, "pre_line_start":
-        4, "pre_line_end": 4, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        IAM Keys", "nature": "specific", "family": "credentials", "category": "cloud_provider",
+        "detector_group_name": "aws_iam", "detector_group_display_name": "AWS IAM
+        Keys"}, "date": "2020-10-29T13:19:59.005564Z", "secret_id": 70588, "secret_hash":
+        "GxuGpow75lYUqq/11F2BTrhvz5MRq7Lp4iegdts1tBbsUTpYL4Qc71cZRqNcojMG", "hmsl_hash":
+        "786f2e4bbe2c1ca4c8d274306a4f598fd8403ec332c2a52e11c3eb2f473c08e7", "occurrences_count":
+        2, "status": "RESOLVED", "triggered_at": "2021-02-11T14:23:22.947577Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
+        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
+        "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
+        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
+        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
+        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
+        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
+        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
+        given access to any sensitive information or services?", "boolean": true},
+        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
+        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
+        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
+        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
+        "ignore_reason": null, "occurrences": [{"id": 78197, "incident_id": 21460,
+        "date": "2020-10-29T13:20:05.797462Z", "filepath": "app.py", "kind": "realtime",
+        "presence": "removed", "matches": [{"name": "client_id", "indice_start": 49,
+        "indice_end": 69, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
+        null, "post_line_end": null}, {"name": "client_secret", "indice_start": 85,
+        "indice_end": 125, "pre_line_start": 4, "pre_line_end": 4, "post_line_start":
+        null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED", "PUBLIC"], "url":
+        "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion",
         "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
@@ -54,13 +56,13 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "304477822", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "provider_metadata": {"archived": false}, "deleted": true}}, {"id": 78198,
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "304477822", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78198,
         "incident_id": 21460, "date": "2020-10-29T13:19:59.005564Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
         "indice_start": 92, "indice_end": 112, "pre_line_start": null, "pre_line_end":
@@ -75,54 +77,62 @@ interactions:
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 926, "duration": "2.398961", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "304477822", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        4, "severity_breakdown": {"critical": 4, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 0, "high": 10, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "provider_metadata": {"archived": false}, "deleted": true}}], "secret_presence":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "304477822", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}}], "secret_presence":
         {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
         "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
         2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21460",
-        "tags": ["PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link":
-        "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}], "custom_tags":
-        []}'
+        "tags": ["REVOCABLE_BY_GG", "PUBLICLY_LEAKED"], "incident_name": "AWS IAM
+        Keys", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "destination_tickets": [{"id":
+        "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
+        "custom_tags": []}'
     headers:
+      CF-RAY:
+      - a10397529fce9eed-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:39 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, PUT, PATCH, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '5516'
+      - '5666'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:32 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '115'
+      - '92'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_get_member_basic.yaml
+++ b/tests/cassettes/tools/vcr/test_get_member_basic.yaml
@@ -22,40 +22,48 @@ interactions:
     body:
       string: '{"id": 13, "role": "manager", "access_level": "manager", "email": "aymeric.sicard@gitguardian.com",
         "name": "Aymeric SICARD", "created_at": "2020-01-21T09:35:47.907207Z", "last_login":
-        "2026-04-02T08:21:40.877924Z", "active": true}'
+        "2026-06-22T14:20:46.680540Z", "active": true}'
     headers:
+      CF-RAY:
+      - a10397590aabd11b-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:40 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '216'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:34 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '33'
+      - '27'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_get_member_has_timestamps.yaml
+++ b/tests/cassettes/tools/vcr/test_get_member_has_timestamps.yaml
@@ -22,40 +22,48 @@ interactions:
     body:
       string: '{"id": 13, "role": "manager", "access_level": "manager", "email": "aymeric.sicard@gitguardian.com",
         "name": "Aymeric SICARD", "created_at": "2020-01-21T09:35:47.907207Z", "last_login":
-        "2026-04-02T08:21:40.877924Z", "active": true}'
+        "2026-06-22T14:20:46.680540Z", "active": true}'
     headers:
+      CF-RAY:
+      - a103975aad54014f-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:41 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '216'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:34 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '35'
+      - '33'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_get_member_verifies_id.yaml
+++ b/tests/cassettes/tools/vcr/test_get_member_verifies_id.yaml
@@ -22,40 +22,48 @@ interactions:
     body:
       string: '{"id": 13, "role": "manager", "access_level": "manager", "email": "aymeric.sicard@gitguardian.com",
         "name": "Aymeric SICARD", "created_at": "2020-01-21T09:35:47.907207Z", "last_login":
-        "2026-04-02T08:21:40.877924Z", "active": true}'
+        "2026-06-22T14:20:46.680540Z", "active": true}'
     headers:
+      CF-RAY:
+      - a103975c6d62bb76-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:41 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '216'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:35 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '37'
+      - '27'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_get_public_incident_basic.yaml
+++ b/tests/cassettes/tools/vcr/test_get_public_incident_basic.yaml
@@ -25,25 +25,25 @@ interactions:
         "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
         "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
         "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
-        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
-        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
-        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
-        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
-        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
-        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
-        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
-        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
-        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
-        "destination_tickets": [], "incident_name": "Stripe Keys"}]'
+        "occurrences_count": 5, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1", "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}]'
     headers:
       CF-RAY:
-      - 9efb89553e898634-CDG
+      - a103975e2e2579d6-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:59:31 GMT
+      - Tue, 23 Jun 2026 12:45:41 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -55,7 +55,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '1195'
+      - '1132'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -70,17 +70,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '71'
+      - '70'
       x-frame-options:
       - DENY
       x-per-page:
       - '1'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -112,25 +112,25 @@ interactions:
         "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
         "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
         "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
-        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
-        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
-        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
-        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
-        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
-        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
-        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
-        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
-        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
-        "destination_tickets": [], "incident_name": "Stripe Keys"}'
+        "occurrences_count": 5, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1", "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}'
     headers:
       CF-RAY:
-      - 9efb8957dd0a52be-CDG
+      - a10397601f750246-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:59:32 GMT
+      - Tue, 23 Jun 2026 12:45:42 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -142,7 +142,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '1193'
+      - '1130'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -154,15 +154,15 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '81'
+      - '53'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_get_public_incident_unknown_id.yaml
+++ b/tests/cassettes/tools/vcr/test_get_public_incident_unknown_id.yaml
@@ -23,7 +23,7 @@ interactions:
       string: '{"detail": "Not found."}'
     headers:
       CF-RAY:
-      - 9efb895a2df26fe8-CDG
+      - a10397622e276fa6-CDG
       Connection:
       - keep-alive
       Content-Length:
@@ -31,7 +31,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:59:32 GMT
+      - Tue, 23 Jun 2026 12:45:42 GMT
       Server:
       - cloudflare
       access-control-expose-headers:
@@ -51,15 +51,15 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '35'
+      - '38'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_get_remediation_workflow_custom.yaml
+++ b/tests/cassettes/tools/vcr/test_get_remediation_workflow_custom.yaml
@@ -39,13 +39,13 @@ interactions:
         "updated_at": "2026-06-23T12:23:58.290253Z"}'
     headers:
       CF-RAY:
-      - a10379974b10cea9-CDG
+      - a1039764199e2a37-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Jun 2026 12:25:22 GMT
+      - Tue, 23 Jun 2026 12:45:42 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -73,7 +73,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '44'
+      - '42'
       x-frame-options:
       - DENY
       x-secrets-engine-version:

--- a/tests/cassettes/tools/vcr/test_list_custom_tags.yaml
+++ b/tests/cassettes/tools/vcr/test_list_custom_tags.yaml
@@ -21,10 +21,11 @@ interactions:
   response:
     body:
       string: '[{"id": "925fe3fa-8810-43a7-8652-8bb3130b671c", "key": "antoine", "value":
-        null}, {"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key": "commiter", "value":
-        "leaky mcgee"}, {"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037", "key": "confrence",
-        "value": "grrcon"}, {"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7", "key":
-        "confrence test", "value": "hacktivity"}, {"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
+        null}, {"id": "2b918aac-f9db-401c-b86e-69839a91ed6a", "key": "BU", "value":
+        "italia"}, {"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key": "commiter",
+        "value": "leaky mcgee"}, {"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037", "key":
+        "confrence", "value": "grrcon"}, {"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        "key": "confrence test", "value": "hacktivity"}, {"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
         "key": "date leaked", "value": "08/09/2023"}, {"id": "a5ad67ad-da66-4b5d-ac94-a079fe470d58",
         "key": "default", "value": "value"}, {"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22",
         "key": "env", "value": "production"}, {"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
@@ -32,53 +33,60 @@ interactions:
         "key": "event", "value": "cab"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
         "key": "format", "value": "public"}, {"id": "6925b698-1dba-4f0f-8c6c-87be4ce3493e",
-        "key": "Generic test", "value": null}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        "key": "Generic test", "value": null}, {"id": "a6772878-f860-4dc1-a45d-7e0b02161c65",
+        "key": "GG test", "value": null}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "e8d2acf7-efa2-4ee5-b2df-1bff3701af31",
         "key": "important_leak", "value": null}, {"id": "21c8f2fd-9a88-42ab-aa1d-16111e371c62",
         "key": "investigation", "value": null}, {"id": "54697103-1a85-4f35-8766-6cf16399f83e",
         "key": "linked incident", "value": null}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}, {"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
-        "key": "location", "value": "slack"}, {"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
-        "key": "location", "value": "sourcecode"}]'
+        "key": "location", "value": "publicrepo"}]'
     headers:
+      CF-RAY:
+      - a10398d1cd141f7e-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:46:41 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, POST, PATCH, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '1614'
+      - '1600'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:44:56 GMT
       link:
-      - <https://api.gitguardian.com/v1/custom_tags?cursor=cD1sb2NhdGlvbiUzQXNvdXJjZWNvZGU%3D>;
+      - <https://api.gitguardian.com/v1/custom_tags?cursor=cD1sb2NhdGlvbiUzQXB1YmxpY3JlcG8%3D>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '30'
+      - '26'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_detectors_basic.yaml
+++ b/tests/cassettes/tools/vcr/test_list_detectors_basic.yaml
@@ -39,49 +39,57 @@ interactions:
         "checkable": false, "frequency": 363.41, "use_with_validity_check_disabled":
         true, "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
         null, "open_incidents_count": 1, "ignored_incidents_count": 0, "resolved_incidents_count":
-        0}, {"name": "adafruit_io_apikey", "display_name": "Adafruit IO API Key",
-        "is_active": false, "type": "specific", "category": "other", "checkable":
-        true, "frequency": 2.12, "use_with_validity_check_disabled": true, "scans_code_only":
-        false, "is_recommended_for_business": false, "removed_at": null, "open_incidents_count":
-        8, "ignored_incidents_count": 0, "resolved_incidents_count": 0}]'
+        0}, {"name": "activemq_credentials", "display_name": "ActiveMQ Credentials",
+        "is_active": true, "type": "specific", "category": "data_storage", "checkable":
+        true, "frequency": 0.01, "use_with_validity_check_disabled": true, "scans_code_only":
+        false, "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
+        0, "ignored_incidents_count": 0, "resolved_incidents_count": 0}]'
     headers:
+      CF-RAY:
+      - a10397661fa98ded-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:42 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '1795'
+      - '1803'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:35 GMT
       link:
-      - <https://api.gitguardian.com/v1/secret_detectors?cursor=cD1hZGFmcnVpdF9pb19hcGlrZXk%3D&per_page=5>;
+      - <https://api.gitguardian.com/v1/secret_detectors?cursor=cD1hY3RpdmVtcV9jcmVkZW50aWFscw%3D%3D&per_page=5>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '49'
+      - '63'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_detectors_get_all.yaml
+++ b/tests/cassettes/tools/vcr/test_list_detectors_get_all.yaml
@@ -39,19 +39,33 @@ interactions:
         "checkable": false, "frequency": 363.41, "use_with_validity_check_disabled":
         true, "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
         null, "open_incidents_count": 1, "ignored_incidents_count": 0, "resolved_incidents_count":
-        0}, {"name": "adafruit_io_apikey", "display_name": "Adafruit IO API Key",
-        "is_active": false, "type": "specific", "category": "other", "checkable":
-        true, "frequency": 2.12, "use_with_validity_check_disabled": true, "scans_code_only":
-        false, "is_recommended_for_business": false, "removed_at": null, "open_incidents_count":
-        8, "ignored_incidents_count": 0, "resolved_incidents_count": 0}, {"name":
+        0}, {"name": "activemq_credentials", "display_name": "ActiveMQ Credentials",
+        "is_active": true, "type": "specific", "category": "data_storage", "checkable":
+        true, "frequency": 0.01, "use_with_validity_check_disabled": true, "scans_code_only":
+        false, "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
+        0, "ignored_incidents_count": 0, "resolved_incidents_count": 0}, {"name":
+        "adafruit_io_apikey", "display_name": "Adafruit IO API Key", "is_active":
+        false, "type": "specific", "category": "other", "checkable": true, "frequency":
+        2.12, "use_with_validity_check_disabled": true, "scans_code_only": false,
+        "is_recommended_for_business": false, "removed_at": null, "open_incidents_count":
+        3, "ignored_incidents_count": 0, "resolved_incidents_count": 0}, {"name":
         "adobe_api_keys", "display_name": "Adobe API Keys", "is_active": true, "type":
         "specific", "category": "other", "checkable": true, "frequency": 0.01, "use_with_validity_check_disabled":
         true, "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
         null, "open_incidents_count": 0, "ignored_incidents_count": 6, "resolved_incidents_count":
-        0}, {"name": "africas_talking_api_key", "display_name": "Africa''s Talking
-        API Key", "is_active": true, "type": "specific", "category": "messaging_system",
-        "checkable": true, "frequency": 0.9, "use_with_validity_check_disabled": true,
-        "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
+        0}, {"name": "adobe_refresh_token", "display_name": "Adobe Refresh Token",
+        "is_active": true, "type": "specific", "category": "other", "checkable": false,
+        "frequency": 0.0, "use_with_validity_check_disabled": true, "scans_code_only":
+        false, "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
+        0, "ignored_incidents_count": 0, "resolved_incidents_count": 0}, {"name":
+        "aes_cipher_key", "display_name": "AES Cipher Key", "is_active": true, "type":
+        "specific", "category": "private_key", "checkable": false, "frequency": 0.0,
+        "use_with_validity_check_disabled": true, "scans_code_only": false, "is_recommended_for_business":
+        true, "removed_at": null, "open_incidents_count": 0, "ignored_incidents_count":
+        0, "resolved_incidents_count": 0}, {"name": "africas_talking_api_key", "display_name":
+        "Africa''s Talking API Key", "is_active": true, "type": "specific", "category":
+        "messaging_system", "checkable": true, "frequency": 0.9, "use_with_validity_check_disabled":
+        true, "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
         null, "open_incidents_count": 0, "ignored_incidents_count": 0, "resolved_incidents_count":
         0}, {"name": "agora_api_keys", "display_name": "Agora API Keys", "is_active":
         true, "type": "specific", "category": "messaging_system", "checkable": true,
@@ -62,16 +76,25 @@ interactions:
         "specific", "category": "ai", "checkable": true, "frequency": 0.57, "use_with_validity_check_disabled":
         true, "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
         null, "open_incidents_count": 0, "ignored_incidents_count": 0, "resolved_incidents_count":
-        0}, {"name": "aiproxy_api_key", "display_name": "AIProxy API Key", "is_active":
-        true, "type": "specific", "category": "ai", "checkable": false, "frequency":
-        11.2, "use_with_validity_check_disabled": true, "scans_code_only": false,
-        "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
+        0}, {"name": "aikido_api_oauth2_credentials", "display_name": "Aikido API
+        OAuth2 Credentials", "is_active": true, "type": "specific", "category": "ai",
+        "checkable": true, "frequency": 0.0, "use_with_validity_check_disabled": true,
+        "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
+        null, "open_incidents_count": 0, "ignored_incidents_count": 0, "resolved_incidents_count":
+        0}, {"name": "aikido_ci_scanning_token", "display_name": "Aikido CI Scanning
+        Token", "is_active": true, "type": "specific", "category": "ai", "checkable":
+        true, "frequency": 0.0, "use_with_validity_check_disabled": false, "scans_code_only":
+        false, "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
         0, "ignored_incidents_count": 0, "resolved_incidents_count": 0}, {"name":
-        "airtable_apikey", "display_name": "Airtable API Key", "is_active": true,
-        "type": "specific", "category": "collaboration_tool", "checkable": true, "frequency":
-        16.53, "use_with_validity_check_disabled": true, "scans_code_only": false,
-        "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
-        0, "ignored_incidents_count": 22, "resolved_incidents_count": 0}, {"name":
+        "aiproxy_api_key", "display_name": "AIProxy API Key", "is_active": true, "type":
+        "specific", "category": "ai", "checkable": false, "frequency": 11.2, "use_with_validity_check_disabled":
+        true, "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
+        null, "open_incidents_count": 0, "ignored_incidents_count": 0, "resolved_incidents_count":
+        0}, {"name": "airtable_apikey", "display_name": "Airtable API Key", "is_active":
+        true, "type": "specific", "category": "collaboration_tool", "checkable": true,
+        "frequency": 16.53, "use_with_validity_check_disabled": true, "scans_code_only":
+        false, "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
+        0, "ignored_incidents_count": 23, "resolved_incidents_count": 0}, {"name":
         "aiven_api_key", "display_name": "Aiven API key", "is_active": true, "type":
         "specific", "category": "cloud_provider", "checkable": true, "frequency":
         0.01, "use_with_validity_check_disabled": false, "scans_code_only": false,
@@ -91,69 +114,53 @@ interactions:
         "checkable": true, "frequency": 345.07, "use_with_validity_check_disabled":
         false, "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
         null, "open_incidents_count": 0, "ignored_incidents_count": 1, "resolved_incidents_count":
-        0}, {"name": "algolia_search", "display_name": "Algolia Search Keys", "is_active":
-        false, "type": "specific", "category": "Api", "checkable": false, "frequency":
-        107.55, "use_with_validity_check_disabled": true, "scans_code_only": false,
-        "is_recommended_for_business": true, "removed_at": "2020-10-28T13:31:39.357988Z",
-        "open_incidents_count": 0, "ignored_incidents_count": 0, "resolved_incidents_count":
-        0}, {"name": "alibaba_cloud_keys", "display_name": "Alibaba Cloud Keys", "is_active":
-        true, "type": "specific", "category": "cloud_provider", "checkable": false,
-        "frequency": 12.06, "use_with_validity_check_disabled": true, "scans_code_only":
-        false, "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
-        30, "ignored_incidents_count": 0, "resolved_incidents_count": 0}, {"name":
-        "amazon_mws_token", "display_name": "Amazon MWS Token", "is_active": true,
-        "type": "specific", "category": "payment_system", "checkable": false, "frequency":
-        0.36, "use_with_validity_check_disabled": true, "scans_code_only": false,
-        "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
-        17, "ignored_incidents_count": 0, "resolved_incidents_count": 0}, {"name":
-        "amp_api_token", "display_name": "AMP API User Token", "is_active": true,
-        "type": "specific", "category": "ai", "checkable": true, "frequency": 0.15,
-        "use_with_validity_check_disabled": true, "scans_code_only": false, "is_recommended_for_business":
-        true, "removed_at": null, "open_incidents_count": 0, "ignored_incidents_count":
-        0, "resolved_incidents_count": 0}, {"name": "amqp_credentials", "display_name":
-        "AMQP Credentials", "is_active": true, "type": "specific", "category": "data_storage",
-        "checkable": true, "frequency": 14.54, "use_with_validity_check_disabled":
-        true, "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
-        null, "open_incidents_count": 46, "ignored_incidents_count": 0, "resolved_incidents_count":
         0}]'
     headers:
+      CF-RAY:
+      - a1039770e8a72a23-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:44 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '7135'
+      - '7133'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:38 GMT
       link:
-      - <https://api.gitguardian.com/v1/secret_detectors?cursor=cD1hbXFwX2NyZWRlbnRpYWxz&per_page=20>;
+      - <https://api.gitguardian.com/v1/secret_detectors?cursor=cD1hbGdvbGlhX2tleXM%3D&per_page=20>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '50'
+      - '62'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -177,10 +184,34 @@ interactions:
       X-Privacy-Mode:
       - 'true'
     method: GET
-    uri: https://api.gitguardian.com/v1/secret_detectors?per_page=20&cursor=cD1hbXFwX2NyZWRlbnRpYWxz
+    uri: https://api.gitguardian.com/v1/secret_detectors?per_page=20&cursor=cD1hbGdvbGlhX2tleXM%3D
   response:
     body:
-      string: '[{"name": "anthropic_admin_key", "display_name": "Anthropic Admin Key",
+      string: '[{"name": "algolia_search", "display_name": "Algolia Search Keys",
+        "is_active": false, "type": "specific", "category": "Api", "checkable": false,
+        "frequency": 107.55, "use_with_validity_check_disabled": true, "scans_code_only":
+        false, "is_recommended_for_business": true, "removed_at": "2020-10-28T13:31:39.357988Z",
+        "open_incidents_count": 0, "ignored_incidents_count": 0, "resolved_incidents_count":
+        0}, {"name": "alibaba_cloud_keys", "display_name": "Alibaba Cloud Keys", "is_active":
+        true, "type": "specific", "category": "cloud_provider", "checkable": false,
+        "frequency": 12.06, "use_with_validity_check_disabled": true, "scans_code_only":
+        false, "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
+        30, "ignored_incidents_count": 0, "resolved_incidents_count": 0}, {"name":
+        "amazon_mws_token", "display_name": "Amazon MWS Token", "is_active": true,
+        "type": "specific", "category": "payment_system", "checkable": false, "frequency":
+        0.36, "use_with_validity_check_disabled": true, "scans_code_only": false,
+        "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
+        18, "ignored_incidents_count": 0, "resolved_incidents_count": 0}, {"name":
+        "amp_api_token", "display_name": "AMP API User Token", "is_active": true,
+        "type": "specific", "category": "ai", "checkable": true, "frequency": 0.15,
+        "use_with_validity_check_disabled": true, "scans_code_only": false, "is_recommended_for_business":
+        true, "removed_at": null, "open_incidents_count": 0, "ignored_incidents_count":
+        0, "resolved_incidents_count": 0}, {"name": "amqp_credentials", "display_name":
+        "AMQP Credentials", "is_active": true, "type": "specific", "category": "data_storage",
+        "checkable": true, "frequency": 14.54, "use_with_validity_check_disabled":
+        true, "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
+        null, "open_incidents_count": 46, "ignored_incidents_count": 0, "resolved_incidents_count":
+        0}, {"name": "anthropic_admin_key", "display_name": "Anthropic Admin Key",
         "is_active": true, "type": "specific", "category": "ai", "checkable": true,
         "frequency": 0.02, "use_with_validity_check_disabled": true, "scans_code_only":
         false, "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
@@ -194,10 +225,14 @@ interactions:
         "category": "other", "checkable": true, "frequency": 19.4, "use_with_validity_check_disabled":
         true, "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
         null, "open_incidents_count": 0, "ignored_incidents_count": 0, "resolved_incidents_count":
-        0}, {"name": "artifactory_access_token", "display_name": "Artifactory Access
-        Token", "is_active": true, "type": "specific", "category": "package_registry",
-        "checkable": true, "frequency": 0.6, "use_with_validity_check_disabled": true,
-        "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
+        0}, {"name": "apollo_api_key", "display_name": "Apollo.io API Key", "is_active":
+        true, "type": "specific", "category": "crm", "checkable": true, "frequency":
+        1.1, "use_with_validity_check_disabled": true, "scans_code_only": false, "is_recommended_for_business":
+        true, "removed_at": null, "open_incidents_count": 0, "ignored_incidents_count":
+        0, "resolved_incidents_count": 0}, {"name": "artifactory_access_token", "display_name":
+        "Artifactory Access Token", "is_active": true, "type": "specific", "category":
+        "package_registry", "checkable": true, "frequency": 0.6, "use_with_validity_check_disabled":
+        true, "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
         null, "open_incidents_count": 0, "ignored_incidents_count": 7, "resolved_incidents_count":
         0}, {"name": "artifactory_basic_auth_credentials", "display_name": "Artifactory
         Basic Auth Credentials", "is_active": true, "type": "specific", "category":
@@ -223,7 +258,7 @@ interactions:
         true, "type": "specific", "category": "package_registry", "checkable": false,
         "frequency": 0.98, "use_with_validity_check_disabled": true, "scans_code_only":
         false, "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
-        20, "ignored_incidents_count": 0, "resolved_incidents_count": 1}, {"name":
+        22, "ignored_incidents_count": 0, "resolved_incidents_count": 1}, {"name":
         "artifactory_token_with_host", "display_name": "Artifactory Token With Host",
         "is_active": true, "type": "specific", "category": "package_registry", "checkable":
         true, "frequency": 0.17, "use_with_validity_check_disabled": true, "scans_code_only":
@@ -233,7 +268,7 @@ interactions:
         "specific", "category": "collaboration_tool", "checkable": true, "frequency":
         0.72, "use_with_validity_check_disabled": true, "scans_code_only": false,
         "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
-        0, "ignored_incidents_count": 29, "resolved_incidents_count": 0}, {"name":
+        0, "ignored_incidents_count": 30, "resolved_incidents_count": 0}, {"name":
         "asi_one_api_key", "display_name": "ASI:One API Key", "is_active": true, "type":
         "specific", "category": "ai", "checkable": true, "frequency": 0.06, "use_with_validity_check_disabled":
         true, "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
@@ -247,76 +282,54 @@ interactions:
         true, "type": "specific", "category": "private_key", "checkable": false, "frequency":
         0.45, "use_with_validity_check_disabled": true, "scans_code_only": false,
         "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
-        1, "ignored_incidents_count": 0, "resolved_incidents_count": 0}, {"name":
-        "assemblyai_access_token", "display_name": "AssemblyAI Access Token", "is_active":
-        true, "type": "specific", "category": "ai", "checkable": true, "frequency":
-        4.9, "use_with_validity_check_disabled": false, "scans_code_only": false,
-        "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
-        0, "ignored_incidents_count": 0, "resolved_incidents_count": 0}, {"name":
-        "atlassian_access_token", "display_name": "Atlassian Access Token", "is_active":
-        true, "type": "specific", "category": "collaboration_tool", "checkable": false,
-        "frequency": 1.06, "use_with_validity_check_disabled": true, "scans_code_only":
-        false, "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
-        2, "ignored_incidents_count": 0, "resolved_incidents_count": 0}, {"name":
-        "atlassian_oauth2", "display_name": "Atlassian Oauth2 Keys", "is_active":
-        true, "type": "specific", "category": "collaboration_tool", "checkable": true,
-        "frequency": 0.2, "use_with_validity_check_disabled": false, "scans_code_only":
-        false, "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
-        0, "ignored_incidents_count": 0, "resolved_incidents_count": 0}, {"name":
-        "auth0_keys", "display_name": "Auth0 Keys", "is_active": true, "type": "specific",
-        "category": "identity_provider", "checkable": true, "frequency": 9.62, "use_with_validity_check_disabled":
-        false, "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
-        null, "open_incidents_count": 0, "ignored_incidents_count": 0, "resolved_incidents_count":
-        0}, {"name": "authentication_tuple", "display_name": "Authentication Tuple",
-        "is_active": true, "type": "generic", "category": "other", "checkable": false,
-        "frequency": 22.74, "use_with_validity_check_disabled": true, "scans_code_only":
-        false, "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
-        4, "ignored_incidents_count": 1, "resolved_incidents_count": 0}, {"name":
-        "aws_bedrock_long_term_api_key", "display_name": "AWS Bedrock Long-term API
-        key", "is_active": true, "type": "specific", "category": "cloud_provider",
-        "checkable": true, "frequency": 0.47, "use_with_validity_check_disabled":
-        true, "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
-        null, "open_incidents_count": 0, "ignored_incidents_count": 0, "resolved_incidents_count":
-        0}]'
+        1, "ignored_incidents_count": 0, "resolved_incidents_count": 0}]'
     headers:
+      CF-RAY:
+      - a1039772fe2711f4-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:45 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '7350'
+      - '7306'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:39 GMT
       link:
-      - <https://api.gitguardian.com/v1/secret_detectors?cursor=cD1hd3NfYmVkcm9ja19sb25nX3Rlcm1fYXBpX2tleQ%3D%3D&per_page=20>;
-        rel="next", <https://api.gitguardian.com/v1/secret_detectors?cursor=cj0xJnA9YW50aHJvcGljX2FkbWluX2tleQ%3D%3D&per_page=20>;
+      - <https://api.gitguardian.com/v1/secret_detectors?cursor=cD1hc3BuZXRfdmFsaWRhdGlvbl9rZXk%3D&per_page=20>;
+        rel="next", <https://api.gitguardian.com/v1/secret_detectors?cursor=cj0xJnA9YWxnb2xpYV9zZWFyY2g%3D&per_page=20>;
         rel="prev"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '51'
+      - '64'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -340,24 +353,58 @@ interactions:
       X-Privacy-Mode:
       - 'true'
     method: GET
-    uri: https://api.gitguardian.com/v1/secret_detectors?per_page=20&cursor=cD1hd3NfYmVkcm9ja19sb25nX3Rlcm1fYXBpX2tleQ%3D%3D
+    uri: https://api.gitguardian.com/v1/secret_detectors?per_page=20&cursor=cD1hc3BuZXRfdmFsaWRhdGlvbl9rZXk%3D
   response:
     body:
-      string: '[{"name": "aws_cognito_oauth_credentials", "display_name": "AWS Cognito
-        OAuth 2.0 Credentials", "is_active": true, "type": "specific", "category":
-        "identity_provider", "checkable": false, "frequency": 3.65, "use_with_validity_check_disabled":
-        true, "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
+      string: '[{"name": "assemblyai_access_token", "display_name": "AssemblyAI Access
+        Token", "is_active": true, "type": "specific", "category": "ai", "checkable":
+        true, "frequency": 4.9, "use_with_validity_check_disabled": false, "scans_code_only":
+        false, "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
+        0, "ignored_incidents_count": 0, "resolved_incidents_count": 0}, {"name":
+        "atlassian_access_token", "display_name": "Atlassian Access Token", "is_active":
+        true, "type": "specific", "category": "collaboration_tool", "checkable": false,
+        "frequency": 1.06, "use_with_validity_check_disabled": true, "scans_code_only":
+        false, "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
+        2, "ignored_incidents_count": 0, "resolved_incidents_count": 0}, {"name":
+        "atlassian_oauth2", "display_name": "Atlassian Oauth2 Keys", "is_active":
+        true, "type": "specific", "category": "collaboration_tool", "checkable": true,
+        "frequency": 0.08, "use_with_validity_check_disabled": false, "scans_code_only":
+        false, "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
+        0, "ignored_incidents_count": 0, "resolved_incidents_count": 0}, {"name":
+        "auth0_keys", "display_name": "Auth0 Keys", "is_active": true, "type": "specific",
+        "category": "identity_provider", "checkable": true, "frequency": 9.62, "use_with_validity_check_disabled":
+        false, "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
         null, "open_incidents_count": 0, "ignored_incidents_count": 0, "resolved_incidents_count":
-        0}, {"name": "aws_cognito_oauth_credentials_with_host", "display_name": "AWS
-        Cognito OAuth 2.0 Credentials with Host", "is_active": true, "type": "specific",
-        "category": "identity_provider", "checkable": true, "frequency": 3.65, "use_with_validity_check_disabled":
+        0}, {"name": "authentication_tuple", "display_name": "Authentication Tuple",
+        "is_active": true, "type": "generic", "category": "other", "checkable": false,
+        "frequency": 22.74, "use_with_validity_check_disabled": true, "scans_code_only":
+        false, "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
+        4, "ignored_incidents_count": 1, "resolved_incidents_count": 0}, {"name":
+        "authentik_api_token", "display_name": "Authentik API Token", "is_active":
+        true, "type": "specific", "category": "other", "checkable": true, "frequency":
+        0.0, "use_with_validity_check_disabled": true, "scans_code_only": false, "is_recommended_for_business":
+        true, "removed_at": null, "open_incidents_count": 0, "ignored_incidents_count":
+        0, "resolved_incidents_count": 0}, {"name": "aws_bedrock_long_term_api_key",
+        "display_name": "AWS Bedrock Long-term API key", "is_active": true, "type":
+        "specific", "category": "cloud_provider", "checkable": true, "frequency":
+        0.47, "use_with_validity_check_disabled": true, "scans_code_only": false,
+        "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
+        0, "ignored_incidents_count": 0, "resolved_incidents_count": 0}, {"name":
+        "aws_cognito_oauth_credentials", "display_name": "AWS Cognito OAuth 2.0 Credentials",
+        "is_active": true, "type": "specific", "category": "identity_provider", "checkable":
+        false, "frequency": 3.65, "use_with_validity_check_disabled": true, "scans_code_only":
+        false, "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
+        0, "ignored_incidents_count": 0, "resolved_incidents_count": 0}, {"name":
+        "aws_cognito_oauth_credentials_with_host", "display_name": "AWS Cognito OAuth
+        2.0 Credentials with Host", "is_active": true, "type": "specific", "category":
+        "identity_provider", "checkable": true, "frequency": 3.65, "use_with_validity_check_disabled":
         true, "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
         null, "open_incidents_count": 0, "ignored_incidents_count": 0, "resolved_incidents_count":
         0}, {"name": "aws_iam", "display_name": "AWS IAM Keys", "is_active": true,
         "type": "specific", "category": "cloud_provider", "checkable": true, "frequency":
         57.66, "use_with_validity_check_disabled": true, "scans_code_only": false,
         "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
-        47, "ignored_incidents_count": 681, "resolved_incidents_count": 338}, {"name":
+        51, "ignored_incidents_count": 686, "resolved_incidents_count": 338}, {"name":
         "aws_iam_sts", "display_name": "AWS IAM STS Keys", "is_active": true, "type":
         "specific", "category": "cloud_provider", "checkable": true, "frequency":
         1.35, "use_with_validity_check_disabled": true, "scans_code_only": false,
@@ -405,85 +452,57 @@ interactions:
         null, "open_incidents_count": 0, "ignored_incidents_count": 0, "resolved_incidents_count":
         0}, {"name": "azure_communication_services_connection_string", "display_name":
         "Azure Communication Services Connection String", "is_active": true, "type":
-        "specific", "category": "cloud_provider", "checkable": false, "frequency":
-        0.98, "use_with_validity_check_disabled": true, "scans_code_only": false,
-        "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
-        0, "ignored_incidents_count": 0, "resolved_incidents_count": 0}, {"name":
-        "azure_computer_vision_key", "display_name": "Azure Computer Vision Key",
-        "is_active": true, "type": "specific", "category": "ai", "checkable": true,
-        "frequency": 0.03, "use_with_validity_check_disabled": true, "scans_code_only":
-        false, "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
-        0, "ignored_incidents_count": 0, "resolved_incidents_count": 0}, {"name":
-        "azure_container_registry_key", "display_name": "Azure Container Registry
-        Key", "is_active": true, "type": "specific", "category": "cloud_provider",
-        "checkable": true, "frequency": 0.01, "use_with_validity_check_disabled":
-        true, "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
-        null, "open_incidents_count": 0, "ignored_incidents_count": 0, "resolved_incidents_count":
-        0}, {"name": "azure_cosmosdb_credentials", "display_name": "Azure Cosmos DB
-        Credentials", "is_active": true, "type": "specific", "category": "data_storage",
-        "checkable": true, "frequency": 0.58, "use_with_validity_check_disabled":
-        true, "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
-        null, "open_incidents_count": 20, "ignored_incidents_count": 0, "resolved_incidents_count":
-        0}, {"name": "azure_devops_pat_with_org", "display_name": "Azure DevOps Personal
-        Access Token with Organization", "is_active": true, "type": "specific", "category":
-        "cloud_provider", "checkable": true, "frequency": 0.05, "use_with_validity_check_disabled":
-        true, "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
-        null, "open_incidents_count": 0, "ignored_incidents_count": 0, "resolved_incidents_count":
-        0}, {"name": "azure_devops_personal_access_token", "display_name": "Azure
-        DevOps Personal Access Token", "is_active": true, "type": "specific", "category":
-        "cloud_provider", "checkable": false, "frequency": 40.2, "use_with_validity_check_disabled":
-        true, "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
-        null, "open_incidents_count": 10, "ignored_incidents_count": 0, "resolved_incidents_count":
-        0}, {"name": "azure_document_intelligence_key", "display_name": "Azure Document
-        Intelligence Key", "is_active": true, "type": "specific", "category": "ai",
-        "checkable": true, "frequency": 0.06, "use_with_validity_check_disabled":
-        true, "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
-        null, "open_incidents_count": 0, "ignored_incidents_count": 0, "resolved_incidents_count":
-        0}, {"name": "azure_entra_access_token", "display_name": "Azure Entra Access
-        Token", "is_active": true, "type": "specific", "category": "cloud_provider",
-        "checkable": true, "frequency": 0.0, "use_with_validity_check_disabled": true,
-        "scans_code_only": false, "is_recommended_for_business": true, "removed_at":
-        null, "open_incidents_count": 0, "ignored_incidents_count": 0, "resolved_incidents_count":
-        0}]'
+        "specific", "category": "cloud_provider", "checkable": true, "frequency":
+        0.2, "use_with_validity_check_disabled": true, "scans_code_only": false, "is_recommended_for_business":
+        true, "removed_at": null, "open_incidents_count": 0, "ignored_incidents_count":
+        0, "resolved_incidents_count": 0}]'
     headers:
+      CF-RAY:
+      - a1039774df032193-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:45 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '7606'
+      - '7481'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:40 GMT
       link:
-      - <https://api.gitguardian.com/v1/secret_detectors?cursor=cD1henVyZV9lbnRyYV9hY2Nlc3NfdG9rZW4%3D&per_page=20>;
-        rel="next", <https://api.gitguardian.com/v1/secret_detectors?cursor=cj0xJnA9YXdzX2NvZ25pdG9fb2F1dGhfY3JlZGVudGlhbHM%3D&per_page=20>;
+      - <https://api.gitguardian.com/v1/secret_detectors?cursor=cD1henVyZV9jb21tdW5pY2F0aW9uX3NlcnZpY2VzX2Nvbm5lY3Rpb25fc3RyaW5n&per_page=20>;
+        rel="next", <https://api.gitguardian.com/v1/secret_detectors?cursor=cj0xJnA9YXNzZW1ibHlhaV9hY2Nlc3NfdG9rZW4%3D&per_page=20>;
         rel="prev"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '52'
+      - '91'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_detectors_pagination.yaml
+++ b/tests/cassettes/tools/vcr/test_list_detectors_pagination.yaml
@@ -36,43 +36,51 @@ interactions:
         true, "removed_at": null, "open_incidents_count": 1, "ignored_incidents_count":
         0, "resolved_incidents_count": 0}]'
     headers:
+      CF-RAY:
+      - a103976eeeddd136-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:44 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '1089'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:38 GMT
       link:
       - <https://api.gitguardian.com/v1/secret_detectors?cursor=cD04X2JsYWJsYXRvdG9fYmlz&per_page=3>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '53'
+      - '34'
       x-frame-options:
       - DENY
       x-per-page:
       - '3'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_detectors_with_per_page.yaml
+++ b/tests/cassettes/tools/vcr/test_list_detectors_with_per_page.yaml
@@ -36,43 +36,51 @@ interactions:
         true, "removed_at": null, "open_incidents_count": 1, "ignored_incidents_count":
         0, "resolved_incidents_count": 0}]'
     headers:
+      CF-RAY:
+      - a103976d19fdf4ff-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:44 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '1089'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:37 GMT
       link:
       - <https://api.gitguardian.com/v1/secret_detectors?cursor=cD04X2JsYWJsYXRvdG9fYmlz&per_page=3>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '49'
+      - '41'
       x-frame-options:
       - DENY
       x-per-page:
       - '3'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_detectors_with_search.yaml
+++ b/tests/cassettes/tools/vcr/test_list_detectors_with_search.yaml
@@ -39,7 +39,7 @@ interactions:
         "type": "specific", "category": "cloud_provider", "checkable": true, "frequency":
         57.66, "use_with_validity_check_disabled": true, "scans_code_only": false,
         "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
-        47, "ignored_incidents_count": 681, "resolved_incidents_count": 338}, {"name":
+        51, "ignored_incidents_count": 686, "resolved_incidents_count": 338}, {"name":
         "aws_iam_sts", "display_name": "AWS IAM STS Keys", "is_active": true, "type":
         "specific", "category": "cloud_provider", "checkable": true, "frequency":
         1.35, "use_with_validity_check_disabled": true, "scans_code_only": false,
@@ -61,42 +61,50 @@ interactions:
         null, "open_incidents_count": 0, "ignored_incidents_count": 2, "resolved_incidents_count":
         0}]'
     headers:
+      CF-RAY:
+      - a1039768287203fb-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:43 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '2961'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:36 GMT
       link:
       - ''
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '71'
+      - '118'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_detectors_with_type_filter.yaml
+++ b/tests/cassettes/tools/vcr/test_list_detectors_with_type_filter.yaml
@@ -48,7 +48,12 @@ interactions:
         "is_active": true, "type": "generic", "category": "other", "checkable": false,
         "frequency": 186.77, "use_with_validity_check_disabled": true, "scans_code_only":
         false, "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
-        63, "ignored_incidents_count": 4, "resolved_incidents_count": 0}, {"name":
+        72, "ignored_incidents_count": 5, "resolved_incidents_count": 0}, {"name":
+        "convertto_securestring_password", "display_name": "ConvertTo-SecureString
+        Password", "is_active": true, "type": "generic", "category": "other", "checkable":
+        false, "frequency": 9.87, "use_with_validity_check_disabled": true, "scans_code_only":
+        false, "is_recommended_for_business": true, "removed_at": null, "open_incidents_count":
+        0, "ignored_incidents_count": 0, "resolved_incidents_count": 0}, {"name":
         "curl_username_password", "display_name": "Curl Username Password", "is_active":
         true, "type": "generic", "category": "other", "checkable": false, "frequency":
         15.17, "use_with_validity_check_disabled": true, "scans_code_only": false,
@@ -63,50 +68,53 @@ interactions:
         "generic", "category": "data_storage", "checkable": false, "frequency": 187.08,
         "use_with_validity_check_disabled": true, "scans_code_only": false, "is_recommended_for_business":
         true, "removed_at": null, "open_incidents_count": 37, "ignored_incidents_count":
-        3, "resolved_incidents_count": 0}, {"name": "generic_high_entropy_secret",
-        "display_name": "Generic High Entropy Secret", "is_active": true, "type":
-        "generic", "category": "other", "checkable": false, "frequency": 24561.06,
-        "use_with_validity_check_disabled": true, "scans_code_only": true, "is_recommended_for_business":
-        true, "removed_at": null, "open_incidents_count": 531, "ignored_incidents_count":
-        191, "resolved_incidents_count": 8}]'
+        3, "resolved_incidents_count": 0}]'
     headers:
+      CF-RAY:
+      - a103976a7b150084-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:43 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '3645'
+      - '3646'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:37 GMT
       link:
-      - <https://api.gitguardian.com/v1/secret_detectors?cursor=cD1nZW5lcmljX2hpZ2hfZW50cm9weV9zZWNyZXQ%3D&per_page=10&type=generic>;
+      - <https://api.gitguardian.com/v1/secret_detectors?cursor=cD1nZW5lcmljX2RhdGFiYXNlX2Fzc2lnbm1lbnQ%3D&per_page=10&type=generic>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '153'
+      - '179'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_honeytokens_basic.yaml
+++ b/tests/cassettes/tools/vcr/test_list_honeytokens_basic.yaml
@@ -25,33 +25,29 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/411d33c0-7fad-4fc1-b94e-bb440c8f9c49",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:11.250010Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}, {"id": "858a3a76-f6f2-4c2e-b0bc-323d9a575413",
-        "name": "test_honey_token", "description": "description", "created_at": "2023-05-15T14:09:09.210845Z",
+        "token": "[REDACTED]"}, {"id": "858a3a76-f6f2-4c2e-b0bc-323d9a575413", "name":
+        "test_honey_token", "description": "description", "created_at": "2023-05-15T14:09:09.210845Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/858a3a76-f6f2-4c2e-b0bc-323d9a575413",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:17.165934Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}, {"id": "72a52279-8e9f-40de-a1d4-bc5fcc48795d",
-        "name": "passwordscon", "description": "", "created_at": "2023-05-16T10:03:49.677782Z",
+        "token": "[REDACTED]"}, {"id": "72a52279-8e9f-40de-a1d4-bc5fcc48795d", "name":
+        "passwordscon", "description": "", "created_at": "2023-05-16T10:03:49.677782Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72a52279-8e9f-40de-a1d4-bc5fcc48795d",
         "status": "triggered", "triggered_at": "2023-05-16T10:04:10.262805Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 222, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
-        "key": "location", "value": "test"}], "custom_tags": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
+        ["publicly_exposed"], "custom_tags": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
         "key": "location", "value": "test"}], "token": "[REDACTED]"}, {"id": "8bf5f99a-538d-4cfe-8e74-61cd7081ae25",
         "name": "PasswordsCon2", "description": "For presentation", "created_at":
         "2023-05-16T11:30:36.210395Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8bf5f99a-538d-4cfe-8e74-61cd7081ae25",
         "status": "triggered", "triggered_at": "2023-05-16T12:29:45.638074Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 344, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "45182b59-b659-41ef-9bb8-44a78740fade", "name": "solid-octo-repo", "description":
         "Placed in solid-octo repo, file ... on 16May2023", "created_at": "2023-05-16T11:51:06.384073Z",
@@ -59,47 +55,41 @@ interactions:
         "status": "triggered", "triggered_at": "2026-02-18T14:51:12.499369Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432", "key": "place",
-        "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
+        [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432", "key":
+        "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
         "name": "jira-OPS-124", "description": "honeytoken deployed in jira ticket
         OPS-124", "created_at": "2023-05-16T11:58:57.713307Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "63bbd74e-bb5f-4910-8e63-eed358af3bc8",
         "name": "improved-carnival repo", "description": "", "created_at": "2023-05-16T14:45:09.811724Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/63bbd74e-bb5f-4910-8e63-eed358af3bc8",
         "status": "revoked", "triggered_at": "2023-05-16T14:49:44.284195Z", "revoked_at":
         "2024-06-19T10:46:44.282148Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "72fcdb5c-e128-4ca5-8970-f1f52f95a78a",
         "name": "slack-chan-website", "description": "", "created_at": "2023-05-16T15:35:26.129025Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72fcdb5c-e128-4ca5-8970-f1f52f95a78a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
-        "key": "place", "value": "website"}], "custom_tags": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
         "key": "place", "value": "website"}], "token": "[REDACTED]"}, {"id": "84d43c23-6d4d-47f8-bf62-e7c1b0ae1625",
         "name": "analytic-repo", "description": "", "created_at": "2023-05-16T16:17:11.435058Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84d43c23-6d4d-47f8-bf62-e7c1b0ae1625",
         "status": "revoked", "triggered_at": "2023-05-16T16:27:55.091410Z", "revoked_at":
         "2023-12-11T14:01:44.427581Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "ef11a80c-6d8e-4fb5-8ee2-4556bae695c3",
         "name": "test ht public", "description": "", "created_at": "2023-05-17T17:00:24.966335Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef11a80c-6d8e-4fb5-8ee2-4556bae695c3",
         "status": "triggered", "triggered_at": "2023-05-17T17:02:33.386529Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 5012, "creator_id": 166199, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
-        "key": "location", "value": "slack"}], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
+        ["publicly_exposed"], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
         "key": "location", "value": "slack"}], "token": "[REDACTED]"}, {"id": "db7bf6ea-57cb-4d13-8ed9-dc59b2620e00",
         "name": "Honeytoken demo 17 may", "description": "This is a token for the
         live demo", "created_at": "2023-05-17T17:15:04.921233Z", "gitguardian_url":
@@ -107,173 +97,161 @@ interactions:
         "status": "triggered", "triggered_at": "2023-05-17T17:16:48.960267Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 5018, "creator_id": 166199, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "79db31fc-ffd1-4bc9-b6e4-3ef37a94712a", "name": "QubitConfrence", "description":
         "", "created_at": "2023-05-18T07:58:37.174577Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/79db31fc-ffd1-4bc9-b6e4-3ef37a94712a",
         "status": "triggered", "triggered_at": "2023-05-18T09:30:01.025933Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 215, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263", "name": "NDC-OSLO Demo", "description":
-        "Demo key for NDC Oslo confrence", "created_at": "2023-05-25T07:59:05.651290Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
+        "name": "NDC-OSLO Demo", "description": "Demo key for NDC Oslo confrence",
+        "created_at": "2023-05-25T07:59:05.651290Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
         "status": "triggered", "triggered_at": "2023-05-25T08:38:27.471330Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 221, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b6f2b765-a8e5-458f-b68a-4b5ef934bcc8", "name": "Pycon Italia", "description":
-        "", "created_at": "2023-05-28T09:34:01.581495Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
+        "name": "Pycon Italia", "description": "", "created_at": "2023-05-28T09:34:01.581495Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
         "status": "revoked", "triggered_at": "2023-05-28T09:45:30.255118Z", "revoked_at":
         "2024-12-10T12:17:08.199275Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "bb494eed-6ba4-4b98-b949-ad5f54d929dd", "name": "ggshield-uORy0any",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "bb494eed-6ba4-4b98-b949-ad5f54d929dd", "name": "ggshield-uORy0any",
         "description": "description", "created_at": "2023-05-30T10:30:39.803353Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bb494eed-6ba4-4b98-b949-ad5f54d929dd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1266b395-a545-42c1-b700-24dbae36447c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1266b395-a545-42c1-b700-24dbae36447c",
         "name": "test_honey_token_previous", "description": "description", "created_at":
         "2023-05-30T10:30:40.547255Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1266b395-a545-42c1-b700-24dbae36447c",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:41:43.173510Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "f60db759-7041-4dfe-80fa-91012d97fdd3",
         "name": "ggshield-tsCPoUcx", "description": "description", "created_at": "2023-05-30T10:37:14.527124Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f60db759-7041-4dfe-80fa-91012d97fdd3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
         "name": "ggshield-BA0VsBh3", "description": "description", "created_at": "2023-05-30T10:39:09.968782Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e7f275d-e115-44d3-8854-5c6472494951",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e7f275d-e115-44d3-8854-5c6472494951",
         "name": "ggshield-UXgNYVXL", "description": "description", "created_at": "2023-05-30T10:42:36.847031Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6e7f275d-e115-44d3-8854-5c6472494951",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7494298b-75c5-44e4-898c-77b3b9017113",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7494298b-75c5-44e4-898c-77b3b9017113",
         "name": "test_honey_token_abc", "description": "description", "created_at":
         "2023-05-30T10:42:37.520767Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7494298b-75c5-44e4-898c-77b3b9017113",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:45:41.905071Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "092dba62-9d82-41bd-84aa-95430d540edc", "name": "ggshield-224Lwv95",
-        "description": "description", "created_at": "2023-05-30T10:46:10.997022Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "092dba62-9d82-41bd-84aa-95430d540edc",
+        "name": "ggshield-224Lwv95", "description": "description", "created_at": "2023-05-30T10:46:10.997022Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/092dba62-9d82-41bd-84aa-95430d540edc",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
         "name": "test_honey_token_previous", "description": "description", "created_at":
         "2023-05-30T10:46:11.714531Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:07.762156Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "13f6dbf3-ae1a-4757-95f6-e0fbc830fc55", "name": "ggshield-agateau",
-        "description": null, "created_at": "2023-05-30T13:32:31.845201Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
+        "name": "ggshield-agateau", "description": null, "created_at": "2023-05-30T13:32:31.845201Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T13:33:03.363563Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 160089, "revoker_id":
         160089, "creator_api_token_id": "425e1a78-209e-4cd5-b08f-8450a0026ac0", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "f17302cd-850b-4b54-9054-60d26a76cf38", "name": "test demo 31may",
-        "description": "", "created_at": "2023-05-31T08:10:36.754144Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f17302cd-850b-4b54-9054-60d26a76cf38",
+        "name": "test demo 31may", "description": "", "created_at": "2023-05-31T08:10:36.754144Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "41d76272-ee3d-4639-93e8-29222b662b93",
         "name": "demo31may-public", "description": "", "created_at": "2023-05-31T08:13:48.373887Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/41d76272-ee3d-4639-93e8-29222b662b93",
         "status": "revoked", "triggered_at": "2023-05-31T08:15:09.926931Z", "revoked_at":
         "2024-12-10T12:16:03.693045Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "63728091-d083-47cc-9898-73c2636f2c7f", "name": "ggshield-ZIU1V3Bv", "description":
         null, "created_at": "2023-05-31T08:17:12.607879Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/63728091-d083-47cc-9898-73c2636f2c7f",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-31T08:17:38.021142Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "001c53df-b63c-4b81-a4fb-35e5b38bf328", "name": "DevOxx Poland", "description":
-        "", "created_at": "2023-05-31T12:28:39.713989Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/001c53df-b63c-4b81-a4fb-35e5b38bf328",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "001c53df-b63c-4b81-a4fb-35e5b38bf328",
+        "name": "DevOxx Poland", "description": "", "created_at": "2023-05-31T12:28:39.713989Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/001c53df-b63c-4b81-a4fb-35e5b38bf328",
         "status": "triggered", "triggered_at": "2023-05-31T14:09:21.767459Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 225, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05", "name": "ggshield-cptptJHt",
-        "description": "ggshield test", "created_at": "2023-06-02T08:47:41.149126Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05",
+        "name": "ggshield-cptptJHt", "description": "ggshield test", "created_at":
+        "2023-06-02T08:47:41.149126Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
-        "name": "ggshield-TtJwtxNE", "description": "ggshield test", "created_at":
-        "2023-06-02T08:48:20.148216Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72", "name": "ggshield-TtJwtxNE",
+        "description": "ggshield test", "created_at": "2023-06-02T08:48:20.148216Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "27379093-c6a4-4732-a64a-715c94e74fd7",
-        "name": "ggshield-TvFzKVed", "description": null, "created_at": "2023-06-09T08:01:57.360210Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/27379093-c6a4-4732-a64a-715c94e74fd7",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "27379093-c6a4-4732-a64a-715c94e74fd7", "name": "ggshield-TvFzKVed",
+        "description": null, "created_at": "2023-06-09T08:01:57.360210Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/27379093-c6a4-4732-a64a-715c94e74fd7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "62cb7048-4302-4b52-9163-e2ceff775b39", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc7214d0-c97a-44b3-b576-664f0a81c4f7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc7214d0-c97a-44b3-b576-664f0a81c4f7",
         "name": "repo analytics 19jun", "description": "", "created_at": "2023-06-19T09:11:21.788070Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc7214d0-c97a-44b3-b576-664f0a81c4f7",
         "status": "revoked", "triggered_at": "2023-06-20T17:24:35.145047Z", "revoked_at":
         "2023-12-11T14:50:27.627289Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb", "name": "ggshield-0etjSvZJ",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb", "name": "ggshield-0etjSvZJ",
         "description": "description", "created_at": "2023-07-05T08:27:14.048162Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-05T08:27:15.756813Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0e4f0dbd-b288-4990-9565-3cc7b0171a79",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:53.240550Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 160089, "revoker_id":
         296618, "creator_api_token_id": "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "14566c1f-0b52-4770-ab68-000704242633", "name": "ggshield-Rv2mUej7",
-        "description": "description", "created_at": "2023-07-05T08:55:23.864812Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "14566c1f-0b52-4770-ab68-000704242633",
+        "name": "ggshield-Rv2mUej7", "description": "description", "created_at": "2023-07-05T08:55:23.864812Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/14566c1f-0b52-4770-ab68-000704242633",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c8c94ffa-c0af-48c6-976a-6502a41811af",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c8c94ffa-c0af-48c6-976a-6502a41811af",
         "name": "honeytoken demo eric", "description": "demo here", "created_at":
         "2023-07-05T14:48:53.893911Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c8c94ffa-c0af-48c6-976a-6502a41811af",
         "status": "triggered", "triggered_at": "2023-07-05T14:49:33.528178Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
         "name": "Example TOken ", "description": "ubvcub", "created_at": "2023-07-12T13:16:10.775681Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
-        "key": "file", "value": ".env"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "0c3f182e-98f5-4a64-aadb-664fd7c9de88", "name": "ggshield-ewIAL7lq", "description":
@@ -282,58 +260,55 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
         "name": "ggshield-w1P1Ggsz", "description": "description", "created_at": "2023-07-27T08:56:55.435203Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a20a718-7b9e-4582-abdf-772053bffd72",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a20a718-7b9e-4582-abdf-772053bffd72",
         "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T08:56:56.138738Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a20a718-7b9e-4582-abdf-772053bffd72",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:58.657957Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "51f41814-f029-4ab4-b863-c0fecba025b3", "name": "ggshield-v3LhZCz8",
-        "description": "description", "created_at": "2023-07-27T09:01:36.117217Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51f41814-f029-4ab4-b863-c0fecba025b3",
+        "name": "ggshield-v3LhZCz8", "description": "description", "created_at": "2023-07-27T09:01:36.117217Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/51f41814-f029-4ab4-b863-c0fecba025b3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T09:01:36.764795Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-27T09:01:37.417151Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e842a635-eb7e-4617-8984-ac57fe909ef7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
         "name": "ggshield-5voYnhhy", "description": null, "created_at": "2023-07-27T13:50:51.332176Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T13:52:58.300149Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "521efd01-bbcc-4380-b548-ed7242c017ea",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "521efd01-bbcc-4380-b548-ed7242c017ea",
         "name": "ggshield-HLZpiznn", "description": null, "created_at": "2023-07-27T14:54:03.198466Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/521efd01-bbcc-4380-b548-ed7242c017ea",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0d81797a-6fc0-4a6e-a211-af16828c0c39",
-        "name": "Webinar Public ", "description": "from webinar ", "created_at": "2023-07-27T15:33:07.472730Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0d81797a-6fc0-4a6e-a211-af16828c0c39", "name": "Webinar
+        Public ", "description": "from webinar ", "created_at": "2023-07-27T15:33:07.472730Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0d81797a-6fc0-4a6e-a211-af16828c0c39",
         "status": "triggered", "triggered_at": "2023-07-27T15:34:48.902462Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 204, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "27e9ba01-4bb6-46ed-84c8-ff14366a3bde", "name": "Private network", "description":
@@ -342,60 +317,55 @@ interactions:
         "status": "triggered", "triggered_at": "2023-07-27T16:23:35.804271Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5670c657-618f-41d7-984b-d59656d905e4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5670c657-618f-41d7-984b-d59656d905e4",
         "name": "ggshield-3KTmbo8u", "description": null, "created_at": "2023-07-27T15:44:43.238742Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5670c657-618f-41d7-984b-d59656d905e4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5d3ad22c-e422-48d2-b7f5-6d52801599aa",
-        "name": "demo 31jul", "description": "", "created_at": "2023-07-31T15:27:18.323098Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d3ad22c-e422-48d2-b7f5-6d52801599aa",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5d3ad22c-e422-48d2-b7f5-6d52801599aa", "name": "demo
+        31jul", "description": "", "created_at": "2023-07-31T15:27:18.323098Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d3ad22c-e422-48d2-b7f5-6d52801599aa",
         "status": "revoked", "triggered_at": "2023-07-31T15:33:49.570793Z", "revoked_at":
         "2023-12-11T14:01:40.706751Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a", "name": "test
-        Antonin 1", "description": "", "created_at": "2023-08-03T08:42:25.251504Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fa63d76d-4297-4d41-8e77-b47d1a97a41a",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a", "name": "test Antonin 1", "description":
+        "", "created_at": "2023-08-03T08:42:25.251504Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fa63d76d-4297-4d41-8e77-b47d1a97a41a",
         "status": "revoked", "triggered_at": "2023-08-03T08:59:58.717709Z", "revoked_at":
         "2023-08-03T09:00:05.809852Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "a11570c6-f472-4fda-a493-30d65fd8e651", "name": "test Antonin 2", "description":
-        "", "created_at": "2023-08-03T14:09:46.046004Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a11570c6-f472-4fda-a493-30d65fd8e651",
+        "name": "test Antonin 2", "description": "", "created_at": "2023-08-03T14:09:46.046004Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40",
-        "name": "vBOY test segment", "description": "sdqsdqsdqsdqsd", "created_at":
-        "2023-08-07T12:45:52.890085Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40", "name": "vBOY
+        test segment", "description": "sdqsdqsdqsdqsd", "created_at": "2023-08-07T12:45:52.890085Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-08-07T12:46:45.470113Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "name": "vBOY test segment 2", "description": "sdqsdqsd", "created_at": "2023-08-07T12:47:49.515448Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "86670f84-e117-4f96-aa16-e399a0bb2cf2",
-        "name": "juuj", "description": "", "created_at": "2023-08-08T15:53:23.097840Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86670f84-e117-4f96-aa16-e399a0bb2cf2",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "86670f84-e117-4f96-aa16-e399a0bb2cf2", "name": "juuj",
+        "description": "", "created_at": "2023-08-08T15:53:23.097840Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/86670f84-e117-4f96-aa16-e399a0bb2cf2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
-        "name": "BSidesLV", "description": "Key leaked publically by leakymcgee again",
-        "created_at": "2023-08-10T00:11:42.132386Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "978bf5aa-1f8e-425b-ac4b-b617ddbc178e", "name": "BSidesLV",
+        "description": "Key leaked publically by leakymcgee again", "created_at":
+        "2023-08-10T00:11:42.132386Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
         "status": "triggered", "triggered_at": "2023-08-10T00:13:19.948280Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
-        "key": "date leaked", "value": "08/09/2023"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
-        "key": "format", "value": "public"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
+        ["publicly_exposed"], "custom_tags": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
         "key": "date leaked", "value": "08/09/2023"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
         "key": "format", "value": "public"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
@@ -405,9 +375,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-08-11T18:55:35.503991Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 61, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
+        ["publicly_exposed"], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "90d4c2b6-ecae-4ef9-a754-4561929b9e38",
         "name": "ggshield-mpkTH5jF", "description": "description", "created_at": "2023-08-16T08:28:18.684517Z",
@@ -415,34 +383,31 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
         "name": "ggshield-mzO8qHEz", "description": "description", "created_at": "2023-08-22T08:19:03.821471Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
         "name": "testket ", "description": "eew", "created_at": "2023-08-29T10:21:29.956291Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "46776cb3-6b11-41fc-b431-07609992f0cb",
-        "name": "HoneyTokenaLARTest", "description": "Testworkshop", "created_at":
-        "2023-08-29T12:07:20.692993Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/46776cb3-6b11-41fc-b431-07609992f0cb",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "46776cb3-6b11-41fc-b431-07609992f0cb", "name": "HoneyTokenaLARTest",
+        "description": "Testworkshop", "created_at": "2023-08-29T12:07:20.692993Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/46776cb3-6b11-41fc-b431-07609992f0cb",
         "status": "revoked", "triggered_at": "2023-08-29T12:09:16.581232Z", "revoked_at":
         "2023-08-29T12:42:37.841866Z", "type": "AWS", "open_events_count": 0, "creator_id":
         37699, "revoker_id": 37699, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "edd96a3b-5c71-4346-b5e2-2150e454dc91", "name": "Bsides Krakow", "description":
-        "Demo for leaking a key on GitHub", "created_at": "2023-09-02T13:20:53.501588Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/edd96a3b-5c71-4346-b5e2-2150e454dc91",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "edd96a3b-5c71-4346-b5e2-2150e454dc91",
+        "name": "Bsides Krakow", "description": "Demo for leaking a key on GitHub",
+        "created_at": "2023-09-02T13:20:53.501588Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/edd96a3b-5c71-4346-b5e2-2150e454dc91",
         "status": "triggered", "triggered_at": "2023-09-02T13:22:51.142717Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "de145bd4-b424-49ab-b95b-80126914bf2e",
         "name": "ctf-demo-test-honeytoken-django-app", "description": "", "created_at":
@@ -450,68 +415,59 @@ interactions:
         "status": "revoked", "triggered_at": "2023-09-06T07:42:55.177580Z", "revoked_at":
         "2023-09-06T10:03:30.948628Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "5564ed3c-3eec-4375-9fc8-e0ada71dce02", "name": "ctf-demo-test-honeytoken-micro-api",
-        "description": "", "created_at": "2023-09-05T19:18:08.504776Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/5564ed3c-3eec-4375-9fc8-e0ada71dce02",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5564ed3c-3eec-4375-9fc8-e0ada71dce02",
+        "name": "ctf-demo-test-honeytoken-micro-api", "description": "", "created_at":
+        "2023-09-05T19:18:08.504776Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5564ed3c-3eec-4375-9fc8-e0ada71dce02",
         "status": "revoked", "triggered_at": "2023-09-06T07:44:18.074891Z", "revoked_at":
         "2023-09-06T10:03:48.581110Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "f246c64a-3494-43ae-9d81-500df2f950c3", "name": "demo-honeytoken-ctf-personal-",
-        "description": "", "created_at": "2023-09-06T11:29:57.547211Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/f246c64a-3494-43ae-9d81-500df2f950c3",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f246c64a-3494-43ae-9d81-500df2f950c3",
+        "name": "demo-honeytoken-ctf-personal-", "description": "", "created_at":
+        "2023-09-06T11:29:57.547211Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f246c64a-3494-43ae-9d81-500df2f950c3",
         "status": "revoked", "triggered_at": "2023-09-06T12:18:14.949044Z", "revoked_at":
         "2024-12-10T12:15:49.265110Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
         "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "ff623703-9ca1-4fba-99dc-c20110894ed3",
         "name": "-demo-honeytoken-ctf-django-app-", "description": "", "created_at":
         "2023-09-06T11:33:27.376222Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff623703-9ca1-4fba-99dc-c20110894ed3",
         "status": "triggered", "triggered_at": "2023-09-06T14:19:10.580142Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 4, "creator_id": null, "revoker_id":
+        null, "type": "AWS", "open_events_count": 9, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "a58154f6-e66f-4079-82b7-aabec70c73ff",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "a58154f6-e66f-4079-82b7-aabec70c73ff",
         "name": "demo-honeytoken-ctf-micro-api", "description": "", "created_at":
         "2023-09-06T11:33:37.828240Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a58154f6-e66f-4079-82b7-aabec70c73ff",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-09-06T14:17:20.708816Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b01db549-a2fa-4527-913d-0715a1119530",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "b01db549-a2fa-4527-913d-0715a1119530",
         "name": "demo-honeytoken-ctf-internal-share-", "description": "", "created_at":
         "2023-09-06T11:33:48.881275Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b01db549-a2fa-4527-913d-0715a1119530",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-09-06T14:21:42.509905Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "89a1745a-f796-4ece-99f7-106671aea57c",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "89a1745a-f796-4ece-99f7-106671aea57c",
         "name": "-demo-honeytoken-ctf-micro-api-", "description": "", "created_at":
         "2023-09-06T14:19:32.695323Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/89a1745a-f796-4ece-99f7-106671aea57c",
         "status": "triggered", "triggered_at": "2023-09-06T14:24:18.462424Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "095d655f-a273-400f-ba01-eff8951242ed",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "095d655f-a273-400f-ba01-eff8951242ed",
         "name": "-demo-honeytoken-ctf-internal-share-", "description": "", "created_at":
         "2023-09-06T14:21:55.062468Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/095d655f-a273-400f-ba01-eff8951242ed",
         "status": "triggered", "triggered_at": "2023-09-08T16:58:49.455578Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 6, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "3664c283-d479-41ac-9ad9-30283731ee25",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "3664c283-d479-41ac-9ad9-30283731ee25",
         "name": "Balccon Demo", "description": "Demo key for Balccon ", "created_at":
         "2023-09-08T14:55:02.417580Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3664c283-d479-41ac-9ad9-30283731ee25",
         "status": "triggered", "triggered_at": "2023-09-08T14:56:49.516889Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
-        "key": "location", "value": "sourcecode"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
-        "key": "visability", "value": "public"}], "custom_tags": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
+        ["publicly_exposed"], "custom_tags": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
         "key": "location", "value": "sourcecode"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
         "key": "visability", "value": "public"}], "token": "[REDACTED]"}, {"id": "7ca5ca92-a0a1-48bf-9618-d7194beaa039",
@@ -520,9 +476,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-09-29T16:11:40.077048Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 344, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
-        "key": "confrence", "value": "grrcon"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}], "custom_tags": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
+        ["publicly_exposed"], "custom_tags": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
         "key": "confrence", "value": "grrcon"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}], "token": "[REDACTED]"}, {"id": "2544b3e6-57b2-48e2-a1a5-c4b6551987bb",
         "name": "SBB demo", "description": "Leaking key on GitHub", "created_at":
@@ -530,11 +484,8 @@ interactions:
         "status": "triggered", "triggered_at": "2024-08-17T15:36:55.810693Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key": "commiter",
-        "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca", "key":
-        "file", "value": ".env"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327", "key":
-        "vcs", "value": "github"}], "custom_tags": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda",
-        "key": "commiter", "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
+        [], "custom_tags": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key":
+        "commiter", "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "7d80793b-c702-441e-837e-b1d3da94d576",
         "name": "Hacktivity Key", "description": "Test Key Leak for Hacktivity", "created_at":
@@ -542,9 +493,7 @@ interactions:
         "status": "revoked", "triggered_at": "2023-10-05T14:42:57.752365Z", "revoked_at":
         "2024-12-10T12:17:33.875750Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "576dc1ce-ab72-4604-934f-526cff5a667e", "name": "BsidesCyprus", "description":
@@ -553,8 +502,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-10-07T11:35:53.017981Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 249, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "22fdf53a-e348-464a-a87f-5bcecb1a4e62", "name": "Slack test", "description":
         "blablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablabla
@@ -567,21 +515,20 @@ interactions:
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-06-03T09:50:06.667490Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 363707, "revoker_id":
         353920, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "137c9fee-4b3c-4231-92fd-98debf6557c2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "137c9fee-4b3c-4231-92fd-98debf6557c2",
         "name": "BSides ATL demo for session", "description": "This one will be triggered
         from 2 different spots online", "created_at": "2023-10-14T12:28:51.206659Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/137c9fee-4b3c-4231-92fd-98debf6557c2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 354585, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "cdaea884-25fb-49db-90ec-a18879be36c4",
-        "name": "Demo Honeytoken", "description": "Leaking on Public Demo", "created_at":
-        "2023-10-16T15:13:10.845487Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cdaea884-25fb-49db-90ec-a18879be36c4",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "cdaea884-25fb-49db-90ec-a18879be36c4", "name": "Demo
+        Honeytoken", "description": "Leaking on Public Demo", "created_at": "2023-10-16T15:13:10.845487Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cdaea884-25fb-49db-90ec-a18879be36c4",
         "status": "revoked", "triggered_at": "2023-10-16T15:14:25.574559Z", "revoked_at":
         "2023-10-27T15:01:19.053629Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "48f7c567-93d1-4925-9f77-d3919f120b88", "name": "ggshield-KlAkKRtE", "description":
         "description", "created_at": "2023-10-16T19:49:08.588391Z", "gitguardian_url":
@@ -589,52 +536,50 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
         "name": "Jason test", "description": "Token for Test ", "created_at": "2023-10-24T13:45:31.371710Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f8e0968-664a-49f3-af85-9cc468b960ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "fe392ff1-b3d7-462f-a26f-d094326f40ed",
-        "name": "Jason and team", "description": "akljdlaj", "created_at": "2023-10-24T14:23:20.991107Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fe392ff1-b3d7-462f-a26f-d094326f40ed", "name": "Jason
+        and team", "description": "akljdlaj", "created_at": "2023-10-24T14:23:20.991107Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fe392ff1-b3d7-462f-a26f-d094326f40ed",
         "status": "triggered", "triggered_at": "2024-05-10T22:15:09.224357Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29",
         "name": "Eric Demo Test 01", "description": "", "created_at": "2023-10-31T12:51:44.535200Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d69a098c-8b61-4102-bb2b-9a82958a3e29",
         "status": "revoked", "triggered_at": "2023-10-31T12:52:49.851916Z", "revoked_at":
         "2024-12-10T12:16:28.115539Z", "type": "AWS", "open_events_count": 0, "creator_id":
         136170, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb", "name": "test
-        eric dd 02", "description": "", "created_at": "2023-10-31T14:33:35.801324Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4affa602-902b-47ff-a1f4-721dc3e671bb",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb", "name": "test eric dd 02",
+        "description": "", "created_at": "2023-10-31T14:33:35.801324Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/4affa602-902b-47ff-a1f4-721dc3e671bb",
         "status": "triggered", "triggered_at": "2023-10-31T14:35:33.676298Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 2897, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "8df388e2-aeb5-42ca-b6d5-221a54a40339", "name": "ggshield-P47kTh7j",
-        "description": null, "created_at": "2023-11-09T15:44:33.671666Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/8df388e2-aeb5-42ca-b6d5-221a54a40339",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8df388e2-aeb5-42ca-b6d5-221a54a40339",
+        "name": "ggshield-P47kTh7j", "description": null, "created_at": "2023-11-09T15:44:33.671666Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8df388e2-aeb5-42ca-b6d5-221a54a40339",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "bd51c3d9-0943-43d5-8f87-359ecee03903",
-        "name": "ggshield-73VAsjsO", "description": null, "created_at": "2023-11-14T08:27:44.885242Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bd51c3d9-0943-43d5-8f87-359ecee03903",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "bd51c3d9-0943-43d5-8f87-359ecee03903", "name": "ggshield-73VAsjsO",
+        "description": null, "created_at": "2023-11-14T08:27:44.885242Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/bd51c3d9-0943-43d5-8f87-359ecee03903",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-11-14T08:28:08.188201Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
         "name": "DeepSec Demo", "description": "Demo for DeepSec Confrence ", "created_at":
         "2023-11-16T16:01:21.723176Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
         "status": "triggered", "triggered_at": "2023-11-16T16:01:58.603599Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "ae448808-3865-4797-a008-9eef6344f9da", "name": "Bsides Berlin", "description":
         "test key for a demo", "created_at": "2023-11-18T16:19:36.463172Z", "gitguardian_url":
@@ -642,9 +587,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-11-18T16:20:14.365596Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 105, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
-        "key": "repo", "value": "mackenziejj"}], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
+        ["publicly_exposed"], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
         "key": "repo", "value": "mackenziejj"}], "token": "[REDACTED]"}, {"id": "ecb3d61d-bdab-4636-a436-bef8079a005d",
         "name": "ggshield-ObfCUUCA", "description": "description", "created_at": "2023-11-28T08:50:32.130230Z",
@@ -652,48 +595,41 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d6d5d79d-08fa-4c8a-bd54-c34851866cde",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d6d5d79d-08fa-4c8a-bd54-c34851866cde",
         "name": "test1112", "description": "test publicly exposed honeytoken", "created_at":
         "2023-12-11T16:24:56.253683Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d6d5d79d-08fa-4c8a-bd54-c34851866cde",
         "status": "triggered", "triggered_at": "2023-12-11T16:26:07.733443Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "4046ccf5-7821-47f4-be7d-8240be69631b",
         "name": "ideal-journey-lena", "description": "", "created_at": "2023-12-11T16:29:20.759489Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4046ccf5-7821-47f4-be7d-8240be69631b",
-        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
-        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
+        "status": "triggered", "triggered_at": "2026-05-28T07:56:58.047592Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 5, "creator_id": 319222, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
         "name": "analytics-repo", "description": "", "created_at": "2023-12-11T17:37:24.471286Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
         "status": "triggered", "triggered_at": "2023-12-11T17:46:48.024345Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "b7daf77c-e3e0-4747-a7e2-485a1a6f05e2",
-        "key": "team", "value": "dev"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "b7daf77c-e3e0-4747-a7e2-485a1a6f05e2",
         "key": "team", "value": "dev"}], "token": "[REDACTED]"}, {"id": "52903632-f6ff-460e-8a68-80a942349979",
         "name": "Network Honeytoken", "description": "Aws Honeytoken on Network",
         "created_at": "2023-12-18T13:47:39.151311Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/52903632-f6ff-460e-8a68-80a942349979",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
-        "key": "network", "value": "directory"}], "custom_tags": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
         "key": "network", "value": "directory"}], "token": "[REDACTED]"}, {"id": "6c5d9856-835e-468c-9448-7bf0e77f1e53",
         "name": "improved carnival", "description": "", "created_at": "2023-12-21T13:43:01.544215Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6c5d9856-835e-468c-9448-7bf0e77f1e53",
         "status": "revoked", "triggered_at": "2023-12-21T13:57:59.435706Z", "revoked_at":
         "2023-12-22T09:33:18.668820Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "4dd77510-fc74-411f-9dbe-77619fa920dd",
         "name": "My Postman Public Collection", "description": "Will it ring?", "created_at":
@@ -701,242 +637,231 @@ interactions:
         "status": "triggered", "triggered_at": "2024-01-04T17:52:01.203498Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 811, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
         "name": "ggshield-JZV5XT71", "description": "description", "created_at": "2024-01-09T09:39:34.421404Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "name": "sss", "description": "test", "created_at": "2024-01-09T14:24:10.741214Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
-        "name": "AWS key honeytoken for Slack", "description": "Honeytoken on Slack
-        channel", "created_at": "2024-01-15T16:13:53.656688Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "123ecd19-e66f-4e5c-ad73-12f0a51eda5a", "name": "AWS
+        key honeytoken for Slack", "description": "Honeytoken on Slack channel", "created_at":
+        "2024-01-15T16:13:53.656688Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
         "status": "triggered", "triggered_at": "2024-01-15T16:14:14.960066Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 104, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "23ca2658-aecf-471c-abf0-add09962e320", "key": "ods",
-        "value": "slack"}], "custom_tags": [{"id": "23ca2658-aecf-471c-abf0-add09962e320",
-        "key": "ods", "value": "slack"}], "token": "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a",
+        [], "custom_tags": [{"id": "23ca2658-aecf-471c-abf0-add09962e320", "key":
+        "ods", "value": "slack"}], "token": "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a",
         "name": "BK Test Paris", "description": "Brandon while in Paris office", "created_at":
         "2024-01-17T11:12:14.759334Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/34d5205b-accd-429c-9efa-eda48989c83a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
-        "name": "Lauren Testing", "description": "Lauren wuz here", "created_at":
-        "2024-01-29T17:37:45.379096Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4", "name": "Lauren
+        Testing", "description": "Lauren wuz here", "created_at": "2024-01-29T17:37:45.379096Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 637596, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "07fb5f6f-23f1-42e8-bdb2-c95864412a16",
         "name": "My Little Honeytoken", "description": "for testing", "created_at":
         "2024-02-02T22:18:06.038874Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/07fb5f6f-23f1-42e8-bdb2-c95864412a16",
         "status": "triggered", "triggered_at": "2024-02-09T20:50:13.173911Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b00bfddb-98c2-48e4-ad38-0cb9bc79cad6", "name": "orga_083643/solid-octo",
-        "description": "", "created_at": "2024-02-09T14:45:12.139727Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
+        "name": "orga_083643/solid-octo", "description": "", "created_at": "2024-02-09T14:45:12.139727Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
         "status": "revoked", "triggered_at": "2024-02-09T14:52:11.339548Z", "revoked_at":
         "2024-05-29T13:09:29.773300Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 2508, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "cf0806c4-093d-4165-9ad3-7e7ded211d3f", "name": "DemoKey", "description":
-        "sss", "created_at": "2024-02-15T12:39:23.633481Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cf0806c4-093d-4165-9ad3-7e7ded211d3f",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cf0806c4-093d-4165-9ad3-7e7ded211d3f",
+        "name": "DemoKey", "description": "sss", "created_at": "2024-02-15T12:39:23.633481Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cf0806c4-093d-4165-9ad3-7e7ded211d3f",
         "status": "triggered", "triggered_at": "2024-02-15T12:45:44.649197Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "638f6f82-6679-4399-a336-dd7996f4beae", "name": "demo-2024-02-16dm",
-        "description": "demo", "created_at": "2024-02-16T19:39:33.970811Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/638f6f82-6679-4399-a336-dd7996f4beae",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "638f6f82-6679-4399-a336-dd7996f4beae",
+        "name": "demo-2024-02-16dm", "description": "demo", "created_at": "2024-02-16T19:39:33.970811Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/638f6f82-6679-4399-a336-dd7996f4beae",
         "status": "revoked", "triggered_at": "2024-02-16T19:40:02.759791Z", "revoked_at":
         "2024-02-16T20:10:11.153368Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "6fcc5cf2-4b47-497d-9a80-c2d794b96ebc", "name": "solid-octo",
-        "description": "", "created_at": "2024-02-19T13:06:26.880374Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "6fcc5cf2-4b47-497d-9a80-c2d794b96ebc", "name": "solid-octo", "description":
+        "", "created_at": "2024-02-19T13:06:26.880374Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
-        "key": "team", "value": "octo"}], "custom_tags": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
         "key": "team", "value": "octo"}], "token": "[REDACTED]"}, {"id": "1592023a-2f39-4ba6-a503-4c07132f1eb0",
         "name": "GGnikalston/rock-paper-scissors-f4c01375", "description": "", "created_at":
         "2024-02-20T13:32:45.163630Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1592023a-2f39-4ba6-a503-4c07132f1eb0",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d024b464-cd1e-4daf-9b1d-863dcf517a7a",
-        "name": "Demo -2024-02-22", "description": "", "created_at": "2024-02-22T18:53:26.142516Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d024b464-cd1e-4daf-9b1d-863dcf517a7a", "name": "Demo
+        -2024-02-22", "description": "", "created_at": "2024-02-22T18:53:26.142516Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d024b464-cd1e-4daf-9b1d-863dcf517a7a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 354585, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0a94480f-5361-47f8-bc23-45a331624e9d",
-        "name": "demo ", "description": "demo ", "created_at": "2024-02-22T19:02:29.338420Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0a94480f-5361-47f8-bc23-45a331624e9d",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0a94480f-5361-47f8-bc23-45a331624e9d", "name": "demo
+        ", "description": "demo ", "created_at": "2024-02-22T19:02:29.338420Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/0a94480f-5361-47f8-bc23-45a331624e9d",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T17:03:31.533534Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86136984-d415-41c2-bfc4-59da8f9584fd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86136984-d415-41c2-bfc4-59da8f9584fd",
         "name": "demo-2024-02-23-dm", "description": "", "created_at": "2024-02-23T15:38:04.895275Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86136984-d415-41c2-bfc4-59da8f9584fd",
         "status": "revoked", "triggered_at": "2024-02-23T15:49:03.613445Z", "revoked_at":
         "2024-02-23T15:59:54.768989Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "b38455f9-822c-4f21-8525-0d4f2fa63850", "name": "demo-dwayne-2024-02-23",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "b38455f9-822c-4f21-8525-0d4f2fa63850", "name": "demo-dwayne-2024-02-23",
         "description": "dfnijsbuisbfids", "created_at": "2024-02-23T15:45:47.636481Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b38455f9-822c-4f21-8525-0d4f2fa63850",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T16:28:23.939971Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "612055eb-7fb5-4ba3-ab10-aa481f3d9962",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "612055eb-7fb5-4ba3-ab10-aa481f3d9962",
         "name": "demo-dwayne-2024-02-23-v2", "description": "Demo for video", "created_at":
         "2024-02-23T16:28:49.949332Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/612055eb-7fb5-4ba3-ab10-aa481f3d9962",
         "status": "revoked", "triggered_at": "2024-02-23T16:31:01.657151Z", "revoked_at":
         "2024-02-23T16:52:50.712289Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e", "name": "myname-dwayneptoday",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e", "name": "myname-dwayneptoday",
         "description": "dfsdfsdf", "created_at": "2024-02-23T16:38:14.323313Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T17:03:21.653827Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1bba091c-fc4c-48b5-b558-46c191f67103",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1bba091c-fc4c-48b5-b558-46c191f67103",
         "name": "ggshield-ldC5hqqo", "description": "description", "created_at": "2024-02-27T13:42:36.686028Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1bba091c-fc4c-48b5-b558-46c191f67103",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d7764013-fdd5-4b08-b195-dff5a338906d",
-        "name": "ggshield-LRYYnjOa", "description": "description", "created_at": "2024-02-27T13:42:37.569678Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d7764013-fdd5-4b08-b195-dff5a338906d", "name": "ggshield-LRYYnjOa",
+        "description": "description", "created_at": "2024-02-27T13:42:37.569678Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d7764013-fdd5-4b08-b195-dff5a338906d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "def4a23d-3d12-4fe1-b8e0-02250e74e47a",
-        "name": "ggshield-itglxnie", "description": "description", "created_at": "2024-02-27T13:58:30.205444Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "def4a23d-3d12-4fe1-b8e0-02250e74e47a", "name": "ggshield-itglxnie",
+        "description": "description", "created_at": "2024-02-27T13:58:30.205444Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/def4a23d-3d12-4fe1-b8e0-02250e74e47a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "33d149f1-68f4-4446-ae4f-def0ce962724",
-        "name": "ggshield-2Mf02eVA", "description": "description", "created_at": "2024-02-27T13:58:31.125075Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "33d149f1-68f4-4446-ae4f-def0ce962724", "name": "ggshield-2Mf02eVA",
+        "description": "description", "created_at": "2024-02-27T13:58:31.125075Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/33d149f1-68f4-4446-ae4f-def0ce962724",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5ff5eee1-fc18-4474-86fa-c46321c903c8",
-        "name": "ggshield-rmnfzrW2", "description": "description", "created_at": "2024-02-27T14:02:45.009113Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5ff5eee1-fc18-4474-86fa-c46321c903c8", "name": "ggshield-rmnfzrW2",
+        "description": "description", "created_at": "2024-02-27T14:02:45.009113Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5ff5eee1-fc18-4474-86fa-c46321c903c8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "4dd6c06e-e2c0-4593-9be0-b0418ba7a370",
-        "name": "ggshield-5YTKZZTB", "description": "description", "created_at": "2024-02-27T14:02:45.717261Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "4dd6c06e-e2c0-4593-9be0-b0418ba7a370", "name": "ggshield-5YTKZZTB",
+        "description": "description", "created_at": "2024-02-27T14:02:45.717261Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4dd6c06e-e2c0-4593-9be0-b0418ba7a370",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "eba79796-4f46-4e10-b876-280f75138cc9",
-        "name": "ggshield-z3Y6zgih", "description": "description", "created_at": "2024-02-27T14:06:02.196977Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "eba79796-4f46-4e10-b876-280f75138cc9", "name": "ggshield-z3Y6zgih",
+        "description": "description", "created_at": "2024-02-27T14:06:02.196977Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/eba79796-4f46-4e10-b876-280f75138cc9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0ebc8091-454b-461e-a6f8-fd17bf412c76",
-        "name": "ggshield-jqk54PrI", "description": "description", "created_at": "2024-02-27T14:06:03.018091Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0ebc8091-454b-461e-a6f8-fd17bf412c76", "name": "ggshield-jqk54PrI",
+        "description": "description", "created_at": "2024-02-27T14:06:03.018091Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ebc8091-454b-461e-a6f8-fd17bf412c76",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "664af568-cfc7-4726-9fb4-0b61606b7386",
-        "name": "ggshield-horgQNnR", "description": "description", "created_at": "2024-02-27T14:19:39.357690Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "664af568-cfc7-4726-9fb4-0b61606b7386", "name": "ggshield-horgQNnR",
+        "description": "description", "created_at": "2024-02-27T14:19:39.357690Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/664af568-cfc7-4726-9fb4-0b61606b7386",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5d915aca-6f6f-4b4e-a996-2c1f53016114",
-        "name": "ggshield-LNgN8R1S", "description": "description", "created_at": "2024-02-27T14:19:40.283320Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5d915aca-6f6f-4b4e-a996-2c1f53016114", "name": "ggshield-LNgN8R1S",
+        "description": "description", "created_at": "2024-02-27T14:19:40.283320Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d915aca-6f6f-4b4e-a996-2c1f53016114",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245",
-        "name": "Test key ", "description": "ss", "created_at": "2024-02-29T13:49:52.467489Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245", "name": "Test
+        key ", "description": "ss", "created_at": "2024-02-29T13:49:52.467489Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e",
-        "name": "test-lena-1903", "description": "", "created_at": "2024-03-19T09:13:00.819618Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/443045cc-7fa4-441d-a161-b060bd7fbb3e",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e", "name": "test-lena-1903",
+        "description": "", "created_at": "2024-03-19T09:13:00.819618Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/443045cc-7fa4-441d-a161-b060bd7fbb3e",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-05-29T09:51:31.597203Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 319222, "revoker_id":
         319222, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
         "name": "ggshield-Psfrcoxl", "description": "description", "created_at": "2024-03-27T08:48:20.857237Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5a01f826-4f8f-4235-8867-ce58ac88ce1c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5a01f826-4f8f-4235-8867-ce58ac88ce1c",
         "name": "ggshield-inUFY47O", "description": "description", "created_at": "2024-03-27T08:48:21.791104Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5a01f826-4f8f-4235-8867-ce58ac88ce1c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d72113d0-c346-42c7-bd88-fd5fe0e716f3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d72113d0-c346-42c7-bd88-fd5fe0e716f3",
         "name": "ggshield-eY0ZOlXS", "description": "description", "created_at": "2024-04-30T09:25:38.689800Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d72113d0-c346-42c7-bd88-fd5fe0e716f3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "7f2873cd-3759-4727-a683-31cac57fe5d8",
-        "name": "ggshield-TvlX76OG", "description": "description", "created_at": "2024-04-30T09:25:39.573115Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "7f2873cd-3759-4727-a683-31cac57fe5d8", "name": "ggshield-TvlX76OG",
+        "description": "description", "created_at": "2024-04-30T09:25:39.573115Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7f2873cd-3759-4727-a683-31cac57fe5d8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "72e98633-9179-4a3e-8908-ea2319d19b3b",
-        "name": "ggshield-XYKDhLUY", "description": "description", "created_at": "2024-04-30T10:19:12.369644Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "72e98633-9179-4a3e-8908-ea2319d19b3b", "name": "ggshield-XYKDhLUY",
+        "description": "description", "created_at": "2024-04-30T10:19:12.369644Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72e98633-9179-4a3e-8908-ea2319d19b3b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
         "name": "ggshield-HRoZzrBq", "description": "description", "created_at": "2024-04-30T10:19:13.126568Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
         "name": "Test key", "description": "Access key", "created_at": "2024-05-22T12:16:55.833940Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c7101eaa-ea38-495d-b3b4-c016db23e859",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "a67f962c-9dde-40c2-b404-e7cd4449cc82",
         "name": "pouet", "description": "", "created_at": "2024-05-22T12:19:03.143437Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a67f962c-9dde-40c2-b404-e7cd4449cc82",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
-        "key": "visability", "value": "public"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
         "key": "visability", "value": "public"}], "token": "[REDACTED]"}, {"id": "9cca01c5-535f-4f89-a214-6c4c5579fd07",
@@ -944,487 +869,473 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9cca01c5-535f-4f89-a214-6c4c5579fd07",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
-        "name": "test lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
-        "status": "triggered", "triggered_at": "2024-06-06T08:19:18.422045Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 319222, "revoker_id":
-        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca", "key": "machine",
-        "value": "ggprdgim01"}], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99", "name": "test
+        lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
         "key": "machine", "value": "ggprdgim01"}], "token": "[REDACTED]"}, {"id":
         "a411fa2c-a465-4099-8353-3c42365aca50", "name": "test MINT", "description":
         "test MINT", "created_at": "2024-06-10T14:40:08.522247Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/a411fa2c-a465-4099-8353-3c42365aca50",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "12c4562e-deb8-4d14-bb23-e344e79b6f04",
-        "name": "ggshield-Wq4EyTMI", "description": "description", "created_at": "2024-06-25T08:36:52.179380Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "12c4562e-deb8-4d14-bb23-e344e79b6f04", "name": "ggshield-Wq4EyTMI",
+        "description": "description", "created_at": "2024-06-25T08:36:52.179380Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/12c4562e-deb8-4d14-bb23-e344e79b6f04",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3407738b-2095-47bb-9cbd-dd16de158d67",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3407738b-2095-47bb-9cbd-dd16de158d67",
         "name": "ggshield-65KCwJls", "description": "description", "created_at": "2024-06-25T08:36:52.873146Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3407738b-2095-47bb-9cbd-dd16de158d67",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
         "name": "ggshield-fb77weow", "description": "description", "created_at": "2024-06-26T09:27:38.724573Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9223e352-43b6-4e06-8d12-682d669cedd7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9223e352-43b6-4e06-8d12-682d669cedd7",
         "name": "ggshield-TRO3H56N", "description": "description", "created_at": "2024-06-26T09:27:39.479744Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9223e352-43b6-4e06-8d12-682d669cedd7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "17e088b8-2463-48f8-957b-41d017f1dc83",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "17e088b8-2463-48f8-957b-41d017f1dc83",
         "name": "ggshield-s7IOqS0q", "description": "description", "created_at": "2024-06-26T09:42:26.454643Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/17e088b8-2463-48f8-957b-41d017f1dc83",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e332d717-641d-4ea4-81fc-e98115178454",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e332d717-641d-4ea4-81fc-e98115178454",
         "name": "ggshield-JaAf9b0W", "description": "description", "created_at": "2024-06-26T09:42:27.174527Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e332d717-641d-4ea4-81fc-e98115178454",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26514e1f-4237-474b-b907-037b88427f29",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26514e1f-4237-474b-b907-037b88427f29",
         "name": "ggshield-Uuc8EiUn", "description": "description", "created_at": "2024-06-26T11:51:19.747630Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/26514e1f-4237-474b-b907-037b88427f29",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
         "name": "ggshield-GL7wc5WW", "description": "description", "created_at": "2024-06-26T11:51:20.402145Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
         "name": "test ericf", "description": "", "created_at": "2024-07-09T09:34:04.089955Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
         "status": "triggered", "triggered_at": "2024-07-09T09:34:57.541777Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "a507d04c-bb61-4f2a-93ea-601b8aa27940",
         "name": "ggshield-w1cOSspy", "description": "description", "created_at": "2024-07-31T15:31:09.349255Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a507d04c-bb61-4f2a-93ea-601b8aa27940",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dafa04c5-299a-4a13-9c35-c523e51763f3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dafa04c5-299a-4a13-9c35-c523e51763f3",
         "name": "ggshield-b7VHMqbK", "description": "description", "created_at": "2024-07-31T15:31:10.071786Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dafa04c5-299a-4a13-9c35-c523e51763f3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
         "name": "ggshield-Fu1nGsc9", "description": "description", "created_at": "2024-08-05T09:03:52.745860Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "83888e42-dc57-471c-9a08-f023e3dc2949",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "83888e42-dc57-471c-9a08-f023e3dc2949",
         "name": "ggshield-5suF2vRt", "description": "description", "created_at": "2024-08-05T09:03:53.434873Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/83888e42-dc57-471c-9a08-f023e3dc2949",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e8aad547-96a7-40a4-a05d-710cf536f3a7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e8aad547-96a7-40a4-a05d-710cf536f3a7",
         "name": "ggshield-Vqz4LULC", "description": "description", "created_at": "2024-08-05T09:21:25.593516Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e8aad547-96a7-40a4-a05d-710cf536f3a7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
         "name": "ggshield-lqX7PlwI", "description": "description", "created_at": "2024-08-05T09:21:26.211228Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b144b1fd-dc5f-4a36-abc7-a95d05331245",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b144b1fd-dc5f-4a36-abc7-a95d05331245",
         "name": "ggshield-uZr6LNDv", "description": "description", "created_at": "2024-08-27T07:44:46.267249Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b144b1fd-dc5f-4a36-abc7-a95d05331245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "903bf588-2a03-4318-be6c-b9e3198d1fd6",
-        "name": "ggshield-5Ty2Hu4r", "description": "description", "created_at": "2024-08-27T07:44:46.871854Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "903bf588-2a03-4318-be6c-b9e3198d1fd6", "name": "ggshield-5Ty2Hu4r",
+        "description": "description", "created_at": "2024-08-27T07:44:46.871854Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/903bf588-2a03-4318-be6c-b9e3198d1fd6",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "11222b98-7705-4180-99d1-6e719d8a05a9",
-        "name": "ggshield-qnLief7n", "description": "description", "created_at": "2024-08-27T08:20:15.846360Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "11222b98-7705-4180-99d1-6e719d8a05a9", "name": "ggshield-qnLief7n",
+        "description": "description", "created_at": "2024-08-27T08:20:15.846360Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/11222b98-7705-4180-99d1-6e719d8a05a9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "707b35fb-685b-4577-88b9-94cccc10e165",
-        "name": "ggshield-wqYwwgeK", "description": "description", "created_at": "2024-08-27T08:20:16.467770Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "707b35fb-685b-4577-88b9-94cccc10e165", "name": "ggshield-wqYwwgeK",
+        "description": "description", "created_at": "2024-08-27T08:20:16.467770Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/707b35fb-685b-4577-88b9-94cccc10e165",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "01c7668d-1467-4cac-a395-4b50fc278407",
-        "name": "ggshield-QkzL5Vyb", "description": "description", "created_at": "2024-09-24T08:50:15.865165Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "01c7668d-1467-4cac-a395-4b50fc278407", "name": "ggshield-QkzL5Vyb",
+        "description": "description", "created_at": "2024-09-24T08:50:15.865165Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/01c7668d-1467-4cac-a395-4b50fc278407",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
         "name": "ggshield-kkpkfk1s", "description": "description", "created_at": "2024-09-24T08:50:16.667172Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "730bdd87-31b2-4b42-a32a-5750bc595c9c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "730bdd87-31b2-4b42-a32a-5750bc595c9c",
         "name": "ggshield-dtxlZtWH", "description": "description", "created_at": "2024-10-01T13:18:29.918337Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/730bdd87-31b2-4b42-a32a-5750bc595c9c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b42c6945-05fc-4c5b-af83-e60478cd9db5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b42c6945-05fc-4c5b-af83-e60478cd9db5",
         "name": "ggshield-WPIELIcW", "description": "description", "created_at": "2024-10-01T13:18:30.820570Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b42c6945-05fc-4c5b-af83-e60478cd9db5",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
         "name": "ggshield-B8LwcRR0", "description": "description", "created_at": "2024-10-16T13:47:50.239094Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "81d30531-a54e-4f67-a46b-a7bac5783995",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "81d30531-a54e-4f67-a46b-a7bac5783995",
         "name": "ggshield-IjJFdqDS", "description": "description", "created_at": "2024-10-16T13:47:51.425195Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/81d30531-a54e-4f67-a46b-a7bac5783995",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a0b24134-0cbc-4ca5-b110-18b3311aef73",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a0b24134-0cbc-4ca5-b110-18b3311aef73",
         "name": "DO-demo", "description": "Digital Ocean Demo", "created_at": "2024-10-23T17:55:40.621634Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a0b24134-0cbc-4ca5-b110-18b3311aef73",
         "status": "revoked", "triggered_at": "2024-10-23T18:03:40.135215Z", "revoked_at":
         "2024-10-23T18:33:47.488182Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "50e53ab6-4950-48e6-9350-b5aaa88fafea", "name": "Demo",
-        "description": "Dev team 1", "created_at": "2024-10-27T21:01:47.725365Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/50e53ab6-4950-48e6-9350-b5aaa88fafea",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "50e53ab6-4950-48e6-9350-b5aaa88fafea", "name": "Demo", "description":
+        "Dev team 1", "created_at": "2024-10-27T21:01:47.725365Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/50e53ab6-4950-48e6-9350-b5aaa88fafea",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582569, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}], "token": "[REDACTED]"},
         {"id": "795decd4-4703-4073-9b3c-3ec2157f6182", "name": "Demo token", "description":
         "Take a look", "created_at": "2024-10-28T00:34:48.214122Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/795decd4-4703-4073-9b3c-3ec2157f6182",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582569, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
-        "name": "ggshield-c6YSc2Ie", "description": "description", "created_at": "2024-10-29T14:36:27.096968Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "c43ee48d-4646-40e8-bd12-3dfa30a6b3db", "name": "ggshield-c6YSc2Ie",
+        "description": "description", "created_at": "2024-10-29T14:36:27.096968Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
         "name": "ggshield-E6IPnu0f", "description": "description", "created_at": "2024-10-29T14:36:28.513178Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a454c002-679b-4250-aacf-28b5207543a4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a454c002-679b-4250-aacf-28b5207543a4",
         "name": "ggshield-HjwRkUAT", "description": "description", "created_at": "2024-11-27T12:32:44.877048Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a454c002-679b-4250-aacf-28b5207543a4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5af2ae0-f3f6-4301-82bc-b49108bd782b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5af2ae0-f3f6-4301-82bc-b49108bd782b",
         "name": "ggshield-hIlrbyRm", "description": "description", "created_at": "2024-11-27T12:32:45.728067Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c5af2ae0-f3f6-4301-82bc-b49108bd782b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "aed37b34-4721-43c2-99e2-2f2e78592f63",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "aed37b34-4721-43c2-99e2-2f2e78592f63",
         "name": "ggshield/setup.cfg", "description": "", "created_at": "2024-12-17T10:10:25.895137Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/aed37b34-4721-43c2-99e2-2f2e78592f63",
         "status": "triggered", "triggered_at": "2024-12-17T10:19:35.167833Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 309802, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476", "name": "pierredethoisy/dockerfile",
-        "description": "", "created_at": "2024-12-17T10:30:41.655876Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
+        "name": "pierredethoisy/dockerfile", "description": "", "created_at": "2024-12-17T10:30:41.655876Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
         "status": "triggered", "triggered_at": "2024-12-17T10:32:09.594850Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 309802, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "4b814f00-0897-479f-8a2d-a9593c5f18fa", "name": "WrongSecrets", "description":
-        "Honeytoken for the wrongsecrets repositort", "created_at": "2025-02-06T13:10:31.569094Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4b814f00-0897-479f-8a2d-a9593c5f18fa",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4b814f00-0897-479f-8a2d-a9593c5f18fa",
+        "name": "WrongSecrets", "description": "Honeytoken for the wrongsecrets repositort",
+        "created_at": "2025-02-06T13:10:31.569094Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4b814f00-0897-479f-8a2d-a9593c5f18fa",
         "status": "triggered", "triggered_at": "2025-02-06T13:16:26.325168Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "7dfdb8ee-56fc-486e-9b7a-e6ff248107fa", "name": "ggshield-AAcFXCwl",
-        "description": "description", "created_at": "2025-02-27T10:23:31.621722Z",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
+        "name": "ggshield-AAcFXCwl", "description": "description", "created_at": "2025-02-27T10:23:31.621722Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "97877334-808d-48c7-8802-2c54e9f43661",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "97877334-808d-48c7-8802-2c54e9f43661",
         "name": "ggshield-srahH0o3", "description": "description", "created_at": "2025-02-27T10:23:32.385844Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/97877334-808d-48c7-8802-2c54e9f43661",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ca642fe-2ce4-42b2-9097-5904093935c1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ca642fe-2ce4-42b2-9097-5904093935c1",
         "name": "ggshield-5Vx0aaQd", "description": "description", "created_at": "2025-02-27T10:31:34.080183Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ca642fe-2ce4-42b2-9097-5904093935c1",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d8590557-764f-4618-9b2e-277d536bd111",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d8590557-764f-4618-9b2e-277d536bd111",
         "name": "ggshield-QYqCVZ4i", "description": "description", "created_at": "2025-02-27T10:31:34.798380Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d8590557-764f-4618-9b2e-277d536bd111",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84b08c90-12f5-48ef-baee-ab8d8b15588c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84b08c90-12f5-48ef-baee-ab8d8b15588c",
         "name": "ggshield-4sJy2SkE", "description": "description", "created_at": "2025-02-27T10:53:01.890617Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84b08c90-12f5-48ef-baee-ab8d8b15588c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72204c1e-12c1-445f-b106-09488214d610",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72204c1e-12c1-445f-b106-09488214d610",
         "name": "ggshield-eqoLjiAS", "description": "description", "created_at": "2025-02-27T10:53:02.563136Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72204c1e-12c1-445f-b106-09488214d610",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
         "name": "ggshield-yaqMNJFA", "description": "description", "created_at": "2025-02-27T11:24:20.630794Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a5d5ca0-000f-4011-aaf2-b4f627c19649",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a5d5ca0-000f-4011-aaf2-b4f627c19649",
         "name": "ggshield-x12c7zPc", "description": "description", "created_at": "2025-02-27T11:24:21.465056Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8a5d5ca0-000f-4011-aaf2-b4f627c19649",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c823f31a-73a8-46cc-be4a-029d6d081793",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c823f31a-73a8-46cc-be4a-029d6d081793",
         "name": "ggshield-9Mq5rTUV", "description": "description", "created_at": "2025-02-27T16:44:10.862683Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c823f31a-73a8-46cc-be4a-029d6d081793",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49f1055b-b505-402b-8b79-e4b2c6cf2041",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49f1055b-b505-402b-8b79-e4b2c6cf2041",
         "name": "ggshield-4MmSKBvx", "description": "description", "created_at": "2025-02-27T16:44:11.663957Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/49f1055b-b505-402b-8b79-e4b2c6cf2041",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be8e40e8-b204-40de-8d37-247ac6ef7077",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be8e40e8-b204-40de-8d37-247ac6ef7077",
         "name": "ggshield-DBuxWn0n", "description": "description", "created_at": "2025-02-27T16:57:21.290157Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be8e40e8-b204-40de-8d37-247ac6ef7077",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d10551f8-36f0-4966-a684-d5f9eca89e8d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d10551f8-36f0-4966-a684-d5f9eca89e8d",
         "name": "ggshield-bukJ4Md2", "description": "description", "created_at": "2025-02-27T16:57:22.079317Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d10551f8-36f0-4966-a684-d5f9eca89e8d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d5385824-6a93-47cb-81f3-e818e64371d7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d5385824-6a93-47cb-81f3-e818e64371d7",
         "name": "ggshield-vI1CTIm2", "description": "description", "created_at": "2025-02-27T17:24:28.533666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d5385824-6a93-47cb-81f3-e818e64371d7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
         "name": "ggshield-C519GYI9", "description": "description", "created_at": "2025-02-27T17:24:29.231126Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
         "name": "ggshield-i8zN7WRH", "description": "description", "created_at": "2025-02-27T17:27:14.478281Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "661dae4d-5944-4a20-b7f7-f74913356479",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "661dae4d-5944-4a20-b7f7-f74913356479",
         "name": "ggshield-IX7GxSIs", "description": "description", "created_at": "2025-02-27T17:27:15.226298Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/661dae4d-5944-4a20-b7f7-f74913356479",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "adaea919-086f-4e37-b4e5-dc8208d0e4f5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "adaea919-086f-4e37-b4e5-dc8208d0e4f5",
         "name": "ggshield-rWApiuse", "description": "description", "created_at": "2025-03-03T09:15:26.314595Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/adaea919-086f-4e37-b4e5-dc8208d0e4f5",
         "status": "triggered", "triggered_at": "2026-02-18T14:51:12.198393Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
-        "key": "env", "value": "staging"}], "custom_tags": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
+        null, "tags": [], "custom_tags": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
         "key": "env", "value": "staging"}], "token": "[REDACTED]"}, {"id": "da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
         "name": "ggshield-jdbeH3gE", "description": "description", "created_at": "2025-03-03T09:15:27.049176Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22", "key": "env",
-        "value": "production"}], "custom_tags": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22",
-        "key": "env", "value": "production"}], "token": "[REDACTED]"}, {"id": "1f4708b2-0e51-458c-abca-c03e502b4a5a",
+        [], "custom_tags": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22", "key":
+        "env", "value": "production"}], "token": "[REDACTED]"}, {"id": "1f4708b2-0e51-458c-abca-c03e502b4a5a",
         "name": "ggshield-QgwFEPjx", "description": "description", "created_at": "2025-03-27T15:12:18.744612Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1f4708b2-0e51-458c-abca-c03e502b4a5a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "a4ced9be-6ad5-4d8a-b188-65a117bc0eba",
-        "name": "ggshield-44tVmSvF", "description": "description", "created_at": "2025-03-27T15:12:19.507492Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "a4ced9be-6ad5-4d8a-b188-65a117bc0eba", "name": "ggshield-44tVmSvF",
+        "description": "description", "created_at": "2025-03-27T15:12:19.507492Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a4ced9be-6ad5-4d8a-b188-65a117bc0eba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5710ee7d-6428-4074-a9ff-09399782242d",
-        "name": "ggshield-bF87lDBl", "description": "description", "created_at": "2025-03-27T15:21:17.135616Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5710ee7d-6428-4074-a9ff-09399782242d", "name": "ggshield-bF87lDBl",
+        "description": "description", "created_at": "2025-03-27T15:21:17.135616Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5710ee7d-6428-4074-a9ff-09399782242d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
-        "name": "ggshield-LbIDqGyA", "description": "description", "created_at": "2025-03-27T15:21:17.953340Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "4cbf7af9-9989-4185-8ef8-0f39e6f3d145", "name": "ggshield-LbIDqGyA",
+        "description": "description", "created_at": "2025-03-27T15:21:17.953340Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2dfa1936-f53f-4d0c-8a69-ae9bab297021",
-        "name": "ggshield-qz84En8W", "description": "description", "created_at": "2025-03-27T15:24:16.907610Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2dfa1936-f53f-4d0c-8a69-ae9bab297021", "name": "ggshield-qz84En8W",
+        "description": "description", "created_at": "2025-03-27T15:24:16.907610Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2dfa1936-f53f-4d0c-8a69-ae9bab297021",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "11213dc7-118d-4997-a96b-714640c3ad0b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "11213dc7-118d-4997-a96b-714640c3ad0b",
         "name": "ggshield-CSF39jm8", "description": "description", "created_at": "2025-03-27T15:24:17.721006Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/11213dc7-118d-4997-a96b-714640c3ad0b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "899dd0b0-20b2-45d2-b779-0331cc448935",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "899dd0b0-20b2-45d2-b779-0331cc448935",
         "name": "toto", "description": "tata", "created_at": "2025-05-12T09:58:35.161641Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/899dd0b0-20b2-45d2-b779-0331cc448935",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "62d71685-2eba-4b88-8edd-cc73e698cfa5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "62d71685-2eba-4b88-8edd-cc73e698cfa5",
         "name": "test-greg", "description": "test greg", "created_at": "2025-05-12T10:06:19.826522Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/62d71685-2eba-4b88-8edd-cc73e698cfa5",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:59.739856Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "e948f77d-5353-413e-b37d-8beba84890ff", "name": "test-greg-2", "description":
-        "test greg", "created_at": "2025-05-12T10:08:11.667578Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e948f77d-5353-413e-b37d-8beba84890ff",
+        "name": "test-greg-2", "description": "test greg", "created_at": "2025-05-12T10:08:11.667578Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:54.809724Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb", "name": "test-greg-3", "description":
-        "test greg", "created_at": "2025-05-12T10:08:58.561160Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        "name": "test-greg-3", "description": "test greg", "created_at": "2025-05-12T10:08:58.561160Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:50.784137Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6", "name": "test-greg-4", "description":
-        "test", "created_at": "2025-05-12T10:10:12.927058Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6",
+        "name": "test-greg-4", "description": "test", "created_at": "2025-05-12T10:10:12.927058Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:46.594085Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a", "name": "test-greg-5", "description":
-        "test", "created_at": "2025-05-12T10:12:50.615700Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
+        "name": "test-greg-5", "description": "test", "created_at": "2025-05-12T10:12:50.615700Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:41.387978Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "9fcf0732-6b8d-41d3-ae98-727bd5dde585", "name": "achille-hackathon",
-        "description": "achille hackathon", "created_at": "2025-05-12T12:01:23.542568Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9fcf0732-6b8d-41d3-ae98-727bd5dde585",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9fcf0732-6b8d-41d3-ae98-727bd5dde585",
+        "name": "achille-hackathon", "description": "achille hackathon", "created_at":
+        "2025-05-12T12:01:23.542568Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9fcf0732-6b8d-41d3-ae98-727bd5dde585",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38",
         "name": "TestHoneytoken", "description": "Testing GitGuardian API connectivity",
         "created_at": "2025-05-12T12:19:05.294638Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b0ddbd44-4054-4127-aa00-cd6727e70d38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
         "name": "AWS Credentials", "description": "Honeytoken for testing, to be injected
         as requested by the user.", "created_at": "2025-05-12T12:38:25.640506Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
         "status": "triggered", "triggered_at": "2026-02-18T13:45:03.781945Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 269050, "revoker_id":
+        null, "type": "AWS", "open_events_count": 9, "creator_id": 269050, "revoker_id":
         null, "creator_api_token_id": "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec", "name": "test-greg-7", "description":
-        "test", "created_at": "2025-05-12T12:54:37.703725Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ab824e92-6068-4a9d-ae36-86a94516f2ec",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec",
+        "name": "test-greg-7", "description": "test", "created_at": "2025-05-12T12:54:37.703725Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ab824e92-6068-4a9d-ae36-86a94516f2ec",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:34.521470Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b65d42a4-587f-4701-a595-8429cbcda70b", "name": "gg-mcp-server-honeytoken",
-        "description": "Honeytoken for security monitoring in the gg-mcp-server project.",
-        "created_at": "2025-05-12T12:54:44.402023Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b65d42a4-587f-4701-a595-8429cbcda70b",
-        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
-        "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
-        "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3fe4aa4f-49f6-42ad-a34a-0c108b544215",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b65d42a4-587f-4701-a595-8429cbcda70b",
+        "name": "gg-mcp-server-honeytoken", "description": "Honeytoken for security
+        monitoring in the gg-mcp-server project.", "created_at": "2025-05-12T12:54:44.402023Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b65d42a4-587f-4701-a595-8429cbcda70b",
+        "status": "triggered", "triggered_at": "2026-06-04T13:16:15.961464Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 4, "creator_id": 269050, "revoker_id":
+        null, "creator_api_token_id": "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id":
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3fe4aa4f-49f6-42ad-a34a-0c108b544215",
         "name": "default-honeytoken", "description": "General purpose honeytoken for
         security monitoring", "created_at": "2025-05-12T13:07:52.676810Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/3fe4aa4f-49f6-42ad-a34a-0c108b544215",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
         "name": "test", "description": "test", "created_at": "2025-05-12T13:09:38.965752Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9844e55d-982c-4458-b65b-592ad99ce77a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1026550, "revoker_id": null, "creator_api_token_id":
         "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
         "name": "Test Honeytoken", "description": "Testing honeytoken generation",
         "created_at": "2025-05-12T14:35:34.295363Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b2a7e759-81ab-465d-a578-e3ce42c18741",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
         "name": "test-greg-9", "description": "", "created_at": "2025-05-12T14:50:23.123299Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6d185a-6f59-4b7c-9248-dd05616090db",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:27.366114Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
+        null, "tags": [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
         "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "fbb93094-9778-4b8b-97d8-de99954a758a",
         "name": "AWS_Honeytoken", "description": "Honeytoken generated via MCP", "created_at":
@@ -1432,17 +1343,15 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "34e08af4-59a7-4a3b-b799-65acb8a2019d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "34e08af4-59a7-4a3b-b799-65acb8a2019d",
         "name": "AWS-MCP-Honeytoken", "description": "Honeytoken for monitoring potential
         AWS credential leaks", "created_at": "2025-05-12T15:07:16.157981Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/34e08af4-59a7-4a3b-b799-65acb8a2019d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "16805984-70d6-4049-844a-79bac3054f6f",
         "name": "AwsTestHoneytoken", "description": "Test honeytoken for development
         and monitoring", "created_at": "2025-05-12T15:09:00.390236Z", "gitguardian_url":
@@ -1450,10 +1359,8 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "d476c118-b210-403d-b685-3d7f0a514950",
         "name": "aws-development-access-key", "description": "Development environment
         AWS access key for monitoring credential leaks", "created_at": "2025-05-12T15:12:56.525944Z",
@@ -1461,9 +1368,7 @@ interactions:
         "status": "triggered", "triggered_at": "2026-02-18T14:50:57.626529Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 2, "creator_id": 270722, "revoker_id":
         null, "creator_api_token_id": "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
+        null, "tags": [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
         "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "0a112323-6906-4bd0-a660-1b45a0fc59ca",
         "name": "NHI-Explorer-Secret", "description": "AWS access key for NHI Explorer
@@ -1472,232 +1377,412 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "69dbbe3c-2dfc-4c93-916c-f70c42f4e2af",
         "name": "ggshield-Leb9CGys", "description": "description", "created_at": "2025-05-27T08:18:31.020533Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/69dbbe3c-2dfc-4c93-916c-f70c42f4e2af",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "029e2aba-796c-47d8-8d52-e14f9868acfc",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "029e2aba-796c-47d8-8d52-e14f9868acfc",
         "name": "ggshield-Fhjl6QxB", "description": "description", "created_at": "2025-05-27T08:18:31.873128Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/029e2aba-796c-47d8-8d52-e14f9868acfc",
         "status": "triggered", "triggered_at": "2025-06-17T09:30:39.728240Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "c77d47b6-8d61-46a7-b6a1-1715fc47c7eb", "name": "ggshield-U8JeiAjO",
-        "description": "description", "created_at": "2025-06-24T13:04:20.196705Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
+        "name": "ggshield-U8JeiAjO", "description": "description", "created_at": "2025-06-24T13:04:20.196705Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab",
-        "name": "ggshield-NiJSM24s", "description": "description", "created_at": "2025-06-24T13:04:21.255669Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab", "name": "ggshield-NiJSM24s",
+        "description": "description", "created_at": "2025-06-24T13:04:21.255669Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5692a982-6603-443e-bdb4-5ea1a5de6f64",
-        "name": "ggshield-JKhVuHaW", "description": "description", "created_at": "2025-06-24T13:06:56.046343Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5692a982-6603-443e-bdb4-5ea1a5de6f64", "name": "ggshield-JKhVuHaW",
+        "description": "description", "created_at": "2025-06-24T13:06:56.046343Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5692a982-6603-443e-bdb4-5ea1a5de6f64",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "17925c95-1df7-4e86-9c42-aabb5dbdea69",
-        "name": "ggshield-vfjAXCfY", "description": "description", "created_at": "2025-06-24T13:06:57.033247Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "17925c95-1df7-4e86-9c42-aabb5dbdea69", "name": "ggshield-vfjAXCfY",
+        "description": "description", "created_at": "2025-06-24T13:06:57.033247Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/17925c95-1df7-4e86-9c42-aabb5dbdea69",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "631ef101-122f-4592-9de1-2d6cb5becafa",
-        "name": "ggshield-dbhOtleP", "description": "description", "created_at": "2025-06-24T13:13:01.219899Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "631ef101-122f-4592-9de1-2d6cb5becafa", "name": "ggshield-dbhOtleP",
+        "description": "description", "created_at": "2025-06-24T13:13:01.219899Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/631ef101-122f-4592-9de1-2d6cb5becafa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "bebc1ca8-933d-45ca-b201-fbabc4eab464",
-        "name": "ggshield-7pQLMJYV", "description": "description", "created_at": "2025-06-24T13:13:01.978212Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "bebc1ca8-933d-45ca-b201-fbabc4eab464", "name": "ggshield-7pQLMJYV",
+        "description": "description", "created_at": "2025-06-24T13:13:01.978212Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bebc1ca8-933d-45ca-b201-fbabc4eab464",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "3983e8ff-7fd6-4fde-9117-9612d4258052",
-        "name": "ggshield-phDsJ9wy", "description": "description", "created_at": "2025-06-24T13:29:15.096198Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "3983e8ff-7fd6-4fde-9117-9612d4258052", "name": "ggshield-phDsJ9wy",
+        "description": "description", "created_at": "2025-06-24T13:29:15.096198Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3983e8ff-7fd6-4fde-9117-9612d4258052",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "9340e7fe-f79c-467e-9dcd-43ddaa77dc0c",
-        "name": "ggshield-Md0MBV0B", "description": "description", "created_at": "2025-06-24T13:29:16.049584Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "9340e7fe-f79c-467e-9dcd-43ddaa77dc0c", "name": "ggshield-Md0MBV0B",
+        "description": "description", "created_at": "2025-06-24T13:29:16.049584Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9340e7fe-f79c-467e-9dcd-43ddaa77dc0c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "08b51a6e-dd6c-4a4b-93f9-b955663c6524",
-        "name": "ggshield-ZoWflf5b", "description": "description", "created_at": "2025-06-24T13:31:49.045062Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "08b51a6e-dd6c-4a4b-93f9-b955663c6524", "name": "ggshield-ZoWflf5b",
+        "description": "description", "created_at": "2025-06-24T13:31:49.045062Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/08b51a6e-dd6c-4a4b-93f9-b955663c6524",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "96da938d-d6fa-4e44-9254-c568a27be484",
-        "name": "ggshield-PirK5h1Q", "description": "description", "created_at": "2025-06-24T13:31:49.827284Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "96da938d-d6fa-4e44-9254-c568a27be484", "name": "ggshield-PirK5h1Q",
+        "description": "description", "created_at": "2025-06-24T13:31:49.827284Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/96da938d-d6fa-4e44-9254-c568a27be484",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f2c61b85-e11d-4db0-a8af-7fc327310b39",
-        "name": "ggshield-ZQ4jUtQr", "description": "description", "created_at": "2025-06-24T13:45:17.477850Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f2c61b85-e11d-4db0-a8af-7fc327310b39", "name": "ggshield-ZQ4jUtQr",
+        "description": "description", "created_at": "2025-06-24T13:45:17.477850Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f2c61b85-e11d-4db0-a8af-7fc327310b39",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f99173ff-9ffe-492c-b8ae-54157df89bac",
-        "name": "ggshield-5uK6KYFh", "description": "description", "created_at": "2025-06-24T13:45:18.309642Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f99173ff-9ffe-492c-b8ae-54157df89bac", "name": "ggshield-5uK6KYFh",
+        "description": "description", "created_at": "2025-06-24T13:45:18.309642Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f99173ff-9ffe-492c-b8ae-54157df89bac",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768",
-        "name": "ggshield-MGXkbqc7", "description": "description", "created_at": "2025-06-24T13:50:43.295521Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768", "name": "ggshield-MGXkbqc7",
+        "description": "description", "created_at": "2025-06-24T13:50:43.295521Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f3252f2c-16a9-45e4-97e8-bed4b5752415",
-        "name": "ggshield-YJd3rq9q", "description": "description", "created_at": "2025-06-24T13:50:44.165951Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f3252f2c-16a9-45e4-97e8-bed4b5752415", "name": "ggshield-YJd3rq9q",
+        "description": "description", "created_at": "2025-06-24T13:50:44.165951Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f3252f2c-16a9-45e4-97e8-bed4b5752415",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "e22705f1-5497-449b-9614-3c2d89e3b705",
-        "name": "ggshield-l4abwnpa", "description": null, "created_at": "2025-06-26T12:32:05.993896Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e22705f1-5497-449b-9614-3c2d89e3b705",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "e22705f1-5497-449b-9614-3c2d89e3b705", "name": "ggshield-l4abwnpa",
+        "description": null, "created_at": "2025-06-26T12:32:05.993896Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e22705f1-5497-449b-9614-3c2d89e3b705",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
         "4ff03654-f280-4c31-8eef-5295d2b75a50", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7691445a-2cb0-4093-94ca-f2c5de877075",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7691445a-2cb0-4093-94ca-f2c5de877075",
         "name": "ggshield-Lwhu1Nax", "description": "description", "created_at": "2025-07-29T10:34:41.534666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7691445a-2cb0-4093-94ca-f2c5de877075",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "951e1f19-5804-444a-b275-b51dc5bf68ee",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "951e1f19-5804-444a-b275-b51dc5bf68ee",
         "name": "ggshield-u9ltlEmT", "description": "description", "created_at": "2025-07-29T10:34:42.385215Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/951e1f19-5804-444a-b275-b51dc5bf68ee",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
         "name": "ggshield-CC0Lj0vS", "description": "description", "created_at": "2025-07-29T10:40:27.317817Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
         "name": "ggshield-0k2Xha2i", "description": "description", "created_at": "2025-07-29T10:40:28.088246Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
         "status": "triggered", "triggered_at": "2025-08-22T16:59:58.315774Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "49e4fce7-aa48-42b0-9fc4-e16105ae08e5", "name": "ggshield-ncOpkfP8",
-        "description": "description", "created_at": "2025-08-27T11:43:11.666517Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
+        "name": "ggshield-ncOpkfP8", "description": "description", "created_at": "2025-08-27T11:43:11.666517Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2b15518b-3100-4736-bee6-b47fe8d26fc1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2b15518b-3100-4736-bee6-b47fe8d26fc1",
         "name": "ggshield-H2eDvilF", "description": "description", "created_at": "2025-08-27T11:43:12.618589Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2b15518b-3100-4736-bee6-b47fe8d26fc1",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "368a90bf-269b-4a60-95c2-1c77c86f7fd4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "368a90bf-269b-4a60-95c2-1c77c86f7fd4",
         "name": "ggshield-V6RzZJGL", "description": "description", "created_at": "2025-11-14T16:54:30.227288Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/368a90bf-269b-4a60-95c2-1c77c86f7fd4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "eae1aaaf-d700-475d-b65a-ffd79f84806d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "eae1aaaf-d700-475d-b65a-ffd79f84806d",
         "name": "ggshield-Pya2g1xF", "description": "description", "created_at": "2025-11-14T16:54:30.933576Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/eae1aaaf-d700-475d-b65a-ffd79f84806d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
         "name": "ggshield-Z2Ji3PxX", "description": "description", "created_at": "2026-03-31T13:26:20.710346Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
         "name": "ggshield-FsL9dCzu", "description": "description", "created_at": "2026-03-31T13:26:21.681383Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7daed77-1fa4-416d-88e2-473200b810aa",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7daed77-1fa4-416d-88e2-473200b810aa",
         "name": "ggshield-dqv39cn2", "description": "description", "created_at": "2026-03-31T13:32:28.824725Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e7daed77-1fa4-416d-88e2-473200b810aa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "601c59d9-7579-402e-90c4-59da055a8d3b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "601c59d9-7579-402e-90c4-59da055a8d3b",
         "name": "ggshield-YpbVgsRl", "description": "description", "created_at": "2026-03-31T13:32:29.820990Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/601c59d9-7579-402e-90c4-59da055a8d3b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "54e52712-a036-4e80-899b-c1a200610339",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "54e52712-a036-4e80-899b-c1a200610339",
         "name": "ggshield-DZ5zVj1p", "description": "description", "created_at": "2026-03-31T13:37:32.513332Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/54e52712-a036-4e80-899b-c1a200610339",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51dc5671-8053-4b87-8174-975ccf7f249c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51dc5671-8053-4b87-8174-975ccf7f249c",
         "name": "ggshield-DXGKK2gC", "description": "description", "created_at": "2026-03-31T13:37:33.559937Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/51dc5671-8053-4b87-8174-975ccf7f249c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}]'
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "name": "test Pierre", "description": "", "created_at": "2026-04-07T18:38:38.199572Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "ae435f66-1ea9-4dfe-b73f-49f451fc00ab", "name": "Demo
+        Romain", "description": "", "created_at": "2026-04-24T12:48:19.654369Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/ae435f66-1ea9-4dfe-b73f-49f451fc00ab",
+        "status": "triggered", "triggered_at": "2026-04-29T12:54:19.464710Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 6, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [{"id": "7a2469eb-2b6b-4248-8103-2b0f6b4fac9b", "key":
+        "romain", "value": null}], "token": "[REDACTED]"}, {"id": "10f6e20b-12ae-4591-aa09-7e1ff00ef408",
+        "name": "qa / xyz-e732d912", "description": "", "created_at": "2026-04-24T16:05:46.508625Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/10f6e20b-12ae-4591-aa09-7e1ff00ef408",
+        "status": "triggered", "triggered_at": "2026-04-24T16:13:17.276672Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9266c0f4-f0e0-41d2-a8c8-c164ccb84e47",
+        "name": "qa / test-nriv-e732d912", "description": "", "created_at": "2026-04-24T16:05:50.013606Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9266c0f4-f0e0-41d2-a8c8-c164ccb84e47",
+        "status": "triggered", "triggered_at": "2026-04-24T16:15:44.494587Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "name": "dev / Salome Test-e732d912", "description": "", "created_at": "2026-04-24T16:05:53.158978Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "status": "triggered", "triggered_at": "2026-04-24T16:16:21.895694Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "name": "qa / test-r8327r-e732d912", "description": "", "created_at": "2026-04-24T16:05:56.586568Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "status": "triggered", "triggered_at": "2026-04-24T16:18:31.419829Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2314a2ef-cec4-4e3d-834a-09b0c40c99d2",
+        "name": "qa / abc-e732d912", "description": "", "created_at": "2026-04-24T16:05:59.728317Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2314a2ef-cec4-4e3d-834a-09b0c40c99d2",
+        "status": "triggered", "triggered_at": "2026-04-24T16:25:50.024911Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "fe96d213-a002-4161-a7c9-cb3be4ad88f8",
+        "name": "qa / Handcrafted Metal Bike-e732d912", "description": "", "created_at":
+        "2026-04-24T16:06:02.936659Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fe96d213-a002-4161-a7c9-cb3be4ad88f8",
+        "status": "triggered", "triggered_at": "2026-04-24T16:35:48.958630Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a72f662-2357-4b93-b48a-00028e36cfff",
+        "name": "test1", "description": "tEST 2", "created_at": "2026-04-30T09:12:55.584248Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a72f662-2357-4b93-b48a-00028e36cfff",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "963fbabe-3d2c-4154-8281-2f13be7c06f7", "name": "test121",
+        "description": "testing 12", "created_at": "2026-04-30T11:31:57.689130Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/963fbabe-3d2c-4154-8281-2f13be7c06f7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "1acff09e-02c1-4a24-8869-568dfab124c9", "name": "test-pierredt",
+        "description": "hello", "created_at": "2026-05-06T19:57:39.689471Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/1acff09e-02c1-4a24-8869-568dfab124c9",
+        "status": "triggered", "triggered_at": "2026-05-06T19:59:18.645288Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 6, "creator_id": 309802, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "name": "qa / test-nriv-d2363bd5", "description": "", "created_at": "2026-05-19T08:29:37.247067Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "status": "triggered", "triggered_at": "2026-05-19T08:33:36.289678Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 1754656, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "03e7e668-6fbf-493a-8d1c-ac9d0c6c1b97",
+        "name": "qa / xyz-d2363bd5", "description": "", "created_at": "2026-05-19T08:29:41.396307Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/03e7e668-6fbf-493a-8d1c-ac9d0c6c1b97",
+        "status": "triggered", "triggered_at": "2026-05-19T08:34:30.001210Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 1754656, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "bb1adf06-28ea-4daf-b338-59d5ef094f67",
+        "name": "TheBigHoney", "description": "Big Honey Pot for our core secrets",
+        "created_at": "2026-05-19T11:51:12.957707Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bb1adf06-28ea-4daf-b338-59d5ef094f67",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "93abaf01-cac6-48f4-bfa1-735cfb7fde7d", "name": "ttoprjog",
+        "description": "Henri", "created_at": "2026-05-20T12:22:37.974250Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/93abaf01-cac6-48f4-bfa1-735cfb7fde7d",
+        "status": "revoked", "triggered_at": null, "revoked_at": "2026-05-20T12:23:19.883989Z",
+        "type": "AWS", "open_events_count": 0, "creator_id": 113168, "revoker_id":
+        113168, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be3d1024-d9df-466c-9e75-afc1ed88b8f5",
+        "name": "test-plc", "description": "", "created_at": "2026-05-26T07:26:21.052034Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be3d1024-d9df-466c-9e75-afc1ed88b8f5",
+        "status": "revoked", "triggered_at": "2026-05-26T08:44:57.678480Z", "revoked_at":
+        "2026-05-26T12:19:01.401494Z", "type": "AWS", "open_events_count": 0, "creator_id":
+        701514, "revoker_id": 701514, "creator_api_token_id": null, "revoker_api_token_id":
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "8409c955-f217-47c9-9cf1-3a6b557c65c9", "name": "Test", "description": "",
+        "created_at": "2026-05-26T14:12:05.347374Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8409c955-f217-47c9-9cf1-3a6b557c65c9",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754650, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "82f00514-d9d3-442c-b575-c40ff77db387", "name": "test-plc2",
+        "description": "", "created_at": "2026-05-27T13:13:33.943814Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/82f00514-d9d3-442c-b575-c40ff77db387",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 701514, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "2fb03282-9878-481c-be5b-eda6036f909d", "name": "ahah-plc", "description":
+        "", "created_at": "2026-06-01T12:43:48.383287Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2fb03282-9878-481c-be5b-eda6036f909d",
+        "status": "triggered", "triggered_at": "2026-06-04T21:49:55.543841Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 701514, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86344c0b-c360-4709-bb6b-fce628ace1d7",
+        "name": "honeytoken-toot-991c4137", "description": "", "created_at": "2026-06-05T17:59:07.240726Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86344c0b-c360-4709-bb6b-fce628ace1d7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
+        "97c1b533-d768-4054-94de-ae3d967a5128", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "949d59d0-c3c2-4d5e-ae3c-4f365b9b8456",
+        "name": "honeytoken-toot-0fefb095", "description": "", "created_at": "2026-06-05T17:59:07.748651Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/949d59d0-c3c2-4d5e-ae3c-4f365b9b8456",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
+        "97c1b533-d768-4054-94de-ae3d967a5128", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ab5965c-8f7e-44ec-b64e-1111e140586f",
+        "name": "ggshield-WOmcC4wM", "description": "description", "created_at": "2026-06-15T15:05:19.990102Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ab5965c-8f7e-44ec-b64e-1111e140586f",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "95786b03-4165-4245-8aef-fac41ff6a1de",
+        "name": "ggshield-E2HxYogl", "description": "description", "created_at": "2026-06-15T15:05:20.446208Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/95786b03-4165-4245-8aef-fac41ff6a1de",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "98271cf2-3025-4e7d-b120-afd29fe20c8f",
+        "name": "ggshield-32Xli2ct", "description": "description", "created_at": "2026-06-15T15:13:44.456933Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/98271cf2-3025-4e7d-b120-afd29fe20c8f",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "68f09d33-1cab-4b93-84a5-2861a7a01fbc",
+        "name": "ggshield-o2ocvFQZ", "description": "description", "created_at": "2026-06-15T15:13:45.228488Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/68f09d33-1cab-4b93-84a5-2861a7a01fbc",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ee69dfd0-fa9c-451d-947e-261c2edd4355",
+        "name": "ggshield-rGxN1k4I", "description": "description", "created_at": "2026-06-15T15:46:58.088837Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ee69dfd0-fa9c-451d-947e-261c2edd4355",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f91525c-02bd-4a0f-9c5d-c9949f7196f4",
+        "name": "ggshield-bZoVll0H", "description": "description", "created_at": "2026-06-15T15:46:58.839510Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f91525c-02bd-4a0f-9c5d-c9949f7196f4",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4a3a3699-fb2e-4e0f-ae02-4905fe8228ec",
+        "name": "ggshield-VuSeELel", "description": "description", "created_at": "2026-06-17T13:23:52.166183Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4a3a3699-fb2e-4e0f-ae02-4905fe8228ec",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "dd2d3e47-d804-41c5-b8b8-f640e6292096", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d82dc520-9ea5-4a38-a9d8-84bf2f94975b",
+        "name": "ggshield-yQlAvTpn", "description": "description", "created_at": "2026-06-17T13:23:52.682610Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d82dc520-9ea5-4a38-a9d8-84bf2f94975b",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "dd2d3e47-d804-41c5-b8b8-f640e6292096", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}]'
     headers:
+      CF-RAY:
+      - a10397779f5cfcf1-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:46 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, POST, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '139756'
+      - '145842'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:41 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '716'
+      - '802'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_honeytokens_get_all.yaml
+++ b/tests/cassettes/tools/vcr/test_list_honeytokens_get_all.yaml
@@ -25,33 +25,29 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/411d33c0-7fad-4fc1-b94e-bb440c8f9c49",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:11.250010Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}, {"id": "858a3a76-f6f2-4c2e-b0bc-323d9a575413",
-        "name": "test_honey_token", "description": "description", "created_at": "2023-05-15T14:09:09.210845Z",
+        "token": "[REDACTED]"}, {"id": "858a3a76-f6f2-4c2e-b0bc-323d9a575413", "name":
+        "test_honey_token", "description": "description", "created_at": "2023-05-15T14:09:09.210845Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/858a3a76-f6f2-4c2e-b0bc-323d9a575413",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:17.165934Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}, {"id": "72a52279-8e9f-40de-a1d4-bc5fcc48795d",
-        "name": "passwordscon", "description": "", "created_at": "2023-05-16T10:03:49.677782Z",
+        "token": "[REDACTED]"}, {"id": "72a52279-8e9f-40de-a1d4-bc5fcc48795d", "name":
+        "passwordscon", "description": "", "created_at": "2023-05-16T10:03:49.677782Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72a52279-8e9f-40de-a1d4-bc5fcc48795d",
         "status": "triggered", "triggered_at": "2023-05-16T10:04:10.262805Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 222, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
-        "key": "location", "value": "test"}], "custom_tags": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
+        ["publicly_exposed"], "custom_tags": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
         "key": "location", "value": "test"}], "token": "[REDACTED]"}, {"id": "8bf5f99a-538d-4cfe-8e74-61cd7081ae25",
         "name": "PasswordsCon2", "description": "For presentation", "created_at":
         "2023-05-16T11:30:36.210395Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8bf5f99a-538d-4cfe-8e74-61cd7081ae25",
         "status": "triggered", "triggered_at": "2023-05-16T12:29:45.638074Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 344, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "45182b59-b659-41ef-9bb8-44a78740fade", "name": "solid-octo-repo", "description":
         "Placed in solid-octo repo, file ... on 16May2023", "created_at": "2023-05-16T11:51:06.384073Z",
@@ -59,47 +55,41 @@ interactions:
         "status": "triggered", "triggered_at": "2026-02-18T14:51:12.499369Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432", "key": "place",
-        "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
+        [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432", "key":
+        "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
         "name": "jira-OPS-124", "description": "honeytoken deployed in jira ticket
         OPS-124", "created_at": "2023-05-16T11:58:57.713307Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "63bbd74e-bb5f-4910-8e63-eed358af3bc8",
         "name": "improved-carnival repo", "description": "", "created_at": "2023-05-16T14:45:09.811724Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/63bbd74e-bb5f-4910-8e63-eed358af3bc8",
         "status": "revoked", "triggered_at": "2023-05-16T14:49:44.284195Z", "revoked_at":
         "2024-06-19T10:46:44.282148Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "72fcdb5c-e128-4ca5-8970-f1f52f95a78a",
         "name": "slack-chan-website", "description": "", "created_at": "2023-05-16T15:35:26.129025Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72fcdb5c-e128-4ca5-8970-f1f52f95a78a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
-        "key": "place", "value": "website"}], "custom_tags": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
         "key": "place", "value": "website"}], "token": "[REDACTED]"}, {"id": "84d43c23-6d4d-47f8-bf62-e7c1b0ae1625",
         "name": "analytic-repo", "description": "", "created_at": "2023-05-16T16:17:11.435058Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84d43c23-6d4d-47f8-bf62-e7c1b0ae1625",
         "status": "revoked", "triggered_at": "2023-05-16T16:27:55.091410Z", "revoked_at":
         "2023-12-11T14:01:44.427581Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "ef11a80c-6d8e-4fb5-8ee2-4556bae695c3",
         "name": "test ht public", "description": "", "created_at": "2023-05-17T17:00:24.966335Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef11a80c-6d8e-4fb5-8ee2-4556bae695c3",
         "status": "triggered", "triggered_at": "2023-05-17T17:02:33.386529Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 5012, "creator_id": 166199, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
-        "key": "location", "value": "slack"}], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
+        ["publicly_exposed"], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
         "key": "location", "value": "slack"}], "token": "[REDACTED]"}, {"id": "db7bf6ea-57cb-4d13-8ed9-dc59b2620e00",
         "name": "Honeytoken demo 17 may", "description": "This is a token for the
         live demo", "created_at": "2023-05-17T17:15:04.921233Z", "gitguardian_url":
@@ -107,173 +97,161 @@ interactions:
         "status": "triggered", "triggered_at": "2023-05-17T17:16:48.960267Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 5018, "creator_id": 166199, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "79db31fc-ffd1-4bc9-b6e4-3ef37a94712a", "name": "QubitConfrence", "description":
         "", "created_at": "2023-05-18T07:58:37.174577Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/79db31fc-ffd1-4bc9-b6e4-3ef37a94712a",
         "status": "triggered", "triggered_at": "2023-05-18T09:30:01.025933Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 215, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263", "name": "NDC-OSLO Demo", "description":
-        "Demo key for NDC Oslo confrence", "created_at": "2023-05-25T07:59:05.651290Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
+        "name": "NDC-OSLO Demo", "description": "Demo key for NDC Oslo confrence",
+        "created_at": "2023-05-25T07:59:05.651290Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
         "status": "triggered", "triggered_at": "2023-05-25T08:38:27.471330Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 221, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b6f2b765-a8e5-458f-b68a-4b5ef934bcc8", "name": "Pycon Italia", "description":
-        "", "created_at": "2023-05-28T09:34:01.581495Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
+        "name": "Pycon Italia", "description": "", "created_at": "2023-05-28T09:34:01.581495Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
         "status": "revoked", "triggered_at": "2023-05-28T09:45:30.255118Z", "revoked_at":
         "2024-12-10T12:17:08.199275Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "bb494eed-6ba4-4b98-b949-ad5f54d929dd", "name": "ggshield-uORy0any",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "bb494eed-6ba4-4b98-b949-ad5f54d929dd", "name": "ggshield-uORy0any",
         "description": "description", "created_at": "2023-05-30T10:30:39.803353Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bb494eed-6ba4-4b98-b949-ad5f54d929dd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1266b395-a545-42c1-b700-24dbae36447c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1266b395-a545-42c1-b700-24dbae36447c",
         "name": "test_honey_token_previous", "description": "description", "created_at":
         "2023-05-30T10:30:40.547255Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1266b395-a545-42c1-b700-24dbae36447c",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:41:43.173510Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "f60db759-7041-4dfe-80fa-91012d97fdd3",
         "name": "ggshield-tsCPoUcx", "description": "description", "created_at": "2023-05-30T10:37:14.527124Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f60db759-7041-4dfe-80fa-91012d97fdd3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
         "name": "ggshield-BA0VsBh3", "description": "description", "created_at": "2023-05-30T10:39:09.968782Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e7f275d-e115-44d3-8854-5c6472494951",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e7f275d-e115-44d3-8854-5c6472494951",
         "name": "ggshield-UXgNYVXL", "description": "description", "created_at": "2023-05-30T10:42:36.847031Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6e7f275d-e115-44d3-8854-5c6472494951",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7494298b-75c5-44e4-898c-77b3b9017113",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7494298b-75c5-44e4-898c-77b3b9017113",
         "name": "test_honey_token_abc", "description": "description", "created_at":
         "2023-05-30T10:42:37.520767Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7494298b-75c5-44e4-898c-77b3b9017113",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:45:41.905071Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "092dba62-9d82-41bd-84aa-95430d540edc", "name": "ggshield-224Lwv95",
-        "description": "description", "created_at": "2023-05-30T10:46:10.997022Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "092dba62-9d82-41bd-84aa-95430d540edc",
+        "name": "ggshield-224Lwv95", "description": "description", "created_at": "2023-05-30T10:46:10.997022Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/092dba62-9d82-41bd-84aa-95430d540edc",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
         "name": "test_honey_token_previous", "description": "description", "created_at":
         "2023-05-30T10:46:11.714531Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:07.762156Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "13f6dbf3-ae1a-4757-95f6-e0fbc830fc55", "name": "ggshield-agateau",
-        "description": null, "created_at": "2023-05-30T13:32:31.845201Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
+        "name": "ggshield-agateau", "description": null, "created_at": "2023-05-30T13:32:31.845201Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T13:33:03.363563Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 160089, "revoker_id":
         160089, "creator_api_token_id": "425e1a78-209e-4cd5-b08f-8450a0026ac0", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "f17302cd-850b-4b54-9054-60d26a76cf38", "name": "test demo 31may",
-        "description": "", "created_at": "2023-05-31T08:10:36.754144Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f17302cd-850b-4b54-9054-60d26a76cf38",
+        "name": "test demo 31may", "description": "", "created_at": "2023-05-31T08:10:36.754144Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "41d76272-ee3d-4639-93e8-29222b662b93",
         "name": "demo31may-public", "description": "", "created_at": "2023-05-31T08:13:48.373887Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/41d76272-ee3d-4639-93e8-29222b662b93",
         "status": "revoked", "triggered_at": "2023-05-31T08:15:09.926931Z", "revoked_at":
         "2024-12-10T12:16:03.693045Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "63728091-d083-47cc-9898-73c2636f2c7f", "name": "ggshield-ZIU1V3Bv", "description":
         null, "created_at": "2023-05-31T08:17:12.607879Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/63728091-d083-47cc-9898-73c2636f2c7f",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-31T08:17:38.021142Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "001c53df-b63c-4b81-a4fb-35e5b38bf328", "name": "DevOxx Poland", "description":
-        "", "created_at": "2023-05-31T12:28:39.713989Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/001c53df-b63c-4b81-a4fb-35e5b38bf328",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "001c53df-b63c-4b81-a4fb-35e5b38bf328",
+        "name": "DevOxx Poland", "description": "", "created_at": "2023-05-31T12:28:39.713989Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/001c53df-b63c-4b81-a4fb-35e5b38bf328",
         "status": "triggered", "triggered_at": "2023-05-31T14:09:21.767459Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 225, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05", "name": "ggshield-cptptJHt",
-        "description": "ggshield test", "created_at": "2023-06-02T08:47:41.149126Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05",
+        "name": "ggshield-cptptJHt", "description": "ggshield test", "created_at":
+        "2023-06-02T08:47:41.149126Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
-        "name": "ggshield-TtJwtxNE", "description": "ggshield test", "created_at":
-        "2023-06-02T08:48:20.148216Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72", "name": "ggshield-TtJwtxNE",
+        "description": "ggshield test", "created_at": "2023-06-02T08:48:20.148216Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "27379093-c6a4-4732-a64a-715c94e74fd7",
-        "name": "ggshield-TvFzKVed", "description": null, "created_at": "2023-06-09T08:01:57.360210Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/27379093-c6a4-4732-a64a-715c94e74fd7",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "27379093-c6a4-4732-a64a-715c94e74fd7", "name": "ggshield-TvFzKVed",
+        "description": null, "created_at": "2023-06-09T08:01:57.360210Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/27379093-c6a4-4732-a64a-715c94e74fd7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "62cb7048-4302-4b52-9163-e2ceff775b39", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc7214d0-c97a-44b3-b576-664f0a81c4f7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc7214d0-c97a-44b3-b576-664f0a81c4f7",
         "name": "repo analytics 19jun", "description": "", "created_at": "2023-06-19T09:11:21.788070Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc7214d0-c97a-44b3-b576-664f0a81c4f7",
         "status": "revoked", "triggered_at": "2023-06-20T17:24:35.145047Z", "revoked_at":
         "2023-12-11T14:50:27.627289Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb", "name": "ggshield-0etjSvZJ",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb", "name": "ggshield-0etjSvZJ",
         "description": "description", "created_at": "2023-07-05T08:27:14.048162Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-05T08:27:15.756813Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0e4f0dbd-b288-4990-9565-3cc7b0171a79",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:53.240550Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 160089, "revoker_id":
         296618, "creator_api_token_id": "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "14566c1f-0b52-4770-ab68-000704242633", "name": "ggshield-Rv2mUej7",
-        "description": "description", "created_at": "2023-07-05T08:55:23.864812Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "14566c1f-0b52-4770-ab68-000704242633",
+        "name": "ggshield-Rv2mUej7", "description": "description", "created_at": "2023-07-05T08:55:23.864812Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/14566c1f-0b52-4770-ab68-000704242633",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c8c94ffa-c0af-48c6-976a-6502a41811af",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c8c94ffa-c0af-48c6-976a-6502a41811af",
         "name": "honeytoken demo eric", "description": "demo here", "created_at":
         "2023-07-05T14:48:53.893911Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c8c94ffa-c0af-48c6-976a-6502a41811af",
         "status": "triggered", "triggered_at": "2023-07-05T14:49:33.528178Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
         "name": "Example TOken ", "description": "ubvcub", "created_at": "2023-07-12T13:16:10.775681Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
-        "key": "file", "value": ".env"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "0c3f182e-98f5-4a64-aadb-664fd7c9de88", "name": "ggshield-ewIAL7lq", "description":
@@ -282,58 +260,55 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
         "name": "ggshield-w1P1Ggsz", "description": "description", "created_at": "2023-07-27T08:56:55.435203Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a20a718-7b9e-4582-abdf-772053bffd72",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a20a718-7b9e-4582-abdf-772053bffd72",
         "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T08:56:56.138738Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a20a718-7b9e-4582-abdf-772053bffd72",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:58.657957Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "51f41814-f029-4ab4-b863-c0fecba025b3", "name": "ggshield-v3LhZCz8",
-        "description": "description", "created_at": "2023-07-27T09:01:36.117217Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51f41814-f029-4ab4-b863-c0fecba025b3",
+        "name": "ggshield-v3LhZCz8", "description": "description", "created_at": "2023-07-27T09:01:36.117217Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/51f41814-f029-4ab4-b863-c0fecba025b3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T09:01:36.764795Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-27T09:01:37.417151Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e842a635-eb7e-4617-8984-ac57fe909ef7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
         "name": "ggshield-5voYnhhy", "description": null, "created_at": "2023-07-27T13:50:51.332176Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T13:52:58.300149Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "521efd01-bbcc-4380-b548-ed7242c017ea",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "521efd01-bbcc-4380-b548-ed7242c017ea",
         "name": "ggshield-HLZpiznn", "description": null, "created_at": "2023-07-27T14:54:03.198466Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/521efd01-bbcc-4380-b548-ed7242c017ea",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0d81797a-6fc0-4a6e-a211-af16828c0c39",
-        "name": "Webinar Public ", "description": "from webinar ", "created_at": "2023-07-27T15:33:07.472730Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0d81797a-6fc0-4a6e-a211-af16828c0c39", "name": "Webinar
+        Public ", "description": "from webinar ", "created_at": "2023-07-27T15:33:07.472730Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0d81797a-6fc0-4a6e-a211-af16828c0c39",
         "status": "triggered", "triggered_at": "2023-07-27T15:34:48.902462Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 204, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "27e9ba01-4bb6-46ed-84c8-ff14366a3bde", "name": "Private network", "description":
@@ -342,60 +317,55 @@ interactions:
         "status": "triggered", "triggered_at": "2023-07-27T16:23:35.804271Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5670c657-618f-41d7-984b-d59656d905e4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5670c657-618f-41d7-984b-d59656d905e4",
         "name": "ggshield-3KTmbo8u", "description": null, "created_at": "2023-07-27T15:44:43.238742Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5670c657-618f-41d7-984b-d59656d905e4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5d3ad22c-e422-48d2-b7f5-6d52801599aa",
-        "name": "demo 31jul", "description": "", "created_at": "2023-07-31T15:27:18.323098Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d3ad22c-e422-48d2-b7f5-6d52801599aa",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5d3ad22c-e422-48d2-b7f5-6d52801599aa", "name": "demo
+        31jul", "description": "", "created_at": "2023-07-31T15:27:18.323098Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d3ad22c-e422-48d2-b7f5-6d52801599aa",
         "status": "revoked", "triggered_at": "2023-07-31T15:33:49.570793Z", "revoked_at":
         "2023-12-11T14:01:40.706751Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a", "name": "test
-        Antonin 1", "description": "", "created_at": "2023-08-03T08:42:25.251504Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fa63d76d-4297-4d41-8e77-b47d1a97a41a",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a", "name": "test Antonin 1", "description":
+        "", "created_at": "2023-08-03T08:42:25.251504Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fa63d76d-4297-4d41-8e77-b47d1a97a41a",
         "status": "revoked", "triggered_at": "2023-08-03T08:59:58.717709Z", "revoked_at":
         "2023-08-03T09:00:05.809852Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "a11570c6-f472-4fda-a493-30d65fd8e651", "name": "test Antonin 2", "description":
-        "", "created_at": "2023-08-03T14:09:46.046004Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a11570c6-f472-4fda-a493-30d65fd8e651",
+        "name": "test Antonin 2", "description": "", "created_at": "2023-08-03T14:09:46.046004Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40",
-        "name": "vBOY test segment", "description": "sdqsdqsdqsdqsd", "created_at":
-        "2023-08-07T12:45:52.890085Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40", "name": "vBOY
+        test segment", "description": "sdqsdqsdqsdqsd", "created_at": "2023-08-07T12:45:52.890085Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-08-07T12:46:45.470113Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "name": "vBOY test segment 2", "description": "sdqsdqsd", "created_at": "2023-08-07T12:47:49.515448Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "86670f84-e117-4f96-aa16-e399a0bb2cf2",
-        "name": "juuj", "description": "", "created_at": "2023-08-08T15:53:23.097840Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86670f84-e117-4f96-aa16-e399a0bb2cf2",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "86670f84-e117-4f96-aa16-e399a0bb2cf2", "name": "juuj",
+        "description": "", "created_at": "2023-08-08T15:53:23.097840Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/86670f84-e117-4f96-aa16-e399a0bb2cf2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
-        "name": "BSidesLV", "description": "Key leaked publically by leakymcgee again",
-        "created_at": "2023-08-10T00:11:42.132386Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "978bf5aa-1f8e-425b-ac4b-b617ddbc178e", "name": "BSidesLV",
+        "description": "Key leaked publically by leakymcgee again", "created_at":
+        "2023-08-10T00:11:42.132386Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
         "status": "triggered", "triggered_at": "2023-08-10T00:13:19.948280Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
-        "key": "date leaked", "value": "08/09/2023"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
-        "key": "format", "value": "public"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
+        ["publicly_exposed"], "custom_tags": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
         "key": "date leaked", "value": "08/09/2023"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
         "key": "format", "value": "public"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
@@ -405,9 +375,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-08-11T18:55:35.503991Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 61, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
+        ["publicly_exposed"], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "90d4c2b6-ecae-4ef9-a754-4561929b9e38",
         "name": "ggshield-mpkTH5jF", "description": "description", "created_at": "2023-08-16T08:28:18.684517Z",
@@ -415,34 +383,31 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
         "name": "ggshield-mzO8qHEz", "description": "description", "created_at": "2023-08-22T08:19:03.821471Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
         "name": "testket ", "description": "eew", "created_at": "2023-08-29T10:21:29.956291Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "46776cb3-6b11-41fc-b431-07609992f0cb",
-        "name": "HoneyTokenaLARTest", "description": "Testworkshop", "created_at":
-        "2023-08-29T12:07:20.692993Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/46776cb3-6b11-41fc-b431-07609992f0cb",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "46776cb3-6b11-41fc-b431-07609992f0cb", "name": "HoneyTokenaLARTest",
+        "description": "Testworkshop", "created_at": "2023-08-29T12:07:20.692993Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/46776cb3-6b11-41fc-b431-07609992f0cb",
         "status": "revoked", "triggered_at": "2023-08-29T12:09:16.581232Z", "revoked_at":
         "2023-08-29T12:42:37.841866Z", "type": "AWS", "open_events_count": 0, "creator_id":
         37699, "revoker_id": 37699, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "edd96a3b-5c71-4346-b5e2-2150e454dc91", "name": "Bsides Krakow", "description":
-        "Demo for leaking a key on GitHub", "created_at": "2023-09-02T13:20:53.501588Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/edd96a3b-5c71-4346-b5e2-2150e454dc91",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "edd96a3b-5c71-4346-b5e2-2150e454dc91",
+        "name": "Bsides Krakow", "description": "Demo for leaking a key on GitHub",
+        "created_at": "2023-09-02T13:20:53.501588Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/edd96a3b-5c71-4346-b5e2-2150e454dc91",
         "status": "triggered", "triggered_at": "2023-09-02T13:22:51.142717Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "de145bd4-b424-49ab-b95b-80126914bf2e",
         "name": "ctf-demo-test-honeytoken-django-app", "description": "", "created_at":
@@ -450,68 +415,59 @@ interactions:
         "status": "revoked", "triggered_at": "2023-09-06T07:42:55.177580Z", "revoked_at":
         "2023-09-06T10:03:30.948628Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "5564ed3c-3eec-4375-9fc8-e0ada71dce02", "name": "ctf-demo-test-honeytoken-micro-api",
-        "description": "", "created_at": "2023-09-05T19:18:08.504776Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/5564ed3c-3eec-4375-9fc8-e0ada71dce02",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5564ed3c-3eec-4375-9fc8-e0ada71dce02",
+        "name": "ctf-demo-test-honeytoken-micro-api", "description": "", "created_at":
+        "2023-09-05T19:18:08.504776Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5564ed3c-3eec-4375-9fc8-e0ada71dce02",
         "status": "revoked", "triggered_at": "2023-09-06T07:44:18.074891Z", "revoked_at":
         "2023-09-06T10:03:48.581110Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "f246c64a-3494-43ae-9d81-500df2f950c3", "name": "demo-honeytoken-ctf-personal-",
-        "description": "", "created_at": "2023-09-06T11:29:57.547211Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/f246c64a-3494-43ae-9d81-500df2f950c3",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f246c64a-3494-43ae-9d81-500df2f950c3",
+        "name": "demo-honeytoken-ctf-personal-", "description": "", "created_at":
+        "2023-09-06T11:29:57.547211Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f246c64a-3494-43ae-9d81-500df2f950c3",
         "status": "revoked", "triggered_at": "2023-09-06T12:18:14.949044Z", "revoked_at":
         "2024-12-10T12:15:49.265110Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
         "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "ff623703-9ca1-4fba-99dc-c20110894ed3",
         "name": "-demo-honeytoken-ctf-django-app-", "description": "", "created_at":
         "2023-09-06T11:33:27.376222Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff623703-9ca1-4fba-99dc-c20110894ed3",
         "status": "triggered", "triggered_at": "2023-09-06T14:19:10.580142Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 4, "creator_id": null, "revoker_id":
+        null, "type": "AWS", "open_events_count": 9, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "a58154f6-e66f-4079-82b7-aabec70c73ff",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "a58154f6-e66f-4079-82b7-aabec70c73ff",
         "name": "demo-honeytoken-ctf-micro-api", "description": "", "created_at":
         "2023-09-06T11:33:37.828240Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a58154f6-e66f-4079-82b7-aabec70c73ff",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-09-06T14:17:20.708816Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b01db549-a2fa-4527-913d-0715a1119530",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "b01db549-a2fa-4527-913d-0715a1119530",
         "name": "demo-honeytoken-ctf-internal-share-", "description": "", "created_at":
         "2023-09-06T11:33:48.881275Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b01db549-a2fa-4527-913d-0715a1119530",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-09-06T14:21:42.509905Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "89a1745a-f796-4ece-99f7-106671aea57c",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "89a1745a-f796-4ece-99f7-106671aea57c",
         "name": "-demo-honeytoken-ctf-micro-api-", "description": "", "created_at":
         "2023-09-06T14:19:32.695323Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/89a1745a-f796-4ece-99f7-106671aea57c",
         "status": "triggered", "triggered_at": "2023-09-06T14:24:18.462424Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "095d655f-a273-400f-ba01-eff8951242ed",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "095d655f-a273-400f-ba01-eff8951242ed",
         "name": "-demo-honeytoken-ctf-internal-share-", "description": "", "created_at":
         "2023-09-06T14:21:55.062468Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/095d655f-a273-400f-ba01-eff8951242ed",
         "status": "triggered", "triggered_at": "2023-09-08T16:58:49.455578Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 6, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "3664c283-d479-41ac-9ad9-30283731ee25",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "3664c283-d479-41ac-9ad9-30283731ee25",
         "name": "Balccon Demo", "description": "Demo key for Balccon ", "created_at":
         "2023-09-08T14:55:02.417580Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3664c283-d479-41ac-9ad9-30283731ee25",
         "status": "triggered", "triggered_at": "2023-09-08T14:56:49.516889Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
-        "key": "location", "value": "sourcecode"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
-        "key": "visability", "value": "public"}], "custom_tags": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
+        ["publicly_exposed"], "custom_tags": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
         "key": "location", "value": "sourcecode"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
         "key": "visability", "value": "public"}], "token": "[REDACTED]"}, {"id": "7ca5ca92-a0a1-48bf-9618-d7194beaa039",
@@ -520,9 +476,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-09-29T16:11:40.077048Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 344, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
-        "key": "confrence", "value": "grrcon"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}], "custom_tags": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
+        ["publicly_exposed"], "custom_tags": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
         "key": "confrence", "value": "grrcon"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}], "token": "[REDACTED]"}, {"id": "2544b3e6-57b2-48e2-a1a5-c4b6551987bb",
         "name": "SBB demo", "description": "Leaking key on GitHub", "created_at":
@@ -530,11 +484,8 @@ interactions:
         "status": "triggered", "triggered_at": "2024-08-17T15:36:55.810693Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key": "commiter",
-        "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca", "key":
-        "file", "value": ".env"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327", "key":
-        "vcs", "value": "github"}], "custom_tags": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda",
-        "key": "commiter", "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
+        [], "custom_tags": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key":
+        "commiter", "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "7d80793b-c702-441e-837e-b1d3da94d576",
         "name": "Hacktivity Key", "description": "Test Key Leak for Hacktivity", "created_at":
@@ -542,9 +493,7 @@ interactions:
         "status": "revoked", "triggered_at": "2023-10-05T14:42:57.752365Z", "revoked_at":
         "2024-12-10T12:17:33.875750Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "576dc1ce-ab72-4604-934f-526cff5a667e", "name": "BsidesCyprus", "description":
@@ -553,8 +502,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-10-07T11:35:53.017981Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 249, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "22fdf53a-e348-464a-a87f-5bcecb1a4e62", "name": "Slack test", "description":
         "blablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablabla
@@ -567,21 +515,20 @@ interactions:
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-06-03T09:50:06.667490Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 363707, "revoker_id":
         353920, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "137c9fee-4b3c-4231-92fd-98debf6557c2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "137c9fee-4b3c-4231-92fd-98debf6557c2",
         "name": "BSides ATL demo for session", "description": "This one will be triggered
         from 2 different spots online", "created_at": "2023-10-14T12:28:51.206659Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/137c9fee-4b3c-4231-92fd-98debf6557c2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 354585, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "cdaea884-25fb-49db-90ec-a18879be36c4",
-        "name": "Demo Honeytoken", "description": "Leaking on Public Demo", "created_at":
-        "2023-10-16T15:13:10.845487Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cdaea884-25fb-49db-90ec-a18879be36c4",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "cdaea884-25fb-49db-90ec-a18879be36c4", "name": "Demo
+        Honeytoken", "description": "Leaking on Public Demo", "created_at": "2023-10-16T15:13:10.845487Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cdaea884-25fb-49db-90ec-a18879be36c4",
         "status": "revoked", "triggered_at": "2023-10-16T15:14:25.574559Z", "revoked_at":
         "2023-10-27T15:01:19.053629Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "48f7c567-93d1-4925-9f77-d3919f120b88", "name": "ggshield-KlAkKRtE", "description":
         "description", "created_at": "2023-10-16T19:49:08.588391Z", "gitguardian_url":
@@ -589,52 +536,50 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
         "name": "Jason test", "description": "Token for Test ", "created_at": "2023-10-24T13:45:31.371710Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f8e0968-664a-49f3-af85-9cc468b960ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "fe392ff1-b3d7-462f-a26f-d094326f40ed",
-        "name": "Jason and team", "description": "akljdlaj", "created_at": "2023-10-24T14:23:20.991107Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fe392ff1-b3d7-462f-a26f-d094326f40ed", "name": "Jason
+        and team", "description": "akljdlaj", "created_at": "2023-10-24T14:23:20.991107Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fe392ff1-b3d7-462f-a26f-d094326f40ed",
         "status": "triggered", "triggered_at": "2024-05-10T22:15:09.224357Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29",
         "name": "Eric Demo Test 01", "description": "", "created_at": "2023-10-31T12:51:44.535200Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d69a098c-8b61-4102-bb2b-9a82958a3e29",
         "status": "revoked", "triggered_at": "2023-10-31T12:52:49.851916Z", "revoked_at":
         "2024-12-10T12:16:28.115539Z", "type": "AWS", "open_events_count": 0, "creator_id":
         136170, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb", "name": "test
-        eric dd 02", "description": "", "created_at": "2023-10-31T14:33:35.801324Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4affa602-902b-47ff-a1f4-721dc3e671bb",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb", "name": "test eric dd 02",
+        "description": "", "created_at": "2023-10-31T14:33:35.801324Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/4affa602-902b-47ff-a1f4-721dc3e671bb",
         "status": "triggered", "triggered_at": "2023-10-31T14:35:33.676298Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 2897, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "8df388e2-aeb5-42ca-b6d5-221a54a40339", "name": "ggshield-P47kTh7j",
-        "description": null, "created_at": "2023-11-09T15:44:33.671666Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/8df388e2-aeb5-42ca-b6d5-221a54a40339",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8df388e2-aeb5-42ca-b6d5-221a54a40339",
+        "name": "ggshield-P47kTh7j", "description": null, "created_at": "2023-11-09T15:44:33.671666Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8df388e2-aeb5-42ca-b6d5-221a54a40339",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "bd51c3d9-0943-43d5-8f87-359ecee03903",
-        "name": "ggshield-73VAsjsO", "description": null, "created_at": "2023-11-14T08:27:44.885242Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bd51c3d9-0943-43d5-8f87-359ecee03903",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "bd51c3d9-0943-43d5-8f87-359ecee03903", "name": "ggshield-73VAsjsO",
+        "description": null, "created_at": "2023-11-14T08:27:44.885242Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/bd51c3d9-0943-43d5-8f87-359ecee03903",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-11-14T08:28:08.188201Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
         "name": "DeepSec Demo", "description": "Demo for DeepSec Confrence ", "created_at":
         "2023-11-16T16:01:21.723176Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
         "status": "triggered", "triggered_at": "2023-11-16T16:01:58.603599Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "ae448808-3865-4797-a008-9eef6344f9da", "name": "Bsides Berlin", "description":
         "test key for a demo", "created_at": "2023-11-18T16:19:36.463172Z", "gitguardian_url":
@@ -642,9 +587,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-11-18T16:20:14.365596Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 105, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
-        "key": "repo", "value": "mackenziejj"}], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
+        ["publicly_exposed"], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
         "key": "repo", "value": "mackenziejj"}], "token": "[REDACTED]"}, {"id": "ecb3d61d-bdab-4636-a436-bef8079a005d",
         "name": "ggshield-ObfCUUCA", "description": "description", "created_at": "2023-11-28T08:50:32.130230Z",
@@ -652,48 +595,41 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d6d5d79d-08fa-4c8a-bd54-c34851866cde",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d6d5d79d-08fa-4c8a-bd54-c34851866cde",
         "name": "test1112", "description": "test publicly exposed honeytoken", "created_at":
         "2023-12-11T16:24:56.253683Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d6d5d79d-08fa-4c8a-bd54-c34851866cde",
         "status": "triggered", "triggered_at": "2023-12-11T16:26:07.733443Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "4046ccf5-7821-47f4-be7d-8240be69631b",
         "name": "ideal-journey-lena", "description": "", "created_at": "2023-12-11T16:29:20.759489Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4046ccf5-7821-47f4-be7d-8240be69631b",
-        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
-        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
+        "status": "triggered", "triggered_at": "2026-05-28T07:56:58.047592Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 5, "creator_id": 319222, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
         "name": "analytics-repo", "description": "", "created_at": "2023-12-11T17:37:24.471286Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
         "status": "triggered", "triggered_at": "2023-12-11T17:46:48.024345Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "b7daf77c-e3e0-4747-a7e2-485a1a6f05e2",
-        "key": "team", "value": "dev"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "b7daf77c-e3e0-4747-a7e2-485a1a6f05e2",
         "key": "team", "value": "dev"}], "token": "[REDACTED]"}, {"id": "52903632-f6ff-460e-8a68-80a942349979",
         "name": "Network Honeytoken", "description": "Aws Honeytoken on Network",
         "created_at": "2023-12-18T13:47:39.151311Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/52903632-f6ff-460e-8a68-80a942349979",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
-        "key": "network", "value": "directory"}], "custom_tags": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
         "key": "network", "value": "directory"}], "token": "[REDACTED]"}, {"id": "6c5d9856-835e-468c-9448-7bf0e77f1e53",
         "name": "improved carnival", "description": "", "created_at": "2023-12-21T13:43:01.544215Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6c5d9856-835e-468c-9448-7bf0e77f1e53",
         "status": "revoked", "triggered_at": "2023-12-21T13:57:59.435706Z", "revoked_at":
         "2023-12-22T09:33:18.668820Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "4dd77510-fc74-411f-9dbe-77619fa920dd",
         "name": "My Postman Public Collection", "description": "Will it ring?", "created_at":
@@ -701,242 +637,231 @@ interactions:
         "status": "triggered", "triggered_at": "2024-01-04T17:52:01.203498Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 811, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
         "name": "ggshield-JZV5XT71", "description": "description", "created_at": "2024-01-09T09:39:34.421404Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "name": "sss", "description": "test", "created_at": "2024-01-09T14:24:10.741214Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
-        "name": "AWS key honeytoken for Slack", "description": "Honeytoken on Slack
-        channel", "created_at": "2024-01-15T16:13:53.656688Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "123ecd19-e66f-4e5c-ad73-12f0a51eda5a", "name": "AWS
+        key honeytoken for Slack", "description": "Honeytoken on Slack channel", "created_at":
+        "2024-01-15T16:13:53.656688Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
         "status": "triggered", "triggered_at": "2024-01-15T16:14:14.960066Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 104, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "23ca2658-aecf-471c-abf0-add09962e320", "key": "ods",
-        "value": "slack"}], "custom_tags": [{"id": "23ca2658-aecf-471c-abf0-add09962e320",
-        "key": "ods", "value": "slack"}], "token": "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a",
+        [], "custom_tags": [{"id": "23ca2658-aecf-471c-abf0-add09962e320", "key":
+        "ods", "value": "slack"}], "token": "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a",
         "name": "BK Test Paris", "description": "Brandon while in Paris office", "created_at":
         "2024-01-17T11:12:14.759334Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/34d5205b-accd-429c-9efa-eda48989c83a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
-        "name": "Lauren Testing", "description": "Lauren wuz here", "created_at":
-        "2024-01-29T17:37:45.379096Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4", "name": "Lauren
+        Testing", "description": "Lauren wuz here", "created_at": "2024-01-29T17:37:45.379096Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 637596, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "07fb5f6f-23f1-42e8-bdb2-c95864412a16",
         "name": "My Little Honeytoken", "description": "for testing", "created_at":
         "2024-02-02T22:18:06.038874Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/07fb5f6f-23f1-42e8-bdb2-c95864412a16",
         "status": "triggered", "triggered_at": "2024-02-09T20:50:13.173911Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b00bfddb-98c2-48e4-ad38-0cb9bc79cad6", "name": "orga_083643/solid-octo",
-        "description": "", "created_at": "2024-02-09T14:45:12.139727Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
+        "name": "orga_083643/solid-octo", "description": "", "created_at": "2024-02-09T14:45:12.139727Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
         "status": "revoked", "triggered_at": "2024-02-09T14:52:11.339548Z", "revoked_at":
         "2024-05-29T13:09:29.773300Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 2508, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "cf0806c4-093d-4165-9ad3-7e7ded211d3f", "name": "DemoKey", "description":
-        "sss", "created_at": "2024-02-15T12:39:23.633481Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cf0806c4-093d-4165-9ad3-7e7ded211d3f",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cf0806c4-093d-4165-9ad3-7e7ded211d3f",
+        "name": "DemoKey", "description": "sss", "created_at": "2024-02-15T12:39:23.633481Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cf0806c4-093d-4165-9ad3-7e7ded211d3f",
         "status": "triggered", "triggered_at": "2024-02-15T12:45:44.649197Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "638f6f82-6679-4399-a336-dd7996f4beae", "name": "demo-2024-02-16dm",
-        "description": "demo", "created_at": "2024-02-16T19:39:33.970811Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/638f6f82-6679-4399-a336-dd7996f4beae",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "638f6f82-6679-4399-a336-dd7996f4beae",
+        "name": "demo-2024-02-16dm", "description": "demo", "created_at": "2024-02-16T19:39:33.970811Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/638f6f82-6679-4399-a336-dd7996f4beae",
         "status": "revoked", "triggered_at": "2024-02-16T19:40:02.759791Z", "revoked_at":
         "2024-02-16T20:10:11.153368Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "6fcc5cf2-4b47-497d-9a80-c2d794b96ebc", "name": "solid-octo",
-        "description": "", "created_at": "2024-02-19T13:06:26.880374Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "6fcc5cf2-4b47-497d-9a80-c2d794b96ebc", "name": "solid-octo", "description":
+        "", "created_at": "2024-02-19T13:06:26.880374Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
-        "key": "team", "value": "octo"}], "custom_tags": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
         "key": "team", "value": "octo"}], "token": "[REDACTED]"}, {"id": "1592023a-2f39-4ba6-a503-4c07132f1eb0",
         "name": "GGnikalston/rock-paper-scissors-f4c01375", "description": "", "created_at":
         "2024-02-20T13:32:45.163630Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1592023a-2f39-4ba6-a503-4c07132f1eb0",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d024b464-cd1e-4daf-9b1d-863dcf517a7a",
-        "name": "Demo -2024-02-22", "description": "", "created_at": "2024-02-22T18:53:26.142516Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d024b464-cd1e-4daf-9b1d-863dcf517a7a", "name": "Demo
+        -2024-02-22", "description": "", "created_at": "2024-02-22T18:53:26.142516Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d024b464-cd1e-4daf-9b1d-863dcf517a7a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 354585, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0a94480f-5361-47f8-bc23-45a331624e9d",
-        "name": "demo ", "description": "demo ", "created_at": "2024-02-22T19:02:29.338420Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0a94480f-5361-47f8-bc23-45a331624e9d",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0a94480f-5361-47f8-bc23-45a331624e9d", "name": "demo
+        ", "description": "demo ", "created_at": "2024-02-22T19:02:29.338420Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/0a94480f-5361-47f8-bc23-45a331624e9d",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T17:03:31.533534Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86136984-d415-41c2-bfc4-59da8f9584fd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86136984-d415-41c2-bfc4-59da8f9584fd",
         "name": "demo-2024-02-23-dm", "description": "", "created_at": "2024-02-23T15:38:04.895275Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86136984-d415-41c2-bfc4-59da8f9584fd",
         "status": "revoked", "triggered_at": "2024-02-23T15:49:03.613445Z", "revoked_at":
         "2024-02-23T15:59:54.768989Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "b38455f9-822c-4f21-8525-0d4f2fa63850", "name": "demo-dwayne-2024-02-23",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "b38455f9-822c-4f21-8525-0d4f2fa63850", "name": "demo-dwayne-2024-02-23",
         "description": "dfnijsbuisbfids", "created_at": "2024-02-23T15:45:47.636481Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b38455f9-822c-4f21-8525-0d4f2fa63850",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T16:28:23.939971Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "612055eb-7fb5-4ba3-ab10-aa481f3d9962",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "612055eb-7fb5-4ba3-ab10-aa481f3d9962",
         "name": "demo-dwayne-2024-02-23-v2", "description": "Demo for video", "created_at":
         "2024-02-23T16:28:49.949332Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/612055eb-7fb5-4ba3-ab10-aa481f3d9962",
         "status": "revoked", "triggered_at": "2024-02-23T16:31:01.657151Z", "revoked_at":
         "2024-02-23T16:52:50.712289Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e", "name": "myname-dwayneptoday",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e", "name": "myname-dwayneptoday",
         "description": "dfsdfsdf", "created_at": "2024-02-23T16:38:14.323313Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T17:03:21.653827Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1bba091c-fc4c-48b5-b558-46c191f67103",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1bba091c-fc4c-48b5-b558-46c191f67103",
         "name": "ggshield-ldC5hqqo", "description": "description", "created_at": "2024-02-27T13:42:36.686028Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1bba091c-fc4c-48b5-b558-46c191f67103",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d7764013-fdd5-4b08-b195-dff5a338906d",
-        "name": "ggshield-LRYYnjOa", "description": "description", "created_at": "2024-02-27T13:42:37.569678Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d7764013-fdd5-4b08-b195-dff5a338906d", "name": "ggshield-LRYYnjOa",
+        "description": "description", "created_at": "2024-02-27T13:42:37.569678Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d7764013-fdd5-4b08-b195-dff5a338906d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "def4a23d-3d12-4fe1-b8e0-02250e74e47a",
-        "name": "ggshield-itglxnie", "description": "description", "created_at": "2024-02-27T13:58:30.205444Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "def4a23d-3d12-4fe1-b8e0-02250e74e47a", "name": "ggshield-itglxnie",
+        "description": "description", "created_at": "2024-02-27T13:58:30.205444Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/def4a23d-3d12-4fe1-b8e0-02250e74e47a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "33d149f1-68f4-4446-ae4f-def0ce962724",
-        "name": "ggshield-2Mf02eVA", "description": "description", "created_at": "2024-02-27T13:58:31.125075Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "33d149f1-68f4-4446-ae4f-def0ce962724", "name": "ggshield-2Mf02eVA",
+        "description": "description", "created_at": "2024-02-27T13:58:31.125075Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/33d149f1-68f4-4446-ae4f-def0ce962724",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5ff5eee1-fc18-4474-86fa-c46321c903c8",
-        "name": "ggshield-rmnfzrW2", "description": "description", "created_at": "2024-02-27T14:02:45.009113Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5ff5eee1-fc18-4474-86fa-c46321c903c8", "name": "ggshield-rmnfzrW2",
+        "description": "description", "created_at": "2024-02-27T14:02:45.009113Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5ff5eee1-fc18-4474-86fa-c46321c903c8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "4dd6c06e-e2c0-4593-9be0-b0418ba7a370",
-        "name": "ggshield-5YTKZZTB", "description": "description", "created_at": "2024-02-27T14:02:45.717261Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "4dd6c06e-e2c0-4593-9be0-b0418ba7a370", "name": "ggshield-5YTKZZTB",
+        "description": "description", "created_at": "2024-02-27T14:02:45.717261Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4dd6c06e-e2c0-4593-9be0-b0418ba7a370",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "eba79796-4f46-4e10-b876-280f75138cc9",
-        "name": "ggshield-z3Y6zgih", "description": "description", "created_at": "2024-02-27T14:06:02.196977Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "eba79796-4f46-4e10-b876-280f75138cc9", "name": "ggshield-z3Y6zgih",
+        "description": "description", "created_at": "2024-02-27T14:06:02.196977Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/eba79796-4f46-4e10-b876-280f75138cc9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0ebc8091-454b-461e-a6f8-fd17bf412c76",
-        "name": "ggshield-jqk54PrI", "description": "description", "created_at": "2024-02-27T14:06:03.018091Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0ebc8091-454b-461e-a6f8-fd17bf412c76", "name": "ggshield-jqk54PrI",
+        "description": "description", "created_at": "2024-02-27T14:06:03.018091Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ebc8091-454b-461e-a6f8-fd17bf412c76",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "664af568-cfc7-4726-9fb4-0b61606b7386",
-        "name": "ggshield-horgQNnR", "description": "description", "created_at": "2024-02-27T14:19:39.357690Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "664af568-cfc7-4726-9fb4-0b61606b7386", "name": "ggshield-horgQNnR",
+        "description": "description", "created_at": "2024-02-27T14:19:39.357690Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/664af568-cfc7-4726-9fb4-0b61606b7386",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5d915aca-6f6f-4b4e-a996-2c1f53016114",
-        "name": "ggshield-LNgN8R1S", "description": "description", "created_at": "2024-02-27T14:19:40.283320Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5d915aca-6f6f-4b4e-a996-2c1f53016114", "name": "ggshield-LNgN8R1S",
+        "description": "description", "created_at": "2024-02-27T14:19:40.283320Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d915aca-6f6f-4b4e-a996-2c1f53016114",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245",
-        "name": "Test key ", "description": "ss", "created_at": "2024-02-29T13:49:52.467489Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245", "name": "Test
+        key ", "description": "ss", "created_at": "2024-02-29T13:49:52.467489Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e",
-        "name": "test-lena-1903", "description": "", "created_at": "2024-03-19T09:13:00.819618Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/443045cc-7fa4-441d-a161-b060bd7fbb3e",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e", "name": "test-lena-1903",
+        "description": "", "created_at": "2024-03-19T09:13:00.819618Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/443045cc-7fa4-441d-a161-b060bd7fbb3e",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-05-29T09:51:31.597203Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 319222, "revoker_id":
         319222, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
         "name": "ggshield-Psfrcoxl", "description": "description", "created_at": "2024-03-27T08:48:20.857237Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5a01f826-4f8f-4235-8867-ce58ac88ce1c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5a01f826-4f8f-4235-8867-ce58ac88ce1c",
         "name": "ggshield-inUFY47O", "description": "description", "created_at": "2024-03-27T08:48:21.791104Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5a01f826-4f8f-4235-8867-ce58ac88ce1c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d72113d0-c346-42c7-bd88-fd5fe0e716f3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d72113d0-c346-42c7-bd88-fd5fe0e716f3",
         "name": "ggshield-eY0ZOlXS", "description": "description", "created_at": "2024-04-30T09:25:38.689800Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d72113d0-c346-42c7-bd88-fd5fe0e716f3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "7f2873cd-3759-4727-a683-31cac57fe5d8",
-        "name": "ggshield-TvlX76OG", "description": "description", "created_at": "2024-04-30T09:25:39.573115Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "7f2873cd-3759-4727-a683-31cac57fe5d8", "name": "ggshield-TvlX76OG",
+        "description": "description", "created_at": "2024-04-30T09:25:39.573115Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7f2873cd-3759-4727-a683-31cac57fe5d8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "72e98633-9179-4a3e-8908-ea2319d19b3b",
-        "name": "ggshield-XYKDhLUY", "description": "description", "created_at": "2024-04-30T10:19:12.369644Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "72e98633-9179-4a3e-8908-ea2319d19b3b", "name": "ggshield-XYKDhLUY",
+        "description": "description", "created_at": "2024-04-30T10:19:12.369644Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72e98633-9179-4a3e-8908-ea2319d19b3b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
         "name": "ggshield-HRoZzrBq", "description": "description", "created_at": "2024-04-30T10:19:13.126568Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
         "name": "Test key", "description": "Access key", "created_at": "2024-05-22T12:16:55.833940Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c7101eaa-ea38-495d-b3b4-c016db23e859",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "a67f962c-9dde-40c2-b404-e7cd4449cc82",
         "name": "pouet", "description": "", "created_at": "2024-05-22T12:19:03.143437Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a67f962c-9dde-40c2-b404-e7cd4449cc82",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
-        "key": "visability", "value": "public"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
         "key": "visability", "value": "public"}], "token": "[REDACTED]"}, {"id": "9cca01c5-535f-4f89-a214-6c4c5579fd07",
@@ -944,487 +869,473 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9cca01c5-535f-4f89-a214-6c4c5579fd07",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
-        "name": "test lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
-        "status": "triggered", "triggered_at": "2024-06-06T08:19:18.422045Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 319222, "revoker_id":
-        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca", "key": "machine",
-        "value": "ggprdgim01"}], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99", "name": "test
+        lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
         "key": "machine", "value": "ggprdgim01"}], "token": "[REDACTED]"}, {"id":
         "a411fa2c-a465-4099-8353-3c42365aca50", "name": "test MINT", "description":
         "test MINT", "created_at": "2024-06-10T14:40:08.522247Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/a411fa2c-a465-4099-8353-3c42365aca50",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "12c4562e-deb8-4d14-bb23-e344e79b6f04",
-        "name": "ggshield-Wq4EyTMI", "description": "description", "created_at": "2024-06-25T08:36:52.179380Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "12c4562e-deb8-4d14-bb23-e344e79b6f04", "name": "ggshield-Wq4EyTMI",
+        "description": "description", "created_at": "2024-06-25T08:36:52.179380Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/12c4562e-deb8-4d14-bb23-e344e79b6f04",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3407738b-2095-47bb-9cbd-dd16de158d67",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3407738b-2095-47bb-9cbd-dd16de158d67",
         "name": "ggshield-65KCwJls", "description": "description", "created_at": "2024-06-25T08:36:52.873146Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3407738b-2095-47bb-9cbd-dd16de158d67",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
         "name": "ggshield-fb77weow", "description": "description", "created_at": "2024-06-26T09:27:38.724573Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9223e352-43b6-4e06-8d12-682d669cedd7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9223e352-43b6-4e06-8d12-682d669cedd7",
         "name": "ggshield-TRO3H56N", "description": "description", "created_at": "2024-06-26T09:27:39.479744Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9223e352-43b6-4e06-8d12-682d669cedd7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "17e088b8-2463-48f8-957b-41d017f1dc83",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "17e088b8-2463-48f8-957b-41d017f1dc83",
         "name": "ggshield-s7IOqS0q", "description": "description", "created_at": "2024-06-26T09:42:26.454643Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/17e088b8-2463-48f8-957b-41d017f1dc83",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e332d717-641d-4ea4-81fc-e98115178454",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e332d717-641d-4ea4-81fc-e98115178454",
         "name": "ggshield-JaAf9b0W", "description": "description", "created_at": "2024-06-26T09:42:27.174527Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e332d717-641d-4ea4-81fc-e98115178454",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26514e1f-4237-474b-b907-037b88427f29",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26514e1f-4237-474b-b907-037b88427f29",
         "name": "ggshield-Uuc8EiUn", "description": "description", "created_at": "2024-06-26T11:51:19.747630Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/26514e1f-4237-474b-b907-037b88427f29",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
         "name": "ggshield-GL7wc5WW", "description": "description", "created_at": "2024-06-26T11:51:20.402145Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
         "name": "test ericf", "description": "", "created_at": "2024-07-09T09:34:04.089955Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
         "status": "triggered", "triggered_at": "2024-07-09T09:34:57.541777Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "a507d04c-bb61-4f2a-93ea-601b8aa27940",
         "name": "ggshield-w1cOSspy", "description": "description", "created_at": "2024-07-31T15:31:09.349255Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a507d04c-bb61-4f2a-93ea-601b8aa27940",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dafa04c5-299a-4a13-9c35-c523e51763f3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dafa04c5-299a-4a13-9c35-c523e51763f3",
         "name": "ggshield-b7VHMqbK", "description": "description", "created_at": "2024-07-31T15:31:10.071786Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dafa04c5-299a-4a13-9c35-c523e51763f3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
         "name": "ggshield-Fu1nGsc9", "description": "description", "created_at": "2024-08-05T09:03:52.745860Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "83888e42-dc57-471c-9a08-f023e3dc2949",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "83888e42-dc57-471c-9a08-f023e3dc2949",
         "name": "ggshield-5suF2vRt", "description": "description", "created_at": "2024-08-05T09:03:53.434873Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/83888e42-dc57-471c-9a08-f023e3dc2949",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e8aad547-96a7-40a4-a05d-710cf536f3a7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e8aad547-96a7-40a4-a05d-710cf536f3a7",
         "name": "ggshield-Vqz4LULC", "description": "description", "created_at": "2024-08-05T09:21:25.593516Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e8aad547-96a7-40a4-a05d-710cf536f3a7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
         "name": "ggshield-lqX7PlwI", "description": "description", "created_at": "2024-08-05T09:21:26.211228Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b144b1fd-dc5f-4a36-abc7-a95d05331245",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b144b1fd-dc5f-4a36-abc7-a95d05331245",
         "name": "ggshield-uZr6LNDv", "description": "description", "created_at": "2024-08-27T07:44:46.267249Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b144b1fd-dc5f-4a36-abc7-a95d05331245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "903bf588-2a03-4318-be6c-b9e3198d1fd6",
-        "name": "ggshield-5Ty2Hu4r", "description": "description", "created_at": "2024-08-27T07:44:46.871854Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "903bf588-2a03-4318-be6c-b9e3198d1fd6", "name": "ggshield-5Ty2Hu4r",
+        "description": "description", "created_at": "2024-08-27T07:44:46.871854Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/903bf588-2a03-4318-be6c-b9e3198d1fd6",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "11222b98-7705-4180-99d1-6e719d8a05a9",
-        "name": "ggshield-qnLief7n", "description": "description", "created_at": "2024-08-27T08:20:15.846360Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "11222b98-7705-4180-99d1-6e719d8a05a9", "name": "ggshield-qnLief7n",
+        "description": "description", "created_at": "2024-08-27T08:20:15.846360Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/11222b98-7705-4180-99d1-6e719d8a05a9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "707b35fb-685b-4577-88b9-94cccc10e165",
-        "name": "ggshield-wqYwwgeK", "description": "description", "created_at": "2024-08-27T08:20:16.467770Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "707b35fb-685b-4577-88b9-94cccc10e165", "name": "ggshield-wqYwwgeK",
+        "description": "description", "created_at": "2024-08-27T08:20:16.467770Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/707b35fb-685b-4577-88b9-94cccc10e165",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "01c7668d-1467-4cac-a395-4b50fc278407",
-        "name": "ggshield-QkzL5Vyb", "description": "description", "created_at": "2024-09-24T08:50:15.865165Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "01c7668d-1467-4cac-a395-4b50fc278407", "name": "ggshield-QkzL5Vyb",
+        "description": "description", "created_at": "2024-09-24T08:50:15.865165Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/01c7668d-1467-4cac-a395-4b50fc278407",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
         "name": "ggshield-kkpkfk1s", "description": "description", "created_at": "2024-09-24T08:50:16.667172Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "730bdd87-31b2-4b42-a32a-5750bc595c9c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "730bdd87-31b2-4b42-a32a-5750bc595c9c",
         "name": "ggshield-dtxlZtWH", "description": "description", "created_at": "2024-10-01T13:18:29.918337Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/730bdd87-31b2-4b42-a32a-5750bc595c9c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b42c6945-05fc-4c5b-af83-e60478cd9db5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b42c6945-05fc-4c5b-af83-e60478cd9db5",
         "name": "ggshield-WPIELIcW", "description": "description", "created_at": "2024-10-01T13:18:30.820570Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b42c6945-05fc-4c5b-af83-e60478cd9db5",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
         "name": "ggshield-B8LwcRR0", "description": "description", "created_at": "2024-10-16T13:47:50.239094Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "81d30531-a54e-4f67-a46b-a7bac5783995",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "81d30531-a54e-4f67-a46b-a7bac5783995",
         "name": "ggshield-IjJFdqDS", "description": "description", "created_at": "2024-10-16T13:47:51.425195Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/81d30531-a54e-4f67-a46b-a7bac5783995",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a0b24134-0cbc-4ca5-b110-18b3311aef73",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a0b24134-0cbc-4ca5-b110-18b3311aef73",
         "name": "DO-demo", "description": "Digital Ocean Demo", "created_at": "2024-10-23T17:55:40.621634Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a0b24134-0cbc-4ca5-b110-18b3311aef73",
         "status": "revoked", "triggered_at": "2024-10-23T18:03:40.135215Z", "revoked_at":
         "2024-10-23T18:33:47.488182Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "50e53ab6-4950-48e6-9350-b5aaa88fafea", "name": "Demo",
-        "description": "Dev team 1", "created_at": "2024-10-27T21:01:47.725365Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/50e53ab6-4950-48e6-9350-b5aaa88fafea",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "50e53ab6-4950-48e6-9350-b5aaa88fafea", "name": "Demo", "description":
+        "Dev team 1", "created_at": "2024-10-27T21:01:47.725365Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/50e53ab6-4950-48e6-9350-b5aaa88fafea",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582569, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}], "token": "[REDACTED]"},
         {"id": "795decd4-4703-4073-9b3c-3ec2157f6182", "name": "Demo token", "description":
         "Take a look", "created_at": "2024-10-28T00:34:48.214122Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/795decd4-4703-4073-9b3c-3ec2157f6182",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582569, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
-        "name": "ggshield-c6YSc2Ie", "description": "description", "created_at": "2024-10-29T14:36:27.096968Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "c43ee48d-4646-40e8-bd12-3dfa30a6b3db", "name": "ggshield-c6YSc2Ie",
+        "description": "description", "created_at": "2024-10-29T14:36:27.096968Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
         "name": "ggshield-E6IPnu0f", "description": "description", "created_at": "2024-10-29T14:36:28.513178Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a454c002-679b-4250-aacf-28b5207543a4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a454c002-679b-4250-aacf-28b5207543a4",
         "name": "ggshield-HjwRkUAT", "description": "description", "created_at": "2024-11-27T12:32:44.877048Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a454c002-679b-4250-aacf-28b5207543a4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5af2ae0-f3f6-4301-82bc-b49108bd782b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5af2ae0-f3f6-4301-82bc-b49108bd782b",
         "name": "ggshield-hIlrbyRm", "description": "description", "created_at": "2024-11-27T12:32:45.728067Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c5af2ae0-f3f6-4301-82bc-b49108bd782b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "aed37b34-4721-43c2-99e2-2f2e78592f63",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "aed37b34-4721-43c2-99e2-2f2e78592f63",
         "name": "ggshield/setup.cfg", "description": "", "created_at": "2024-12-17T10:10:25.895137Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/aed37b34-4721-43c2-99e2-2f2e78592f63",
         "status": "triggered", "triggered_at": "2024-12-17T10:19:35.167833Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 309802, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476", "name": "pierredethoisy/dockerfile",
-        "description": "", "created_at": "2024-12-17T10:30:41.655876Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
+        "name": "pierredethoisy/dockerfile", "description": "", "created_at": "2024-12-17T10:30:41.655876Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
         "status": "triggered", "triggered_at": "2024-12-17T10:32:09.594850Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 309802, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "4b814f00-0897-479f-8a2d-a9593c5f18fa", "name": "WrongSecrets", "description":
-        "Honeytoken for the wrongsecrets repositort", "created_at": "2025-02-06T13:10:31.569094Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4b814f00-0897-479f-8a2d-a9593c5f18fa",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4b814f00-0897-479f-8a2d-a9593c5f18fa",
+        "name": "WrongSecrets", "description": "Honeytoken for the wrongsecrets repositort",
+        "created_at": "2025-02-06T13:10:31.569094Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4b814f00-0897-479f-8a2d-a9593c5f18fa",
         "status": "triggered", "triggered_at": "2025-02-06T13:16:26.325168Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "7dfdb8ee-56fc-486e-9b7a-e6ff248107fa", "name": "ggshield-AAcFXCwl",
-        "description": "description", "created_at": "2025-02-27T10:23:31.621722Z",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
+        "name": "ggshield-AAcFXCwl", "description": "description", "created_at": "2025-02-27T10:23:31.621722Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "97877334-808d-48c7-8802-2c54e9f43661",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "97877334-808d-48c7-8802-2c54e9f43661",
         "name": "ggshield-srahH0o3", "description": "description", "created_at": "2025-02-27T10:23:32.385844Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/97877334-808d-48c7-8802-2c54e9f43661",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ca642fe-2ce4-42b2-9097-5904093935c1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ca642fe-2ce4-42b2-9097-5904093935c1",
         "name": "ggshield-5Vx0aaQd", "description": "description", "created_at": "2025-02-27T10:31:34.080183Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ca642fe-2ce4-42b2-9097-5904093935c1",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d8590557-764f-4618-9b2e-277d536bd111",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d8590557-764f-4618-9b2e-277d536bd111",
         "name": "ggshield-QYqCVZ4i", "description": "description", "created_at": "2025-02-27T10:31:34.798380Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d8590557-764f-4618-9b2e-277d536bd111",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84b08c90-12f5-48ef-baee-ab8d8b15588c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84b08c90-12f5-48ef-baee-ab8d8b15588c",
         "name": "ggshield-4sJy2SkE", "description": "description", "created_at": "2025-02-27T10:53:01.890617Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84b08c90-12f5-48ef-baee-ab8d8b15588c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72204c1e-12c1-445f-b106-09488214d610",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72204c1e-12c1-445f-b106-09488214d610",
         "name": "ggshield-eqoLjiAS", "description": "description", "created_at": "2025-02-27T10:53:02.563136Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72204c1e-12c1-445f-b106-09488214d610",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
         "name": "ggshield-yaqMNJFA", "description": "description", "created_at": "2025-02-27T11:24:20.630794Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a5d5ca0-000f-4011-aaf2-b4f627c19649",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a5d5ca0-000f-4011-aaf2-b4f627c19649",
         "name": "ggshield-x12c7zPc", "description": "description", "created_at": "2025-02-27T11:24:21.465056Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8a5d5ca0-000f-4011-aaf2-b4f627c19649",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c823f31a-73a8-46cc-be4a-029d6d081793",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c823f31a-73a8-46cc-be4a-029d6d081793",
         "name": "ggshield-9Mq5rTUV", "description": "description", "created_at": "2025-02-27T16:44:10.862683Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c823f31a-73a8-46cc-be4a-029d6d081793",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49f1055b-b505-402b-8b79-e4b2c6cf2041",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49f1055b-b505-402b-8b79-e4b2c6cf2041",
         "name": "ggshield-4MmSKBvx", "description": "description", "created_at": "2025-02-27T16:44:11.663957Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/49f1055b-b505-402b-8b79-e4b2c6cf2041",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be8e40e8-b204-40de-8d37-247ac6ef7077",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be8e40e8-b204-40de-8d37-247ac6ef7077",
         "name": "ggshield-DBuxWn0n", "description": "description", "created_at": "2025-02-27T16:57:21.290157Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be8e40e8-b204-40de-8d37-247ac6ef7077",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d10551f8-36f0-4966-a684-d5f9eca89e8d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d10551f8-36f0-4966-a684-d5f9eca89e8d",
         "name": "ggshield-bukJ4Md2", "description": "description", "created_at": "2025-02-27T16:57:22.079317Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d10551f8-36f0-4966-a684-d5f9eca89e8d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d5385824-6a93-47cb-81f3-e818e64371d7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d5385824-6a93-47cb-81f3-e818e64371d7",
         "name": "ggshield-vI1CTIm2", "description": "description", "created_at": "2025-02-27T17:24:28.533666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d5385824-6a93-47cb-81f3-e818e64371d7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
         "name": "ggshield-C519GYI9", "description": "description", "created_at": "2025-02-27T17:24:29.231126Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
         "name": "ggshield-i8zN7WRH", "description": "description", "created_at": "2025-02-27T17:27:14.478281Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "661dae4d-5944-4a20-b7f7-f74913356479",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "661dae4d-5944-4a20-b7f7-f74913356479",
         "name": "ggshield-IX7GxSIs", "description": "description", "created_at": "2025-02-27T17:27:15.226298Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/661dae4d-5944-4a20-b7f7-f74913356479",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "adaea919-086f-4e37-b4e5-dc8208d0e4f5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "adaea919-086f-4e37-b4e5-dc8208d0e4f5",
         "name": "ggshield-rWApiuse", "description": "description", "created_at": "2025-03-03T09:15:26.314595Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/adaea919-086f-4e37-b4e5-dc8208d0e4f5",
         "status": "triggered", "triggered_at": "2026-02-18T14:51:12.198393Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
-        "key": "env", "value": "staging"}], "custom_tags": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
+        null, "tags": [], "custom_tags": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
         "key": "env", "value": "staging"}], "token": "[REDACTED]"}, {"id": "da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
         "name": "ggshield-jdbeH3gE", "description": "description", "created_at": "2025-03-03T09:15:27.049176Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22", "key": "env",
-        "value": "production"}], "custom_tags": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22",
-        "key": "env", "value": "production"}], "token": "[REDACTED]"}, {"id": "1f4708b2-0e51-458c-abca-c03e502b4a5a",
+        [], "custom_tags": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22", "key":
+        "env", "value": "production"}], "token": "[REDACTED]"}, {"id": "1f4708b2-0e51-458c-abca-c03e502b4a5a",
         "name": "ggshield-QgwFEPjx", "description": "description", "created_at": "2025-03-27T15:12:18.744612Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1f4708b2-0e51-458c-abca-c03e502b4a5a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "a4ced9be-6ad5-4d8a-b188-65a117bc0eba",
-        "name": "ggshield-44tVmSvF", "description": "description", "created_at": "2025-03-27T15:12:19.507492Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "a4ced9be-6ad5-4d8a-b188-65a117bc0eba", "name": "ggshield-44tVmSvF",
+        "description": "description", "created_at": "2025-03-27T15:12:19.507492Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a4ced9be-6ad5-4d8a-b188-65a117bc0eba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5710ee7d-6428-4074-a9ff-09399782242d",
-        "name": "ggshield-bF87lDBl", "description": "description", "created_at": "2025-03-27T15:21:17.135616Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5710ee7d-6428-4074-a9ff-09399782242d", "name": "ggshield-bF87lDBl",
+        "description": "description", "created_at": "2025-03-27T15:21:17.135616Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5710ee7d-6428-4074-a9ff-09399782242d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
-        "name": "ggshield-LbIDqGyA", "description": "description", "created_at": "2025-03-27T15:21:17.953340Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "4cbf7af9-9989-4185-8ef8-0f39e6f3d145", "name": "ggshield-LbIDqGyA",
+        "description": "description", "created_at": "2025-03-27T15:21:17.953340Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2dfa1936-f53f-4d0c-8a69-ae9bab297021",
-        "name": "ggshield-qz84En8W", "description": "description", "created_at": "2025-03-27T15:24:16.907610Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2dfa1936-f53f-4d0c-8a69-ae9bab297021", "name": "ggshield-qz84En8W",
+        "description": "description", "created_at": "2025-03-27T15:24:16.907610Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2dfa1936-f53f-4d0c-8a69-ae9bab297021",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "11213dc7-118d-4997-a96b-714640c3ad0b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "11213dc7-118d-4997-a96b-714640c3ad0b",
         "name": "ggshield-CSF39jm8", "description": "description", "created_at": "2025-03-27T15:24:17.721006Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/11213dc7-118d-4997-a96b-714640c3ad0b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "899dd0b0-20b2-45d2-b779-0331cc448935",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "899dd0b0-20b2-45d2-b779-0331cc448935",
         "name": "toto", "description": "tata", "created_at": "2025-05-12T09:58:35.161641Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/899dd0b0-20b2-45d2-b779-0331cc448935",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "62d71685-2eba-4b88-8edd-cc73e698cfa5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "62d71685-2eba-4b88-8edd-cc73e698cfa5",
         "name": "test-greg", "description": "test greg", "created_at": "2025-05-12T10:06:19.826522Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/62d71685-2eba-4b88-8edd-cc73e698cfa5",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:59.739856Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "e948f77d-5353-413e-b37d-8beba84890ff", "name": "test-greg-2", "description":
-        "test greg", "created_at": "2025-05-12T10:08:11.667578Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e948f77d-5353-413e-b37d-8beba84890ff",
+        "name": "test-greg-2", "description": "test greg", "created_at": "2025-05-12T10:08:11.667578Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:54.809724Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb", "name": "test-greg-3", "description":
-        "test greg", "created_at": "2025-05-12T10:08:58.561160Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        "name": "test-greg-3", "description": "test greg", "created_at": "2025-05-12T10:08:58.561160Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:50.784137Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6", "name": "test-greg-4", "description":
-        "test", "created_at": "2025-05-12T10:10:12.927058Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6",
+        "name": "test-greg-4", "description": "test", "created_at": "2025-05-12T10:10:12.927058Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:46.594085Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a", "name": "test-greg-5", "description":
-        "test", "created_at": "2025-05-12T10:12:50.615700Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
+        "name": "test-greg-5", "description": "test", "created_at": "2025-05-12T10:12:50.615700Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:41.387978Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "9fcf0732-6b8d-41d3-ae98-727bd5dde585", "name": "achille-hackathon",
-        "description": "achille hackathon", "created_at": "2025-05-12T12:01:23.542568Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9fcf0732-6b8d-41d3-ae98-727bd5dde585",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9fcf0732-6b8d-41d3-ae98-727bd5dde585",
+        "name": "achille-hackathon", "description": "achille hackathon", "created_at":
+        "2025-05-12T12:01:23.542568Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9fcf0732-6b8d-41d3-ae98-727bd5dde585",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38",
         "name": "TestHoneytoken", "description": "Testing GitGuardian API connectivity",
         "created_at": "2025-05-12T12:19:05.294638Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b0ddbd44-4054-4127-aa00-cd6727e70d38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
         "name": "AWS Credentials", "description": "Honeytoken for testing, to be injected
         as requested by the user.", "created_at": "2025-05-12T12:38:25.640506Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
         "status": "triggered", "triggered_at": "2026-02-18T13:45:03.781945Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 269050, "revoker_id":
+        null, "type": "AWS", "open_events_count": 9, "creator_id": 269050, "revoker_id":
         null, "creator_api_token_id": "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec", "name": "test-greg-7", "description":
-        "test", "created_at": "2025-05-12T12:54:37.703725Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ab824e92-6068-4a9d-ae36-86a94516f2ec",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec",
+        "name": "test-greg-7", "description": "test", "created_at": "2025-05-12T12:54:37.703725Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ab824e92-6068-4a9d-ae36-86a94516f2ec",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:34.521470Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b65d42a4-587f-4701-a595-8429cbcda70b", "name": "gg-mcp-server-honeytoken",
-        "description": "Honeytoken for security monitoring in the gg-mcp-server project.",
-        "created_at": "2025-05-12T12:54:44.402023Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b65d42a4-587f-4701-a595-8429cbcda70b",
-        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
-        "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
-        "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3fe4aa4f-49f6-42ad-a34a-0c108b544215",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b65d42a4-587f-4701-a595-8429cbcda70b",
+        "name": "gg-mcp-server-honeytoken", "description": "Honeytoken for security
+        monitoring in the gg-mcp-server project.", "created_at": "2025-05-12T12:54:44.402023Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b65d42a4-587f-4701-a595-8429cbcda70b",
+        "status": "triggered", "triggered_at": "2026-06-04T13:16:15.961464Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 4, "creator_id": 269050, "revoker_id":
+        null, "creator_api_token_id": "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id":
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3fe4aa4f-49f6-42ad-a34a-0c108b544215",
         "name": "default-honeytoken", "description": "General purpose honeytoken for
         security monitoring", "created_at": "2025-05-12T13:07:52.676810Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/3fe4aa4f-49f6-42ad-a34a-0c108b544215",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
         "name": "test", "description": "test", "created_at": "2025-05-12T13:09:38.965752Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9844e55d-982c-4458-b65b-592ad99ce77a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1026550, "revoker_id": null, "creator_api_token_id":
         "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
         "name": "Test Honeytoken", "description": "Testing honeytoken generation",
         "created_at": "2025-05-12T14:35:34.295363Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b2a7e759-81ab-465d-a578-e3ce42c18741",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
         "name": "test-greg-9", "description": "", "created_at": "2025-05-12T14:50:23.123299Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6d185a-6f59-4b7c-9248-dd05616090db",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:27.366114Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
+        null, "tags": [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
         "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "fbb93094-9778-4b8b-97d8-de99954a758a",
         "name": "AWS_Honeytoken", "description": "Honeytoken generated via MCP", "created_at":
@@ -1432,17 +1343,15 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "34e08af4-59a7-4a3b-b799-65acb8a2019d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "34e08af4-59a7-4a3b-b799-65acb8a2019d",
         "name": "AWS-MCP-Honeytoken", "description": "Honeytoken for monitoring potential
         AWS credential leaks", "created_at": "2025-05-12T15:07:16.157981Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/34e08af4-59a7-4a3b-b799-65acb8a2019d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "16805984-70d6-4049-844a-79bac3054f6f",
         "name": "AwsTestHoneytoken", "description": "Test honeytoken for development
         and monitoring", "created_at": "2025-05-12T15:09:00.390236Z", "gitguardian_url":
@@ -1450,10 +1359,8 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "d476c118-b210-403d-b685-3d7f0a514950",
         "name": "aws-development-access-key", "description": "Development environment
         AWS access key for monitoring credential leaks", "created_at": "2025-05-12T15:12:56.525944Z",
@@ -1461,9 +1368,7 @@ interactions:
         "status": "triggered", "triggered_at": "2026-02-18T14:50:57.626529Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 2, "creator_id": 270722, "revoker_id":
         null, "creator_api_token_id": "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
+        null, "tags": [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
         "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "0a112323-6906-4bd0-a660-1b45a0fc59ca",
         "name": "NHI-Explorer-Secret", "description": "AWS access key for NHI Explorer
@@ -1472,232 +1377,412 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "69dbbe3c-2dfc-4c93-916c-f70c42f4e2af",
         "name": "ggshield-Leb9CGys", "description": "description", "created_at": "2025-05-27T08:18:31.020533Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/69dbbe3c-2dfc-4c93-916c-f70c42f4e2af",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "029e2aba-796c-47d8-8d52-e14f9868acfc",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "029e2aba-796c-47d8-8d52-e14f9868acfc",
         "name": "ggshield-Fhjl6QxB", "description": "description", "created_at": "2025-05-27T08:18:31.873128Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/029e2aba-796c-47d8-8d52-e14f9868acfc",
         "status": "triggered", "triggered_at": "2025-06-17T09:30:39.728240Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "c77d47b6-8d61-46a7-b6a1-1715fc47c7eb", "name": "ggshield-U8JeiAjO",
-        "description": "description", "created_at": "2025-06-24T13:04:20.196705Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
+        "name": "ggshield-U8JeiAjO", "description": "description", "created_at": "2025-06-24T13:04:20.196705Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab",
-        "name": "ggshield-NiJSM24s", "description": "description", "created_at": "2025-06-24T13:04:21.255669Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab", "name": "ggshield-NiJSM24s",
+        "description": "description", "created_at": "2025-06-24T13:04:21.255669Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5692a982-6603-443e-bdb4-5ea1a5de6f64",
-        "name": "ggshield-JKhVuHaW", "description": "description", "created_at": "2025-06-24T13:06:56.046343Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5692a982-6603-443e-bdb4-5ea1a5de6f64", "name": "ggshield-JKhVuHaW",
+        "description": "description", "created_at": "2025-06-24T13:06:56.046343Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5692a982-6603-443e-bdb4-5ea1a5de6f64",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "17925c95-1df7-4e86-9c42-aabb5dbdea69",
-        "name": "ggshield-vfjAXCfY", "description": "description", "created_at": "2025-06-24T13:06:57.033247Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "17925c95-1df7-4e86-9c42-aabb5dbdea69", "name": "ggshield-vfjAXCfY",
+        "description": "description", "created_at": "2025-06-24T13:06:57.033247Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/17925c95-1df7-4e86-9c42-aabb5dbdea69",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "631ef101-122f-4592-9de1-2d6cb5becafa",
-        "name": "ggshield-dbhOtleP", "description": "description", "created_at": "2025-06-24T13:13:01.219899Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "631ef101-122f-4592-9de1-2d6cb5becafa", "name": "ggshield-dbhOtleP",
+        "description": "description", "created_at": "2025-06-24T13:13:01.219899Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/631ef101-122f-4592-9de1-2d6cb5becafa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "bebc1ca8-933d-45ca-b201-fbabc4eab464",
-        "name": "ggshield-7pQLMJYV", "description": "description", "created_at": "2025-06-24T13:13:01.978212Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "bebc1ca8-933d-45ca-b201-fbabc4eab464", "name": "ggshield-7pQLMJYV",
+        "description": "description", "created_at": "2025-06-24T13:13:01.978212Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bebc1ca8-933d-45ca-b201-fbabc4eab464",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "3983e8ff-7fd6-4fde-9117-9612d4258052",
-        "name": "ggshield-phDsJ9wy", "description": "description", "created_at": "2025-06-24T13:29:15.096198Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "3983e8ff-7fd6-4fde-9117-9612d4258052", "name": "ggshield-phDsJ9wy",
+        "description": "description", "created_at": "2025-06-24T13:29:15.096198Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3983e8ff-7fd6-4fde-9117-9612d4258052",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "9340e7fe-f79c-467e-9dcd-43ddaa77dc0c",
-        "name": "ggshield-Md0MBV0B", "description": "description", "created_at": "2025-06-24T13:29:16.049584Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "9340e7fe-f79c-467e-9dcd-43ddaa77dc0c", "name": "ggshield-Md0MBV0B",
+        "description": "description", "created_at": "2025-06-24T13:29:16.049584Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9340e7fe-f79c-467e-9dcd-43ddaa77dc0c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "08b51a6e-dd6c-4a4b-93f9-b955663c6524",
-        "name": "ggshield-ZoWflf5b", "description": "description", "created_at": "2025-06-24T13:31:49.045062Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "08b51a6e-dd6c-4a4b-93f9-b955663c6524", "name": "ggshield-ZoWflf5b",
+        "description": "description", "created_at": "2025-06-24T13:31:49.045062Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/08b51a6e-dd6c-4a4b-93f9-b955663c6524",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "96da938d-d6fa-4e44-9254-c568a27be484",
-        "name": "ggshield-PirK5h1Q", "description": "description", "created_at": "2025-06-24T13:31:49.827284Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "96da938d-d6fa-4e44-9254-c568a27be484", "name": "ggshield-PirK5h1Q",
+        "description": "description", "created_at": "2025-06-24T13:31:49.827284Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/96da938d-d6fa-4e44-9254-c568a27be484",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f2c61b85-e11d-4db0-a8af-7fc327310b39",
-        "name": "ggshield-ZQ4jUtQr", "description": "description", "created_at": "2025-06-24T13:45:17.477850Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f2c61b85-e11d-4db0-a8af-7fc327310b39", "name": "ggshield-ZQ4jUtQr",
+        "description": "description", "created_at": "2025-06-24T13:45:17.477850Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f2c61b85-e11d-4db0-a8af-7fc327310b39",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f99173ff-9ffe-492c-b8ae-54157df89bac",
-        "name": "ggshield-5uK6KYFh", "description": "description", "created_at": "2025-06-24T13:45:18.309642Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f99173ff-9ffe-492c-b8ae-54157df89bac", "name": "ggshield-5uK6KYFh",
+        "description": "description", "created_at": "2025-06-24T13:45:18.309642Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f99173ff-9ffe-492c-b8ae-54157df89bac",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768",
-        "name": "ggshield-MGXkbqc7", "description": "description", "created_at": "2025-06-24T13:50:43.295521Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768", "name": "ggshield-MGXkbqc7",
+        "description": "description", "created_at": "2025-06-24T13:50:43.295521Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f3252f2c-16a9-45e4-97e8-bed4b5752415",
-        "name": "ggshield-YJd3rq9q", "description": "description", "created_at": "2025-06-24T13:50:44.165951Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f3252f2c-16a9-45e4-97e8-bed4b5752415", "name": "ggshield-YJd3rq9q",
+        "description": "description", "created_at": "2025-06-24T13:50:44.165951Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f3252f2c-16a9-45e4-97e8-bed4b5752415",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "e22705f1-5497-449b-9614-3c2d89e3b705",
-        "name": "ggshield-l4abwnpa", "description": null, "created_at": "2025-06-26T12:32:05.993896Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e22705f1-5497-449b-9614-3c2d89e3b705",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "e22705f1-5497-449b-9614-3c2d89e3b705", "name": "ggshield-l4abwnpa",
+        "description": null, "created_at": "2025-06-26T12:32:05.993896Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e22705f1-5497-449b-9614-3c2d89e3b705",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
         "4ff03654-f280-4c31-8eef-5295d2b75a50", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7691445a-2cb0-4093-94ca-f2c5de877075",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7691445a-2cb0-4093-94ca-f2c5de877075",
         "name": "ggshield-Lwhu1Nax", "description": "description", "created_at": "2025-07-29T10:34:41.534666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7691445a-2cb0-4093-94ca-f2c5de877075",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "951e1f19-5804-444a-b275-b51dc5bf68ee",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "951e1f19-5804-444a-b275-b51dc5bf68ee",
         "name": "ggshield-u9ltlEmT", "description": "description", "created_at": "2025-07-29T10:34:42.385215Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/951e1f19-5804-444a-b275-b51dc5bf68ee",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
         "name": "ggshield-CC0Lj0vS", "description": "description", "created_at": "2025-07-29T10:40:27.317817Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
         "name": "ggshield-0k2Xha2i", "description": "description", "created_at": "2025-07-29T10:40:28.088246Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
         "status": "triggered", "triggered_at": "2025-08-22T16:59:58.315774Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "49e4fce7-aa48-42b0-9fc4-e16105ae08e5", "name": "ggshield-ncOpkfP8",
-        "description": "description", "created_at": "2025-08-27T11:43:11.666517Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
+        "name": "ggshield-ncOpkfP8", "description": "description", "created_at": "2025-08-27T11:43:11.666517Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2b15518b-3100-4736-bee6-b47fe8d26fc1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2b15518b-3100-4736-bee6-b47fe8d26fc1",
         "name": "ggshield-H2eDvilF", "description": "description", "created_at": "2025-08-27T11:43:12.618589Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2b15518b-3100-4736-bee6-b47fe8d26fc1",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "368a90bf-269b-4a60-95c2-1c77c86f7fd4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "368a90bf-269b-4a60-95c2-1c77c86f7fd4",
         "name": "ggshield-V6RzZJGL", "description": "description", "created_at": "2025-11-14T16:54:30.227288Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/368a90bf-269b-4a60-95c2-1c77c86f7fd4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "eae1aaaf-d700-475d-b65a-ffd79f84806d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "eae1aaaf-d700-475d-b65a-ffd79f84806d",
         "name": "ggshield-Pya2g1xF", "description": "description", "created_at": "2025-11-14T16:54:30.933576Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/eae1aaaf-d700-475d-b65a-ffd79f84806d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
         "name": "ggshield-Z2Ji3PxX", "description": "description", "created_at": "2026-03-31T13:26:20.710346Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
         "name": "ggshield-FsL9dCzu", "description": "description", "created_at": "2026-03-31T13:26:21.681383Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7daed77-1fa4-416d-88e2-473200b810aa",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7daed77-1fa4-416d-88e2-473200b810aa",
         "name": "ggshield-dqv39cn2", "description": "description", "created_at": "2026-03-31T13:32:28.824725Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e7daed77-1fa4-416d-88e2-473200b810aa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "601c59d9-7579-402e-90c4-59da055a8d3b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "601c59d9-7579-402e-90c4-59da055a8d3b",
         "name": "ggshield-YpbVgsRl", "description": "description", "created_at": "2026-03-31T13:32:29.820990Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/601c59d9-7579-402e-90c4-59da055a8d3b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "54e52712-a036-4e80-899b-c1a200610339",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "54e52712-a036-4e80-899b-c1a200610339",
         "name": "ggshield-DZ5zVj1p", "description": "description", "created_at": "2026-03-31T13:37:32.513332Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/54e52712-a036-4e80-899b-c1a200610339",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51dc5671-8053-4b87-8174-975ccf7f249c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51dc5671-8053-4b87-8174-975ccf7f249c",
         "name": "ggshield-DXGKK2gC", "description": "description", "created_at": "2026-03-31T13:37:33.559937Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/51dc5671-8053-4b87-8174-975ccf7f249c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}]'
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "name": "test Pierre", "description": "", "created_at": "2026-04-07T18:38:38.199572Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "ae435f66-1ea9-4dfe-b73f-49f451fc00ab", "name": "Demo
+        Romain", "description": "", "created_at": "2026-04-24T12:48:19.654369Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/ae435f66-1ea9-4dfe-b73f-49f451fc00ab",
+        "status": "triggered", "triggered_at": "2026-04-29T12:54:19.464710Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 6, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [{"id": "7a2469eb-2b6b-4248-8103-2b0f6b4fac9b", "key":
+        "romain", "value": null}], "token": "[REDACTED]"}, {"id": "10f6e20b-12ae-4591-aa09-7e1ff00ef408",
+        "name": "qa / xyz-e732d912", "description": "", "created_at": "2026-04-24T16:05:46.508625Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/10f6e20b-12ae-4591-aa09-7e1ff00ef408",
+        "status": "triggered", "triggered_at": "2026-04-24T16:13:17.276672Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9266c0f4-f0e0-41d2-a8c8-c164ccb84e47",
+        "name": "qa / test-nriv-e732d912", "description": "", "created_at": "2026-04-24T16:05:50.013606Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9266c0f4-f0e0-41d2-a8c8-c164ccb84e47",
+        "status": "triggered", "triggered_at": "2026-04-24T16:15:44.494587Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "name": "dev / Salome Test-e732d912", "description": "", "created_at": "2026-04-24T16:05:53.158978Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "status": "triggered", "triggered_at": "2026-04-24T16:16:21.895694Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "name": "qa / test-r8327r-e732d912", "description": "", "created_at": "2026-04-24T16:05:56.586568Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "status": "triggered", "triggered_at": "2026-04-24T16:18:31.419829Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2314a2ef-cec4-4e3d-834a-09b0c40c99d2",
+        "name": "qa / abc-e732d912", "description": "", "created_at": "2026-04-24T16:05:59.728317Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2314a2ef-cec4-4e3d-834a-09b0c40c99d2",
+        "status": "triggered", "triggered_at": "2026-04-24T16:25:50.024911Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "fe96d213-a002-4161-a7c9-cb3be4ad88f8",
+        "name": "qa / Handcrafted Metal Bike-e732d912", "description": "", "created_at":
+        "2026-04-24T16:06:02.936659Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fe96d213-a002-4161-a7c9-cb3be4ad88f8",
+        "status": "triggered", "triggered_at": "2026-04-24T16:35:48.958630Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a72f662-2357-4b93-b48a-00028e36cfff",
+        "name": "test1", "description": "tEST 2", "created_at": "2026-04-30T09:12:55.584248Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a72f662-2357-4b93-b48a-00028e36cfff",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "963fbabe-3d2c-4154-8281-2f13be7c06f7", "name": "test121",
+        "description": "testing 12", "created_at": "2026-04-30T11:31:57.689130Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/963fbabe-3d2c-4154-8281-2f13be7c06f7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "1acff09e-02c1-4a24-8869-568dfab124c9", "name": "test-pierredt",
+        "description": "hello", "created_at": "2026-05-06T19:57:39.689471Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/1acff09e-02c1-4a24-8869-568dfab124c9",
+        "status": "triggered", "triggered_at": "2026-05-06T19:59:18.645288Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 6, "creator_id": 309802, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "name": "qa / test-nriv-d2363bd5", "description": "", "created_at": "2026-05-19T08:29:37.247067Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "status": "triggered", "triggered_at": "2026-05-19T08:33:36.289678Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 1754656, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "03e7e668-6fbf-493a-8d1c-ac9d0c6c1b97",
+        "name": "qa / xyz-d2363bd5", "description": "", "created_at": "2026-05-19T08:29:41.396307Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/03e7e668-6fbf-493a-8d1c-ac9d0c6c1b97",
+        "status": "triggered", "triggered_at": "2026-05-19T08:34:30.001210Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 1754656, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "bb1adf06-28ea-4daf-b338-59d5ef094f67",
+        "name": "TheBigHoney", "description": "Big Honey Pot for our core secrets",
+        "created_at": "2026-05-19T11:51:12.957707Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bb1adf06-28ea-4daf-b338-59d5ef094f67",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "93abaf01-cac6-48f4-bfa1-735cfb7fde7d", "name": "ttoprjog",
+        "description": "Henri", "created_at": "2026-05-20T12:22:37.974250Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/93abaf01-cac6-48f4-bfa1-735cfb7fde7d",
+        "status": "revoked", "triggered_at": null, "revoked_at": "2026-05-20T12:23:19.883989Z",
+        "type": "AWS", "open_events_count": 0, "creator_id": 113168, "revoker_id":
+        113168, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be3d1024-d9df-466c-9e75-afc1ed88b8f5",
+        "name": "test-plc", "description": "", "created_at": "2026-05-26T07:26:21.052034Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be3d1024-d9df-466c-9e75-afc1ed88b8f5",
+        "status": "revoked", "triggered_at": "2026-05-26T08:44:57.678480Z", "revoked_at":
+        "2026-05-26T12:19:01.401494Z", "type": "AWS", "open_events_count": 0, "creator_id":
+        701514, "revoker_id": 701514, "creator_api_token_id": null, "revoker_api_token_id":
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "8409c955-f217-47c9-9cf1-3a6b557c65c9", "name": "Test", "description": "",
+        "created_at": "2026-05-26T14:12:05.347374Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8409c955-f217-47c9-9cf1-3a6b557c65c9",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754650, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "82f00514-d9d3-442c-b575-c40ff77db387", "name": "test-plc2",
+        "description": "", "created_at": "2026-05-27T13:13:33.943814Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/82f00514-d9d3-442c-b575-c40ff77db387",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 701514, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "2fb03282-9878-481c-be5b-eda6036f909d", "name": "ahah-plc", "description":
+        "", "created_at": "2026-06-01T12:43:48.383287Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2fb03282-9878-481c-be5b-eda6036f909d",
+        "status": "triggered", "triggered_at": "2026-06-04T21:49:55.543841Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 701514, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86344c0b-c360-4709-bb6b-fce628ace1d7",
+        "name": "honeytoken-toot-991c4137", "description": "", "created_at": "2026-06-05T17:59:07.240726Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86344c0b-c360-4709-bb6b-fce628ace1d7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
+        "97c1b533-d768-4054-94de-ae3d967a5128", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "949d59d0-c3c2-4d5e-ae3c-4f365b9b8456",
+        "name": "honeytoken-toot-0fefb095", "description": "", "created_at": "2026-06-05T17:59:07.748651Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/949d59d0-c3c2-4d5e-ae3c-4f365b9b8456",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
+        "97c1b533-d768-4054-94de-ae3d967a5128", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ab5965c-8f7e-44ec-b64e-1111e140586f",
+        "name": "ggshield-WOmcC4wM", "description": "description", "created_at": "2026-06-15T15:05:19.990102Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ab5965c-8f7e-44ec-b64e-1111e140586f",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "95786b03-4165-4245-8aef-fac41ff6a1de",
+        "name": "ggshield-E2HxYogl", "description": "description", "created_at": "2026-06-15T15:05:20.446208Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/95786b03-4165-4245-8aef-fac41ff6a1de",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "98271cf2-3025-4e7d-b120-afd29fe20c8f",
+        "name": "ggshield-32Xli2ct", "description": "description", "created_at": "2026-06-15T15:13:44.456933Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/98271cf2-3025-4e7d-b120-afd29fe20c8f",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "68f09d33-1cab-4b93-84a5-2861a7a01fbc",
+        "name": "ggshield-o2ocvFQZ", "description": "description", "created_at": "2026-06-15T15:13:45.228488Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/68f09d33-1cab-4b93-84a5-2861a7a01fbc",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ee69dfd0-fa9c-451d-947e-261c2edd4355",
+        "name": "ggshield-rGxN1k4I", "description": "description", "created_at": "2026-06-15T15:46:58.088837Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ee69dfd0-fa9c-451d-947e-261c2edd4355",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f91525c-02bd-4a0f-9c5d-c9949f7196f4",
+        "name": "ggshield-bZoVll0H", "description": "description", "created_at": "2026-06-15T15:46:58.839510Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f91525c-02bd-4a0f-9c5d-c9949f7196f4",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4a3a3699-fb2e-4e0f-ae02-4905fe8228ec",
+        "name": "ggshield-VuSeELel", "description": "description", "created_at": "2026-06-17T13:23:52.166183Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4a3a3699-fb2e-4e0f-ae02-4905fe8228ec",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "dd2d3e47-d804-41c5-b8b8-f640e6292096", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d82dc520-9ea5-4a38-a9d8-84bf2f94975b",
+        "name": "ggshield-yQlAvTpn", "description": "description", "created_at": "2026-06-17T13:23:52.682610Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d82dc520-9ea5-4a38-a9d8-84bf2f94975b",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "dd2d3e47-d804-41c5-b8b8-f640e6292096", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}]'
     headers:
+      CF-RAY:
+      - a10397a38d147e9b-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:53 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, POST, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '139756'
+      - '145842'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:49 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '720'
+      - '766'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_honeytokens_show_token.yaml
+++ b/tests/cassettes/tools/vcr/test_list_honeytokens_show_token.yaml
@@ -25,33 +25,29 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/411d33c0-7fad-4fc1-b94e-bb440c8f9c49",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:11.250010Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}, {"id": "858a3a76-f6f2-4c2e-b0bc-323d9a575413",
-        "name": "test_honey_token", "description": "description", "created_at": "2023-05-15T14:09:09.210845Z",
+        "token": "[REDACTED]"}, {"id": "858a3a76-f6f2-4c2e-b0bc-323d9a575413", "name":
+        "test_honey_token", "description": "description", "created_at": "2023-05-15T14:09:09.210845Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/858a3a76-f6f2-4c2e-b0bc-323d9a575413",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:17.165934Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}, {"id": "72a52279-8e9f-40de-a1d4-bc5fcc48795d",
-        "name": "passwordscon", "description": "", "created_at": "2023-05-16T10:03:49.677782Z",
+        "token": "[REDACTED]"}, {"id": "72a52279-8e9f-40de-a1d4-bc5fcc48795d", "name":
+        "passwordscon", "description": "", "created_at": "2023-05-16T10:03:49.677782Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72a52279-8e9f-40de-a1d4-bc5fcc48795d",
         "status": "triggered", "triggered_at": "2023-05-16T10:04:10.262805Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 222, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
-        "key": "location", "value": "test"}], "custom_tags": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
+        ["publicly_exposed"], "custom_tags": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
         "key": "location", "value": "test"}], "token": "[REDACTED]"}, {"id": "8bf5f99a-538d-4cfe-8e74-61cd7081ae25",
         "name": "PasswordsCon2", "description": "For presentation", "created_at":
         "2023-05-16T11:30:36.210395Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8bf5f99a-538d-4cfe-8e74-61cd7081ae25",
         "status": "triggered", "triggered_at": "2023-05-16T12:29:45.638074Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 344, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "45182b59-b659-41ef-9bb8-44a78740fade", "name": "solid-octo-repo", "description":
         "Placed in solid-octo repo, file ... on 16May2023", "created_at": "2023-05-16T11:51:06.384073Z",
@@ -59,47 +55,41 @@ interactions:
         "status": "triggered", "triggered_at": "2026-02-18T14:51:12.499369Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432", "key": "place",
-        "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
+        [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432", "key":
+        "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
         "name": "jira-OPS-124", "description": "honeytoken deployed in jira ticket
         OPS-124", "created_at": "2023-05-16T11:58:57.713307Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "63bbd74e-bb5f-4910-8e63-eed358af3bc8",
         "name": "improved-carnival repo", "description": "", "created_at": "2023-05-16T14:45:09.811724Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/63bbd74e-bb5f-4910-8e63-eed358af3bc8",
         "status": "revoked", "triggered_at": "2023-05-16T14:49:44.284195Z", "revoked_at":
         "2024-06-19T10:46:44.282148Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "72fcdb5c-e128-4ca5-8970-f1f52f95a78a",
         "name": "slack-chan-website", "description": "", "created_at": "2023-05-16T15:35:26.129025Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72fcdb5c-e128-4ca5-8970-f1f52f95a78a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
-        "key": "place", "value": "website"}], "custom_tags": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
         "key": "place", "value": "website"}], "token": "[REDACTED]"}, {"id": "84d43c23-6d4d-47f8-bf62-e7c1b0ae1625",
         "name": "analytic-repo", "description": "", "created_at": "2023-05-16T16:17:11.435058Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84d43c23-6d4d-47f8-bf62-e7c1b0ae1625",
         "status": "revoked", "triggered_at": "2023-05-16T16:27:55.091410Z", "revoked_at":
         "2023-12-11T14:01:44.427581Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "ef11a80c-6d8e-4fb5-8ee2-4556bae695c3",
         "name": "test ht public", "description": "", "created_at": "2023-05-17T17:00:24.966335Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef11a80c-6d8e-4fb5-8ee2-4556bae695c3",
         "status": "triggered", "triggered_at": "2023-05-17T17:02:33.386529Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 5012, "creator_id": 166199, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
-        "key": "location", "value": "slack"}], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
+        ["publicly_exposed"], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
         "key": "location", "value": "slack"}], "token": "[REDACTED]"}, {"id": "db7bf6ea-57cb-4d13-8ed9-dc59b2620e00",
         "name": "Honeytoken demo 17 may", "description": "This is a token for the
         live demo", "created_at": "2023-05-17T17:15:04.921233Z", "gitguardian_url":
@@ -107,173 +97,161 @@ interactions:
         "status": "triggered", "triggered_at": "2023-05-17T17:16:48.960267Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 5018, "creator_id": 166199, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "79db31fc-ffd1-4bc9-b6e4-3ef37a94712a", "name": "QubitConfrence", "description":
         "", "created_at": "2023-05-18T07:58:37.174577Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/79db31fc-ffd1-4bc9-b6e4-3ef37a94712a",
         "status": "triggered", "triggered_at": "2023-05-18T09:30:01.025933Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 215, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263", "name": "NDC-OSLO Demo", "description":
-        "Demo key for NDC Oslo confrence", "created_at": "2023-05-25T07:59:05.651290Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
+        "name": "NDC-OSLO Demo", "description": "Demo key for NDC Oslo confrence",
+        "created_at": "2023-05-25T07:59:05.651290Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
         "status": "triggered", "triggered_at": "2023-05-25T08:38:27.471330Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 221, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b6f2b765-a8e5-458f-b68a-4b5ef934bcc8", "name": "Pycon Italia", "description":
-        "", "created_at": "2023-05-28T09:34:01.581495Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
+        "name": "Pycon Italia", "description": "", "created_at": "2023-05-28T09:34:01.581495Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
         "status": "revoked", "triggered_at": "2023-05-28T09:45:30.255118Z", "revoked_at":
         "2024-12-10T12:17:08.199275Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "bb494eed-6ba4-4b98-b949-ad5f54d929dd", "name": "ggshield-uORy0any",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "bb494eed-6ba4-4b98-b949-ad5f54d929dd", "name": "ggshield-uORy0any",
         "description": "description", "created_at": "2023-05-30T10:30:39.803353Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bb494eed-6ba4-4b98-b949-ad5f54d929dd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1266b395-a545-42c1-b700-24dbae36447c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1266b395-a545-42c1-b700-24dbae36447c",
         "name": "test_honey_token_previous", "description": "description", "created_at":
         "2023-05-30T10:30:40.547255Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1266b395-a545-42c1-b700-24dbae36447c",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:41:43.173510Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "f60db759-7041-4dfe-80fa-91012d97fdd3",
         "name": "ggshield-tsCPoUcx", "description": "description", "created_at": "2023-05-30T10:37:14.527124Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f60db759-7041-4dfe-80fa-91012d97fdd3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
         "name": "ggshield-BA0VsBh3", "description": "description", "created_at": "2023-05-30T10:39:09.968782Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e7f275d-e115-44d3-8854-5c6472494951",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e7f275d-e115-44d3-8854-5c6472494951",
         "name": "ggshield-UXgNYVXL", "description": "description", "created_at": "2023-05-30T10:42:36.847031Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6e7f275d-e115-44d3-8854-5c6472494951",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7494298b-75c5-44e4-898c-77b3b9017113",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7494298b-75c5-44e4-898c-77b3b9017113",
         "name": "test_honey_token_abc", "description": "description", "created_at":
         "2023-05-30T10:42:37.520767Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7494298b-75c5-44e4-898c-77b3b9017113",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:45:41.905071Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "092dba62-9d82-41bd-84aa-95430d540edc", "name": "ggshield-224Lwv95",
-        "description": "description", "created_at": "2023-05-30T10:46:10.997022Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "092dba62-9d82-41bd-84aa-95430d540edc",
+        "name": "ggshield-224Lwv95", "description": "description", "created_at": "2023-05-30T10:46:10.997022Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/092dba62-9d82-41bd-84aa-95430d540edc",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
         "name": "test_honey_token_previous", "description": "description", "created_at":
         "2023-05-30T10:46:11.714531Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:07.762156Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "13f6dbf3-ae1a-4757-95f6-e0fbc830fc55", "name": "ggshield-agateau",
-        "description": null, "created_at": "2023-05-30T13:32:31.845201Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
+        "name": "ggshield-agateau", "description": null, "created_at": "2023-05-30T13:32:31.845201Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T13:33:03.363563Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 160089, "revoker_id":
         160089, "creator_api_token_id": "425e1a78-209e-4cd5-b08f-8450a0026ac0", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "f17302cd-850b-4b54-9054-60d26a76cf38", "name": "test demo 31may",
-        "description": "", "created_at": "2023-05-31T08:10:36.754144Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f17302cd-850b-4b54-9054-60d26a76cf38",
+        "name": "test demo 31may", "description": "", "created_at": "2023-05-31T08:10:36.754144Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "41d76272-ee3d-4639-93e8-29222b662b93",
         "name": "demo31may-public", "description": "", "created_at": "2023-05-31T08:13:48.373887Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/41d76272-ee3d-4639-93e8-29222b662b93",
         "status": "revoked", "triggered_at": "2023-05-31T08:15:09.926931Z", "revoked_at":
         "2024-12-10T12:16:03.693045Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "63728091-d083-47cc-9898-73c2636f2c7f", "name": "ggshield-ZIU1V3Bv", "description":
         null, "created_at": "2023-05-31T08:17:12.607879Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/63728091-d083-47cc-9898-73c2636f2c7f",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-31T08:17:38.021142Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "001c53df-b63c-4b81-a4fb-35e5b38bf328", "name": "DevOxx Poland", "description":
-        "", "created_at": "2023-05-31T12:28:39.713989Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/001c53df-b63c-4b81-a4fb-35e5b38bf328",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "001c53df-b63c-4b81-a4fb-35e5b38bf328",
+        "name": "DevOxx Poland", "description": "", "created_at": "2023-05-31T12:28:39.713989Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/001c53df-b63c-4b81-a4fb-35e5b38bf328",
         "status": "triggered", "triggered_at": "2023-05-31T14:09:21.767459Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 225, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05", "name": "ggshield-cptptJHt",
-        "description": "ggshield test", "created_at": "2023-06-02T08:47:41.149126Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05",
+        "name": "ggshield-cptptJHt", "description": "ggshield test", "created_at":
+        "2023-06-02T08:47:41.149126Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
-        "name": "ggshield-TtJwtxNE", "description": "ggshield test", "created_at":
-        "2023-06-02T08:48:20.148216Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72", "name": "ggshield-TtJwtxNE",
+        "description": "ggshield test", "created_at": "2023-06-02T08:48:20.148216Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "27379093-c6a4-4732-a64a-715c94e74fd7",
-        "name": "ggshield-TvFzKVed", "description": null, "created_at": "2023-06-09T08:01:57.360210Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/27379093-c6a4-4732-a64a-715c94e74fd7",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "27379093-c6a4-4732-a64a-715c94e74fd7", "name": "ggshield-TvFzKVed",
+        "description": null, "created_at": "2023-06-09T08:01:57.360210Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/27379093-c6a4-4732-a64a-715c94e74fd7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "62cb7048-4302-4b52-9163-e2ceff775b39", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc7214d0-c97a-44b3-b576-664f0a81c4f7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc7214d0-c97a-44b3-b576-664f0a81c4f7",
         "name": "repo analytics 19jun", "description": "", "created_at": "2023-06-19T09:11:21.788070Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc7214d0-c97a-44b3-b576-664f0a81c4f7",
         "status": "revoked", "triggered_at": "2023-06-20T17:24:35.145047Z", "revoked_at":
         "2023-12-11T14:50:27.627289Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb", "name": "ggshield-0etjSvZJ",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb", "name": "ggshield-0etjSvZJ",
         "description": "description", "created_at": "2023-07-05T08:27:14.048162Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-05T08:27:15.756813Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0e4f0dbd-b288-4990-9565-3cc7b0171a79",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:53.240550Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 160089, "revoker_id":
         296618, "creator_api_token_id": "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "14566c1f-0b52-4770-ab68-000704242633", "name": "ggshield-Rv2mUej7",
-        "description": "description", "created_at": "2023-07-05T08:55:23.864812Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "14566c1f-0b52-4770-ab68-000704242633",
+        "name": "ggshield-Rv2mUej7", "description": "description", "created_at": "2023-07-05T08:55:23.864812Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/14566c1f-0b52-4770-ab68-000704242633",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c8c94ffa-c0af-48c6-976a-6502a41811af",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c8c94ffa-c0af-48c6-976a-6502a41811af",
         "name": "honeytoken demo eric", "description": "demo here", "created_at":
         "2023-07-05T14:48:53.893911Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c8c94ffa-c0af-48c6-976a-6502a41811af",
         "status": "triggered", "triggered_at": "2023-07-05T14:49:33.528178Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
         "name": "Example TOken ", "description": "ubvcub", "created_at": "2023-07-12T13:16:10.775681Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
-        "key": "file", "value": ".env"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "0c3f182e-98f5-4a64-aadb-664fd7c9de88", "name": "ggshield-ewIAL7lq", "description":
@@ -282,58 +260,55 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
         "name": "ggshield-w1P1Ggsz", "description": "description", "created_at": "2023-07-27T08:56:55.435203Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a20a718-7b9e-4582-abdf-772053bffd72",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a20a718-7b9e-4582-abdf-772053bffd72",
         "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T08:56:56.138738Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a20a718-7b9e-4582-abdf-772053bffd72",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:58.657957Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "51f41814-f029-4ab4-b863-c0fecba025b3", "name": "ggshield-v3LhZCz8",
-        "description": "description", "created_at": "2023-07-27T09:01:36.117217Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51f41814-f029-4ab4-b863-c0fecba025b3",
+        "name": "ggshield-v3LhZCz8", "description": "description", "created_at": "2023-07-27T09:01:36.117217Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/51f41814-f029-4ab4-b863-c0fecba025b3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T09:01:36.764795Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-27T09:01:37.417151Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e842a635-eb7e-4617-8984-ac57fe909ef7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
         "name": "ggshield-5voYnhhy", "description": null, "created_at": "2023-07-27T13:50:51.332176Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T13:52:58.300149Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "521efd01-bbcc-4380-b548-ed7242c017ea",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "521efd01-bbcc-4380-b548-ed7242c017ea",
         "name": "ggshield-HLZpiznn", "description": null, "created_at": "2023-07-27T14:54:03.198466Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/521efd01-bbcc-4380-b548-ed7242c017ea",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0d81797a-6fc0-4a6e-a211-af16828c0c39",
-        "name": "Webinar Public ", "description": "from webinar ", "created_at": "2023-07-27T15:33:07.472730Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0d81797a-6fc0-4a6e-a211-af16828c0c39", "name": "Webinar
+        Public ", "description": "from webinar ", "created_at": "2023-07-27T15:33:07.472730Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0d81797a-6fc0-4a6e-a211-af16828c0c39",
         "status": "triggered", "triggered_at": "2023-07-27T15:34:48.902462Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 204, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "27e9ba01-4bb6-46ed-84c8-ff14366a3bde", "name": "Private network", "description":
@@ -342,60 +317,55 @@ interactions:
         "status": "triggered", "triggered_at": "2023-07-27T16:23:35.804271Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5670c657-618f-41d7-984b-d59656d905e4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5670c657-618f-41d7-984b-d59656d905e4",
         "name": "ggshield-3KTmbo8u", "description": null, "created_at": "2023-07-27T15:44:43.238742Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5670c657-618f-41d7-984b-d59656d905e4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5d3ad22c-e422-48d2-b7f5-6d52801599aa",
-        "name": "demo 31jul", "description": "", "created_at": "2023-07-31T15:27:18.323098Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d3ad22c-e422-48d2-b7f5-6d52801599aa",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5d3ad22c-e422-48d2-b7f5-6d52801599aa", "name": "demo
+        31jul", "description": "", "created_at": "2023-07-31T15:27:18.323098Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d3ad22c-e422-48d2-b7f5-6d52801599aa",
         "status": "revoked", "triggered_at": "2023-07-31T15:33:49.570793Z", "revoked_at":
         "2023-12-11T14:01:40.706751Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a", "name": "test
-        Antonin 1", "description": "", "created_at": "2023-08-03T08:42:25.251504Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fa63d76d-4297-4d41-8e77-b47d1a97a41a",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a", "name": "test Antonin 1", "description":
+        "", "created_at": "2023-08-03T08:42:25.251504Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fa63d76d-4297-4d41-8e77-b47d1a97a41a",
         "status": "revoked", "triggered_at": "2023-08-03T08:59:58.717709Z", "revoked_at":
         "2023-08-03T09:00:05.809852Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "a11570c6-f472-4fda-a493-30d65fd8e651", "name": "test Antonin 2", "description":
-        "", "created_at": "2023-08-03T14:09:46.046004Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a11570c6-f472-4fda-a493-30d65fd8e651",
+        "name": "test Antonin 2", "description": "", "created_at": "2023-08-03T14:09:46.046004Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40",
-        "name": "vBOY test segment", "description": "sdqsdqsdqsdqsd", "created_at":
-        "2023-08-07T12:45:52.890085Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40", "name": "vBOY
+        test segment", "description": "sdqsdqsdqsdqsd", "created_at": "2023-08-07T12:45:52.890085Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-08-07T12:46:45.470113Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "name": "vBOY test segment 2", "description": "sdqsdqsd", "created_at": "2023-08-07T12:47:49.515448Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "86670f84-e117-4f96-aa16-e399a0bb2cf2",
-        "name": "juuj", "description": "", "created_at": "2023-08-08T15:53:23.097840Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86670f84-e117-4f96-aa16-e399a0bb2cf2",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "86670f84-e117-4f96-aa16-e399a0bb2cf2", "name": "juuj",
+        "description": "", "created_at": "2023-08-08T15:53:23.097840Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/86670f84-e117-4f96-aa16-e399a0bb2cf2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
-        "name": "BSidesLV", "description": "Key leaked publically by leakymcgee again",
-        "created_at": "2023-08-10T00:11:42.132386Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "978bf5aa-1f8e-425b-ac4b-b617ddbc178e", "name": "BSidesLV",
+        "description": "Key leaked publically by leakymcgee again", "created_at":
+        "2023-08-10T00:11:42.132386Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
         "status": "triggered", "triggered_at": "2023-08-10T00:13:19.948280Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
-        "key": "date leaked", "value": "08/09/2023"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
-        "key": "format", "value": "public"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
+        ["publicly_exposed"], "custom_tags": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
         "key": "date leaked", "value": "08/09/2023"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
         "key": "format", "value": "public"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
@@ -405,9 +375,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-08-11T18:55:35.503991Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 61, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
+        ["publicly_exposed"], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "90d4c2b6-ecae-4ef9-a754-4561929b9e38",
         "name": "ggshield-mpkTH5jF", "description": "description", "created_at": "2023-08-16T08:28:18.684517Z",
@@ -415,34 +383,31 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
         "name": "ggshield-mzO8qHEz", "description": "description", "created_at": "2023-08-22T08:19:03.821471Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
         "name": "testket ", "description": "eew", "created_at": "2023-08-29T10:21:29.956291Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "46776cb3-6b11-41fc-b431-07609992f0cb",
-        "name": "HoneyTokenaLARTest", "description": "Testworkshop", "created_at":
-        "2023-08-29T12:07:20.692993Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/46776cb3-6b11-41fc-b431-07609992f0cb",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "46776cb3-6b11-41fc-b431-07609992f0cb", "name": "HoneyTokenaLARTest",
+        "description": "Testworkshop", "created_at": "2023-08-29T12:07:20.692993Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/46776cb3-6b11-41fc-b431-07609992f0cb",
         "status": "revoked", "triggered_at": "2023-08-29T12:09:16.581232Z", "revoked_at":
         "2023-08-29T12:42:37.841866Z", "type": "AWS", "open_events_count": 0, "creator_id":
         37699, "revoker_id": 37699, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "edd96a3b-5c71-4346-b5e2-2150e454dc91", "name": "Bsides Krakow", "description":
-        "Demo for leaking a key on GitHub", "created_at": "2023-09-02T13:20:53.501588Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/edd96a3b-5c71-4346-b5e2-2150e454dc91",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "edd96a3b-5c71-4346-b5e2-2150e454dc91",
+        "name": "Bsides Krakow", "description": "Demo for leaking a key on GitHub",
+        "created_at": "2023-09-02T13:20:53.501588Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/edd96a3b-5c71-4346-b5e2-2150e454dc91",
         "status": "triggered", "triggered_at": "2023-09-02T13:22:51.142717Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "de145bd4-b424-49ab-b95b-80126914bf2e",
         "name": "ctf-demo-test-honeytoken-django-app", "description": "", "created_at":
@@ -450,68 +415,59 @@ interactions:
         "status": "revoked", "triggered_at": "2023-09-06T07:42:55.177580Z", "revoked_at":
         "2023-09-06T10:03:30.948628Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "5564ed3c-3eec-4375-9fc8-e0ada71dce02", "name": "ctf-demo-test-honeytoken-micro-api",
-        "description": "", "created_at": "2023-09-05T19:18:08.504776Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/5564ed3c-3eec-4375-9fc8-e0ada71dce02",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5564ed3c-3eec-4375-9fc8-e0ada71dce02",
+        "name": "ctf-demo-test-honeytoken-micro-api", "description": "", "created_at":
+        "2023-09-05T19:18:08.504776Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5564ed3c-3eec-4375-9fc8-e0ada71dce02",
         "status": "revoked", "triggered_at": "2023-09-06T07:44:18.074891Z", "revoked_at":
         "2023-09-06T10:03:48.581110Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "f246c64a-3494-43ae-9d81-500df2f950c3", "name": "demo-honeytoken-ctf-personal-",
-        "description": "", "created_at": "2023-09-06T11:29:57.547211Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/f246c64a-3494-43ae-9d81-500df2f950c3",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f246c64a-3494-43ae-9d81-500df2f950c3",
+        "name": "demo-honeytoken-ctf-personal-", "description": "", "created_at":
+        "2023-09-06T11:29:57.547211Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f246c64a-3494-43ae-9d81-500df2f950c3",
         "status": "revoked", "triggered_at": "2023-09-06T12:18:14.949044Z", "revoked_at":
         "2024-12-10T12:15:49.265110Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
         "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "ff623703-9ca1-4fba-99dc-c20110894ed3",
         "name": "-demo-honeytoken-ctf-django-app-", "description": "", "created_at":
         "2023-09-06T11:33:27.376222Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff623703-9ca1-4fba-99dc-c20110894ed3",
         "status": "triggered", "triggered_at": "2023-09-06T14:19:10.580142Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 4, "creator_id": null, "revoker_id":
+        null, "type": "AWS", "open_events_count": 9, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "a58154f6-e66f-4079-82b7-aabec70c73ff",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "a58154f6-e66f-4079-82b7-aabec70c73ff",
         "name": "demo-honeytoken-ctf-micro-api", "description": "", "created_at":
         "2023-09-06T11:33:37.828240Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a58154f6-e66f-4079-82b7-aabec70c73ff",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-09-06T14:17:20.708816Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b01db549-a2fa-4527-913d-0715a1119530",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "b01db549-a2fa-4527-913d-0715a1119530",
         "name": "demo-honeytoken-ctf-internal-share-", "description": "", "created_at":
         "2023-09-06T11:33:48.881275Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b01db549-a2fa-4527-913d-0715a1119530",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-09-06T14:21:42.509905Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "89a1745a-f796-4ece-99f7-106671aea57c",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "89a1745a-f796-4ece-99f7-106671aea57c",
         "name": "-demo-honeytoken-ctf-micro-api-", "description": "", "created_at":
         "2023-09-06T14:19:32.695323Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/89a1745a-f796-4ece-99f7-106671aea57c",
         "status": "triggered", "triggered_at": "2023-09-06T14:24:18.462424Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "095d655f-a273-400f-ba01-eff8951242ed",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "095d655f-a273-400f-ba01-eff8951242ed",
         "name": "-demo-honeytoken-ctf-internal-share-", "description": "", "created_at":
         "2023-09-06T14:21:55.062468Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/095d655f-a273-400f-ba01-eff8951242ed",
         "status": "triggered", "triggered_at": "2023-09-08T16:58:49.455578Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 6, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "3664c283-d479-41ac-9ad9-30283731ee25",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "3664c283-d479-41ac-9ad9-30283731ee25",
         "name": "Balccon Demo", "description": "Demo key for Balccon ", "created_at":
         "2023-09-08T14:55:02.417580Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3664c283-d479-41ac-9ad9-30283731ee25",
         "status": "triggered", "triggered_at": "2023-09-08T14:56:49.516889Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
-        "key": "location", "value": "sourcecode"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
-        "key": "visability", "value": "public"}], "custom_tags": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
+        ["publicly_exposed"], "custom_tags": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
         "key": "location", "value": "sourcecode"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
         "key": "visability", "value": "public"}], "token": "[REDACTED]"}, {"id": "7ca5ca92-a0a1-48bf-9618-d7194beaa039",
@@ -520,9 +476,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-09-29T16:11:40.077048Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 344, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
-        "key": "confrence", "value": "grrcon"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}], "custom_tags": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
+        ["publicly_exposed"], "custom_tags": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
         "key": "confrence", "value": "grrcon"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}], "token": "[REDACTED]"}, {"id": "2544b3e6-57b2-48e2-a1a5-c4b6551987bb",
         "name": "SBB demo", "description": "Leaking key on GitHub", "created_at":
@@ -530,11 +484,8 @@ interactions:
         "status": "triggered", "triggered_at": "2024-08-17T15:36:55.810693Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key": "commiter",
-        "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca", "key":
-        "file", "value": ".env"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327", "key":
-        "vcs", "value": "github"}], "custom_tags": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda",
-        "key": "commiter", "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
+        [], "custom_tags": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key":
+        "commiter", "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "7d80793b-c702-441e-837e-b1d3da94d576",
         "name": "Hacktivity Key", "description": "Test Key Leak for Hacktivity", "created_at":
@@ -542,9 +493,7 @@ interactions:
         "status": "revoked", "triggered_at": "2023-10-05T14:42:57.752365Z", "revoked_at":
         "2024-12-10T12:17:33.875750Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "576dc1ce-ab72-4604-934f-526cff5a667e", "name": "BsidesCyprus", "description":
@@ -553,8 +502,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-10-07T11:35:53.017981Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 249, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "22fdf53a-e348-464a-a87f-5bcecb1a4e62", "name": "Slack test", "description":
         "blablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablabla
@@ -567,21 +515,20 @@ interactions:
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-06-03T09:50:06.667490Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 363707, "revoker_id":
         353920, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "137c9fee-4b3c-4231-92fd-98debf6557c2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "137c9fee-4b3c-4231-92fd-98debf6557c2",
         "name": "BSides ATL demo for session", "description": "This one will be triggered
         from 2 different spots online", "created_at": "2023-10-14T12:28:51.206659Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/137c9fee-4b3c-4231-92fd-98debf6557c2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 354585, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "cdaea884-25fb-49db-90ec-a18879be36c4",
-        "name": "Demo Honeytoken", "description": "Leaking on Public Demo", "created_at":
-        "2023-10-16T15:13:10.845487Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cdaea884-25fb-49db-90ec-a18879be36c4",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "cdaea884-25fb-49db-90ec-a18879be36c4", "name": "Demo
+        Honeytoken", "description": "Leaking on Public Demo", "created_at": "2023-10-16T15:13:10.845487Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cdaea884-25fb-49db-90ec-a18879be36c4",
         "status": "revoked", "triggered_at": "2023-10-16T15:14:25.574559Z", "revoked_at":
         "2023-10-27T15:01:19.053629Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "48f7c567-93d1-4925-9f77-d3919f120b88", "name": "ggshield-KlAkKRtE", "description":
         "description", "created_at": "2023-10-16T19:49:08.588391Z", "gitguardian_url":
@@ -589,52 +536,50 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
         "name": "Jason test", "description": "Token for Test ", "created_at": "2023-10-24T13:45:31.371710Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f8e0968-664a-49f3-af85-9cc468b960ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "fe392ff1-b3d7-462f-a26f-d094326f40ed",
-        "name": "Jason and team", "description": "akljdlaj", "created_at": "2023-10-24T14:23:20.991107Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fe392ff1-b3d7-462f-a26f-d094326f40ed", "name": "Jason
+        and team", "description": "akljdlaj", "created_at": "2023-10-24T14:23:20.991107Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fe392ff1-b3d7-462f-a26f-d094326f40ed",
         "status": "triggered", "triggered_at": "2024-05-10T22:15:09.224357Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29",
         "name": "Eric Demo Test 01", "description": "", "created_at": "2023-10-31T12:51:44.535200Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d69a098c-8b61-4102-bb2b-9a82958a3e29",
         "status": "revoked", "triggered_at": "2023-10-31T12:52:49.851916Z", "revoked_at":
         "2024-12-10T12:16:28.115539Z", "type": "AWS", "open_events_count": 0, "creator_id":
         136170, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb", "name": "test
-        eric dd 02", "description": "", "created_at": "2023-10-31T14:33:35.801324Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4affa602-902b-47ff-a1f4-721dc3e671bb",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb", "name": "test eric dd 02",
+        "description": "", "created_at": "2023-10-31T14:33:35.801324Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/4affa602-902b-47ff-a1f4-721dc3e671bb",
         "status": "triggered", "triggered_at": "2023-10-31T14:35:33.676298Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 2897, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "8df388e2-aeb5-42ca-b6d5-221a54a40339", "name": "ggshield-P47kTh7j",
-        "description": null, "created_at": "2023-11-09T15:44:33.671666Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/8df388e2-aeb5-42ca-b6d5-221a54a40339",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8df388e2-aeb5-42ca-b6d5-221a54a40339",
+        "name": "ggshield-P47kTh7j", "description": null, "created_at": "2023-11-09T15:44:33.671666Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8df388e2-aeb5-42ca-b6d5-221a54a40339",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "bd51c3d9-0943-43d5-8f87-359ecee03903",
-        "name": "ggshield-73VAsjsO", "description": null, "created_at": "2023-11-14T08:27:44.885242Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bd51c3d9-0943-43d5-8f87-359ecee03903",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "bd51c3d9-0943-43d5-8f87-359ecee03903", "name": "ggshield-73VAsjsO",
+        "description": null, "created_at": "2023-11-14T08:27:44.885242Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/bd51c3d9-0943-43d5-8f87-359ecee03903",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-11-14T08:28:08.188201Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
         "name": "DeepSec Demo", "description": "Demo for DeepSec Confrence ", "created_at":
         "2023-11-16T16:01:21.723176Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
         "status": "triggered", "triggered_at": "2023-11-16T16:01:58.603599Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "ae448808-3865-4797-a008-9eef6344f9da", "name": "Bsides Berlin", "description":
         "test key for a demo", "created_at": "2023-11-18T16:19:36.463172Z", "gitguardian_url":
@@ -642,9 +587,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-11-18T16:20:14.365596Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 105, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
-        "key": "repo", "value": "mackenziejj"}], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
+        ["publicly_exposed"], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
         "key": "repo", "value": "mackenziejj"}], "token": "[REDACTED]"}, {"id": "ecb3d61d-bdab-4636-a436-bef8079a005d",
         "name": "ggshield-ObfCUUCA", "description": "description", "created_at": "2023-11-28T08:50:32.130230Z",
@@ -652,48 +595,41 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d6d5d79d-08fa-4c8a-bd54-c34851866cde",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d6d5d79d-08fa-4c8a-bd54-c34851866cde",
         "name": "test1112", "description": "test publicly exposed honeytoken", "created_at":
         "2023-12-11T16:24:56.253683Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d6d5d79d-08fa-4c8a-bd54-c34851866cde",
         "status": "triggered", "triggered_at": "2023-12-11T16:26:07.733443Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "4046ccf5-7821-47f4-be7d-8240be69631b",
         "name": "ideal-journey-lena", "description": "", "created_at": "2023-12-11T16:29:20.759489Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4046ccf5-7821-47f4-be7d-8240be69631b",
-        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
-        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
+        "status": "triggered", "triggered_at": "2026-05-28T07:56:58.047592Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 5, "creator_id": 319222, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
         "name": "analytics-repo", "description": "", "created_at": "2023-12-11T17:37:24.471286Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
         "status": "triggered", "triggered_at": "2023-12-11T17:46:48.024345Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "b7daf77c-e3e0-4747-a7e2-485a1a6f05e2",
-        "key": "team", "value": "dev"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "b7daf77c-e3e0-4747-a7e2-485a1a6f05e2",
         "key": "team", "value": "dev"}], "token": "[REDACTED]"}, {"id": "52903632-f6ff-460e-8a68-80a942349979",
         "name": "Network Honeytoken", "description": "Aws Honeytoken on Network",
         "created_at": "2023-12-18T13:47:39.151311Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/52903632-f6ff-460e-8a68-80a942349979",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
-        "key": "network", "value": "directory"}], "custom_tags": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
         "key": "network", "value": "directory"}], "token": "[REDACTED]"}, {"id": "6c5d9856-835e-468c-9448-7bf0e77f1e53",
         "name": "improved carnival", "description": "", "created_at": "2023-12-21T13:43:01.544215Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6c5d9856-835e-468c-9448-7bf0e77f1e53",
         "status": "revoked", "triggered_at": "2023-12-21T13:57:59.435706Z", "revoked_at":
         "2023-12-22T09:33:18.668820Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "4dd77510-fc74-411f-9dbe-77619fa920dd",
         "name": "My Postman Public Collection", "description": "Will it ring?", "created_at":
@@ -701,242 +637,231 @@ interactions:
         "status": "triggered", "triggered_at": "2024-01-04T17:52:01.203498Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 811, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
         "name": "ggshield-JZV5XT71", "description": "description", "created_at": "2024-01-09T09:39:34.421404Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "name": "sss", "description": "test", "created_at": "2024-01-09T14:24:10.741214Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
-        "name": "AWS key honeytoken for Slack", "description": "Honeytoken on Slack
-        channel", "created_at": "2024-01-15T16:13:53.656688Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "123ecd19-e66f-4e5c-ad73-12f0a51eda5a", "name": "AWS
+        key honeytoken for Slack", "description": "Honeytoken on Slack channel", "created_at":
+        "2024-01-15T16:13:53.656688Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
         "status": "triggered", "triggered_at": "2024-01-15T16:14:14.960066Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 104, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "23ca2658-aecf-471c-abf0-add09962e320", "key": "ods",
-        "value": "slack"}], "custom_tags": [{"id": "23ca2658-aecf-471c-abf0-add09962e320",
-        "key": "ods", "value": "slack"}], "token": "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a",
+        [], "custom_tags": [{"id": "23ca2658-aecf-471c-abf0-add09962e320", "key":
+        "ods", "value": "slack"}], "token": "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a",
         "name": "BK Test Paris", "description": "Brandon while in Paris office", "created_at":
         "2024-01-17T11:12:14.759334Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/34d5205b-accd-429c-9efa-eda48989c83a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
-        "name": "Lauren Testing", "description": "Lauren wuz here", "created_at":
-        "2024-01-29T17:37:45.379096Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4", "name": "Lauren
+        Testing", "description": "Lauren wuz here", "created_at": "2024-01-29T17:37:45.379096Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 637596, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "07fb5f6f-23f1-42e8-bdb2-c95864412a16",
         "name": "My Little Honeytoken", "description": "for testing", "created_at":
         "2024-02-02T22:18:06.038874Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/07fb5f6f-23f1-42e8-bdb2-c95864412a16",
         "status": "triggered", "triggered_at": "2024-02-09T20:50:13.173911Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b00bfddb-98c2-48e4-ad38-0cb9bc79cad6", "name": "orga_083643/solid-octo",
-        "description": "", "created_at": "2024-02-09T14:45:12.139727Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
+        "name": "orga_083643/solid-octo", "description": "", "created_at": "2024-02-09T14:45:12.139727Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
         "status": "revoked", "triggered_at": "2024-02-09T14:52:11.339548Z", "revoked_at":
         "2024-05-29T13:09:29.773300Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 2508, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "cf0806c4-093d-4165-9ad3-7e7ded211d3f", "name": "DemoKey", "description":
-        "sss", "created_at": "2024-02-15T12:39:23.633481Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cf0806c4-093d-4165-9ad3-7e7ded211d3f",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cf0806c4-093d-4165-9ad3-7e7ded211d3f",
+        "name": "DemoKey", "description": "sss", "created_at": "2024-02-15T12:39:23.633481Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cf0806c4-093d-4165-9ad3-7e7ded211d3f",
         "status": "triggered", "triggered_at": "2024-02-15T12:45:44.649197Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "638f6f82-6679-4399-a336-dd7996f4beae", "name": "demo-2024-02-16dm",
-        "description": "demo", "created_at": "2024-02-16T19:39:33.970811Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/638f6f82-6679-4399-a336-dd7996f4beae",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "638f6f82-6679-4399-a336-dd7996f4beae",
+        "name": "demo-2024-02-16dm", "description": "demo", "created_at": "2024-02-16T19:39:33.970811Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/638f6f82-6679-4399-a336-dd7996f4beae",
         "status": "revoked", "triggered_at": "2024-02-16T19:40:02.759791Z", "revoked_at":
         "2024-02-16T20:10:11.153368Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "6fcc5cf2-4b47-497d-9a80-c2d794b96ebc", "name": "solid-octo",
-        "description": "", "created_at": "2024-02-19T13:06:26.880374Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "6fcc5cf2-4b47-497d-9a80-c2d794b96ebc", "name": "solid-octo", "description":
+        "", "created_at": "2024-02-19T13:06:26.880374Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
-        "key": "team", "value": "octo"}], "custom_tags": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
         "key": "team", "value": "octo"}], "token": "[REDACTED]"}, {"id": "1592023a-2f39-4ba6-a503-4c07132f1eb0",
         "name": "GGnikalston/rock-paper-scissors-f4c01375", "description": "", "created_at":
         "2024-02-20T13:32:45.163630Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1592023a-2f39-4ba6-a503-4c07132f1eb0",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d024b464-cd1e-4daf-9b1d-863dcf517a7a",
-        "name": "Demo -2024-02-22", "description": "", "created_at": "2024-02-22T18:53:26.142516Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d024b464-cd1e-4daf-9b1d-863dcf517a7a", "name": "Demo
+        -2024-02-22", "description": "", "created_at": "2024-02-22T18:53:26.142516Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d024b464-cd1e-4daf-9b1d-863dcf517a7a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 354585, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0a94480f-5361-47f8-bc23-45a331624e9d",
-        "name": "demo ", "description": "demo ", "created_at": "2024-02-22T19:02:29.338420Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0a94480f-5361-47f8-bc23-45a331624e9d",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0a94480f-5361-47f8-bc23-45a331624e9d", "name": "demo
+        ", "description": "demo ", "created_at": "2024-02-22T19:02:29.338420Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/0a94480f-5361-47f8-bc23-45a331624e9d",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T17:03:31.533534Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86136984-d415-41c2-bfc4-59da8f9584fd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86136984-d415-41c2-bfc4-59da8f9584fd",
         "name": "demo-2024-02-23-dm", "description": "", "created_at": "2024-02-23T15:38:04.895275Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86136984-d415-41c2-bfc4-59da8f9584fd",
         "status": "revoked", "triggered_at": "2024-02-23T15:49:03.613445Z", "revoked_at":
         "2024-02-23T15:59:54.768989Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "b38455f9-822c-4f21-8525-0d4f2fa63850", "name": "demo-dwayne-2024-02-23",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "b38455f9-822c-4f21-8525-0d4f2fa63850", "name": "demo-dwayne-2024-02-23",
         "description": "dfnijsbuisbfids", "created_at": "2024-02-23T15:45:47.636481Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b38455f9-822c-4f21-8525-0d4f2fa63850",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T16:28:23.939971Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "612055eb-7fb5-4ba3-ab10-aa481f3d9962",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "612055eb-7fb5-4ba3-ab10-aa481f3d9962",
         "name": "demo-dwayne-2024-02-23-v2", "description": "Demo for video", "created_at":
         "2024-02-23T16:28:49.949332Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/612055eb-7fb5-4ba3-ab10-aa481f3d9962",
         "status": "revoked", "triggered_at": "2024-02-23T16:31:01.657151Z", "revoked_at":
         "2024-02-23T16:52:50.712289Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e", "name": "myname-dwayneptoday",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e", "name": "myname-dwayneptoday",
         "description": "dfsdfsdf", "created_at": "2024-02-23T16:38:14.323313Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T17:03:21.653827Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1bba091c-fc4c-48b5-b558-46c191f67103",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1bba091c-fc4c-48b5-b558-46c191f67103",
         "name": "ggshield-ldC5hqqo", "description": "description", "created_at": "2024-02-27T13:42:36.686028Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1bba091c-fc4c-48b5-b558-46c191f67103",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d7764013-fdd5-4b08-b195-dff5a338906d",
-        "name": "ggshield-LRYYnjOa", "description": "description", "created_at": "2024-02-27T13:42:37.569678Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d7764013-fdd5-4b08-b195-dff5a338906d", "name": "ggshield-LRYYnjOa",
+        "description": "description", "created_at": "2024-02-27T13:42:37.569678Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d7764013-fdd5-4b08-b195-dff5a338906d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "def4a23d-3d12-4fe1-b8e0-02250e74e47a",
-        "name": "ggshield-itglxnie", "description": "description", "created_at": "2024-02-27T13:58:30.205444Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "def4a23d-3d12-4fe1-b8e0-02250e74e47a", "name": "ggshield-itglxnie",
+        "description": "description", "created_at": "2024-02-27T13:58:30.205444Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/def4a23d-3d12-4fe1-b8e0-02250e74e47a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "33d149f1-68f4-4446-ae4f-def0ce962724",
-        "name": "ggshield-2Mf02eVA", "description": "description", "created_at": "2024-02-27T13:58:31.125075Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "33d149f1-68f4-4446-ae4f-def0ce962724", "name": "ggshield-2Mf02eVA",
+        "description": "description", "created_at": "2024-02-27T13:58:31.125075Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/33d149f1-68f4-4446-ae4f-def0ce962724",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5ff5eee1-fc18-4474-86fa-c46321c903c8",
-        "name": "ggshield-rmnfzrW2", "description": "description", "created_at": "2024-02-27T14:02:45.009113Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5ff5eee1-fc18-4474-86fa-c46321c903c8", "name": "ggshield-rmnfzrW2",
+        "description": "description", "created_at": "2024-02-27T14:02:45.009113Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5ff5eee1-fc18-4474-86fa-c46321c903c8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "4dd6c06e-e2c0-4593-9be0-b0418ba7a370",
-        "name": "ggshield-5YTKZZTB", "description": "description", "created_at": "2024-02-27T14:02:45.717261Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "4dd6c06e-e2c0-4593-9be0-b0418ba7a370", "name": "ggshield-5YTKZZTB",
+        "description": "description", "created_at": "2024-02-27T14:02:45.717261Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4dd6c06e-e2c0-4593-9be0-b0418ba7a370",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "eba79796-4f46-4e10-b876-280f75138cc9",
-        "name": "ggshield-z3Y6zgih", "description": "description", "created_at": "2024-02-27T14:06:02.196977Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "eba79796-4f46-4e10-b876-280f75138cc9", "name": "ggshield-z3Y6zgih",
+        "description": "description", "created_at": "2024-02-27T14:06:02.196977Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/eba79796-4f46-4e10-b876-280f75138cc9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0ebc8091-454b-461e-a6f8-fd17bf412c76",
-        "name": "ggshield-jqk54PrI", "description": "description", "created_at": "2024-02-27T14:06:03.018091Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0ebc8091-454b-461e-a6f8-fd17bf412c76", "name": "ggshield-jqk54PrI",
+        "description": "description", "created_at": "2024-02-27T14:06:03.018091Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ebc8091-454b-461e-a6f8-fd17bf412c76",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "664af568-cfc7-4726-9fb4-0b61606b7386",
-        "name": "ggshield-horgQNnR", "description": "description", "created_at": "2024-02-27T14:19:39.357690Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "664af568-cfc7-4726-9fb4-0b61606b7386", "name": "ggshield-horgQNnR",
+        "description": "description", "created_at": "2024-02-27T14:19:39.357690Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/664af568-cfc7-4726-9fb4-0b61606b7386",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5d915aca-6f6f-4b4e-a996-2c1f53016114",
-        "name": "ggshield-LNgN8R1S", "description": "description", "created_at": "2024-02-27T14:19:40.283320Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5d915aca-6f6f-4b4e-a996-2c1f53016114", "name": "ggshield-LNgN8R1S",
+        "description": "description", "created_at": "2024-02-27T14:19:40.283320Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d915aca-6f6f-4b4e-a996-2c1f53016114",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245",
-        "name": "Test key ", "description": "ss", "created_at": "2024-02-29T13:49:52.467489Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245", "name": "Test
+        key ", "description": "ss", "created_at": "2024-02-29T13:49:52.467489Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e",
-        "name": "test-lena-1903", "description": "", "created_at": "2024-03-19T09:13:00.819618Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/443045cc-7fa4-441d-a161-b060bd7fbb3e",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e", "name": "test-lena-1903",
+        "description": "", "created_at": "2024-03-19T09:13:00.819618Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/443045cc-7fa4-441d-a161-b060bd7fbb3e",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-05-29T09:51:31.597203Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 319222, "revoker_id":
         319222, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
         "name": "ggshield-Psfrcoxl", "description": "description", "created_at": "2024-03-27T08:48:20.857237Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5a01f826-4f8f-4235-8867-ce58ac88ce1c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5a01f826-4f8f-4235-8867-ce58ac88ce1c",
         "name": "ggshield-inUFY47O", "description": "description", "created_at": "2024-03-27T08:48:21.791104Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5a01f826-4f8f-4235-8867-ce58ac88ce1c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d72113d0-c346-42c7-bd88-fd5fe0e716f3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d72113d0-c346-42c7-bd88-fd5fe0e716f3",
         "name": "ggshield-eY0ZOlXS", "description": "description", "created_at": "2024-04-30T09:25:38.689800Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d72113d0-c346-42c7-bd88-fd5fe0e716f3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "7f2873cd-3759-4727-a683-31cac57fe5d8",
-        "name": "ggshield-TvlX76OG", "description": "description", "created_at": "2024-04-30T09:25:39.573115Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "7f2873cd-3759-4727-a683-31cac57fe5d8", "name": "ggshield-TvlX76OG",
+        "description": "description", "created_at": "2024-04-30T09:25:39.573115Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7f2873cd-3759-4727-a683-31cac57fe5d8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "72e98633-9179-4a3e-8908-ea2319d19b3b",
-        "name": "ggshield-XYKDhLUY", "description": "description", "created_at": "2024-04-30T10:19:12.369644Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "72e98633-9179-4a3e-8908-ea2319d19b3b", "name": "ggshield-XYKDhLUY",
+        "description": "description", "created_at": "2024-04-30T10:19:12.369644Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72e98633-9179-4a3e-8908-ea2319d19b3b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
         "name": "ggshield-HRoZzrBq", "description": "description", "created_at": "2024-04-30T10:19:13.126568Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
         "name": "Test key", "description": "Access key", "created_at": "2024-05-22T12:16:55.833940Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c7101eaa-ea38-495d-b3b4-c016db23e859",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "a67f962c-9dde-40c2-b404-e7cd4449cc82",
         "name": "pouet", "description": "", "created_at": "2024-05-22T12:19:03.143437Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a67f962c-9dde-40c2-b404-e7cd4449cc82",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
-        "key": "visability", "value": "public"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
         "key": "visability", "value": "public"}], "token": "[REDACTED]"}, {"id": "9cca01c5-535f-4f89-a214-6c4c5579fd07",
@@ -944,487 +869,473 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9cca01c5-535f-4f89-a214-6c4c5579fd07",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
-        "name": "test lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
-        "status": "triggered", "triggered_at": "2024-06-06T08:19:18.422045Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 319222, "revoker_id":
-        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca", "key": "machine",
-        "value": "ggprdgim01"}], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99", "name": "test
+        lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
         "key": "machine", "value": "ggprdgim01"}], "token": "[REDACTED]"}, {"id":
         "a411fa2c-a465-4099-8353-3c42365aca50", "name": "test MINT", "description":
         "test MINT", "created_at": "2024-06-10T14:40:08.522247Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/a411fa2c-a465-4099-8353-3c42365aca50",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "12c4562e-deb8-4d14-bb23-e344e79b6f04",
-        "name": "ggshield-Wq4EyTMI", "description": "description", "created_at": "2024-06-25T08:36:52.179380Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "12c4562e-deb8-4d14-bb23-e344e79b6f04", "name": "ggshield-Wq4EyTMI",
+        "description": "description", "created_at": "2024-06-25T08:36:52.179380Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/12c4562e-deb8-4d14-bb23-e344e79b6f04",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3407738b-2095-47bb-9cbd-dd16de158d67",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3407738b-2095-47bb-9cbd-dd16de158d67",
         "name": "ggshield-65KCwJls", "description": "description", "created_at": "2024-06-25T08:36:52.873146Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3407738b-2095-47bb-9cbd-dd16de158d67",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
         "name": "ggshield-fb77weow", "description": "description", "created_at": "2024-06-26T09:27:38.724573Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9223e352-43b6-4e06-8d12-682d669cedd7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9223e352-43b6-4e06-8d12-682d669cedd7",
         "name": "ggshield-TRO3H56N", "description": "description", "created_at": "2024-06-26T09:27:39.479744Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9223e352-43b6-4e06-8d12-682d669cedd7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "17e088b8-2463-48f8-957b-41d017f1dc83",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "17e088b8-2463-48f8-957b-41d017f1dc83",
         "name": "ggshield-s7IOqS0q", "description": "description", "created_at": "2024-06-26T09:42:26.454643Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/17e088b8-2463-48f8-957b-41d017f1dc83",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e332d717-641d-4ea4-81fc-e98115178454",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e332d717-641d-4ea4-81fc-e98115178454",
         "name": "ggshield-JaAf9b0W", "description": "description", "created_at": "2024-06-26T09:42:27.174527Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e332d717-641d-4ea4-81fc-e98115178454",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26514e1f-4237-474b-b907-037b88427f29",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26514e1f-4237-474b-b907-037b88427f29",
         "name": "ggshield-Uuc8EiUn", "description": "description", "created_at": "2024-06-26T11:51:19.747630Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/26514e1f-4237-474b-b907-037b88427f29",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
         "name": "ggshield-GL7wc5WW", "description": "description", "created_at": "2024-06-26T11:51:20.402145Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
         "name": "test ericf", "description": "", "created_at": "2024-07-09T09:34:04.089955Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
         "status": "triggered", "triggered_at": "2024-07-09T09:34:57.541777Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "a507d04c-bb61-4f2a-93ea-601b8aa27940",
         "name": "ggshield-w1cOSspy", "description": "description", "created_at": "2024-07-31T15:31:09.349255Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a507d04c-bb61-4f2a-93ea-601b8aa27940",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dafa04c5-299a-4a13-9c35-c523e51763f3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dafa04c5-299a-4a13-9c35-c523e51763f3",
         "name": "ggshield-b7VHMqbK", "description": "description", "created_at": "2024-07-31T15:31:10.071786Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dafa04c5-299a-4a13-9c35-c523e51763f3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
         "name": "ggshield-Fu1nGsc9", "description": "description", "created_at": "2024-08-05T09:03:52.745860Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "83888e42-dc57-471c-9a08-f023e3dc2949",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "83888e42-dc57-471c-9a08-f023e3dc2949",
         "name": "ggshield-5suF2vRt", "description": "description", "created_at": "2024-08-05T09:03:53.434873Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/83888e42-dc57-471c-9a08-f023e3dc2949",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e8aad547-96a7-40a4-a05d-710cf536f3a7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e8aad547-96a7-40a4-a05d-710cf536f3a7",
         "name": "ggshield-Vqz4LULC", "description": "description", "created_at": "2024-08-05T09:21:25.593516Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e8aad547-96a7-40a4-a05d-710cf536f3a7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
         "name": "ggshield-lqX7PlwI", "description": "description", "created_at": "2024-08-05T09:21:26.211228Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b144b1fd-dc5f-4a36-abc7-a95d05331245",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b144b1fd-dc5f-4a36-abc7-a95d05331245",
         "name": "ggshield-uZr6LNDv", "description": "description", "created_at": "2024-08-27T07:44:46.267249Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b144b1fd-dc5f-4a36-abc7-a95d05331245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "903bf588-2a03-4318-be6c-b9e3198d1fd6",
-        "name": "ggshield-5Ty2Hu4r", "description": "description", "created_at": "2024-08-27T07:44:46.871854Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "903bf588-2a03-4318-be6c-b9e3198d1fd6", "name": "ggshield-5Ty2Hu4r",
+        "description": "description", "created_at": "2024-08-27T07:44:46.871854Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/903bf588-2a03-4318-be6c-b9e3198d1fd6",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "11222b98-7705-4180-99d1-6e719d8a05a9",
-        "name": "ggshield-qnLief7n", "description": "description", "created_at": "2024-08-27T08:20:15.846360Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "11222b98-7705-4180-99d1-6e719d8a05a9", "name": "ggshield-qnLief7n",
+        "description": "description", "created_at": "2024-08-27T08:20:15.846360Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/11222b98-7705-4180-99d1-6e719d8a05a9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "707b35fb-685b-4577-88b9-94cccc10e165",
-        "name": "ggshield-wqYwwgeK", "description": "description", "created_at": "2024-08-27T08:20:16.467770Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "707b35fb-685b-4577-88b9-94cccc10e165", "name": "ggshield-wqYwwgeK",
+        "description": "description", "created_at": "2024-08-27T08:20:16.467770Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/707b35fb-685b-4577-88b9-94cccc10e165",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "01c7668d-1467-4cac-a395-4b50fc278407",
-        "name": "ggshield-QkzL5Vyb", "description": "description", "created_at": "2024-09-24T08:50:15.865165Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "01c7668d-1467-4cac-a395-4b50fc278407", "name": "ggshield-QkzL5Vyb",
+        "description": "description", "created_at": "2024-09-24T08:50:15.865165Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/01c7668d-1467-4cac-a395-4b50fc278407",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
         "name": "ggshield-kkpkfk1s", "description": "description", "created_at": "2024-09-24T08:50:16.667172Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "730bdd87-31b2-4b42-a32a-5750bc595c9c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "730bdd87-31b2-4b42-a32a-5750bc595c9c",
         "name": "ggshield-dtxlZtWH", "description": "description", "created_at": "2024-10-01T13:18:29.918337Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/730bdd87-31b2-4b42-a32a-5750bc595c9c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b42c6945-05fc-4c5b-af83-e60478cd9db5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b42c6945-05fc-4c5b-af83-e60478cd9db5",
         "name": "ggshield-WPIELIcW", "description": "description", "created_at": "2024-10-01T13:18:30.820570Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b42c6945-05fc-4c5b-af83-e60478cd9db5",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
         "name": "ggshield-B8LwcRR0", "description": "description", "created_at": "2024-10-16T13:47:50.239094Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "81d30531-a54e-4f67-a46b-a7bac5783995",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "81d30531-a54e-4f67-a46b-a7bac5783995",
         "name": "ggshield-IjJFdqDS", "description": "description", "created_at": "2024-10-16T13:47:51.425195Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/81d30531-a54e-4f67-a46b-a7bac5783995",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a0b24134-0cbc-4ca5-b110-18b3311aef73",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a0b24134-0cbc-4ca5-b110-18b3311aef73",
         "name": "DO-demo", "description": "Digital Ocean Demo", "created_at": "2024-10-23T17:55:40.621634Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a0b24134-0cbc-4ca5-b110-18b3311aef73",
         "status": "revoked", "triggered_at": "2024-10-23T18:03:40.135215Z", "revoked_at":
         "2024-10-23T18:33:47.488182Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "50e53ab6-4950-48e6-9350-b5aaa88fafea", "name": "Demo",
-        "description": "Dev team 1", "created_at": "2024-10-27T21:01:47.725365Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/50e53ab6-4950-48e6-9350-b5aaa88fafea",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "50e53ab6-4950-48e6-9350-b5aaa88fafea", "name": "Demo", "description":
+        "Dev team 1", "created_at": "2024-10-27T21:01:47.725365Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/50e53ab6-4950-48e6-9350-b5aaa88fafea",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582569, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}], "token": "[REDACTED]"},
         {"id": "795decd4-4703-4073-9b3c-3ec2157f6182", "name": "Demo token", "description":
         "Take a look", "created_at": "2024-10-28T00:34:48.214122Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/795decd4-4703-4073-9b3c-3ec2157f6182",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582569, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
-        "name": "ggshield-c6YSc2Ie", "description": "description", "created_at": "2024-10-29T14:36:27.096968Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "c43ee48d-4646-40e8-bd12-3dfa30a6b3db", "name": "ggshield-c6YSc2Ie",
+        "description": "description", "created_at": "2024-10-29T14:36:27.096968Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
         "name": "ggshield-E6IPnu0f", "description": "description", "created_at": "2024-10-29T14:36:28.513178Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a454c002-679b-4250-aacf-28b5207543a4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a454c002-679b-4250-aacf-28b5207543a4",
         "name": "ggshield-HjwRkUAT", "description": "description", "created_at": "2024-11-27T12:32:44.877048Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a454c002-679b-4250-aacf-28b5207543a4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5af2ae0-f3f6-4301-82bc-b49108bd782b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5af2ae0-f3f6-4301-82bc-b49108bd782b",
         "name": "ggshield-hIlrbyRm", "description": "description", "created_at": "2024-11-27T12:32:45.728067Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c5af2ae0-f3f6-4301-82bc-b49108bd782b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "aed37b34-4721-43c2-99e2-2f2e78592f63",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "aed37b34-4721-43c2-99e2-2f2e78592f63",
         "name": "ggshield/setup.cfg", "description": "", "created_at": "2024-12-17T10:10:25.895137Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/aed37b34-4721-43c2-99e2-2f2e78592f63",
         "status": "triggered", "triggered_at": "2024-12-17T10:19:35.167833Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 309802, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476", "name": "pierredethoisy/dockerfile",
-        "description": "", "created_at": "2024-12-17T10:30:41.655876Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
+        "name": "pierredethoisy/dockerfile", "description": "", "created_at": "2024-12-17T10:30:41.655876Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
         "status": "triggered", "triggered_at": "2024-12-17T10:32:09.594850Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 309802, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "4b814f00-0897-479f-8a2d-a9593c5f18fa", "name": "WrongSecrets", "description":
-        "Honeytoken for the wrongsecrets repositort", "created_at": "2025-02-06T13:10:31.569094Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4b814f00-0897-479f-8a2d-a9593c5f18fa",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4b814f00-0897-479f-8a2d-a9593c5f18fa",
+        "name": "WrongSecrets", "description": "Honeytoken for the wrongsecrets repositort",
+        "created_at": "2025-02-06T13:10:31.569094Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4b814f00-0897-479f-8a2d-a9593c5f18fa",
         "status": "triggered", "triggered_at": "2025-02-06T13:16:26.325168Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "7dfdb8ee-56fc-486e-9b7a-e6ff248107fa", "name": "ggshield-AAcFXCwl",
-        "description": "description", "created_at": "2025-02-27T10:23:31.621722Z",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
+        "name": "ggshield-AAcFXCwl", "description": "description", "created_at": "2025-02-27T10:23:31.621722Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "97877334-808d-48c7-8802-2c54e9f43661",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "97877334-808d-48c7-8802-2c54e9f43661",
         "name": "ggshield-srahH0o3", "description": "description", "created_at": "2025-02-27T10:23:32.385844Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/97877334-808d-48c7-8802-2c54e9f43661",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ca642fe-2ce4-42b2-9097-5904093935c1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ca642fe-2ce4-42b2-9097-5904093935c1",
         "name": "ggshield-5Vx0aaQd", "description": "description", "created_at": "2025-02-27T10:31:34.080183Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ca642fe-2ce4-42b2-9097-5904093935c1",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d8590557-764f-4618-9b2e-277d536bd111",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d8590557-764f-4618-9b2e-277d536bd111",
         "name": "ggshield-QYqCVZ4i", "description": "description", "created_at": "2025-02-27T10:31:34.798380Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d8590557-764f-4618-9b2e-277d536bd111",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84b08c90-12f5-48ef-baee-ab8d8b15588c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84b08c90-12f5-48ef-baee-ab8d8b15588c",
         "name": "ggshield-4sJy2SkE", "description": "description", "created_at": "2025-02-27T10:53:01.890617Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84b08c90-12f5-48ef-baee-ab8d8b15588c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72204c1e-12c1-445f-b106-09488214d610",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72204c1e-12c1-445f-b106-09488214d610",
         "name": "ggshield-eqoLjiAS", "description": "description", "created_at": "2025-02-27T10:53:02.563136Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72204c1e-12c1-445f-b106-09488214d610",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
         "name": "ggshield-yaqMNJFA", "description": "description", "created_at": "2025-02-27T11:24:20.630794Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a5d5ca0-000f-4011-aaf2-b4f627c19649",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a5d5ca0-000f-4011-aaf2-b4f627c19649",
         "name": "ggshield-x12c7zPc", "description": "description", "created_at": "2025-02-27T11:24:21.465056Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8a5d5ca0-000f-4011-aaf2-b4f627c19649",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c823f31a-73a8-46cc-be4a-029d6d081793",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c823f31a-73a8-46cc-be4a-029d6d081793",
         "name": "ggshield-9Mq5rTUV", "description": "description", "created_at": "2025-02-27T16:44:10.862683Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c823f31a-73a8-46cc-be4a-029d6d081793",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49f1055b-b505-402b-8b79-e4b2c6cf2041",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49f1055b-b505-402b-8b79-e4b2c6cf2041",
         "name": "ggshield-4MmSKBvx", "description": "description", "created_at": "2025-02-27T16:44:11.663957Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/49f1055b-b505-402b-8b79-e4b2c6cf2041",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be8e40e8-b204-40de-8d37-247ac6ef7077",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be8e40e8-b204-40de-8d37-247ac6ef7077",
         "name": "ggshield-DBuxWn0n", "description": "description", "created_at": "2025-02-27T16:57:21.290157Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be8e40e8-b204-40de-8d37-247ac6ef7077",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d10551f8-36f0-4966-a684-d5f9eca89e8d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d10551f8-36f0-4966-a684-d5f9eca89e8d",
         "name": "ggshield-bukJ4Md2", "description": "description", "created_at": "2025-02-27T16:57:22.079317Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d10551f8-36f0-4966-a684-d5f9eca89e8d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d5385824-6a93-47cb-81f3-e818e64371d7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d5385824-6a93-47cb-81f3-e818e64371d7",
         "name": "ggshield-vI1CTIm2", "description": "description", "created_at": "2025-02-27T17:24:28.533666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d5385824-6a93-47cb-81f3-e818e64371d7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
         "name": "ggshield-C519GYI9", "description": "description", "created_at": "2025-02-27T17:24:29.231126Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
         "name": "ggshield-i8zN7WRH", "description": "description", "created_at": "2025-02-27T17:27:14.478281Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "661dae4d-5944-4a20-b7f7-f74913356479",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "661dae4d-5944-4a20-b7f7-f74913356479",
         "name": "ggshield-IX7GxSIs", "description": "description", "created_at": "2025-02-27T17:27:15.226298Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/661dae4d-5944-4a20-b7f7-f74913356479",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "adaea919-086f-4e37-b4e5-dc8208d0e4f5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "adaea919-086f-4e37-b4e5-dc8208d0e4f5",
         "name": "ggshield-rWApiuse", "description": "description", "created_at": "2025-03-03T09:15:26.314595Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/adaea919-086f-4e37-b4e5-dc8208d0e4f5",
         "status": "triggered", "triggered_at": "2026-02-18T14:51:12.198393Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
-        "key": "env", "value": "staging"}], "custom_tags": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
+        null, "tags": [], "custom_tags": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
         "key": "env", "value": "staging"}], "token": "[REDACTED]"}, {"id": "da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
         "name": "ggshield-jdbeH3gE", "description": "description", "created_at": "2025-03-03T09:15:27.049176Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22", "key": "env",
-        "value": "production"}], "custom_tags": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22",
-        "key": "env", "value": "production"}], "token": "[REDACTED]"}, {"id": "1f4708b2-0e51-458c-abca-c03e502b4a5a",
+        [], "custom_tags": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22", "key":
+        "env", "value": "production"}], "token": "[REDACTED]"}, {"id": "1f4708b2-0e51-458c-abca-c03e502b4a5a",
         "name": "ggshield-QgwFEPjx", "description": "description", "created_at": "2025-03-27T15:12:18.744612Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1f4708b2-0e51-458c-abca-c03e502b4a5a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "a4ced9be-6ad5-4d8a-b188-65a117bc0eba",
-        "name": "ggshield-44tVmSvF", "description": "description", "created_at": "2025-03-27T15:12:19.507492Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "a4ced9be-6ad5-4d8a-b188-65a117bc0eba", "name": "ggshield-44tVmSvF",
+        "description": "description", "created_at": "2025-03-27T15:12:19.507492Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a4ced9be-6ad5-4d8a-b188-65a117bc0eba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5710ee7d-6428-4074-a9ff-09399782242d",
-        "name": "ggshield-bF87lDBl", "description": "description", "created_at": "2025-03-27T15:21:17.135616Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5710ee7d-6428-4074-a9ff-09399782242d", "name": "ggshield-bF87lDBl",
+        "description": "description", "created_at": "2025-03-27T15:21:17.135616Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5710ee7d-6428-4074-a9ff-09399782242d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
-        "name": "ggshield-LbIDqGyA", "description": "description", "created_at": "2025-03-27T15:21:17.953340Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "4cbf7af9-9989-4185-8ef8-0f39e6f3d145", "name": "ggshield-LbIDqGyA",
+        "description": "description", "created_at": "2025-03-27T15:21:17.953340Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2dfa1936-f53f-4d0c-8a69-ae9bab297021",
-        "name": "ggshield-qz84En8W", "description": "description", "created_at": "2025-03-27T15:24:16.907610Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2dfa1936-f53f-4d0c-8a69-ae9bab297021", "name": "ggshield-qz84En8W",
+        "description": "description", "created_at": "2025-03-27T15:24:16.907610Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2dfa1936-f53f-4d0c-8a69-ae9bab297021",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "11213dc7-118d-4997-a96b-714640c3ad0b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "11213dc7-118d-4997-a96b-714640c3ad0b",
         "name": "ggshield-CSF39jm8", "description": "description", "created_at": "2025-03-27T15:24:17.721006Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/11213dc7-118d-4997-a96b-714640c3ad0b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "899dd0b0-20b2-45d2-b779-0331cc448935",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "899dd0b0-20b2-45d2-b779-0331cc448935",
         "name": "toto", "description": "tata", "created_at": "2025-05-12T09:58:35.161641Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/899dd0b0-20b2-45d2-b779-0331cc448935",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "62d71685-2eba-4b88-8edd-cc73e698cfa5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "62d71685-2eba-4b88-8edd-cc73e698cfa5",
         "name": "test-greg", "description": "test greg", "created_at": "2025-05-12T10:06:19.826522Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/62d71685-2eba-4b88-8edd-cc73e698cfa5",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:59.739856Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "e948f77d-5353-413e-b37d-8beba84890ff", "name": "test-greg-2", "description":
-        "test greg", "created_at": "2025-05-12T10:08:11.667578Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e948f77d-5353-413e-b37d-8beba84890ff",
+        "name": "test-greg-2", "description": "test greg", "created_at": "2025-05-12T10:08:11.667578Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:54.809724Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb", "name": "test-greg-3", "description":
-        "test greg", "created_at": "2025-05-12T10:08:58.561160Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        "name": "test-greg-3", "description": "test greg", "created_at": "2025-05-12T10:08:58.561160Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:50.784137Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6", "name": "test-greg-4", "description":
-        "test", "created_at": "2025-05-12T10:10:12.927058Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6",
+        "name": "test-greg-4", "description": "test", "created_at": "2025-05-12T10:10:12.927058Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:46.594085Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a", "name": "test-greg-5", "description":
-        "test", "created_at": "2025-05-12T10:12:50.615700Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
+        "name": "test-greg-5", "description": "test", "created_at": "2025-05-12T10:12:50.615700Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:41.387978Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "9fcf0732-6b8d-41d3-ae98-727bd5dde585", "name": "achille-hackathon",
-        "description": "achille hackathon", "created_at": "2025-05-12T12:01:23.542568Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9fcf0732-6b8d-41d3-ae98-727bd5dde585",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9fcf0732-6b8d-41d3-ae98-727bd5dde585",
+        "name": "achille-hackathon", "description": "achille hackathon", "created_at":
+        "2025-05-12T12:01:23.542568Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9fcf0732-6b8d-41d3-ae98-727bd5dde585",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38",
         "name": "TestHoneytoken", "description": "Testing GitGuardian API connectivity",
         "created_at": "2025-05-12T12:19:05.294638Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b0ddbd44-4054-4127-aa00-cd6727e70d38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
         "name": "AWS Credentials", "description": "Honeytoken for testing, to be injected
         as requested by the user.", "created_at": "2025-05-12T12:38:25.640506Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
         "status": "triggered", "triggered_at": "2026-02-18T13:45:03.781945Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 269050, "revoker_id":
+        null, "type": "AWS", "open_events_count": 9, "creator_id": 269050, "revoker_id":
         null, "creator_api_token_id": "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec", "name": "test-greg-7", "description":
-        "test", "created_at": "2025-05-12T12:54:37.703725Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ab824e92-6068-4a9d-ae36-86a94516f2ec",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec",
+        "name": "test-greg-7", "description": "test", "created_at": "2025-05-12T12:54:37.703725Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ab824e92-6068-4a9d-ae36-86a94516f2ec",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:34.521470Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b65d42a4-587f-4701-a595-8429cbcda70b", "name": "gg-mcp-server-honeytoken",
-        "description": "Honeytoken for security monitoring in the gg-mcp-server project.",
-        "created_at": "2025-05-12T12:54:44.402023Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b65d42a4-587f-4701-a595-8429cbcda70b",
-        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
-        "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
-        "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3fe4aa4f-49f6-42ad-a34a-0c108b544215",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b65d42a4-587f-4701-a595-8429cbcda70b",
+        "name": "gg-mcp-server-honeytoken", "description": "Honeytoken for security
+        monitoring in the gg-mcp-server project.", "created_at": "2025-05-12T12:54:44.402023Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b65d42a4-587f-4701-a595-8429cbcda70b",
+        "status": "triggered", "triggered_at": "2026-06-04T13:16:15.961464Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 4, "creator_id": 269050, "revoker_id":
+        null, "creator_api_token_id": "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id":
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3fe4aa4f-49f6-42ad-a34a-0c108b544215",
         "name": "default-honeytoken", "description": "General purpose honeytoken for
         security monitoring", "created_at": "2025-05-12T13:07:52.676810Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/3fe4aa4f-49f6-42ad-a34a-0c108b544215",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
         "name": "test", "description": "test", "created_at": "2025-05-12T13:09:38.965752Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9844e55d-982c-4458-b65b-592ad99ce77a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1026550, "revoker_id": null, "creator_api_token_id":
         "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
         "name": "Test Honeytoken", "description": "Testing honeytoken generation",
         "created_at": "2025-05-12T14:35:34.295363Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b2a7e759-81ab-465d-a578-e3ce42c18741",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
         "name": "test-greg-9", "description": "", "created_at": "2025-05-12T14:50:23.123299Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6d185a-6f59-4b7c-9248-dd05616090db",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:27.366114Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
+        null, "tags": [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
         "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "fbb93094-9778-4b8b-97d8-de99954a758a",
         "name": "AWS_Honeytoken", "description": "Honeytoken generated via MCP", "created_at":
@@ -1432,17 +1343,15 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "34e08af4-59a7-4a3b-b799-65acb8a2019d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "34e08af4-59a7-4a3b-b799-65acb8a2019d",
         "name": "AWS-MCP-Honeytoken", "description": "Honeytoken for monitoring potential
         AWS credential leaks", "created_at": "2025-05-12T15:07:16.157981Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/34e08af4-59a7-4a3b-b799-65acb8a2019d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "16805984-70d6-4049-844a-79bac3054f6f",
         "name": "AwsTestHoneytoken", "description": "Test honeytoken for development
         and monitoring", "created_at": "2025-05-12T15:09:00.390236Z", "gitguardian_url":
@@ -1450,10 +1359,8 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "d476c118-b210-403d-b685-3d7f0a514950",
         "name": "aws-development-access-key", "description": "Development environment
         AWS access key for monitoring credential leaks", "created_at": "2025-05-12T15:12:56.525944Z",
@@ -1461,9 +1368,7 @@ interactions:
         "status": "triggered", "triggered_at": "2026-02-18T14:50:57.626529Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 2, "creator_id": 270722, "revoker_id":
         null, "creator_api_token_id": "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
+        null, "tags": [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
         "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "0a112323-6906-4bd0-a660-1b45a0fc59ca",
         "name": "NHI-Explorer-Secret", "description": "AWS access key for NHI Explorer
@@ -1472,232 +1377,412 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "69dbbe3c-2dfc-4c93-916c-f70c42f4e2af",
         "name": "ggshield-Leb9CGys", "description": "description", "created_at": "2025-05-27T08:18:31.020533Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/69dbbe3c-2dfc-4c93-916c-f70c42f4e2af",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "029e2aba-796c-47d8-8d52-e14f9868acfc",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "029e2aba-796c-47d8-8d52-e14f9868acfc",
         "name": "ggshield-Fhjl6QxB", "description": "description", "created_at": "2025-05-27T08:18:31.873128Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/029e2aba-796c-47d8-8d52-e14f9868acfc",
         "status": "triggered", "triggered_at": "2025-06-17T09:30:39.728240Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "c77d47b6-8d61-46a7-b6a1-1715fc47c7eb", "name": "ggshield-U8JeiAjO",
-        "description": "description", "created_at": "2025-06-24T13:04:20.196705Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
+        "name": "ggshield-U8JeiAjO", "description": "description", "created_at": "2025-06-24T13:04:20.196705Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab",
-        "name": "ggshield-NiJSM24s", "description": "description", "created_at": "2025-06-24T13:04:21.255669Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab", "name": "ggshield-NiJSM24s",
+        "description": "description", "created_at": "2025-06-24T13:04:21.255669Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5692a982-6603-443e-bdb4-5ea1a5de6f64",
-        "name": "ggshield-JKhVuHaW", "description": "description", "created_at": "2025-06-24T13:06:56.046343Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5692a982-6603-443e-bdb4-5ea1a5de6f64", "name": "ggshield-JKhVuHaW",
+        "description": "description", "created_at": "2025-06-24T13:06:56.046343Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5692a982-6603-443e-bdb4-5ea1a5de6f64",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "17925c95-1df7-4e86-9c42-aabb5dbdea69",
-        "name": "ggshield-vfjAXCfY", "description": "description", "created_at": "2025-06-24T13:06:57.033247Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "17925c95-1df7-4e86-9c42-aabb5dbdea69", "name": "ggshield-vfjAXCfY",
+        "description": "description", "created_at": "2025-06-24T13:06:57.033247Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/17925c95-1df7-4e86-9c42-aabb5dbdea69",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "631ef101-122f-4592-9de1-2d6cb5becafa",
-        "name": "ggshield-dbhOtleP", "description": "description", "created_at": "2025-06-24T13:13:01.219899Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "631ef101-122f-4592-9de1-2d6cb5becafa", "name": "ggshield-dbhOtleP",
+        "description": "description", "created_at": "2025-06-24T13:13:01.219899Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/631ef101-122f-4592-9de1-2d6cb5becafa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "bebc1ca8-933d-45ca-b201-fbabc4eab464",
-        "name": "ggshield-7pQLMJYV", "description": "description", "created_at": "2025-06-24T13:13:01.978212Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "bebc1ca8-933d-45ca-b201-fbabc4eab464", "name": "ggshield-7pQLMJYV",
+        "description": "description", "created_at": "2025-06-24T13:13:01.978212Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bebc1ca8-933d-45ca-b201-fbabc4eab464",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "3983e8ff-7fd6-4fde-9117-9612d4258052",
-        "name": "ggshield-phDsJ9wy", "description": "description", "created_at": "2025-06-24T13:29:15.096198Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "3983e8ff-7fd6-4fde-9117-9612d4258052", "name": "ggshield-phDsJ9wy",
+        "description": "description", "created_at": "2025-06-24T13:29:15.096198Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3983e8ff-7fd6-4fde-9117-9612d4258052",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "9340e7fe-f79c-467e-9dcd-43ddaa77dc0c",
-        "name": "ggshield-Md0MBV0B", "description": "description", "created_at": "2025-06-24T13:29:16.049584Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "9340e7fe-f79c-467e-9dcd-43ddaa77dc0c", "name": "ggshield-Md0MBV0B",
+        "description": "description", "created_at": "2025-06-24T13:29:16.049584Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9340e7fe-f79c-467e-9dcd-43ddaa77dc0c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "08b51a6e-dd6c-4a4b-93f9-b955663c6524",
-        "name": "ggshield-ZoWflf5b", "description": "description", "created_at": "2025-06-24T13:31:49.045062Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "08b51a6e-dd6c-4a4b-93f9-b955663c6524", "name": "ggshield-ZoWflf5b",
+        "description": "description", "created_at": "2025-06-24T13:31:49.045062Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/08b51a6e-dd6c-4a4b-93f9-b955663c6524",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "96da938d-d6fa-4e44-9254-c568a27be484",
-        "name": "ggshield-PirK5h1Q", "description": "description", "created_at": "2025-06-24T13:31:49.827284Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "96da938d-d6fa-4e44-9254-c568a27be484", "name": "ggshield-PirK5h1Q",
+        "description": "description", "created_at": "2025-06-24T13:31:49.827284Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/96da938d-d6fa-4e44-9254-c568a27be484",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f2c61b85-e11d-4db0-a8af-7fc327310b39",
-        "name": "ggshield-ZQ4jUtQr", "description": "description", "created_at": "2025-06-24T13:45:17.477850Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f2c61b85-e11d-4db0-a8af-7fc327310b39", "name": "ggshield-ZQ4jUtQr",
+        "description": "description", "created_at": "2025-06-24T13:45:17.477850Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f2c61b85-e11d-4db0-a8af-7fc327310b39",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f99173ff-9ffe-492c-b8ae-54157df89bac",
-        "name": "ggshield-5uK6KYFh", "description": "description", "created_at": "2025-06-24T13:45:18.309642Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f99173ff-9ffe-492c-b8ae-54157df89bac", "name": "ggshield-5uK6KYFh",
+        "description": "description", "created_at": "2025-06-24T13:45:18.309642Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f99173ff-9ffe-492c-b8ae-54157df89bac",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768",
-        "name": "ggshield-MGXkbqc7", "description": "description", "created_at": "2025-06-24T13:50:43.295521Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768", "name": "ggshield-MGXkbqc7",
+        "description": "description", "created_at": "2025-06-24T13:50:43.295521Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f3252f2c-16a9-45e4-97e8-bed4b5752415",
-        "name": "ggshield-YJd3rq9q", "description": "description", "created_at": "2025-06-24T13:50:44.165951Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f3252f2c-16a9-45e4-97e8-bed4b5752415", "name": "ggshield-YJd3rq9q",
+        "description": "description", "created_at": "2025-06-24T13:50:44.165951Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f3252f2c-16a9-45e4-97e8-bed4b5752415",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "e22705f1-5497-449b-9614-3c2d89e3b705",
-        "name": "ggshield-l4abwnpa", "description": null, "created_at": "2025-06-26T12:32:05.993896Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e22705f1-5497-449b-9614-3c2d89e3b705",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "e22705f1-5497-449b-9614-3c2d89e3b705", "name": "ggshield-l4abwnpa",
+        "description": null, "created_at": "2025-06-26T12:32:05.993896Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e22705f1-5497-449b-9614-3c2d89e3b705",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
         "4ff03654-f280-4c31-8eef-5295d2b75a50", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7691445a-2cb0-4093-94ca-f2c5de877075",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7691445a-2cb0-4093-94ca-f2c5de877075",
         "name": "ggshield-Lwhu1Nax", "description": "description", "created_at": "2025-07-29T10:34:41.534666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7691445a-2cb0-4093-94ca-f2c5de877075",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "951e1f19-5804-444a-b275-b51dc5bf68ee",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "951e1f19-5804-444a-b275-b51dc5bf68ee",
         "name": "ggshield-u9ltlEmT", "description": "description", "created_at": "2025-07-29T10:34:42.385215Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/951e1f19-5804-444a-b275-b51dc5bf68ee",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
         "name": "ggshield-CC0Lj0vS", "description": "description", "created_at": "2025-07-29T10:40:27.317817Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
         "name": "ggshield-0k2Xha2i", "description": "description", "created_at": "2025-07-29T10:40:28.088246Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
         "status": "triggered", "triggered_at": "2025-08-22T16:59:58.315774Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "49e4fce7-aa48-42b0-9fc4-e16105ae08e5", "name": "ggshield-ncOpkfP8",
-        "description": "description", "created_at": "2025-08-27T11:43:11.666517Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
+        "name": "ggshield-ncOpkfP8", "description": "description", "created_at": "2025-08-27T11:43:11.666517Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2b15518b-3100-4736-bee6-b47fe8d26fc1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2b15518b-3100-4736-bee6-b47fe8d26fc1",
         "name": "ggshield-H2eDvilF", "description": "description", "created_at": "2025-08-27T11:43:12.618589Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2b15518b-3100-4736-bee6-b47fe8d26fc1",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "368a90bf-269b-4a60-95c2-1c77c86f7fd4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "368a90bf-269b-4a60-95c2-1c77c86f7fd4",
         "name": "ggshield-V6RzZJGL", "description": "description", "created_at": "2025-11-14T16:54:30.227288Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/368a90bf-269b-4a60-95c2-1c77c86f7fd4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "eae1aaaf-d700-475d-b65a-ffd79f84806d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "eae1aaaf-d700-475d-b65a-ffd79f84806d",
         "name": "ggshield-Pya2g1xF", "description": "description", "created_at": "2025-11-14T16:54:30.933576Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/eae1aaaf-d700-475d-b65a-ffd79f84806d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
         "name": "ggshield-Z2Ji3PxX", "description": "description", "created_at": "2026-03-31T13:26:20.710346Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
         "name": "ggshield-FsL9dCzu", "description": "description", "created_at": "2026-03-31T13:26:21.681383Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7daed77-1fa4-416d-88e2-473200b810aa",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7daed77-1fa4-416d-88e2-473200b810aa",
         "name": "ggshield-dqv39cn2", "description": "description", "created_at": "2026-03-31T13:32:28.824725Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e7daed77-1fa4-416d-88e2-473200b810aa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "601c59d9-7579-402e-90c4-59da055a8d3b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "601c59d9-7579-402e-90c4-59da055a8d3b",
         "name": "ggshield-YpbVgsRl", "description": "description", "created_at": "2026-03-31T13:32:29.820990Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/601c59d9-7579-402e-90c4-59da055a8d3b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "54e52712-a036-4e80-899b-c1a200610339",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "54e52712-a036-4e80-899b-c1a200610339",
         "name": "ggshield-DZ5zVj1p", "description": "description", "created_at": "2026-03-31T13:37:32.513332Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/54e52712-a036-4e80-899b-c1a200610339",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51dc5671-8053-4b87-8174-975ccf7f249c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51dc5671-8053-4b87-8174-975ccf7f249c",
         "name": "ggshield-DXGKK2gC", "description": "description", "created_at": "2026-03-31T13:37:33.559937Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/51dc5671-8053-4b87-8174-975ccf7f249c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}]'
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "name": "test Pierre", "description": "", "created_at": "2026-04-07T18:38:38.199572Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "ae435f66-1ea9-4dfe-b73f-49f451fc00ab", "name": "Demo
+        Romain", "description": "", "created_at": "2026-04-24T12:48:19.654369Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/ae435f66-1ea9-4dfe-b73f-49f451fc00ab",
+        "status": "triggered", "triggered_at": "2026-04-29T12:54:19.464710Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 6, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [{"id": "7a2469eb-2b6b-4248-8103-2b0f6b4fac9b", "key":
+        "romain", "value": null}], "token": "[REDACTED]"}, {"id": "10f6e20b-12ae-4591-aa09-7e1ff00ef408",
+        "name": "qa / xyz-e732d912", "description": "", "created_at": "2026-04-24T16:05:46.508625Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/10f6e20b-12ae-4591-aa09-7e1ff00ef408",
+        "status": "triggered", "triggered_at": "2026-04-24T16:13:17.276672Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9266c0f4-f0e0-41d2-a8c8-c164ccb84e47",
+        "name": "qa / test-nriv-e732d912", "description": "", "created_at": "2026-04-24T16:05:50.013606Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9266c0f4-f0e0-41d2-a8c8-c164ccb84e47",
+        "status": "triggered", "triggered_at": "2026-04-24T16:15:44.494587Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "name": "dev / Salome Test-e732d912", "description": "", "created_at": "2026-04-24T16:05:53.158978Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "status": "triggered", "triggered_at": "2026-04-24T16:16:21.895694Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "name": "qa / test-r8327r-e732d912", "description": "", "created_at": "2026-04-24T16:05:56.586568Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "status": "triggered", "triggered_at": "2026-04-24T16:18:31.419829Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2314a2ef-cec4-4e3d-834a-09b0c40c99d2",
+        "name": "qa / abc-e732d912", "description": "", "created_at": "2026-04-24T16:05:59.728317Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2314a2ef-cec4-4e3d-834a-09b0c40c99d2",
+        "status": "triggered", "triggered_at": "2026-04-24T16:25:50.024911Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "fe96d213-a002-4161-a7c9-cb3be4ad88f8",
+        "name": "qa / Handcrafted Metal Bike-e732d912", "description": "", "created_at":
+        "2026-04-24T16:06:02.936659Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fe96d213-a002-4161-a7c9-cb3be4ad88f8",
+        "status": "triggered", "triggered_at": "2026-04-24T16:35:48.958630Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a72f662-2357-4b93-b48a-00028e36cfff",
+        "name": "test1", "description": "tEST 2", "created_at": "2026-04-30T09:12:55.584248Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a72f662-2357-4b93-b48a-00028e36cfff",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "963fbabe-3d2c-4154-8281-2f13be7c06f7", "name": "test121",
+        "description": "testing 12", "created_at": "2026-04-30T11:31:57.689130Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/963fbabe-3d2c-4154-8281-2f13be7c06f7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "1acff09e-02c1-4a24-8869-568dfab124c9", "name": "test-pierredt",
+        "description": "hello", "created_at": "2026-05-06T19:57:39.689471Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/1acff09e-02c1-4a24-8869-568dfab124c9",
+        "status": "triggered", "triggered_at": "2026-05-06T19:59:18.645288Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 6, "creator_id": 309802, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "name": "qa / test-nriv-d2363bd5", "description": "", "created_at": "2026-05-19T08:29:37.247067Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "status": "triggered", "triggered_at": "2026-05-19T08:33:36.289678Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 1754656, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "03e7e668-6fbf-493a-8d1c-ac9d0c6c1b97",
+        "name": "qa / xyz-d2363bd5", "description": "", "created_at": "2026-05-19T08:29:41.396307Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/03e7e668-6fbf-493a-8d1c-ac9d0c6c1b97",
+        "status": "triggered", "triggered_at": "2026-05-19T08:34:30.001210Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 1754656, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "bb1adf06-28ea-4daf-b338-59d5ef094f67",
+        "name": "TheBigHoney", "description": "Big Honey Pot for our core secrets",
+        "created_at": "2026-05-19T11:51:12.957707Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bb1adf06-28ea-4daf-b338-59d5ef094f67",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "93abaf01-cac6-48f4-bfa1-735cfb7fde7d", "name": "ttoprjog",
+        "description": "Henri", "created_at": "2026-05-20T12:22:37.974250Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/93abaf01-cac6-48f4-bfa1-735cfb7fde7d",
+        "status": "revoked", "triggered_at": null, "revoked_at": "2026-05-20T12:23:19.883989Z",
+        "type": "AWS", "open_events_count": 0, "creator_id": 113168, "revoker_id":
+        113168, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be3d1024-d9df-466c-9e75-afc1ed88b8f5",
+        "name": "test-plc", "description": "", "created_at": "2026-05-26T07:26:21.052034Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be3d1024-d9df-466c-9e75-afc1ed88b8f5",
+        "status": "revoked", "triggered_at": "2026-05-26T08:44:57.678480Z", "revoked_at":
+        "2026-05-26T12:19:01.401494Z", "type": "AWS", "open_events_count": 0, "creator_id":
+        701514, "revoker_id": 701514, "creator_api_token_id": null, "revoker_api_token_id":
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "8409c955-f217-47c9-9cf1-3a6b557c65c9", "name": "Test", "description": "",
+        "created_at": "2026-05-26T14:12:05.347374Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8409c955-f217-47c9-9cf1-3a6b557c65c9",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754650, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "82f00514-d9d3-442c-b575-c40ff77db387", "name": "test-plc2",
+        "description": "", "created_at": "2026-05-27T13:13:33.943814Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/82f00514-d9d3-442c-b575-c40ff77db387",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 701514, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "2fb03282-9878-481c-be5b-eda6036f909d", "name": "ahah-plc", "description":
+        "", "created_at": "2026-06-01T12:43:48.383287Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2fb03282-9878-481c-be5b-eda6036f909d",
+        "status": "triggered", "triggered_at": "2026-06-04T21:49:55.543841Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 701514, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86344c0b-c360-4709-bb6b-fce628ace1d7",
+        "name": "honeytoken-toot-991c4137", "description": "", "created_at": "2026-06-05T17:59:07.240726Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86344c0b-c360-4709-bb6b-fce628ace1d7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
+        "97c1b533-d768-4054-94de-ae3d967a5128", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "949d59d0-c3c2-4d5e-ae3c-4f365b9b8456",
+        "name": "honeytoken-toot-0fefb095", "description": "", "created_at": "2026-06-05T17:59:07.748651Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/949d59d0-c3c2-4d5e-ae3c-4f365b9b8456",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
+        "97c1b533-d768-4054-94de-ae3d967a5128", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ab5965c-8f7e-44ec-b64e-1111e140586f",
+        "name": "ggshield-WOmcC4wM", "description": "description", "created_at": "2026-06-15T15:05:19.990102Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ab5965c-8f7e-44ec-b64e-1111e140586f",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "95786b03-4165-4245-8aef-fac41ff6a1de",
+        "name": "ggshield-E2HxYogl", "description": "description", "created_at": "2026-06-15T15:05:20.446208Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/95786b03-4165-4245-8aef-fac41ff6a1de",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "98271cf2-3025-4e7d-b120-afd29fe20c8f",
+        "name": "ggshield-32Xli2ct", "description": "description", "created_at": "2026-06-15T15:13:44.456933Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/98271cf2-3025-4e7d-b120-afd29fe20c8f",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "68f09d33-1cab-4b93-84a5-2861a7a01fbc",
+        "name": "ggshield-o2ocvFQZ", "description": "description", "created_at": "2026-06-15T15:13:45.228488Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/68f09d33-1cab-4b93-84a5-2861a7a01fbc",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ee69dfd0-fa9c-451d-947e-261c2edd4355",
+        "name": "ggshield-rGxN1k4I", "description": "description", "created_at": "2026-06-15T15:46:58.088837Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ee69dfd0-fa9c-451d-947e-261c2edd4355",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f91525c-02bd-4a0f-9c5d-c9949f7196f4",
+        "name": "ggshield-bZoVll0H", "description": "description", "created_at": "2026-06-15T15:46:58.839510Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f91525c-02bd-4a0f-9c5d-c9949f7196f4",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4a3a3699-fb2e-4e0f-ae02-4905fe8228ec",
+        "name": "ggshield-VuSeELel", "description": "description", "created_at": "2026-06-17T13:23:52.166183Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4a3a3699-fb2e-4e0f-ae02-4905fe8228ec",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "dd2d3e47-d804-41c5-b8b8-f640e6292096", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d82dc520-9ea5-4a38-a9d8-84bf2f94975b",
+        "name": "ggshield-yQlAvTpn", "description": "description", "created_at": "2026-06-17T13:23:52.682610Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d82dc520-9ea5-4a38-a9d8-84bf2f94975b",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "dd2d3e47-d804-41c5-b8b8-f640e6292096", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}]'
     headers:
+      CF-RAY:
+      - a1039796ba7445f1-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:52 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, POST, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '157664'
+      - '165896'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:47 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '1301'
+      - '1167'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_honeytokens_with_ordering.yaml
+++ b/tests/cassettes/tools/vcr/test_list_honeytokens_with_ordering.yaml
@@ -20,205 +20,377 @@ interactions:
     uri: https://api.gitguardian.com/v1/honeytokens?ordering=-created_at&show_token=false&per_page=5
   response:
     body:
-      string: '[{"id": "51dc5671-8053-4b87-8174-975ccf7f249c", "name": "ggshield-DXGKK2gC",
+      string: '[{"id": "d82dc520-9ea5-4a38-a9d8-84bf2f94975b", "name": "ggshield-yQlAvTpn",
+        "description": "description", "created_at": "2026-06-17T13:23:52.682610Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d82dc520-9ea5-4a38-a9d8-84bf2f94975b",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "dd2d3e47-d804-41c5-b8b8-f640e6292096", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4a3a3699-fb2e-4e0f-ae02-4905fe8228ec",
+        "name": "ggshield-VuSeELel", "description": "description", "created_at": "2026-06-17T13:23:52.166183Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4a3a3699-fb2e-4e0f-ae02-4905fe8228ec",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "dd2d3e47-d804-41c5-b8b8-f640e6292096", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f91525c-02bd-4a0f-9c5d-c9949f7196f4",
+        "name": "ggshield-bZoVll0H", "description": "description", "created_at": "2026-06-15T15:46:58.839510Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f91525c-02bd-4a0f-9c5d-c9949f7196f4",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ee69dfd0-fa9c-451d-947e-261c2edd4355",
+        "name": "ggshield-rGxN1k4I", "description": "description", "created_at": "2026-06-15T15:46:58.088837Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ee69dfd0-fa9c-451d-947e-261c2edd4355",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "68f09d33-1cab-4b93-84a5-2861a7a01fbc",
+        "name": "ggshield-o2ocvFQZ", "description": "description", "created_at": "2026-06-15T15:13:45.228488Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/68f09d33-1cab-4b93-84a5-2861a7a01fbc",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "98271cf2-3025-4e7d-b120-afd29fe20c8f",
+        "name": "ggshield-32Xli2ct", "description": "description", "created_at": "2026-06-15T15:13:44.456933Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/98271cf2-3025-4e7d-b120-afd29fe20c8f",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "95786b03-4165-4245-8aef-fac41ff6a1de",
+        "name": "ggshield-E2HxYogl", "description": "description", "created_at": "2026-06-15T15:05:20.446208Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/95786b03-4165-4245-8aef-fac41ff6a1de",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ab5965c-8f7e-44ec-b64e-1111e140586f",
+        "name": "ggshield-WOmcC4wM", "description": "description", "created_at": "2026-06-15T15:05:19.990102Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ab5965c-8f7e-44ec-b64e-1111e140586f",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "949d59d0-c3c2-4d5e-ae3c-4f365b9b8456",
+        "name": "honeytoken-toot-0fefb095", "description": "", "created_at": "2026-06-05T17:59:07.748651Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/949d59d0-c3c2-4d5e-ae3c-4f365b9b8456",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
+        "97c1b533-d768-4054-94de-ae3d967a5128", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86344c0b-c360-4709-bb6b-fce628ace1d7",
+        "name": "honeytoken-toot-991c4137", "description": "", "created_at": "2026-06-05T17:59:07.240726Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86344c0b-c360-4709-bb6b-fce628ace1d7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
+        "97c1b533-d768-4054-94de-ae3d967a5128", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2fb03282-9878-481c-be5b-eda6036f909d",
+        "name": "ahah-plc", "description": "", "created_at": "2026-06-01T12:43:48.383287Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2fb03282-9878-481c-be5b-eda6036f909d",
+        "status": "triggered", "triggered_at": "2026-06-04T21:49:55.543841Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 701514, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "82f00514-d9d3-442c-b575-c40ff77db387",
+        "name": "test-plc2", "description": "", "created_at": "2026-05-27T13:13:33.943814Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/82f00514-d9d3-442c-b575-c40ff77db387",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 701514, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "8409c955-f217-47c9-9cf1-3a6b557c65c9", "name": "Test", "description": "",
+        "created_at": "2026-05-26T14:12:05.347374Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8409c955-f217-47c9-9cf1-3a6b557c65c9",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754650, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "be3d1024-d9df-466c-9e75-afc1ed88b8f5", "name": "test-plc",
+        "description": "", "created_at": "2026-05-26T07:26:21.052034Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/be3d1024-d9df-466c-9e75-afc1ed88b8f5",
+        "status": "revoked", "triggered_at": "2026-05-26T08:44:57.678480Z", "revoked_at":
+        "2026-05-26T12:19:01.401494Z", "type": "AWS", "open_events_count": 0, "creator_id":
+        701514, "revoker_id": 701514, "creator_api_token_id": null, "revoker_api_token_id":
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "93abaf01-cac6-48f4-bfa1-735cfb7fde7d", "name": "ttoprjog", "description":
+        "Henri", "created_at": "2026-05-20T12:22:37.974250Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/93abaf01-cac6-48f4-bfa1-735cfb7fde7d",
+        "status": "revoked", "triggered_at": null, "revoked_at": "2026-05-20T12:23:19.883989Z",
+        "type": "AWS", "open_events_count": 0, "creator_id": 113168, "revoker_id":
+        113168, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "bb1adf06-28ea-4daf-b338-59d5ef094f67",
+        "name": "TheBigHoney", "description": "Big Honey Pot for our core secrets",
+        "created_at": "2026-05-19T11:51:12.957707Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bb1adf06-28ea-4daf-b338-59d5ef094f67",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "03e7e668-6fbf-493a-8d1c-ac9d0c6c1b97", "name": "qa
+        / xyz-d2363bd5", "description": "", "created_at": "2026-05-19T08:29:41.396307Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/03e7e668-6fbf-493a-8d1c-ac9d0c6c1b97",
+        "status": "triggered", "triggered_at": "2026-05-19T08:34:30.001210Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 1754656, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "name": "qa / test-nriv-d2363bd5", "description": "", "created_at": "2026-05-19T08:29:37.247067Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "status": "triggered", "triggered_at": "2026-05-19T08:33:36.289678Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 1754656, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1acff09e-02c1-4a24-8869-568dfab124c9",
+        "name": "test-pierredt", "description": "hello", "created_at": "2026-05-06T19:57:39.689471Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1acff09e-02c1-4a24-8869-568dfab124c9",
+        "status": "triggered", "triggered_at": "2026-05-06T19:59:18.645288Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 6, "creator_id": 309802, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "963fbabe-3d2c-4154-8281-2f13be7c06f7",
+        "name": "test121", "description": "testing 12", "created_at": "2026-04-30T11:31:57.689130Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/963fbabe-3d2c-4154-8281-2f13be7c06f7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2a72f662-2357-4b93-b48a-00028e36cfff", "name": "test1",
+        "description": "tEST 2", "created_at": "2026-04-30T09:12:55.584248Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a72f662-2357-4b93-b48a-00028e36cfff",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fe96d213-a002-4161-a7c9-cb3be4ad88f8", "name": "qa
+        / Handcrafted Metal Bike-e732d912", "description": "", "created_at": "2026-04-24T16:06:02.936659Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fe96d213-a002-4161-a7c9-cb3be4ad88f8",
+        "status": "triggered", "triggered_at": "2026-04-24T16:35:48.958630Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2314a2ef-cec4-4e3d-834a-09b0c40c99d2",
+        "name": "qa / abc-e732d912", "description": "", "created_at": "2026-04-24T16:05:59.728317Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2314a2ef-cec4-4e3d-834a-09b0c40c99d2",
+        "status": "triggered", "triggered_at": "2026-04-24T16:25:50.024911Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "name": "qa / test-r8327r-e732d912", "description": "", "created_at": "2026-04-24T16:05:56.586568Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "status": "triggered", "triggered_at": "2026-04-24T16:18:31.419829Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "name": "dev / Salome Test-e732d912", "description": "", "created_at": "2026-04-24T16:05:53.158978Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "status": "triggered", "triggered_at": "2026-04-24T16:16:21.895694Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9266c0f4-f0e0-41d2-a8c8-c164ccb84e47",
+        "name": "qa / test-nriv-e732d912", "description": "", "created_at": "2026-04-24T16:05:50.013606Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9266c0f4-f0e0-41d2-a8c8-c164ccb84e47",
+        "status": "triggered", "triggered_at": "2026-04-24T16:15:44.494587Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "10f6e20b-12ae-4591-aa09-7e1ff00ef408",
+        "name": "qa / xyz-e732d912", "description": "", "created_at": "2026-04-24T16:05:46.508625Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/10f6e20b-12ae-4591-aa09-7e1ff00ef408",
+        "status": "triggered", "triggered_at": "2026-04-24T16:13:17.276672Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ae435f66-1ea9-4dfe-b73f-49f451fc00ab",
+        "name": "Demo Romain", "description": "", "created_at": "2026-04-24T12:48:19.654369Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ae435f66-1ea9-4dfe-b73f-49f451fc00ab",
+        "status": "triggered", "triggered_at": "2026-04-29T12:54:19.464710Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 6, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [{"id": "7a2469eb-2b6b-4248-8103-2b0f6b4fac9b", "key":
+        "romain", "value": null}], "token": "[REDACTED]"}, {"id": "84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "name": "test Pierre", "description": "", "created_at": "2026-04-07T18:38:38.199572Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "51dc5671-8053-4b87-8174-975ccf7f249c", "name": "ggshield-DXGKK2gC",
         "description": "description", "created_at": "2026-03-31T13:37:33.559937Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/51dc5671-8053-4b87-8174-975ccf7f249c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "54e52712-a036-4e80-899b-c1a200610339",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "54e52712-a036-4e80-899b-c1a200610339",
         "name": "ggshield-DZ5zVj1p", "description": "description", "created_at": "2026-03-31T13:37:32.513332Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/54e52712-a036-4e80-899b-c1a200610339",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "601c59d9-7579-402e-90c4-59da055a8d3b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "601c59d9-7579-402e-90c4-59da055a8d3b",
         "name": "ggshield-YpbVgsRl", "description": "description", "created_at": "2026-03-31T13:32:29.820990Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/601c59d9-7579-402e-90c4-59da055a8d3b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7daed77-1fa4-416d-88e2-473200b810aa",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7daed77-1fa4-416d-88e2-473200b810aa",
         "name": "ggshield-dqv39cn2", "description": "description", "created_at": "2026-03-31T13:32:28.824725Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e7daed77-1fa4-416d-88e2-473200b810aa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
         "name": "ggshield-FsL9dCzu", "description": "description", "created_at": "2026-03-31T13:26:21.681383Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
         "name": "ggshield-Z2Ji3PxX", "description": "description", "created_at": "2026-03-31T13:26:20.710346Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "eae1aaaf-d700-475d-b65a-ffd79f84806d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "eae1aaaf-d700-475d-b65a-ffd79f84806d",
         "name": "ggshield-Pya2g1xF", "description": "description", "created_at": "2025-11-14T16:54:30.933576Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/eae1aaaf-d700-475d-b65a-ffd79f84806d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "368a90bf-269b-4a60-95c2-1c77c86f7fd4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "368a90bf-269b-4a60-95c2-1c77c86f7fd4",
         "name": "ggshield-V6RzZJGL", "description": "description", "created_at": "2025-11-14T16:54:30.227288Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/368a90bf-269b-4a60-95c2-1c77c86f7fd4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2b15518b-3100-4736-bee6-b47fe8d26fc1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2b15518b-3100-4736-bee6-b47fe8d26fc1",
         "name": "ggshield-H2eDvilF", "description": "description", "created_at": "2025-08-27T11:43:12.618589Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2b15518b-3100-4736-bee6-b47fe8d26fc1",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
         "name": "ggshield-ncOpkfP8", "description": "description", "created_at": "2025-08-27T11:43:11.666517Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
         "name": "ggshield-0k2Xha2i", "description": "description", "created_at": "2025-07-29T10:40:28.088246Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/043cd1a9-11c8-42b0-ac4b-3cc95b6596ce",
         "status": "triggered", "triggered_at": "2025-08-22T16:59:58.315774Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8", "name": "ggshield-CC0Lj0vS",
-        "description": "description", "created_at": "2025-07-29T10:40:27.317817Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
+        "name": "ggshield-CC0Lj0vS", "description": "description", "created_at": "2025-07-29T10:40:27.317817Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "951e1f19-5804-444a-b275-b51dc5bf68ee",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "951e1f19-5804-444a-b275-b51dc5bf68ee",
         "name": "ggshield-u9ltlEmT", "description": "description", "created_at": "2025-07-29T10:34:42.385215Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/951e1f19-5804-444a-b275-b51dc5bf68ee",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7691445a-2cb0-4093-94ca-f2c5de877075",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7691445a-2cb0-4093-94ca-f2c5de877075",
         "name": "ggshield-Lwhu1Nax", "description": "description", "created_at": "2025-07-29T10:34:41.534666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7691445a-2cb0-4093-94ca-f2c5de877075",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e22705f1-5497-449b-9614-3c2d89e3b705",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e22705f1-5497-449b-9614-3c2d89e3b705",
         "name": "ggshield-l4abwnpa", "description": null, "created_at": "2025-06-26T12:32:05.993896Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e22705f1-5497-449b-9614-3c2d89e3b705",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
         "4ff03654-f280-4c31-8eef-5295d2b75a50", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f3252f2c-16a9-45e4-97e8-bed4b5752415",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f3252f2c-16a9-45e4-97e8-bed4b5752415",
         "name": "ggshield-YJd3rq9q", "description": "description", "created_at": "2025-06-24T13:50:44.165951Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f3252f2c-16a9-45e4-97e8-bed4b5752415",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768",
-        "name": "ggshield-MGXkbqc7", "description": "description", "created_at": "2025-06-24T13:50:43.295521Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768", "name": "ggshield-MGXkbqc7",
+        "description": "description", "created_at": "2025-06-24T13:50:43.295521Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f99173ff-9ffe-492c-b8ae-54157df89bac",
-        "name": "ggshield-5uK6KYFh", "description": "description", "created_at": "2025-06-24T13:45:18.309642Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f99173ff-9ffe-492c-b8ae-54157df89bac", "name": "ggshield-5uK6KYFh",
+        "description": "description", "created_at": "2025-06-24T13:45:18.309642Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f99173ff-9ffe-492c-b8ae-54157df89bac",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f2c61b85-e11d-4db0-a8af-7fc327310b39",
-        "name": "ggshield-ZQ4jUtQr", "description": "description", "created_at": "2025-06-24T13:45:17.477850Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f2c61b85-e11d-4db0-a8af-7fc327310b39", "name": "ggshield-ZQ4jUtQr",
+        "description": "description", "created_at": "2025-06-24T13:45:17.477850Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f2c61b85-e11d-4db0-a8af-7fc327310b39",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "96da938d-d6fa-4e44-9254-c568a27be484",
-        "name": "ggshield-PirK5h1Q", "description": "description", "created_at": "2025-06-24T13:31:49.827284Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "96da938d-d6fa-4e44-9254-c568a27be484", "name": "ggshield-PirK5h1Q",
+        "description": "description", "created_at": "2025-06-24T13:31:49.827284Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/96da938d-d6fa-4e44-9254-c568a27be484",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "08b51a6e-dd6c-4a4b-93f9-b955663c6524",
-        "name": "ggshield-ZoWflf5b", "description": "description", "created_at": "2025-06-24T13:31:49.045062Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "08b51a6e-dd6c-4a4b-93f9-b955663c6524", "name": "ggshield-ZoWflf5b",
+        "description": "description", "created_at": "2025-06-24T13:31:49.045062Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/08b51a6e-dd6c-4a4b-93f9-b955663c6524",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "9340e7fe-f79c-467e-9dcd-43ddaa77dc0c",
-        "name": "ggshield-Md0MBV0B", "description": "description", "created_at": "2025-06-24T13:29:16.049584Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "9340e7fe-f79c-467e-9dcd-43ddaa77dc0c", "name": "ggshield-Md0MBV0B",
+        "description": "description", "created_at": "2025-06-24T13:29:16.049584Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9340e7fe-f79c-467e-9dcd-43ddaa77dc0c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "3983e8ff-7fd6-4fde-9117-9612d4258052",
-        "name": "ggshield-phDsJ9wy", "description": "description", "created_at": "2025-06-24T13:29:15.096198Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "3983e8ff-7fd6-4fde-9117-9612d4258052", "name": "ggshield-phDsJ9wy",
+        "description": "description", "created_at": "2025-06-24T13:29:15.096198Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3983e8ff-7fd6-4fde-9117-9612d4258052",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "bebc1ca8-933d-45ca-b201-fbabc4eab464",
-        "name": "ggshield-7pQLMJYV", "description": "description", "created_at": "2025-06-24T13:13:01.978212Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "bebc1ca8-933d-45ca-b201-fbabc4eab464", "name": "ggshield-7pQLMJYV",
+        "description": "description", "created_at": "2025-06-24T13:13:01.978212Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bebc1ca8-933d-45ca-b201-fbabc4eab464",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "631ef101-122f-4592-9de1-2d6cb5becafa",
-        "name": "ggshield-dbhOtleP", "description": "description", "created_at": "2025-06-24T13:13:01.219899Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "631ef101-122f-4592-9de1-2d6cb5becafa", "name": "ggshield-dbhOtleP",
+        "description": "description", "created_at": "2025-06-24T13:13:01.219899Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/631ef101-122f-4592-9de1-2d6cb5becafa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "17925c95-1df7-4e86-9c42-aabb5dbdea69",
-        "name": "ggshield-vfjAXCfY", "description": "description", "created_at": "2025-06-24T13:06:57.033247Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "17925c95-1df7-4e86-9c42-aabb5dbdea69", "name": "ggshield-vfjAXCfY",
+        "description": "description", "created_at": "2025-06-24T13:06:57.033247Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/17925c95-1df7-4e86-9c42-aabb5dbdea69",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5692a982-6603-443e-bdb4-5ea1a5de6f64",
-        "name": "ggshield-JKhVuHaW", "description": "description", "created_at": "2025-06-24T13:06:56.046343Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5692a982-6603-443e-bdb4-5ea1a5de6f64", "name": "ggshield-JKhVuHaW",
+        "description": "description", "created_at": "2025-06-24T13:06:56.046343Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5692a982-6603-443e-bdb4-5ea1a5de6f64",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab",
-        "name": "ggshield-NiJSM24s", "description": "description", "created_at": "2025-06-24T13:04:21.255669Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab", "name": "ggshield-NiJSM24s",
+        "description": "description", "created_at": "2025-06-24T13:04:21.255669Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
-        "name": "ggshield-U8JeiAjO", "description": "description", "created_at": "2025-06-24T13:04:20.196705Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "c77d47b6-8d61-46a7-b6a1-1715fc47c7eb", "name": "ggshield-U8JeiAjO",
+        "description": "description", "created_at": "2025-06-24T13:04:20.196705Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "029e2aba-796c-47d8-8d52-e14f9868acfc",
-        "name": "ggshield-Fhjl6QxB", "description": "description", "created_at": "2025-05-27T08:18:31.873128Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "029e2aba-796c-47d8-8d52-e14f9868acfc", "name": "ggshield-Fhjl6QxB",
+        "description": "description", "created_at": "2025-05-27T08:18:31.873128Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/029e2aba-796c-47d8-8d52-e14f9868acfc",
         "status": "triggered", "triggered_at": "2025-06-17T09:30:39.728240Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "69dbbe3c-2dfc-4c93-916c-f70c42f4e2af", "name": "ggshield-Leb9CGys",
-        "description": "description", "created_at": "2025-05-27T08:18:31.020533Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "69dbbe3c-2dfc-4c93-916c-f70c42f4e2af",
+        "name": "ggshield-Leb9CGys", "description": "description", "created_at": "2025-05-27T08:18:31.020533Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/69dbbe3c-2dfc-4c93-916c-f70c42f4e2af",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0a112323-6906-4bd0-a660-1b45a0fc59ca",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0a112323-6906-4bd0-a660-1b45a0fc59ca",
         "name": "NHI-Explorer-Secret", "description": "AWS access key for NHI Explorer
         project", "created_at": "2025-05-13T14:55:28.755591Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/0a112323-6906-4bd0-a660-1b45a0fc59ca",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "d476c118-b210-403d-b685-3d7f0a514950",
         "name": "aws-development-access-key", "description": "Development environment
         AWS access key for monitoring credential leaks", "created_at": "2025-05-12T15:12:56.525944Z",
@@ -226,9 +398,7 @@ interactions:
         "status": "triggered", "triggered_at": "2026-02-18T14:50:57.626529Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 2, "creator_id": 270722, "revoker_id":
         null, "creator_api_token_id": "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
+        null, "tags": [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
         "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "16805984-70d6-4049-844a-79bac3054f6f",
         "name": "AwsTestHoneytoken", "description": "Test honeytoken for development
@@ -237,10 +407,8 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "34e08af4-59a7-4a3b-b799-65acb8a2019d",
         "name": "AWS-MCP-Honeytoken", "description": "Honeytoken for monitoring potential
         AWS credential leaks", "created_at": "2025-05-12T15:07:16.157981Z", "gitguardian_url":
@@ -248,25 +416,21 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "fbb93094-9778-4b8b-97d8-de99954a758a",
         "name": "AWS_Honeytoken", "description": "Honeytoken generated via MCP", "created_at":
         "2025-05-12T15:01:37.478675Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fbb93094-9778-4b8b-97d8-de99954a758a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
         "name": "test-greg-9", "description": "", "created_at": "2025-05-12T14:50:23.123299Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6d185a-6f59-4b7c-9248-dd05616090db",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:27.366114Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
+        null, "tags": [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
         "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
         "name": "Test Honeytoken", "description": "Testing honeytoken generation",
@@ -274,297 +438,287 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
         "name": "test", "description": "test", "created_at": "2025-05-12T13:09:38.965752Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9844e55d-982c-4458-b65b-592ad99ce77a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1026550, "revoker_id": null, "creator_api_token_id":
         "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3fe4aa4f-49f6-42ad-a34a-0c108b544215",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3fe4aa4f-49f6-42ad-a34a-0c108b544215",
         "name": "default-honeytoken", "description": "General purpose honeytoken for
         security monitoring", "created_at": "2025-05-12T13:07:52.676810Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/3fe4aa4f-49f6-42ad-a34a-0c108b544215",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b65d42a4-587f-4701-a595-8429cbcda70b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b65d42a4-587f-4701-a595-8429cbcda70b",
         "name": "gg-mcp-server-honeytoken", "description": "Honeytoken for security
         monitoring in the gg-mcp-server project.", "created_at": "2025-05-12T12:54:44.402023Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b65d42a4-587f-4701-a595-8429cbcda70b",
-        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
-        "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
-        "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec",
+        "status": "triggered", "triggered_at": "2026-06-04T13:16:15.961464Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 4, "creator_id": 269050, "revoker_id":
+        null, "creator_api_token_id": "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id":
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec",
         "name": "test-greg-7", "description": "test", "created_at": "2025-05-12T12:54:37.703725Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ab824e92-6068-4a9d-ae36-86a94516f2ec",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:34.521470Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1", "name": "AWS Credentials",
-        "description": "Honeytoken for testing, to be injected as requested by the
-        user.", "created_at": "2025-05-12T12:38:25.640506Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
+        "name": "AWS Credentials", "description": "Honeytoken for testing, to be injected
+        as requested by the user.", "created_at": "2025-05-12T12:38:25.640506Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
         "status": "triggered", "triggered_at": "2026-02-18T13:45:03.781945Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 269050, "revoker_id":
+        null, "type": "AWS", "open_events_count": 9, "creator_id": 269050, "revoker_id":
         null, "creator_api_token_id": "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38", "name": "TestHoneytoken", "description":
-        "Testing GitGuardian API connectivity", "created_at": "2025-05-12T12:19:05.294638Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b0ddbd44-4054-4127-aa00-cd6727e70d38",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38",
+        "name": "TestHoneytoken", "description": "Testing GitGuardian API connectivity",
+        "created_at": "2025-05-12T12:19:05.294638Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b0ddbd44-4054-4127-aa00-cd6727e70d38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9fcf0732-6b8d-41d3-ae98-727bd5dde585",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9fcf0732-6b8d-41d3-ae98-727bd5dde585",
         "name": "achille-hackathon", "description": "achille hackathon", "created_at":
         "2025-05-12T12:01:23.542568Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9fcf0732-6b8d-41d3-ae98-727bd5dde585",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
         "name": "test-greg-5", "description": "test", "created_at": "2025-05-12T10:12:50.615700Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:41.387978Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6", "name": "test-greg-4", "description":
-        "test", "created_at": "2025-05-12T10:10:12.927058Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6",
+        "name": "test-greg-4", "description": "test", "created_at": "2025-05-12T10:10:12.927058Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:46.594085Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb", "name": "test-greg-3", "description":
-        "test greg", "created_at": "2025-05-12T10:08:58.561160Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        "name": "test-greg-3", "description": "test greg", "created_at": "2025-05-12T10:08:58.561160Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:50.784137Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "e948f77d-5353-413e-b37d-8beba84890ff", "name": "test-greg-2", "description":
-        "test greg", "created_at": "2025-05-12T10:08:11.667578Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e948f77d-5353-413e-b37d-8beba84890ff",
+        "name": "test-greg-2", "description": "test greg", "created_at": "2025-05-12T10:08:11.667578Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:54.809724Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "62d71685-2eba-4b88-8edd-cc73e698cfa5", "name": "test-greg", "description":
-        "test greg", "created_at": "2025-05-12T10:06:19.826522Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/62d71685-2eba-4b88-8edd-cc73e698cfa5",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "62d71685-2eba-4b88-8edd-cc73e698cfa5",
+        "name": "test-greg", "description": "test greg", "created_at": "2025-05-12T10:06:19.826522Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/62d71685-2eba-4b88-8edd-cc73e698cfa5",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:59.739856Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "899dd0b0-20b2-45d2-b779-0331cc448935", "name": "toto", "description":
-        "tata", "created_at": "2025-05-12T09:58:35.161641Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/899dd0b0-20b2-45d2-b779-0331cc448935",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "899dd0b0-20b2-45d2-b779-0331cc448935",
+        "name": "toto", "description": "tata", "created_at": "2025-05-12T09:58:35.161641Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/899dd0b0-20b2-45d2-b779-0331cc448935",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "11213dc7-118d-4997-a96b-714640c3ad0b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "11213dc7-118d-4997-a96b-714640c3ad0b",
         "name": "ggshield-CSF39jm8", "description": "description", "created_at": "2025-03-27T15:24:17.721006Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/11213dc7-118d-4997-a96b-714640c3ad0b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2dfa1936-f53f-4d0c-8a69-ae9bab297021",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2dfa1936-f53f-4d0c-8a69-ae9bab297021",
         "name": "ggshield-qz84En8W", "description": "description", "created_at": "2025-03-27T15:24:16.907610Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2dfa1936-f53f-4d0c-8a69-ae9bab297021",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
         "name": "ggshield-LbIDqGyA", "description": "description", "created_at": "2025-03-27T15:21:17.953340Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5710ee7d-6428-4074-a9ff-09399782242d",
-        "name": "ggshield-bF87lDBl", "description": "description", "created_at": "2025-03-27T15:21:17.135616Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5710ee7d-6428-4074-a9ff-09399782242d", "name": "ggshield-bF87lDBl",
+        "description": "description", "created_at": "2025-03-27T15:21:17.135616Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5710ee7d-6428-4074-a9ff-09399782242d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "a4ced9be-6ad5-4d8a-b188-65a117bc0eba",
-        "name": "ggshield-44tVmSvF", "description": "description", "created_at": "2025-03-27T15:12:19.507492Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "a4ced9be-6ad5-4d8a-b188-65a117bc0eba", "name": "ggshield-44tVmSvF",
+        "description": "description", "created_at": "2025-03-27T15:12:19.507492Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a4ced9be-6ad5-4d8a-b188-65a117bc0eba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "1f4708b2-0e51-458c-abca-c03e502b4a5a",
-        "name": "ggshield-QgwFEPjx", "description": "description", "created_at": "2025-03-27T15:12:18.744612Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "1f4708b2-0e51-458c-abca-c03e502b4a5a", "name": "ggshield-QgwFEPjx",
+        "description": "description", "created_at": "2025-03-27T15:12:18.744612Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1f4708b2-0e51-458c-abca-c03e502b4a5a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
-        "name": "ggshield-jdbeH3gE", "description": "description", "created_at": "2025-03-03T09:15:27.049176Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c", "name": "ggshield-jdbeH3gE",
+        "description": "description", "created_at": "2025-03-03T09:15:27.049176Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22", "key": "env",
-        "value": "production"}], "custom_tags": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22",
-        "key": "env", "value": "production"}], "token": "[REDACTED]"}, {"id": "adaea919-086f-4e37-b4e5-dc8208d0e4f5",
+        [], "custom_tags": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22", "key":
+        "env", "value": "production"}], "token": "[REDACTED]"}, {"id": "adaea919-086f-4e37-b4e5-dc8208d0e4f5",
         "name": "ggshield-rWApiuse", "description": "description", "created_at": "2025-03-03T09:15:26.314595Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/adaea919-086f-4e37-b4e5-dc8208d0e4f5",
         "status": "triggered", "triggered_at": "2026-02-18T14:51:12.198393Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 160089, "revoker_id":
         null, "creator_api_token_id": "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
-        "key": "env", "value": "staging"}], "custom_tags": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
+        null, "tags": [], "custom_tags": [{"id": "e4a53b9e-3584-4814-b959-8801472a6f04",
         "key": "env", "value": "staging"}], "token": "[REDACTED]"}, {"id": "661dae4d-5944-4a20-b7f7-f74913356479",
         "name": "ggshield-IX7GxSIs", "description": "description", "created_at": "2025-02-27T17:27:15.226298Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/661dae4d-5944-4a20-b7f7-f74913356479",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
         "name": "ggshield-i8zN7WRH", "description": "description", "created_at": "2025-02-27T17:27:14.478281Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
         "name": "ggshield-C519GYI9", "description": "description", "created_at": "2025-02-27T17:24:29.231126Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d5385824-6a93-47cb-81f3-e818e64371d7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d5385824-6a93-47cb-81f3-e818e64371d7",
         "name": "ggshield-vI1CTIm2", "description": "description", "created_at": "2025-02-27T17:24:28.533666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d5385824-6a93-47cb-81f3-e818e64371d7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d10551f8-36f0-4966-a684-d5f9eca89e8d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d10551f8-36f0-4966-a684-d5f9eca89e8d",
         "name": "ggshield-bukJ4Md2", "description": "description", "created_at": "2025-02-27T16:57:22.079317Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d10551f8-36f0-4966-a684-d5f9eca89e8d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be8e40e8-b204-40de-8d37-247ac6ef7077",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be8e40e8-b204-40de-8d37-247ac6ef7077",
         "name": "ggshield-DBuxWn0n", "description": "description", "created_at": "2025-02-27T16:57:21.290157Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be8e40e8-b204-40de-8d37-247ac6ef7077",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49f1055b-b505-402b-8b79-e4b2c6cf2041",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49f1055b-b505-402b-8b79-e4b2c6cf2041",
         "name": "ggshield-4MmSKBvx", "description": "description", "created_at": "2025-02-27T16:44:11.663957Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/49f1055b-b505-402b-8b79-e4b2c6cf2041",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c823f31a-73a8-46cc-be4a-029d6d081793",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c823f31a-73a8-46cc-be4a-029d6d081793",
         "name": "ggshield-9Mq5rTUV", "description": "description", "created_at": "2025-02-27T16:44:10.862683Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c823f31a-73a8-46cc-be4a-029d6d081793",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a5d5ca0-000f-4011-aaf2-b4f627c19649",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a5d5ca0-000f-4011-aaf2-b4f627c19649",
         "name": "ggshield-x12c7zPc", "description": "description", "created_at": "2025-02-27T11:24:21.465056Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8a5d5ca0-000f-4011-aaf2-b4f627c19649",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
         "name": "ggshield-yaqMNJFA", "description": "description", "created_at": "2025-02-27T11:24:20.630794Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72204c1e-12c1-445f-b106-09488214d610",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72204c1e-12c1-445f-b106-09488214d610",
         "name": "ggshield-eqoLjiAS", "description": "description", "created_at": "2025-02-27T10:53:02.563136Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72204c1e-12c1-445f-b106-09488214d610",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84b08c90-12f5-48ef-baee-ab8d8b15588c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84b08c90-12f5-48ef-baee-ab8d8b15588c",
         "name": "ggshield-4sJy2SkE", "description": "description", "created_at": "2025-02-27T10:53:01.890617Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84b08c90-12f5-48ef-baee-ab8d8b15588c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d8590557-764f-4618-9b2e-277d536bd111",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d8590557-764f-4618-9b2e-277d536bd111",
         "name": "ggshield-QYqCVZ4i", "description": "description", "created_at": "2025-02-27T10:31:34.798380Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d8590557-764f-4618-9b2e-277d536bd111",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ca642fe-2ce4-42b2-9097-5904093935c1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ca642fe-2ce4-42b2-9097-5904093935c1",
         "name": "ggshield-5Vx0aaQd", "description": "description", "created_at": "2025-02-27T10:31:34.080183Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ca642fe-2ce4-42b2-9097-5904093935c1",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "97877334-808d-48c7-8802-2c54e9f43661",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "97877334-808d-48c7-8802-2c54e9f43661",
         "name": "ggshield-srahH0o3", "description": "description", "created_at": "2025-02-27T10:23:32.385844Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/97877334-808d-48c7-8802-2c54e9f43661",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
         "name": "ggshield-AAcFXCwl", "description": "description", "created_at": "2025-02-27T10:23:31.621722Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4b814f00-0897-479f-8a2d-a9593c5f18fa",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4b814f00-0897-479f-8a2d-a9593c5f18fa",
         "name": "WrongSecrets", "description": "Honeytoken for the wrongsecrets repositort",
         "created_at": "2025-02-06T13:10:31.569094Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4b814f00-0897-479f-8a2d-a9593c5f18fa",
         "status": "triggered", "triggered_at": "2025-02-06T13:16:26.325168Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476", "name": "pierredethoisy/dockerfile",
-        "description": "", "created_at": "2024-12-17T10:30:41.655876Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
+        "name": "pierredethoisy/dockerfile", "description": "", "created_at": "2024-12-17T10:30:41.655876Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/75c5b3fe-3c6d-43ee-9fdd-a8d39d7a9476",
         "status": "triggered", "triggered_at": "2024-12-17T10:32:09.594850Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 309802, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "aed37b34-4721-43c2-99e2-2f2e78592f63", "name": "ggshield/setup.cfg",
-        "description": "", "created_at": "2024-12-17T10:10:25.895137Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/aed37b34-4721-43c2-99e2-2f2e78592f63",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "aed37b34-4721-43c2-99e2-2f2e78592f63",
+        "name": "ggshield/setup.cfg", "description": "", "created_at": "2024-12-17T10:10:25.895137Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/aed37b34-4721-43c2-99e2-2f2e78592f63",
         "status": "triggered", "triggered_at": "2024-12-17T10:19:35.167833Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 309802, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "c5af2ae0-f3f6-4301-82bc-b49108bd782b", "name": "ggshield-hIlrbyRm",
-        "description": "description", "created_at": "2024-11-27T12:32:45.728067Z",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5af2ae0-f3f6-4301-82bc-b49108bd782b",
+        "name": "ggshield-hIlrbyRm", "description": "description", "created_at": "2024-11-27T12:32:45.728067Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c5af2ae0-f3f6-4301-82bc-b49108bd782b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a454c002-679b-4250-aacf-28b5207543a4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a454c002-679b-4250-aacf-28b5207543a4",
         "name": "ggshield-HjwRkUAT", "description": "description", "created_at": "2024-11-27T12:32:44.877048Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a454c002-679b-4250-aacf-28b5207543a4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
         "name": "ggshield-E6IPnu0f", "description": "description", "created_at": "2024-10-29T14:36:28.513178Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
         "name": "ggshield-c6YSc2Ie", "description": "description", "created_at": "2024-10-29T14:36:27.096968Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "795decd4-4703-4073-9b3c-3ec2157f6182",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "795decd4-4703-4073-9b3c-3ec2157f6182",
         "name": "Demo token", "description": "Take a look", "created_at": "2024-10-28T00:34:48.214122Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/795decd4-4703-4073-9b3c-3ec2157f6182",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582569, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "50e53ab6-4950-48e6-9350-b5aaa88fafea",
-        "name": "Demo", "description": "Dev team 1", "created_at": "2024-10-27T21:01:47.725365Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "50e53ab6-4950-48e6-9350-b5aaa88fafea", "name": "Demo",
+        "description": "Dev team 1", "created_at": "2024-10-27T21:01:47.725365Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/50e53ab6-4950-48e6-9350-b5aaa88fafea",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582569, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}], "token": "[REDACTED]"},
         {"id": "a0b24134-0cbc-4ca5-b110-18b3311aef73", "name": "DO-demo", "description":
         "Digital Ocean Demo", "created_at": "2024-10-23T17:55:40.621634Z", "gitguardian_url":
@@ -572,189 +726,183 @@ interactions:
         "status": "revoked", "triggered_at": "2024-10-23T18:03:40.135215Z", "revoked_at":
         "2024-10-23T18:33:47.488182Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "81d30531-a54e-4f67-a46b-a7bac5783995", "name": "ggshield-IjJFdqDS",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "81d30531-a54e-4f67-a46b-a7bac5783995", "name": "ggshield-IjJFdqDS",
         "description": "description", "created_at": "2024-10-16T13:47:51.425195Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/81d30531-a54e-4f67-a46b-a7bac5783995",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
         "name": "ggshield-B8LwcRR0", "description": "description", "created_at": "2024-10-16T13:47:50.239094Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b42c6945-05fc-4c5b-af83-e60478cd9db5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b42c6945-05fc-4c5b-af83-e60478cd9db5",
         "name": "ggshield-WPIELIcW", "description": "description", "created_at": "2024-10-01T13:18:30.820570Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b42c6945-05fc-4c5b-af83-e60478cd9db5",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "730bdd87-31b2-4b42-a32a-5750bc595c9c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "730bdd87-31b2-4b42-a32a-5750bc595c9c",
         "name": "ggshield-dtxlZtWH", "description": "description", "created_at": "2024-10-01T13:18:29.918337Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/730bdd87-31b2-4b42-a32a-5750bc595c9c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
         "name": "ggshield-kkpkfk1s", "description": "description", "created_at": "2024-09-24T08:50:16.667172Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "01c7668d-1467-4cac-a395-4b50fc278407",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "01c7668d-1467-4cac-a395-4b50fc278407",
         "name": "ggshield-QkzL5Vyb", "description": "description", "created_at": "2024-09-24T08:50:15.865165Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/01c7668d-1467-4cac-a395-4b50fc278407",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "707b35fb-685b-4577-88b9-94cccc10e165",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "707b35fb-685b-4577-88b9-94cccc10e165",
         "name": "ggshield-wqYwwgeK", "description": "description", "created_at": "2024-08-27T08:20:16.467770Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/707b35fb-685b-4577-88b9-94cccc10e165",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "11222b98-7705-4180-99d1-6e719d8a05a9",
-        "name": "ggshield-qnLief7n", "description": "description", "created_at": "2024-08-27T08:20:15.846360Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "11222b98-7705-4180-99d1-6e719d8a05a9", "name": "ggshield-qnLief7n",
+        "description": "description", "created_at": "2024-08-27T08:20:15.846360Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/11222b98-7705-4180-99d1-6e719d8a05a9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "903bf588-2a03-4318-be6c-b9e3198d1fd6",
-        "name": "ggshield-5Ty2Hu4r", "description": "description", "created_at": "2024-08-27T07:44:46.871854Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "903bf588-2a03-4318-be6c-b9e3198d1fd6", "name": "ggshield-5Ty2Hu4r",
+        "description": "description", "created_at": "2024-08-27T07:44:46.871854Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/903bf588-2a03-4318-be6c-b9e3198d1fd6",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "b144b1fd-dc5f-4a36-abc7-a95d05331245",
-        "name": "ggshield-uZr6LNDv", "description": "description", "created_at": "2024-08-27T07:44:46.267249Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "b144b1fd-dc5f-4a36-abc7-a95d05331245", "name": "ggshield-uZr6LNDv",
+        "description": "description", "created_at": "2024-08-27T07:44:46.267249Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b144b1fd-dc5f-4a36-abc7-a95d05331245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
-        "name": "ggshield-lqX7PlwI", "description": "description", "created_at": "2024-08-05T09:21:26.211228Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "88c38ccf-471f-4e32-bf58-b1c2ebeb25bb", "name": "ggshield-lqX7PlwI",
+        "description": "description", "created_at": "2024-08-05T09:21:26.211228Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e8aad547-96a7-40a4-a05d-710cf536f3a7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e8aad547-96a7-40a4-a05d-710cf536f3a7",
         "name": "ggshield-Vqz4LULC", "description": "description", "created_at": "2024-08-05T09:21:25.593516Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e8aad547-96a7-40a4-a05d-710cf536f3a7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "83888e42-dc57-471c-9a08-f023e3dc2949",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "83888e42-dc57-471c-9a08-f023e3dc2949",
         "name": "ggshield-5suF2vRt", "description": "description", "created_at": "2024-08-05T09:03:53.434873Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/83888e42-dc57-471c-9a08-f023e3dc2949",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
         "name": "ggshield-Fu1nGsc9", "description": "description", "created_at": "2024-08-05T09:03:52.745860Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dafa04c5-299a-4a13-9c35-c523e51763f3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dafa04c5-299a-4a13-9c35-c523e51763f3",
         "name": "ggshield-b7VHMqbK", "description": "description", "created_at": "2024-07-31T15:31:10.071786Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dafa04c5-299a-4a13-9c35-c523e51763f3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a507d04c-bb61-4f2a-93ea-601b8aa27940",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a507d04c-bb61-4f2a-93ea-601b8aa27940",
         "name": "ggshield-w1cOSspy", "description": "description", "created_at": "2024-07-31T15:31:09.349255Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a507d04c-bb61-4f2a-93ea-601b8aa27940",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
         "name": "test ericf", "description": "", "created_at": "2024-07-09T09:34:04.089955Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
         "status": "triggered", "triggered_at": "2024-07-09T09:34:57.541777Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
         "name": "ggshield-GL7wc5WW", "description": "description", "created_at": "2024-06-26T11:51:20.402145Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26514e1f-4237-474b-b907-037b88427f29",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26514e1f-4237-474b-b907-037b88427f29",
         "name": "ggshield-Uuc8EiUn", "description": "description", "created_at": "2024-06-26T11:51:19.747630Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/26514e1f-4237-474b-b907-037b88427f29",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e332d717-641d-4ea4-81fc-e98115178454",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e332d717-641d-4ea4-81fc-e98115178454",
         "name": "ggshield-JaAf9b0W", "description": "description", "created_at": "2024-06-26T09:42:27.174527Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e332d717-641d-4ea4-81fc-e98115178454",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "17e088b8-2463-48f8-957b-41d017f1dc83",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "17e088b8-2463-48f8-957b-41d017f1dc83",
         "name": "ggshield-s7IOqS0q", "description": "description", "created_at": "2024-06-26T09:42:26.454643Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/17e088b8-2463-48f8-957b-41d017f1dc83",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9223e352-43b6-4e06-8d12-682d669cedd7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9223e352-43b6-4e06-8d12-682d669cedd7",
         "name": "ggshield-TRO3H56N", "description": "description", "created_at": "2024-06-26T09:27:39.479744Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9223e352-43b6-4e06-8d12-682d669cedd7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
         "name": "ggshield-fb77weow", "description": "description", "created_at": "2024-06-26T09:27:38.724573Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3407738b-2095-47bb-9cbd-dd16de158d67",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3407738b-2095-47bb-9cbd-dd16de158d67",
         "name": "ggshield-65KCwJls", "description": "description", "created_at": "2024-06-25T08:36:52.873146Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3407738b-2095-47bb-9cbd-dd16de158d67",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "12c4562e-deb8-4d14-bb23-e344e79b6f04",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "12c4562e-deb8-4d14-bb23-e344e79b6f04",
         "name": "ggshield-Wq4EyTMI", "description": "description", "created_at": "2024-06-25T08:36:52.179380Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/12c4562e-deb8-4d14-bb23-e344e79b6f04",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a411fa2c-a465-4099-8353-3c42365aca50",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a411fa2c-a465-4099-8353-3c42365aca50",
         "name": "test MINT", "description": "test MINT", "created_at": "2024-06-10T14:40:08.522247Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a411fa2c-a465-4099-8353-3c42365aca50",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
-        "name": "test lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
-        "status": "triggered", "triggered_at": "2024-06-06T08:19:18.422045Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 319222, "revoker_id":
-        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca", "key": "machine",
-        "value": "ggprdgim01"}], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99", "name": "test
+        lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
         "key": "machine", "value": "ggprdgim01"}], "token": "[REDACTED]"}, {"id":
         "9cca01c5-535f-4f89-a214-6c4c5579fd07", "name": "ggshield-3xRVfevR", "description":
         "description", "created_at": "2024-05-29T11:39:10.494259Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/9cca01c5-535f-4f89-a214-6c4c5579fd07",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "a67f962c-9dde-40c2-b404-e7cd4449cc82",
-        "name": "pouet", "description": "", "created_at": "2024-05-22T12:19:03.143437Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a67f962c-9dde-40c2-b404-e7cd4449cc82",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "a67f962c-9dde-40c2-b404-e7cd4449cc82", "name": "pouet",
+        "description": "", "created_at": "2024-05-22T12:19:03.143437Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/a67f962c-9dde-40c2-b404-e7cd4449cc82",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
-        "key": "visability", "value": "public"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
         "key": "visability", "value": "public"}], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
@@ -762,277 +910,260 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c7101eaa-ea38-495d-b3b4-c016db23e859",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
         "name": "ggshield-HRoZzrBq", "description": "description", "created_at": "2024-04-30T10:19:13.126568Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72e98633-9179-4a3e-8908-ea2319d19b3b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72e98633-9179-4a3e-8908-ea2319d19b3b",
         "name": "ggshield-XYKDhLUY", "description": "description", "created_at": "2024-04-30T10:19:12.369644Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72e98633-9179-4a3e-8908-ea2319d19b3b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7f2873cd-3759-4727-a683-31cac57fe5d8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7f2873cd-3759-4727-a683-31cac57fe5d8",
         "name": "ggshield-TvlX76OG", "description": "description", "created_at": "2024-04-30T09:25:39.573115Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7f2873cd-3759-4727-a683-31cac57fe5d8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d72113d0-c346-42c7-bd88-fd5fe0e716f3",
-        "name": "ggshield-eY0ZOlXS", "description": "description", "created_at": "2024-04-30T09:25:38.689800Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d72113d0-c346-42c7-bd88-fd5fe0e716f3", "name": "ggshield-eY0ZOlXS",
+        "description": "description", "created_at": "2024-04-30T09:25:38.689800Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d72113d0-c346-42c7-bd88-fd5fe0e716f3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5a01f826-4f8f-4235-8867-ce58ac88ce1c",
-        "name": "ggshield-inUFY47O", "description": "description", "created_at": "2024-03-27T08:48:21.791104Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5a01f826-4f8f-4235-8867-ce58ac88ce1c", "name": "ggshield-inUFY47O",
+        "description": "description", "created_at": "2024-03-27T08:48:21.791104Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5a01f826-4f8f-4235-8867-ce58ac88ce1c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
         "name": "ggshield-Psfrcoxl", "description": "description", "created_at": "2024-03-27T08:48:20.857237Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e",
         "name": "test-lena-1903", "description": "", "created_at": "2024-03-19T09:13:00.819618Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/443045cc-7fa4-441d-a161-b060bd7fbb3e",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-05-29T09:51:31.597203Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 319222, "revoker_id":
         319222, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245",
         "name": "Test key ", "description": "ss", "created_at": "2024-02-29T13:49:52.467489Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5d915aca-6f6f-4b4e-a996-2c1f53016114",
-        "name": "ggshield-LNgN8R1S", "description": "description", "created_at": "2024-02-27T14:19:40.283320Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5d915aca-6f6f-4b4e-a996-2c1f53016114", "name": "ggshield-LNgN8R1S",
+        "description": "description", "created_at": "2024-02-27T14:19:40.283320Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d915aca-6f6f-4b4e-a996-2c1f53016114",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "664af568-cfc7-4726-9fb4-0b61606b7386",
-        "name": "ggshield-horgQNnR", "description": "description", "created_at": "2024-02-27T14:19:39.357690Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "664af568-cfc7-4726-9fb4-0b61606b7386", "name": "ggshield-horgQNnR",
+        "description": "description", "created_at": "2024-02-27T14:19:39.357690Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/664af568-cfc7-4726-9fb4-0b61606b7386",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0ebc8091-454b-461e-a6f8-fd17bf412c76",
-        "name": "ggshield-jqk54PrI", "description": "description", "created_at": "2024-02-27T14:06:03.018091Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0ebc8091-454b-461e-a6f8-fd17bf412c76", "name": "ggshield-jqk54PrI",
+        "description": "description", "created_at": "2024-02-27T14:06:03.018091Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ebc8091-454b-461e-a6f8-fd17bf412c76",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "eba79796-4f46-4e10-b876-280f75138cc9",
-        "name": "ggshield-z3Y6zgih", "description": "description", "created_at": "2024-02-27T14:06:02.196977Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "eba79796-4f46-4e10-b876-280f75138cc9", "name": "ggshield-z3Y6zgih",
+        "description": "description", "created_at": "2024-02-27T14:06:02.196977Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/eba79796-4f46-4e10-b876-280f75138cc9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "4dd6c06e-e2c0-4593-9be0-b0418ba7a370",
-        "name": "ggshield-5YTKZZTB", "description": "description", "created_at": "2024-02-27T14:02:45.717261Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "4dd6c06e-e2c0-4593-9be0-b0418ba7a370", "name": "ggshield-5YTKZZTB",
+        "description": "description", "created_at": "2024-02-27T14:02:45.717261Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4dd6c06e-e2c0-4593-9be0-b0418ba7a370",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5ff5eee1-fc18-4474-86fa-c46321c903c8",
-        "name": "ggshield-rmnfzrW2", "description": "description", "created_at": "2024-02-27T14:02:45.009113Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5ff5eee1-fc18-4474-86fa-c46321c903c8", "name": "ggshield-rmnfzrW2",
+        "description": "description", "created_at": "2024-02-27T14:02:45.009113Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5ff5eee1-fc18-4474-86fa-c46321c903c8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "33d149f1-68f4-4446-ae4f-def0ce962724",
-        "name": "ggshield-2Mf02eVA", "description": "description", "created_at": "2024-02-27T13:58:31.125075Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "33d149f1-68f4-4446-ae4f-def0ce962724", "name": "ggshield-2Mf02eVA",
+        "description": "description", "created_at": "2024-02-27T13:58:31.125075Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/33d149f1-68f4-4446-ae4f-def0ce962724",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "def4a23d-3d12-4fe1-b8e0-02250e74e47a",
-        "name": "ggshield-itglxnie", "description": "description", "created_at": "2024-02-27T13:58:30.205444Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "def4a23d-3d12-4fe1-b8e0-02250e74e47a", "name": "ggshield-itglxnie",
+        "description": "description", "created_at": "2024-02-27T13:58:30.205444Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/def4a23d-3d12-4fe1-b8e0-02250e74e47a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d7764013-fdd5-4b08-b195-dff5a338906d",
-        "name": "ggshield-LRYYnjOa", "description": "description", "created_at": "2024-02-27T13:42:37.569678Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d7764013-fdd5-4b08-b195-dff5a338906d", "name": "ggshield-LRYYnjOa",
+        "description": "description", "created_at": "2024-02-27T13:42:37.569678Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d7764013-fdd5-4b08-b195-dff5a338906d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "1bba091c-fc4c-48b5-b558-46c191f67103",
-        "name": "ggshield-ldC5hqqo", "description": "description", "created_at": "2024-02-27T13:42:36.686028Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "1bba091c-fc4c-48b5-b558-46c191f67103", "name": "ggshield-ldC5hqqo",
+        "description": "description", "created_at": "2024-02-27T13:42:36.686028Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1bba091c-fc4c-48b5-b558-46c191f67103",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e",
-        "name": "myname-dwayneptoday", "description": "dfsdfsdf", "created_at": "2024-02-23T16:38:14.323313Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e", "name": "myname-dwayneptoday",
+        "description": "dfsdfsdf", "created_at": "2024-02-23T16:38:14.323313Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/0be0a9c5-7df9-4d52-8c20-65b8e0cfa92e",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T17:03:21.653827Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "612055eb-7fb5-4ba3-ab10-aa481f3d9962",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "612055eb-7fb5-4ba3-ab10-aa481f3d9962",
         "name": "demo-dwayne-2024-02-23-v2", "description": "Demo for video", "created_at":
         "2024-02-23T16:28:49.949332Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/612055eb-7fb5-4ba3-ab10-aa481f3d9962",
         "status": "revoked", "triggered_at": "2024-02-23T16:31:01.657151Z", "revoked_at":
         "2024-02-23T16:52:50.712289Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "b38455f9-822c-4f21-8525-0d4f2fa63850", "name": "demo-dwayne-2024-02-23",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "b38455f9-822c-4f21-8525-0d4f2fa63850", "name": "demo-dwayne-2024-02-23",
         "description": "dfnijsbuisbfids", "created_at": "2024-02-23T15:45:47.636481Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b38455f9-822c-4f21-8525-0d4f2fa63850",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T16:28:23.939971Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86136984-d415-41c2-bfc4-59da8f9584fd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "86136984-d415-41c2-bfc4-59da8f9584fd",
         "name": "demo-2024-02-23-dm", "description": "", "created_at": "2024-02-23T15:38:04.895275Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86136984-d415-41c2-bfc4-59da8f9584fd",
         "status": "revoked", "triggered_at": "2024-02-23T15:49:03.613445Z", "revoked_at":
         "2024-02-23T15:59:54.768989Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "0a94480f-5361-47f8-bc23-45a331624e9d", "name": "demo
-        ", "description": "demo ", "created_at": "2024-02-22T19:02:29.338420Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/0a94480f-5361-47f8-bc23-45a331624e9d",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "0a94480f-5361-47f8-bc23-45a331624e9d", "name": "demo ", "description":
+        "demo ", "created_at": "2024-02-22T19:02:29.338420Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0a94480f-5361-47f8-bc23-45a331624e9d",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-02-23T17:03:31.533534Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 354585, "revoker_id":
         354585, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d024b464-cd1e-4daf-9b1d-863dcf517a7a",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d024b464-cd1e-4daf-9b1d-863dcf517a7a",
         "name": "Demo -2024-02-22", "description": "", "created_at": "2024-02-22T18:53:26.142516Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d024b464-cd1e-4daf-9b1d-863dcf517a7a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 354585, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "1592023a-2f39-4ba6-a503-4c07132f1eb0",
-        "name": "GGnikalston/rock-paper-scissors-f4c01375", "description": "", "created_at":
-        "2024-02-20T13:32:45.163630Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1592023a-2f39-4ba6-a503-4c07132f1eb0",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "1592023a-2f39-4ba6-a503-4c07132f1eb0", "name": "GGnikalston/rock-paper-scissors-f4c01375",
+        "description": "", "created_at": "2024-02-20T13:32:45.163630Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/1592023a-2f39-4ba6-a503-4c07132f1eb0",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
-        "name": "solid-octo", "description": "", "created_at": "2024-02-19T13:06:26.880374Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "6fcc5cf2-4b47-497d-9a80-c2d794b96ebc", "name": "solid-octo",
+        "description": "", "created_at": "2024-02-19T13:06:26.880374Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
-        "key": "team", "value": "octo"}], "custom_tags": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
         "key": "team", "value": "octo"}], "token": "[REDACTED]"}, {"id": "638f6f82-6679-4399-a336-dd7996f4beae",
         "name": "demo-2024-02-16dm", "description": "demo", "created_at": "2024-02-16T19:39:33.970811Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/638f6f82-6679-4399-a336-dd7996f4beae",
         "status": "revoked", "triggered_at": "2024-02-16T19:40:02.759791Z", "revoked_at":
         "2024-02-16T20:10:11.153368Z", "type": "AWS", "open_events_count": 0, "creator_id":
         354585, "revoker_id": 354585, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "cf0806c4-093d-4165-9ad3-7e7ded211d3f", "name": "DemoKey",
-        "description": "sss", "created_at": "2024-02-15T12:39:23.633481Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/cf0806c4-093d-4165-9ad3-7e7ded211d3f",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "cf0806c4-093d-4165-9ad3-7e7ded211d3f", "name": "DemoKey", "description":
+        "sss", "created_at": "2024-02-15T12:39:23.633481Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cf0806c4-093d-4165-9ad3-7e7ded211d3f",
         "status": "triggered", "triggered_at": "2024-02-15T12:45:44.649197Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b00bfddb-98c2-48e4-ad38-0cb9bc79cad6", "name": "orga_083643/solid-octo",
-        "description": "", "created_at": "2024-02-09T14:45:12.139727Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
+        "name": "orga_083643/solid-octo", "description": "", "created_at": "2024-02-09T14:45:12.139727Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b00bfddb-98c2-48e4-ad38-0cb9bc79cad6",
         "status": "revoked", "triggered_at": "2024-02-09T14:52:11.339548Z", "revoked_at":
         "2024-05-29T13:09:29.773300Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 2508, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "07fb5f6f-23f1-42e8-bdb2-c95864412a16", "name": "My Little Honeytoken",
-        "description": "for testing", "created_at": "2024-02-02T22:18:06.038874Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/07fb5f6f-23f1-42e8-bdb2-c95864412a16",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "07fb5f6f-23f1-42e8-bdb2-c95864412a16",
+        "name": "My Little Honeytoken", "description": "for testing", "created_at":
+        "2024-02-02T22:18:06.038874Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/07fb5f6f-23f1-42e8-bdb2-c95864412a16",
         "status": "triggered", "triggered_at": "2024-02-09T20:50:13.173911Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4", "name": "Lauren Testing", "description":
-        "Lauren wuz here", "created_at": "2024-01-29T17:37:45.379096Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
+        "name": "Lauren Testing", "description": "Lauren wuz here", "created_at":
+        "2024-01-29T17:37:45.379096Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 637596, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a",
         "name": "BK Test Paris", "description": "Brandon while in Paris office", "created_at":
         "2024-01-17T11:12:14.759334Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/34d5205b-accd-429c-9efa-eda48989c83a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
-        "name": "AWS key honeytoken for Slack", "description": "Honeytoken on Slack
-        channel", "created_at": "2024-01-15T16:13:53.656688Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "123ecd19-e66f-4e5c-ad73-12f0a51eda5a", "name": "AWS
+        key honeytoken for Slack", "description": "Honeytoken on Slack channel", "created_at":
+        "2024-01-15T16:13:53.656688Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/123ecd19-e66f-4e5c-ad73-12f0a51eda5a",
         "status": "triggered", "triggered_at": "2024-01-15T16:14:14.960066Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 104, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "23ca2658-aecf-471c-abf0-add09962e320", "key": "ods",
-        "value": "slack"}], "custom_tags": [{"id": "23ca2658-aecf-471c-abf0-add09962e320",
-        "key": "ods", "value": "slack"}], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
+        [], "custom_tags": [{"id": "23ca2658-aecf-471c-abf0-add09962e320", "key":
+        "ods", "value": "slack"}], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "name": "sss", "description": "test", "created_at": "2024-01-09T14:24:10.741214Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
-        "name": "ggshield-JZV5XT71", "description": "description", "created_at": "2024-01-09T09:39:34.421404Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c", "name": "ggshield-JZV5XT71",
+        "description": "description", "created_at": "2024-01-09T09:39:34.421404Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4dd77510-fc74-411f-9dbe-77619fa920dd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4dd77510-fc74-411f-9dbe-77619fa920dd",
         "name": "My Postman Public Collection", "description": "Will it ring?", "created_at":
         "2024-01-02T16:36:46.008155Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4dd77510-fc74-411f-9dbe-77619fa920dd",
         "status": "triggered", "triggered_at": "2024-01-04T17:52:01.203498Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 811, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6c5d9856-835e-468c-9448-7bf0e77f1e53",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6c5d9856-835e-468c-9448-7bf0e77f1e53",
         "name": "improved carnival", "description": "", "created_at": "2023-12-21T13:43:01.544215Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6c5d9856-835e-468c-9448-7bf0e77f1e53",
         "status": "revoked", "triggered_at": "2023-12-21T13:57:59.435706Z", "revoked_at":
         "2023-12-22T09:33:18.668820Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "52903632-f6ff-460e-8a68-80a942349979",
         "name": "Network Honeytoken", "description": "Aws Honeytoken on Network",
         "created_at": "2023-12-18T13:47:39.151311Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/52903632-f6ff-460e-8a68-80a942349979",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
-        "key": "network", "value": "directory"}], "custom_tags": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
         "key": "network", "value": "directory"}], "token": "[REDACTED]"}, {"id": "7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
         "name": "analytics-repo", "description": "", "created_at": "2023-12-11T17:37:24.471286Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7df3dd33-dddf-49e6-a9e0-d0bf9aa0d548",
         "status": "triggered", "triggered_at": "2023-12-11T17:46:48.024345Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "b7daf77c-e3e0-4747-a7e2-485a1a6f05e2",
-        "key": "team", "value": "dev"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "b7daf77c-e3e0-4747-a7e2-485a1a6f05e2",
         "key": "team", "value": "dev"}], "token": "[REDACTED]"}, {"id": "4046ccf5-7821-47f4-be7d-8240be69631b",
         "name": "ideal-journey-lena", "description": "", "created_at": "2023-12-11T16:29:20.759489Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4046ccf5-7821-47f4-be7d-8240be69631b",
-        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
-        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d6d5d79d-08fa-4c8a-bd54-c34851866cde",
+        "status": "triggered", "triggered_at": "2026-05-28T07:56:58.047592Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 5, "creator_id": 319222, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d6d5d79d-08fa-4c8a-bd54-c34851866cde",
         "name": "test1112", "description": "test publicly exposed honeytoken", "created_at":
         "2023-12-11T16:24:56.253683Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d6d5d79d-08fa-4c8a-bd54-c34851866cde",
         "status": "triggered", "triggered_at": "2023-12-11T16:26:07.733443Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "ecb3d61d-bdab-4636-a436-bef8079a005d",
         "name": "ggshield-ObfCUUCA", "description": "description", "created_at": "2023-11-28T08:50:32.130230Z",
@@ -1040,15 +1171,13 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ae448808-3865-4797-a008-9eef6344f9da",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ae448808-3865-4797-a008-9eef6344f9da",
         "name": "Bsides Berlin", "description": "test key for a demo", "created_at":
         "2023-11-18T16:19:36.463172Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ae448808-3865-4797-a008-9eef6344f9da",
         "status": "triggered", "triggered_at": "2023-11-18T16:20:14.365596Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 105, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
-        "key": "repo", "value": "mackenziejj"}], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
+        ["publicly_exposed"], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
         "key": "repo", "value": "mackenziejj"}], "token": "[REDACTED]"}, {"id": "c60d6dc1-c35a-4a84-bb3f-684911c7e2f0",
         "name": "DeepSec Demo", "description": "Demo for DeepSec Confrence ", "created_at":
@@ -1056,69 +1185,66 @@ interactions:
         "status": "triggered", "triggered_at": "2023-11-16T16:01:58.603599Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "bd51c3d9-0943-43d5-8f87-359ecee03903", "name": "ggshield-73VAsjsO", "description":
         null, "created_at": "2023-11-14T08:27:44.885242Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bd51c3d9-0943-43d5-8f87-359ecee03903",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-11-14T08:28:08.188201Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8df388e2-aeb5-42ca-b6d5-221a54a40339",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "8df388e2-aeb5-42ca-b6d5-221a54a40339",
         "name": "ggshield-P47kTh7j", "description": null, "created_at": "2023-11-09T15:44:33.671666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8df388e2-aeb5-42ca-b6d5-221a54a40339",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb",
-        "name": "test eric dd 02", "description": "", "created_at": "2023-10-31T14:33:35.801324Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb", "name": "test
+        eric dd 02", "description": "", "created_at": "2023-10-31T14:33:35.801324Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4affa602-902b-47ff-a1f4-721dc3e671bb",
         "status": "triggered", "triggered_at": "2023-10-31T14:35:33.676298Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 2897, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29", "name": "Eric Demo Test 01",
-        "description": "", "created_at": "2023-10-31T12:51:44.535200Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/d69a098c-8b61-4102-bb2b-9a82958a3e29",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29",
+        "name": "Eric Demo Test 01", "description": "", "created_at": "2023-10-31T12:51:44.535200Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d69a098c-8b61-4102-bb2b-9a82958a3e29",
         "status": "revoked", "triggered_at": "2023-10-31T12:52:49.851916Z", "revoked_at":
         "2024-12-10T12:16:28.115539Z", "type": "AWS", "open_events_count": 0, "creator_id":
         136170, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "fe392ff1-b3d7-462f-a26f-d094326f40ed", "name": "Jason
-        and team", "description": "akljdlaj", "created_at": "2023-10-24T14:23:20.991107Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fe392ff1-b3d7-462f-a26f-d094326f40ed",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "fe392ff1-b3d7-462f-a26f-d094326f40ed", "name": "Jason and team", "description":
+        "akljdlaj", "created_at": "2023-10-24T14:23:20.991107Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/fe392ff1-b3d7-462f-a26f-d094326f40ed",
         "status": "triggered", "triggered_at": "2024-05-10T22:15:09.224357Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
         "name": "Jason test", "description": "Token for Test ", "created_at": "2023-10-24T13:45:31.371710Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f8e0968-664a-49f3-af85-9cc468b960ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "48f7c567-93d1-4925-9f77-d3919f120b88",
-        "name": "ggshield-KlAkKRtE", "description": "description", "created_at": "2023-10-16T19:49:08.588391Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "48f7c567-93d1-4925-9f77-d3919f120b88", "name": "ggshield-KlAkKRtE",
+        "description": "description", "created_at": "2023-10-16T19:49:08.588391Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/48f7c567-93d1-4925-9f77-d3919f120b88",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cdaea884-25fb-49db-90ec-a18879be36c4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cdaea884-25fb-49db-90ec-a18879be36c4",
         "name": "Demo Honeytoken", "description": "Leaking on Public Demo", "created_at":
         "2023-10-16T15:13:10.845487Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cdaea884-25fb-49db-90ec-a18879be36c4",
         "status": "revoked", "triggered_at": "2023-10-16T15:14:25.574559Z", "revoked_at":
         "2023-10-27T15:01:19.053629Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "137c9fee-4b3c-4231-92fd-98debf6557c2", "name": "BSides ATL demo for session",
         "description": "This one will be triggered from 2 different spots online",
         "created_at": "2023-10-14T12:28:51.206659Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/137c9fee-4b3c-4231-92fd-98debf6557c2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 354585, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "22fdf53a-e348-464a-a87f-5bcecb1a4e62",
-        "name": "Slack test", "description": "blablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablabla
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "22fdf53a-e348-464a-a87f-5bcecb1a4e62", "name": "Slack
+        test", "description": "blablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablabla
         blablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablabla
         blablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablabla
         blablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablablabla
@@ -1128,14 +1254,13 @@ interactions:
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-06-03T09:50:06.667490Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 363707, "revoker_id":
         353920, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "576dc1ce-ab72-4604-934f-526cff5a667e",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "576dc1ce-ab72-4604-934f-526cff5a667e",
         "name": "BsidesCyprus", "description": "Live demo ", "created_at": "2023-10-07T11:34:54.740226Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/576dc1ce-ab72-4604-934f-526cff5a667e",
         "status": "triggered", "triggered_at": "2023-10-07T11:35:53.017981Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 249, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "7d80793b-c702-441e-837e-b1d3da94d576", "name": "Hacktivity Key", "description":
         "Test Key Leak for Hacktivity", "created_at": "2023-10-05T14:41:56.632793Z",
@@ -1143,9 +1268,7 @@ interactions:
         "status": "revoked", "triggered_at": "2023-10-05T14:42:57.752365Z", "revoked_at":
         "2024-12-10T12:17:33.875750Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "2544b3e6-57b2-48e2-a1a5-c4b6551987bb", "name": "SBB demo", "description":
@@ -1154,11 +1277,8 @@ interactions:
         "status": "triggered", "triggered_at": "2024-08-17T15:36:55.810693Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key": "commiter",
-        "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca", "key":
-        "file", "value": ".env"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327", "key":
-        "vcs", "value": "github"}], "custom_tags": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda",
-        "key": "commiter", "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
+        [], "custom_tags": [{"id": "9df8c1c9-7367-4c77-a0f0-9f2d4b22bdda", "key":
+        "commiter", "value": "leaky mcgee"}, {"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "7ca5ca92-a0a1-48bf-9618-d7194beaa039",
         "name": "Demo GrrCon", "description": "Leaking a secret at GrrCon on GitHub.com",
@@ -1166,9 +1286,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-09-29T16:11:40.077048Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 344, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
-        "key": "confrence", "value": "grrcon"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}], "custom_tags": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
+        ["publicly_exposed"], "custom_tags": [{"id": "1aa3ae34-f9f0-42e1-a687-9fed877a9037",
         "key": "confrence", "value": "grrcon"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}], "token": "[REDACTED]"}, {"id": "3664c283-d479-41ac-9ad9-30283731ee25",
         "name": "Balccon Demo", "description": "Demo key for Balccon ", "created_at":
@@ -1176,10 +1294,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-09-08T14:56:49.516889Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
-        "key": "location", "value": "sourcecode"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
-        "key": "visability", "value": "public"}], "custom_tags": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
+        ["publicly_exposed"], "custom_tags": [{"id": "b8419819-fb1e-4a9f-b592-5e0395ca802d",
         "key": "location", "value": "sourcecode"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
         "key": "visability", "value": "public"}], "token": "[REDACTED]"}, {"id": "095d655f-a273-400f-ba01-eff8951242ed",
@@ -1188,67 +1303,59 @@ interactions:
         "status": "triggered", "triggered_at": "2023-09-08T16:58:49.455578Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 6, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "89a1745a-f796-4ece-99f7-106671aea57c",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "89a1745a-f796-4ece-99f7-106671aea57c",
         "name": "-demo-honeytoken-ctf-micro-api-", "description": "", "created_at":
         "2023-09-06T14:19:32.695323Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/89a1745a-f796-4ece-99f7-106671aea57c",
         "status": "triggered", "triggered_at": "2023-09-06T14:24:18.462424Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "b01db549-a2fa-4527-913d-0715a1119530",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "b01db549-a2fa-4527-913d-0715a1119530",
         "name": "demo-honeytoken-ctf-internal-share-", "description": "", "created_at":
         "2023-09-06T11:33:48.881275Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b01db549-a2fa-4527-913d-0715a1119530",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-09-06T14:21:42.509905Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a58154f6-e66f-4079-82b7-aabec70c73ff",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "a58154f6-e66f-4079-82b7-aabec70c73ff",
         "name": "demo-honeytoken-ctf-micro-api", "description": "", "created_at":
         "2023-09-06T11:33:37.828240Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a58154f6-e66f-4079-82b7-aabec70c73ff",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-09-06T14:17:20.708816Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ff623703-9ca1-4fba-99dc-c20110894ed3",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "ff623703-9ca1-4fba-99dc-c20110894ed3",
         "name": "-demo-honeytoken-ctf-django-app-", "description": "", "created_at":
         "2023-09-06T11:33:27.376222Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff623703-9ca1-4fba-99dc-c20110894ed3",
         "status": "triggered", "triggered_at": "2023-09-06T14:19:10.580142Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 4, "creator_id": null, "revoker_id":
+        null, "type": "AWS", "open_events_count": 9, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key": "event",
-        "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "f246c64a-3494-43ae-9d81-500df2f950c3",
+        [], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11", "key":
+        "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "f246c64a-3494-43ae-9d81-500df2f950c3",
         "name": "demo-honeytoken-ctf-personal-", "description": "", "created_at":
         "2023-09-06T11:29:57.547211Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f246c64a-3494-43ae-9d81-500df2f950c3",
         "status": "revoked", "triggered_at": "2023-09-06T12:18:14.949044Z", "revoked_at":
         "2024-12-10T12:15:49.265110Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
-        "key": "event", "value": "cab"}], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "58717e34-f865-4d0b-bde9-677e027dbf11",
         "key": "event", "value": "cab"}], "token": "[REDACTED]"}, {"id": "5564ed3c-3eec-4375-9fc8-e0ada71dce02",
         "name": "ctf-demo-test-honeytoken-micro-api", "description": "", "created_at":
         "2023-09-05T19:18:08.504776Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5564ed3c-3eec-4375-9fc8-e0ada71dce02",
         "status": "revoked", "triggered_at": "2023-09-06T07:44:18.074891Z", "revoked_at":
         "2023-09-06T10:03:48.581110Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "de145bd4-b424-49ab-b95b-80126914bf2e", "name": "ctf-demo-test-honeytoken-django-app",
-        "description": "", "created_at": "2023-09-05T19:13:53.491842Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/de145bd4-b424-49ab-b95b-80126914bf2e",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "de145bd4-b424-49ab-b95b-80126914bf2e",
+        "name": "ctf-demo-test-honeytoken-django-app", "description": "", "created_at":
+        "2023-09-05T19:13:53.491842Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/de145bd4-b424-49ab-b95b-80126914bf2e",
         "status": "revoked", "triggered_at": "2023-09-06T07:42:55.177580Z", "revoked_at":
         "2023-09-06T10:03:30.948628Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "edd96a3b-5c71-4346-b5e2-2150e454dc91", "name": "Bsides Krakow", "description":
-        "Demo for leaking a key on GitHub", "created_at": "2023-09-02T13:20:53.501588Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/edd96a3b-5c71-4346-b5e2-2150e454dc91",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "edd96a3b-5c71-4346-b5e2-2150e454dc91",
+        "name": "Bsides Krakow", "description": "Demo for leaking a key on GitHub",
+        "created_at": "2023-09-02T13:20:53.501588Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/edd96a3b-5c71-4346-b5e2-2150e454dc91",
         "status": "triggered", "triggered_at": "2023-09-02T13:22:51.142717Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "46776cb3-6b11-41fc-b431-07609992f0cb",
         "name": "HoneyTokenaLARTest", "description": "Testworkshop", "created_at":
@@ -1256,33 +1363,31 @@ interactions:
         "status": "revoked", "triggered_at": "2023-08-29T12:09:16.581232Z", "revoked_at":
         "2023-08-29T12:42:37.841866Z", "type": "AWS", "open_events_count": 0, "creator_id":
         37699, "revoker_id": 37699, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51", "name": "testket ", "description":
-        "eew", "created_at": "2023-08-29T10:21:29.956291Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
+        "name": "testket ", "description": "eew", "created_at": "2023-08-29T10:21:29.956291Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
-        "name": "ggshield-mzO8qHEz", "description": "description", "created_at": "2023-08-22T08:19:03.821471Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "dc69f522-32ec-4f5f-b6be-516fb00a2bcd", "name": "ggshield-mzO8qHEz",
+        "description": "description", "created_at": "2023-08-22T08:19:03.821471Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "90d4c2b6-ecae-4ef9-a754-4561929b9e38",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "90d4c2b6-ecae-4ef9-a754-4561929b9e38",
         "name": "ggshield-mpkTH5jF", "description": "description", "created_at": "2023-08-16T08:28:18.684517Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/90d4c2b6-ecae-4ef9-a754-4561929b9e38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f418401f-9c6e-4490-893c-b640283c93c3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f418401f-9c6e-4490-893c-b640283c93c3",
         "name": "defcon-appsecvillage", "description": "publically leaked keys", "created_at":
         "2023-08-11T18:53:51.136748Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f418401f-9c6e-4490-893c-b640283c93c3",
         "status": "triggered", "triggered_at": "2023-08-11T18:55:35.503991Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 61, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
+        ["publicly_exposed"], "custom_tags": [{"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "978bf5aa-1f8e-425b-ac4b-b617ddbc178e",
         "name": "BSidesLV", "description": "Key leaked publically by leakymcgee again",
@@ -1290,11 +1395,7 @@ interactions:
         "status": "triggered", "triggered_at": "2023-08-10T00:13:19.948280Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
-        "key": "date leaked", "value": "08/09/2023"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
-        "key": "format", "value": "public"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
+        ["publicly_exposed"], "custom_tags": [{"id": "3fd32605-4aec-4285-9fcd-3f63ac764924",
         "key": "date leaked", "value": "08/09/2023"}, {"id": "9b2b852e-b0c2-4674-9b34-a35a8d26902f",
         "key": "format", "value": "public"}, {"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
@@ -1303,117 +1404,112 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86670f84-e117-4f96-aa16-e399a0bb2cf2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
-        "name": "vBOY test segment 2", "description": "sdqsdqsd", "created_at": "2023-08-07T12:47:49.515448Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7", "name": "vBOY
+        test segment 2", "description": "sdqsdqsd", "created_at": "2023-08-07T12:47:49.515448Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40",
-        "name": "vBOY test segment", "description": "sdqsdqsdqsdqsd", "created_at":
-        "2023-08-07T12:45:52.890085Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40", "name": "vBOY
+        test segment", "description": "sdqsdqsdqsdqsd", "created_at": "2023-08-07T12:45:52.890085Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-08-07T12:46:45.470113Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a11570c6-f472-4fda-a493-30d65fd8e651",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "a11570c6-f472-4fda-a493-30d65fd8e651",
         "name": "test Antonin 2", "description": "", "created_at": "2023-08-03T14:09:46.046004Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a",
-        "name": "test Antonin 1", "description": "", "created_at": "2023-08-03T08:42:25.251504Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a", "name": "test
+        Antonin 1", "description": "", "created_at": "2023-08-03T08:42:25.251504Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fa63d76d-4297-4d41-8e77-b47d1a97a41a",
         "status": "revoked", "triggered_at": "2023-08-03T08:59:58.717709Z", "revoked_at":
         "2023-08-03T09:00:05.809852Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "5d3ad22c-e422-48d2-b7f5-6d52801599aa", "name": "demo 31jul", "description":
-        "", "created_at": "2023-07-31T15:27:18.323098Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d3ad22c-e422-48d2-b7f5-6d52801599aa",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5d3ad22c-e422-48d2-b7f5-6d52801599aa",
+        "name": "demo 31jul", "description": "", "created_at": "2023-07-31T15:27:18.323098Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d3ad22c-e422-48d2-b7f5-6d52801599aa",
         "status": "revoked", "triggered_at": "2023-07-31T15:33:49.570793Z", "revoked_at":
         "2023-12-11T14:01:40.706751Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "5670c657-618f-41d7-984b-d59656d905e4", "name": "ggshield-3KTmbo8u",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "5670c657-618f-41d7-984b-d59656d905e4", "name": "ggshield-3KTmbo8u",
         "description": null, "created_at": "2023-07-27T15:44:43.238742Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/5670c657-618f-41d7-984b-d59656d905e4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "27e9ba01-4bb6-46ed-84c8-ff14366a3bde",
-        "name": "Private network", "description": "Inside private network ", "created_at":
-        "2023-07-27T15:39:32.979325Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/27e9ba01-4bb6-46ed-84c8-ff14366a3bde",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "27e9ba01-4bb6-46ed-84c8-ff14366a3bde", "name": "Private
+        network", "description": "Inside private network ", "created_at": "2023-07-27T15:39:32.979325Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/27e9ba01-4bb6-46ed-84c8-ff14366a3bde",
         "status": "triggered", "triggered_at": "2023-07-27T16:23:35.804271Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0d81797a-6fc0-4a6e-a211-af16828c0c39",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0d81797a-6fc0-4a6e-a211-af16828c0c39",
         "name": "Webinar Public ", "description": "from webinar ", "created_at": "2023-07-27T15:33:07.472730Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0d81797a-6fc0-4a6e-a211-af16828c0c39",
         "status": "triggered", "triggered_at": "2023-07-27T15:34:48.902462Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 204, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
+        ["publicly_exposed"], "custom_tags": [{"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "521efd01-bbcc-4380-b548-ed7242c017ea", "name": "ggshield-HLZpiznn", "description":
         null, "created_at": "2023-07-27T14:54:03.198466Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/521efd01-bbcc-4380-b548-ed7242c017ea",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
-        "name": "ggshield-5voYnhhy", "description": null, "created_at": "2023-07-27T13:50:51.332176Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0659fa04-b5f8-4f5b-a0d1-66cb53fc9709", "name": "ggshield-5voYnhhy",
+        "description": null, "created_at": "2023-07-27T13:50:51.332176Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/0659fa04-b5f8-4f5b-a0d1-66cb53fc9709",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T13:52:58.300149Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-27T09:01:37.417151Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e842a635-eb7e-4617-8984-ac57fe909ef7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T09:01:36.764795Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51f41814-f029-4ab4-b863-c0fecba025b3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51f41814-f029-4ab4-b863-c0fecba025b3",
         "name": "ggshield-v3LhZCz8", "description": "description", "created_at": "2023-07-27T09:01:36.117217Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/51f41814-f029-4ab4-b863-c0fecba025b3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a20a718-7b9e-4582-abdf-772053bffd72",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a20a718-7b9e-4582-abdf-772053bffd72",
         "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T08:56:56.138738Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a20a718-7b9e-4582-abdf-772053bffd72",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:58.657957Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "812090ee-17e2-4df4-a6d6-0da0e4d64cd3", "name": "ggshield-w1P1Ggsz",
-        "description": "description", "created_at": "2023-07-27T08:56:55.435203Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
+        "name": "ggshield-w1P1Ggsz", "description": "description", "created_at": "2023-07-27T08:56:55.435203Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0c3f182e-98f5-4a64-aadb-664fd7c9de88",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0c3f182e-98f5-4a64-aadb-664fd7c9de88",
         "name": "ggshield-ewIAL7lq", "description": "description", "created_at": "2023-07-27T08:54:41.926242Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0c3f182e-98f5-4a64-aadb-664fd7c9de88",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
         "name": "Example TOken ", "description": "ubvcub", "created_at": "2023-07-12T13:16:10.775681Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
-        "key": "file", "value": ".env"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "c8c94ffa-c0af-48c6-976a-6502a41811af", "name": "honeytoken demo eric", "description":
@@ -1422,205 +1518,190 @@ interactions:
         "status": "triggered", "triggered_at": "2023-07-05T14:49:33.528178Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "14566c1f-0b52-4770-ab68-000704242633",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "14566c1f-0b52-4770-ab68-000704242633",
         "name": "ggshield-Rv2mUej7", "description": "description", "created_at": "2023-07-05T08:55:23.864812Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/14566c1f-0b52-4770-ab68-000704242633",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-05T08:27:15.756813Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0e4f0dbd-b288-4990-9565-3cc7b0171a79",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:53.240550Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 160089, "revoker_id":
         296618, "creator_api_token_id": "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb", "name": "ggshield-0etjSvZJ",
-        "description": "description", "created_at": "2023-07-05T08:27:14.048162Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb",
+        "name": "ggshield-0etjSvZJ", "description": "description", "created_at": "2023-07-05T08:27:14.048162Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc7214d0-c97a-44b3-b576-664f0a81c4f7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc7214d0-c97a-44b3-b576-664f0a81c4f7",
         "name": "repo analytics 19jun", "description": "", "created_at": "2023-06-19T09:11:21.788070Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc7214d0-c97a-44b3-b576-664f0a81c4f7",
         "status": "revoked", "triggered_at": "2023-06-20T17:24:35.145047Z", "revoked_at":
         "2023-12-11T14:50:27.627289Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "27379093-c6a4-4732-a64a-715c94e74fd7", "name": "ggshield-TvFzKVed",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "27379093-c6a4-4732-a64a-715c94e74fd7", "name": "ggshield-TvFzKVed",
         "description": null, "created_at": "2023-06-09T08:01:57.360210Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/27379093-c6a4-4732-a64a-715c94e74fd7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "62cb7048-4302-4b52-9163-e2ceff775b39", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
         "name": "ggshield-TtJwtxNE", "description": "ggshield test", "created_at":
         "2023-06-02T08:48:20.148216Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05",
-        "name": "ggshield-cptptJHt", "description": "ggshield test", "created_at":
-        "2023-06-02T08:47:41.149126Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05", "name": "ggshield-cptptJHt",
+        "description": "ggshield test", "created_at": "2023-06-02T08:47:41.149126Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "001c53df-b63c-4b81-a4fb-35e5b38bf328",
-        "name": "DevOxx Poland", "description": "", "created_at": "2023-05-31T12:28:39.713989Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/001c53df-b63c-4b81-a4fb-35e5b38bf328",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "001c53df-b63c-4b81-a4fb-35e5b38bf328", "name": "DevOxx
+        Poland", "description": "", "created_at": "2023-05-31T12:28:39.713989Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/001c53df-b63c-4b81-a4fb-35e5b38bf328",
         "status": "triggered", "triggered_at": "2023-05-31T14:09:21.767459Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 225, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "63728091-d083-47cc-9898-73c2636f2c7f", "name": "ggshield-ZIU1V3Bv",
-        "description": null, "created_at": "2023-05-31T08:17:12.607879Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/63728091-d083-47cc-9898-73c2636f2c7f",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "63728091-d083-47cc-9898-73c2636f2c7f",
+        "name": "ggshield-ZIU1V3Bv", "description": null, "created_at": "2023-05-31T08:17:12.607879Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/63728091-d083-47cc-9898-73c2636f2c7f",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-31T08:17:38.021142Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "41d76272-ee3d-4639-93e8-29222b662b93", "name": "demo31may-public",
-        "description": "", "created_at": "2023-05-31T08:13:48.373887Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/41d76272-ee3d-4639-93e8-29222b662b93",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "41d76272-ee3d-4639-93e8-29222b662b93",
+        "name": "demo31may-public", "description": "", "created_at": "2023-05-31T08:13:48.373887Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/41d76272-ee3d-4639-93e8-29222b662b93",
         "status": "revoked", "triggered_at": "2023-05-31T08:15:09.926931Z", "revoked_at":
         "2024-12-10T12:16:03.693045Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "f17302cd-850b-4b54-9054-60d26a76cf38", "name": "test demo 31may", "description":
         "", "created_at": "2023-05-31T08:10:36.754144Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
         "name": "ggshield-agateau", "description": null, "created_at": "2023-05-30T13:32:31.845201Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/13f6dbf3-ae1a-4757-95f6-e0fbc830fc55",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T13:33:03.363563Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 160089, "revoker_id":
         160089, "creator_api_token_id": "425e1a78-209e-4cd5-b08f-8450a0026ac0", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b", "name": "test_honey_token_previous",
-        "description": "description", "created_at": "2023-05-30T10:46:11.714531Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
+        "name": "test_honey_token_previous", "description": "description", "created_at":
+        "2023-05-30T10:46:11.714531Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:07.762156Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "092dba62-9d82-41bd-84aa-95430d540edc", "name": "ggshield-224Lwv95",
-        "description": "description", "created_at": "2023-05-30T10:46:10.997022Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "092dba62-9d82-41bd-84aa-95430d540edc",
+        "name": "ggshield-224Lwv95", "description": "description", "created_at": "2023-05-30T10:46:10.997022Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/092dba62-9d82-41bd-84aa-95430d540edc",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7494298b-75c5-44e4-898c-77b3b9017113",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7494298b-75c5-44e4-898c-77b3b9017113",
         "name": "test_honey_token_abc", "description": "description", "created_at":
         "2023-05-30T10:42:37.520767Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7494298b-75c5-44e4-898c-77b3b9017113",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:45:41.905071Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "6e7f275d-e115-44d3-8854-5c6472494951", "name": "ggshield-UXgNYVXL",
-        "description": "description", "created_at": "2023-05-30T10:42:36.847031Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e7f275d-e115-44d3-8854-5c6472494951",
+        "name": "ggshield-UXgNYVXL", "description": "description", "created_at": "2023-05-30T10:42:36.847031Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6e7f275d-e115-44d3-8854-5c6472494951",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
         "name": "ggshield-BA0VsBh3", "description": "description", "created_at": "2023-05-30T10:39:09.968782Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f60db759-7041-4dfe-80fa-91012d97fdd3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f60db759-7041-4dfe-80fa-91012d97fdd3",
         "name": "ggshield-tsCPoUcx", "description": "description", "created_at": "2023-05-30T10:37:14.527124Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f60db759-7041-4dfe-80fa-91012d97fdd3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1266b395-a545-42c1-b700-24dbae36447c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "1266b395-a545-42c1-b700-24dbae36447c",
         "name": "test_honey_token_previous", "description": "description", "created_at":
         "2023-05-30T10:30:40.547255Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1266b395-a545-42c1-b700-24dbae36447c",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:41:43.173510Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "bb494eed-6ba4-4b98-b949-ad5f54d929dd",
         "name": "ggshield-uORy0any", "description": "description", "created_at": "2023-05-30T10:30:39.803353Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bb494eed-6ba4-4b98-b949-ad5f54d929dd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
         "name": "Pycon Italia", "description": "", "created_at": "2023-05-28T09:34:01.581495Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b6f2b765-a8e5-458f-b68a-4b5ef934bcc8",
         "status": "revoked", "triggered_at": "2023-05-28T09:45:30.255118Z", "revoked_at":
         "2024-12-10T12:17:08.199275Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263", "name": "NDC-OSLO
-        Demo", "description": "Demo key for NDC Oslo confrence", "created_at": "2023-05-25T07:59:05.651290Z",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263", "name": "NDC-OSLO Demo", "description":
+        "Demo key for NDC Oslo confrence", "created_at": "2023-05-25T07:59:05.651290Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7b1cb8c6-2ff2-4ba8-adc2-9d4a61d3b263",
         "status": "triggered", "triggered_at": "2023-05-25T08:38:27.471330Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 221, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "79db31fc-ffd1-4bc9-b6e4-3ef37a94712a", "name": "QubitConfrence", "description":
-        "", "created_at": "2023-05-18T07:58:37.174577Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/79db31fc-ffd1-4bc9-b6e4-3ef37a94712a",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "79db31fc-ffd1-4bc9-b6e4-3ef37a94712a",
+        "name": "QubitConfrence", "description": "", "created_at": "2023-05-18T07:58:37.174577Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/79db31fc-ffd1-4bc9-b6e4-3ef37a94712a",
         "status": "triggered", "triggered_at": "2023-05-18T09:30:01.025933Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 215, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "db7bf6ea-57cb-4d13-8ed9-dc59b2620e00", "name": "Honeytoken demo 17
-        may", "description": "This is a token for the live demo", "created_at": "2023-05-17T17:15:04.921233Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/db7bf6ea-57cb-4d13-8ed9-dc59b2620e00",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "db7bf6ea-57cb-4d13-8ed9-dc59b2620e00",
+        "name": "Honeytoken demo 17 may", "description": "This is a token for the
+        live demo", "created_at": "2023-05-17T17:15:04.921233Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/db7bf6ea-57cb-4d13-8ed9-dc59b2620e00",
         "status": "triggered", "triggered_at": "2023-05-17T17:16:48.960267Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 5018, "creator_id": 166199, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "ef11a80c-6d8e-4fb5-8ee2-4556bae695c3", "name": "test ht public", "description":
         "", "created_at": "2023-05-17T17:00:24.966335Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef11a80c-6d8e-4fb5-8ee2-4556bae695c3",
         "status": "triggered", "triggered_at": "2023-05-17T17:02:33.386529Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 5012, "creator_id": 166199, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
-        "key": "location", "value": "slack"}], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
+        ["publicly_exposed"], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
         "key": "location", "value": "slack"}], "token": "[REDACTED]"}, {"id": "84d43c23-6d4d-47f8-bf62-e7c1b0ae1625",
         "name": "analytic-repo", "description": "", "created_at": "2023-05-16T16:17:11.435058Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84d43c23-6d4d-47f8-bf62-e7c1b0ae1625",
         "status": "revoked", "triggered_at": "2023-05-16T16:27:55.091410Z", "revoked_at":
         "2023-12-11T14:01:44.427581Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "72fcdb5c-e128-4ca5-8970-f1f52f95a78a",
         "name": "slack-chan-website", "description": "", "created_at": "2023-05-16T15:35:26.129025Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72fcdb5c-e128-4ca5-8970-f1f52f95a78a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
-        "key": "place", "value": "website"}], "custom_tags": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
         "key": "place", "value": "website"}], "token": "[REDACTED]"}, {"id": "63bbd74e-bb5f-4910-8e63-eed358af3bc8",
         "name": "improved-carnival repo", "description": "", "created_at": "2023-05-16T14:45:09.811724Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/63bbd74e-bb5f-4910-8e63-eed358af3bc8",
         "status": "revoked", "triggered_at": "2023-05-16T14:49:44.284195Z", "revoked_at":
         "2024-06-19T10:46:44.282148Z", "type": "AWS", "open_events_count": 0, "creator_id":
         319222, "revoker_id": 319222, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
         "name": "jira-OPS-124", "description": "honeytoken deployed in jira ticket
         OPS-124", "created_at": "2023-05-16T11:58:57.713307Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "45182b59-b659-41ef-9bb8-44a78740fade",
         "name": "solid-octo-repo", "description": "Placed in solid-octo repo, file
         ... on 16May2023", "created_at": "2023-05-16T11:51:06.384073Z", "gitguardian_url":
@@ -1628,74 +1709,77 @@ interactions:
         "status": "triggered", "triggered_at": "2026-02-18T14:51:12.499369Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 1, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432", "key": "place",
-        "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "8bf5f99a-538d-4cfe-8e74-61cd7081ae25",
+        [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432", "key":
+        "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "8bf5f99a-538d-4cfe-8e74-61cd7081ae25",
         "name": "PasswordsCon2", "description": "For presentation", "created_at":
         "2023-05-16T11:30:36.210395Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8bf5f99a-538d-4cfe-8e74-61cd7081ae25",
         "status": "triggered", "triggered_at": "2023-05-16T12:29:45.638074Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 344, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
-        "key": "location", "value": "publicrepo"}], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
+        ["publicly_exposed"], "custom_tags": [{"id": "7e61fc25-e730-4124-aa9c-79d9fad76092",
         "key": "location", "value": "publicrepo"}], "token": "[REDACTED]"}, {"id":
         "72a52279-8e9f-40de-a1d4-bc5fcc48795d", "name": "passwordscon", "description":
         "", "created_at": "2023-05-16T10:03:49.677782Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72a52279-8e9f-40de-a1d4-bc5fcc48795d",
         "status": "triggered", "triggered_at": "2023-05-16T10:04:10.262805Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 222, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
-        "key": "location", "value": "test"}], "custom_tags": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
+        ["publicly_exposed"], "custom_tags": [{"id": "10c41365-e0c1-4038-b09e-c746de4169db",
         "key": "location", "value": "test"}], "token": "[REDACTED]"}, {"id": "858a3a76-f6f2-4c2e-b0bc-323d9a575413",
         "name": "test_honey_token", "description": "description", "created_at": "2023-05-15T14:09:09.210845Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/858a3a76-f6f2-4c2e-b0bc-323d9a575413",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:17.165934Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}, {"id": "411d33c0-7fad-4fc1-b94e-bb440c8f9c49",
-        "name": "ggshield-wv7vMain", "description": "description", "created_at": "2023-05-15T14:09:08.478482Z",
+        "token": "[REDACTED]"}, {"id": "411d33c0-7fad-4fc1-b94e-bb440c8f9c49", "name":
+        "ggshield-wv7vMain", "description": "description", "created_at": "2023-05-15T14:09:08.478482Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/411d33c0-7fad-4fc1-b94e-bb440c8f9c49",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:11.250010Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}]'
+        "token": "[REDACTED]"}]'
     headers:
+      CF-RAY:
+      - a103978b4922d11d-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:50 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, POST, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '139756'
+      - '145842'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:45 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '762'
+      - '1084'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_honeytokens_with_search.yaml
+++ b/tests/cassettes/tools/vcr/test_list_honeytokens_with_search.yaml
@@ -25,144 +25,131 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/858a3a76-f6f2-4c2e-b0bc-323d9a575413",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-16T09:34:17.165934Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
         [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place", "value": "ggshield"}],
-        "custom_tags": [{"id": "e29e158e-ef22-4055-9694-9711eea8ec48", "key": "place",
-        "value": "ggshield"}], "token": "[REDACTED]"}, {"id": "ef11a80c-6d8e-4fb5-8ee2-4556bae695c3",
-        "name": "test ht public", "description": "", "created_at": "2023-05-17T17:00:24.966335Z",
+        "token": "[REDACTED]"}, {"id": "ef11a80c-6d8e-4fb5-8ee2-4556bae695c3", "name":
+        "test ht public", "description": "", "created_at": "2023-05-17T17:00:24.966335Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef11a80c-6d8e-4fb5-8ee2-4556bae695c3",
         "status": "triggered", "triggered_at": "2023-05-17T17:02:33.386529Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 5012, "creator_id": 166199, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
-        "key": "location", "value": "slack"}], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
+        ["publicly_exposed"], "custom_tags": [{"id": "027d3742-6fad-4c75-9319-be7ffa5fbd1d",
         "key": "location", "value": "slack"}], "token": "[REDACTED]"}, {"id": "1266b395-a545-42c1-b700-24dbae36447c",
         "name": "test_honey_token_previous", "description": "description", "created_at":
         "2023-05-30T10:30:40.547255Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1266b395-a545-42c1-b700-24dbae36447c",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:41:43.173510Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "7494298b-75c5-44e4-898c-77b3b9017113",
         "name": "test_honey_token_abc", "description": "description", "created_at":
         "2023-05-30T10:42:37.520767Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7494298b-75c5-44e4-898c-77b3b9017113",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-05-30T10:45:41.905071Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b", "name": "test_honey_token_previous",
-        "description": "description", "created_at": "2023-05-30T10:46:11.714531Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
+        "name": "test_honey_token_previous", "description": "description", "created_at":
+        "2023-05-30T10:46:11.714531Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3bf3bcb3-ab5b-42a3-b8f0-ac7b29e6933b",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:07.762156Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "f17302cd-850b-4b54-9054-60d26a76cf38", "name": "test demo 31may",
-        "description": "", "created_at": "2023-05-31T08:10:36.754144Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f17302cd-850b-4b54-9054-60d26a76cf38",
+        "name": "test demo 31may", "description": "", "created_at": "2023-05-31T08:10:36.754144Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05",
         "name": "ggshield-cptptJHt", "description": "ggshield test", "created_at":
         "2023-06-02T08:47:41.149126Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
-        "name": "ggshield-TtJwtxNE", "description": "ggshield test", "created_at":
-        "2023-06-02T08:48:20.148216Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72", "name": "ggshield-TtJwtxNE",
+        "description": "ggshield test", "created_at": "2023-06-02T08:48:20.148216Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79",
-        "name": "test_honey_token_error_403", "description": "description", "created_at":
-        "2023-07-05T08:27:15.756813Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0e4f0dbd-b288-4990-9565-3cc7b0171a79",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0e4f0dbd-b288-4990-9565-3cc7b0171a79", "name": "test_honey_token_error_403",
+        "description": "description", "created_at": "2023-07-05T08:27:15.756813Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0e4f0dbd-b288-4990-9565-3cc7b0171a79",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:53.240550Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 160089, "revoker_id":
         296618, "creator_api_token_id": "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "2a20a718-7b9e-4582-abdf-772053bffd72", "name": "test_honey_token",
-        "description": "description", "created_at": "2023-07-27T08:56:56.138738Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a20a718-7b9e-4582-abdf-772053bffd72",
+        "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T08:56:56.138738Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a20a718-7b9e-4582-abdf-772053bffd72",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-07-27T09:00:58.657957Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 296618, "revoker_id":
         296618, "creator_api_token_id": "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba", "name": "test_honey_token",
-        "description": "description", "created_at": "2023-07-27T09:01:36.764795Z",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
+        "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T09:01:36.764795Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-27T09:01:37.417151Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e842a635-eb7e-4617-8984-ac57fe909ef7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "fa63d76d-4297-4d41-8e77-b47d1a97a41a",
         "name": "test Antonin 1", "description": "", "created_at": "2023-08-03T08:42:25.251504Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fa63d76d-4297-4d41-8e77-b47d1a97a41a",
         "status": "revoked", "triggered_at": "2023-08-03T08:59:58.717709Z", "revoked_at":
         "2023-08-03T09:00:05.809852Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "a11570c6-f472-4fda-a493-30d65fd8e651", "name": "test Antonin 2", "description":
-        "", "created_at": "2023-08-03T14:09:46.046004Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a11570c6-f472-4fda-a493-30d65fd8e651",
+        "name": "test Antonin 2", "description": "", "created_at": "2023-08-03T14:09:46.046004Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40",
-        "name": "vBOY test segment", "description": "sdqsdqsdqsdqsd", "created_at":
-        "2023-08-07T12:45:52.890085Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "b7fcef49-f696-4954-bca7-f9949de2ab40", "name": "vBOY
+        test segment", "description": "sdqsdqsdqsdqsd", "created_at": "2023-08-07T12:45:52.890085Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b7fcef49-f696-4954-bca7-f9949de2ab40",
         "status": "revoked", "triggered_at": null, "revoked_at": "2023-08-07T12:46:45.470113Z",
         "type": "AWS", "open_events_count": 0, "creator_id": null, "revoker_id": null,
-        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "labels":
-        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
+        "creator_api_token_id": null, "revoker_api_token_id": null, "tags": [], "custom_tags":
+        [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "name": "vBOY test segment 2", "description": "sdqsdqsd", "created_at": "2023-08-07T12:47:49.515448Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
-        "name": "testket ", "description": "eew", "created_at": "2023-08-29T10:21:29.956291Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51", "name": "testket
+        ", "description": "eew", "created_at": "2023-08-29T10:21:29.956291Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "46776cb3-6b11-41fc-b431-07609992f0cb",
-        "name": "HoneyTokenaLARTest", "description": "Testworkshop", "created_at":
-        "2023-08-29T12:07:20.692993Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/46776cb3-6b11-41fc-b431-07609992f0cb",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "46776cb3-6b11-41fc-b431-07609992f0cb", "name": "HoneyTokenaLARTest",
+        "description": "Testworkshop", "created_at": "2023-08-29T12:07:20.692993Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/46776cb3-6b11-41fc-b431-07609992f0cb",
         "status": "revoked", "triggered_at": "2023-08-29T12:09:16.581232Z", "revoked_at":
         "2023-08-29T12:42:37.841866Z", "type": "AWS", "open_events_count": 0, "creator_id":
         37699, "revoker_id": 37699, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "de145bd4-b424-49ab-b95b-80126914bf2e", "name": "ctf-demo-test-honeytoken-django-app",
-        "description": "", "created_at": "2023-09-05T19:13:53.491842Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/de145bd4-b424-49ab-b95b-80126914bf2e",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "de145bd4-b424-49ab-b95b-80126914bf2e",
+        "name": "ctf-demo-test-honeytoken-django-app", "description": "", "created_at":
+        "2023-09-05T19:13:53.491842Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/de145bd4-b424-49ab-b95b-80126914bf2e",
         "status": "revoked", "triggered_at": "2023-09-06T07:42:55.177580Z", "revoked_at":
         "2023-09-06T10:03:30.948628Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "5564ed3c-3eec-4375-9fc8-e0ada71dce02", "name": "ctf-demo-test-honeytoken-micro-api",
-        "description": "", "created_at": "2023-09-05T19:18:08.504776Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/5564ed3c-3eec-4375-9fc8-e0ada71dce02",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5564ed3c-3eec-4375-9fc8-e0ada71dce02",
+        "name": "ctf-demo-test-honeytoken-micro-api", "description": "", "created_at":
+        "2023-09-05T19:18:08.504776Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5564ed3c-3eec-4375-9fc8-e0ada71dce02",
         "status": "revoked", "triggered_at": "2023-09-06T07:44:18.074891Z", "revoked_at":
         "2023-09-06T10:03:48.581110Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": null, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "7d80793b-c702-441e-837e-b1d3da94d576", "name": "Hacktivity Key", "description":
-        "Test Key Leak for Hacktivity", "created_at": "2023-10-05T14:41:56.632793Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7d80793b-c702-441e-837e-b1d3da94d576",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7d80793b-c702-441e-837e-b1d3da94d576",
+        "name": "Hacktivity Key", "description": "Test Key Leak for Hacktivity", "created_at":
+        "2023-10-05T14:41:56.632793Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7d80793b-c702-441e-837e-b1d3da94d576",
         "status": "revoked", "triggered_at": "2023-10-05T14:42:57.752365Z", "revoked_at":
         "2024-12-10T12:17:33.875750Z", "type": "AWS", "open_events_count": 0, "creator_id":
         null, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
-        "key": "github", "value": "public repo"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}, {"id": "eb81c8ab-124d-41d9-b476-c6387b330201",
         "key": "github", "value": "public repo"}], "token": "[REDACTED]"}, {"id":
         "22fdf53a-e348-464a-a87f-5bcecb1a4e62", "name": "Slack test", "description":
@@ -176,35 +163,32 @@ interactions:
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-06-03T09:50:06.667490Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 363707, "revoker_id":
         353920, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
         "name": "Jason test", "description": "Token for Test ", "created_at": "2023-10-24T13:45:31.371710Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f8e0968-664a-49f3-af85-9cc468b960ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29",
-        "name": "Eric Demo Test 01", "description": "", "created_at": "2023-10-31T12:51:44.535200Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d69a098c-8b61-4102-bb2b-9a82958a3e29", "name": "Eric
+        Demo Test 01", "description": "", "created_at": "2023-10-31T12:51:44.535200Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d69a098c-8b61-4102-bb2b-9a82958a3e29",
         "status": "revoked", "triggered_at": "2023-10-31T12:52:49.851916Z", "revoked_at":
         "2024-12-10T12:16:28.115539Z", "type": "AWS", "open_events_count": 0, "creator_id":
         136170, "revoker_id": 113168, "creator_api_token_id": null, "revoker_api_token_id":
-        null, "tags": ["publicly_exposed"], "labels": [], "custom_tags": [], "token":
-        "[REDACTED]"}, {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb", "name": "test
-        eric dd 02", "description": "", "created_at": "2023-10-31T14:33:35.801324Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4affa602-902b-47ff-a1f4-721dc3e671bb",
+        null, "tags": ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"},
+        {"id": "4affa602-902b-47ff-a1f4-721dc3e671bb", "name": "test eric dd 02",
+        "description": "", "created_at": "2023-10-31T14:33:35.801324Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/4affa602-902b-47ff-a1f4-721dc3e671bb",
         "status": "triggered", "triggered_at": "2023-10-31T14:35:33.676298Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 2897, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "ae448808-3865-4797-a008-9eef6344f9da", "name": "Bsides Berlin", "description":
-        "test key for a demo", "created_at": "2023-11-18T16:19:36.463172Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/ae448808-3865-4797-a008-9eef6344f9da",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ae448808-3865-4797-a008-9eef6344f9da",
+        "name": "Bsides Berlin", "description": "test key for a demo", "created_at":
+        "2023-11-18T16:19:36.463172Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ae448808-3865-4797-a008-9eef6344f9da",
         "status": "triggered", "triggered_at": "2023-11-18T16:20:14.365596Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 105, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
-        "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
-        "key": "repo", "value": "mackenziejj"}], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
+        ["publicly_exposed"], "custom_tags": [{"id": "9bfc9a64-306a-46da-a968-161e45761a3c",
         "key": "location", "value": "github"}, {"id": "e5308391-2271-423a-b14b-933842eea075",
         "key": "repo", "value": "mackenziejj"}], "token": "[REDACTED]"}, {"id": "d6d5d79d-08fa-4c8a-bd54-c34851866cde",
         "name": "test1112", "description": "test publicly exposed honeytoken", "created_at":
@@ -212,150 +196,138 @@ interactions:
         "status": "triggered", "triggered_at": "2023-12-11T16:26:07.733443Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 319222, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "name": "sss", "description": "test", "created_at": "2024-01-09T14:24:10.741214Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a",
-        "name": "BK Test Paris", "description": "Brandon while in Paris office", "created_at":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a", "name": "BK
+        Test Paris", "description": "Brandon while in Paris office", "created_at":
         "2024-01-17T11:12:14.759334Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/34d5205b-accd-429c-9efa-eda48989c83a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
-        "name": "Lauren Testing", "description": "Lauren wuz here", "created_at":
-        "2024-01-29T17:37:45.379096Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4", "name": "Lauren
+        Testing", "description": "Lauren wuz here", "created_at": "2024-01-29T17:37:45.379096Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 637596, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "07fb5f6f-23f1-42e8-bdb2-c95864412a16",
         "name": "My Little Honeytoken", "description": "for testing", "created_at":
         "2024-02-02T22:18:06.038874Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/07fb5f6f-23f1-42e8-bdb2-c95864412a16",
         "status": "triggered", "triggered_at": "2024-02-09T20:50:13.173911Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": null, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "2e904370-faa8-4842-8e5e-552902fdd245", "name": "Test key ", "description":
-        "ss", "created_at": "2024-02-29T13:49:52.467489Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
+        ["publicly_exposed"], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245",
+        "name": "Test key ", "description": "ss", "created_at": "2024-02-29T13:49:52.467489Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e",
-        "name": "test-lena-1903", "description": "", "created_at": "2024-03-19T09:13:00.819618Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/443045cc-7fa4-441d-a161-b060bd7fbb3e",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "443045cc-7fa4-441d-a161-b060bd7fbb3e", "name": "test-lena-1903",
+        "description": "", "created_at": "2024-03-19T09:13:00.819618Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/443045cc-7fa4-441d-a161-b060bd7fbb3e",
         "status": "revoked", "triggered_at": null, "revoked_at": "2024-05-29T09:51:31.597203Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 319222, "revoker_id":
         319222, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
         "name": "Test key", "description": "Access key", "created_at": "2024-05-22T12:16:55.833940Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c7101eaa-ea38-495d-b3b4-c016db23e859",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
         "name": "test lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
-        "status": "triggered", "triggered_at": "2024-06-06T08:19:18.422045Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 319222, "revoker_id":
-        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca", "key": "machine",
-        "value": "ggprdgim01"}], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
         "key": "machine", "value": "ggprdgim01"}], "token": "[REDACTED]"}, {"id":
         "a411fa2c-a465-4099-8353-3c42365aca50", "name": "test MINT", "description":
         "test MINT", "created_at": "2024-06-10T14:40:08.522247Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/a411fa2c-a465-4099-8353-3c42365aca50",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
-        "name": "test ericf", "description": "", "created_at": "2024-07-09T09:34:04.089955Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "faaa4d1e-82ec-4a06-a73d-27ac4fd625e5", "name": "test
+        ericf", "description": "", "created_at": "2024-07-09T09:34:04.089955Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/faaa4d1e-82ec-4a06-a73d-27ac4fd625e5",
         "status": "triggered", "triggered_at": "2024-07-09T09:34:57.541777Z", "revoked_at":
         null, "type": "AWS", "open_events_count": 100, "creator_id": 136170, "revoker_id":
         null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
-        ["publicly_exposed"], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        ["publicly_exposed"], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "62d71685-2eba-4b88-8edd-cc73e698cfa5",
         "name": "test-greg", "description": "test greg", "created_at": "2025-05-12T10:06:19.826522Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/62d71685-2eba-4b88-8edd-cc73e698cfa5",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:59.739856Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "e948f77d-5353-413e-b37d-8beba84890ff", "name": "test-greg-2", "description":
-        "test greg", "created_at": "2025-05-12T10:08:11.667578Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e948f77d-5353-413e-b37d-8beba84890ff",
+        "name": "test-greg-2", "description": "test greg", "created_at": "2025-05-12T10:08:11.667578Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e948f77d-5353-413e-b37d-8beba84890ff",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:54.809724Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb", "name": "test-greg-3", "description":
-        "test greg", "created_at": "2025-05-12T10:08:58.561160Z", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
+        "name": "test-greg-3", "description": "test greg", "created_at": "2025-05-12T10:08:58.561160Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4fdb8243-72a8-47ca-beba-7a2ea1f293eb",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:50.784137Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6", "name": "test-greg-4", "description":
-        "test", "created_at": "2025-05-12T10:10:12.927058Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b8223745-eae8-42bf-9cc6-7630c27646c6",
+        "name": "test-greg-4", "description": "test", "created_at": "2025-05-12T10:10:12.927058Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b8223745-eae8-42bf-9cc6-7630c27646c6",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:46.594085Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a", "name": "test-greg-5", "description":
-        "test", "created_at": "2025-05-12T10:12:50.615700Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
+        "name": "test-greg-5", "description": "test", "created_at": "2025-05-12T10:12:50.615700Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ff2b13a8-b32c-4c78-8503-3d0f19eb035a",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:41.387978Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "f1080264-0c2c-4abb-817f-f36c06ac5dba", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38", "name": "TestHoneytoken", "description":
-        "Testing GitGuardian API connectivity", "created_at": "2025-05-12T12:19:05.294638Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b0ddbd44-4054-4127-aa00-cd6727e70d38",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38",
+        "name": "TestHoneytoken", "description": "Testing GitGuardian API connectivity",
+        "created_at": "2025-05-12T12:19:05.294638Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b0ddbd44-4054-4127-aa00-cd6727e70d38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
         "name": "AWS Credentials", "description": "Honeytoken for testing, to be injected
         as requested by the user.", "created_at": "2025-05-12T12:38:25.640506Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/60ba06e9-b9ec-41d4-8656-35c839e3c1d1",
         "status": "triggered", "triggered_at": "2026-02-18T13:45:03.781945Z", "revoked_at":
-        null, "type": "AWS", "open_events_count": 1, "creator_id": 269050, "revoker_id":
+        null, "type": "AWS", "open_events_count": 9, "creator_id": 269050, "revoker_id":
         null, "creator_api_token_id": "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec", "name": "test-greg-7", "description":
-        "test", "created_at": "2025-05-12T12:54:37.703725Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ab824e92-6068-4a9d-ae36-86a94516f2ec",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ab824e92-6068-4a9d-ae36-86a94516f2ec",
+        "name": "test-greg-7", "description": "test", "created_at": "2025-05-12T12:54:37.703725Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ab824e92-6068-4a9d-ae36-86a94516f2ec",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:34.521470Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [], "custom_tags": [], "token": "[REDACTED]"},
-        {"id": "9844e55d-982c-4458-b65b-592ad99ce77a", "name": "test", "description":
-        "test", "created_at": "2025-05-12T13:09:38.965752Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9844e55d-982c-4458-b65b-592ad99ce77a",
+        null, "tags": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
+        "name": "test", "description": "test", "created_at": "2025-05-12T13:09:38.965752Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9844e55d-982c-4458-b65b-592ad99ce77a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1026550, "revoker_id": null, "creator_api_token_id":
         "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
         "name": "Test Honeytoken", "description": "Testing honeytoken generation",
         "created_at": "2025-05-12T14:35:34.295363Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b2a7e759-81ab-465d-a578-e3ce42c18741",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6d185a-6f59-4b7c-9248-dd05616090db",
         "name": "test-greg-9", "description": "", "created_at": "2025-05-12T14:50:23.123299Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6d185a-6f59-4b7c-9248-dd05616090db",
         "status": "revoked", "triggered_at": null, "revoked_at": "2025-05-12T15:17:27.366114Z",
         "type": "AWS", "open_events_count": 0, "creator_id": 1026550, "revoker_id":
         1026550, "creator_api_token_id": "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id":
-        null, "tags": [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
+        null, "tags": [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
         "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "16805984-70d6-4049-844a-79bac3054f6f",
         "name": "AwsTestHoneytoken", "description": "Test honeytoken for development
@@ -364,44 +336,117 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "token": "[REDACTED]"}]'
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "name": "test Pierre", "description": "", "created_at": "2026-04-07T18:38:38.199572Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "9266c0f4-f0e0-41d2-a8c8-c164ccb84e47", "name": "qa
+        / test-nriv-e732d912", "description": "", "created_at": "2026-04-24T16:05:50.013606Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9266c0f4-f0e0-41d2-a8c8-c164ccb84e47",
+        "status": "triggered", "triggered_at": "2026-04-24T16:15:44.494587Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "name": "dev / Salome Test-e732d912", "description": "", "created_at": "2026-04-24T16:05:53.158978Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f8df1e68-fa53-42a8-8658-a3925a1b972b",
+        "status": "triggered", "triggered_at": "2026-04-24T16:16:21.895694Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "name": "qa / test-r8327r-e732d912", "description": "", "created_at": "2026-04-24T16:05:56.586568Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3f7f9b66-cc2a-4aae-b8e2-e90e482069be",
+        "status": "triggered", "triggered_at": "2026-04-24T16:18:31.419829Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 790733, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2a72f662-2357-4b93-b48a-00028e36cfff",
+        "name": "test1", "description": "tEST 2", "created_at": "2026-04-30T09:12:55.584248Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a72f662-2357-4b93-b48a-00028e36cfff",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "963fbabe-3d2c-4154-8281-2f13be7c06f7", "name": "test121",
+        "description": "testing 12", "created_at": "2026-04-30T11:31:57.689130Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/963fbabe-3d2c-4154-8281-2f13be7c06f7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "1acff09e-02c1-4a24-8869-568dfab124c9", "name": "test-pierredt",
+        "description": "hello", "created_at": "2026-05-06T19:57:39.689471Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/1acff09e-02c1-4a24-8869-568dfab124c9",
+        "status": "triggered", "triggered_at": "2026-05-06T19:59:18.645288Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 6, "creator_id": 309802, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "name": "qa / test-nriv-d2363bd5", "description": "", "created_at": "2026-05-19T08:29:37.247067Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6345f1ff-6834-465c-a7f9-16a818de15eb",
+        "status": "triggered", "triggered_at": "2026-05-19T08:33:36.289678Z", "revoked_at":
+        null, "type": "AWS", "open_events_count": 100, "creator_id": 1754656, "revoker_id":
+        null, "creator_api_token_id": null, "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be3d1024-d9df-466c-9e75-afc1ed88b8f5",
+        "name": "test-plc", "description": "", "created_at": "2026-05-26T07:26:21.052034Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be3d1024-d9df-466c-9e75-afc1ed88b8f5",
+        "status": "revoked", "triggered_at": "2026-05-26T08:44:57.678480Z", "revoked_at":
+        "2026-05-26T12:19:01.401494Z", "type": "AWS", "open_events_count": 0, "creator_id":
+        701514, "revoker_id": 701514, "creator_api_token_id": null, "revoker_api_token_id":
+        null, "tags": ["publicly_exposed"], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "8409c955-f217-47c9-9cf1-3a6b557c65c9", "name": "Test", "description": "",
+        "created_at": "2026-05-26T14:12:05.347374Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8409c955-f217-47c9-9cf1-3a6b557c65c9",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754650, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "82f00514-d9d3-442c-b575-c40ff77db387", "name": "test-plc2",
+        "description": "", "created_at": "2026-05-27T13:13:33.943814Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/82f00514-d9d3-442c-b575-c40ff77db387",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 701514, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}]'
     headers:
+      CF-RAY:
+      - a1039785998b008e-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:48 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, POST, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '29870'
+      - '33390'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:43 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '438'
+      - '500'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_honeytokens_with_status_filter.yaml
+++ b/tests/cassettes/tools/vcr/test_list_honeytokens_with_status_filter.yaml
@@ -25,90 +25,85 @@ interactions:
         "2023-05-16T11:58:57.713307Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bfa8a9c0-547e-4e61-b366-8ec0a23e2601",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
-        "key": "place", "value": "jira"}], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "93e3e01c-6ca2-42b7-a422-af277c35cece",
         "key": "place", "value": "jira"}], "token": "[REDACTED]"}, {"id": "72fcdb5c-e128-4ca5-8970-f1f52f95a78a",
         "name": "slack-chan-website", "description": "", "created_at": "2023-05-16T15:35:26.129025Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72fcdb5c-e128-4ca5-8970-f1f52f95a78a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
-        "key": "place", "value": "website"}], "custom_tags": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ef72b4fe-a9d8-40ef-9334-2df15434764d",
         "key": "place", "value": "website"}], "token": "[REDACTED]"}, {"id": "bb494eed-6ba4-4b98-b949-ad5f54d929dd",
         "name": "ggshield-uORy0any", "description": "description", "created_at": "2023-05-30T10:30:39.803353Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bb494eed-6ba4-4b98-b949-ad5f54d929dd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f60db759-7041-4dfe-80fa-91012d97fdd3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f60db759-7041-4dfe-80fa-91012d97fdd3",
         "name": "ggshield-tsCPoUcx", "description": "description", "created_at": "2023-05-30T10:37:14.527124Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f60db759-7041-4dfe-80fa-91012d97fdd3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
         "name": "ggshield-BA0VsBh3", "description": "description", "created_at": "2023-05-30T10:39:09.968782Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/26bd6c6e-0b91-490d-b000-d1fd97d4d70c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e7f275d-e115-44d3-8854-5c6472494951",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e7f275d-e115-44d3-8854-5c6472494951",
         "name": "ggshield-UXgNYVXL", "description": "description", "created_at": "2023-05-30T10:42:36.847031Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6e7f275d-e115-44d3-8854-5c6472494951",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "092dba62-9d82-41bd-84aa-95430d540edc",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "092dba62-9d82-41bd-84aa-95430d540edc",
         "name": "ggshield-224Lwv95", "description": "description", "created_at": "2023-05-30T10:46:10.997022Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/092dba62-9d82-41bd-84aa-95430d540edc",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f17302cd-850b-4b54-9054-60d26a76cf38",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "f17302cd-850b-4b54-9054-60d26a76cf38",
         "name": "test demo 31may", "description": "", "created_at": "2023-05-31T08:10:36.754144Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f17302cd-850b-4b54-9054-60d26a76cf38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}], "token": "[REDACTED]"}, {"id": "32d65c31-5c7d-463a-b789-3845f6ac4c05",
         "name": "ggshield-cptptJHt", "description": "ggshield test", "created_at":
         "2023-06-02T08:47:41.149126Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/32d65c31-5c7d-463a-b789-3845f6ac4c05",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
-        "name": "ggshield-TtJwtxNE", "description": "ggshield test", "created_at":
-        "2023-06-02T08:48:20.148216Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72", "name": "ggshield-TtJwtxNE",
+        "description": "ggshield test", "created_at": "2023-06-02T08:48:20.148216Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fc7cb1bb-a725-4c9f-a0cb-f85cc9f84f72",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "27379093-c6a4-4732-a64a-715c94e74fd7",
-        "name": "ggshield-TvFzKVed", "description": null, "created_at": "2023-06-09T08:01:57.360210Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/27379093-c6a4-4732-a64a-715c94e74fd7",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "27379093-c6a4-4732-a64a-715c94e74fd7", "name": "ggshield-TvFzKVed",
+        "description": null, "created_at": "2023-06-09T08:01:57.360210Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/27379093-c6a4-4732-a64a-715c94e74fd7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "62cb7048-4302-4b52-9163-e2ceff775b39", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb",
         "name": "ggshield-0etjSvZJ", "description": "description", "created_at": "2023-07-05T08:27:14.048162Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/828b38c9-ba38-4ecd-a83c-6d6c3b39f0eb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "14566c1f-0b52-4770-ab68-000704242633",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "14566c1f-0b52-4770-ab68-000704242633",
         "name": "ggshield-Rv2mUej7", "description": "description", "created_at": "2023-07-05T08:55:23.864812Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/14566c1f-0b52-4770-ab68-000704242633",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
         "name": "Example TOken ", "description": "ubvcub", "created_at": "2023-07-12T13:16:10.775681Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6e3ec3ae-2158-4e6e-b23e-b2eabe50d880",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
-        "key": "file", "value": ".env"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
-        "key": "repo", "value": "secretproject"}], "custom_tags": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "307456bf-ed02-4944-8119-b9c3652032ca",
         "key": "file", "value": ".env"}, {"id": "6174702f-4a50-44a4-be57-2edfa45351e9",
         "key": "repo", "value": "secretproject"}], "token": "[REDACTED]"}, {"id":
         "0c3f182e-98f5-4a64-aadb-664fd7c9de88", "name": "ggshield-ewIAL7lq", "description":
@@ -117,284 +112,271 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
         "name": "ggshield-w1P1Ggsz", "description": "description", "created_at": "2023-07-27T08:56:55.435203Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/812090ee-17e2-4df4-a6d6-0da0e4d64cd3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51f41814-f029-4ab4-b863-c0fecba025b3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51f41814-f029-4ab4-b863-c0fecba025b3",
         "name": "ggshield-v3LhZCz8", "description": "description", "created_at": "2023-07-27T09:01:36.117217Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/51f41814-f029-4ab4-b863-c0fecba025b3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "name": "test_honey_token", "description": "description", "created_at": "2023-07-27T09:01:36.764795Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be5c419c-ef54-414f-8f1a-97afcb27aaba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e842a635-eb7e-4617-8984-ac57fe909ef7",
         "name": "test_honey_token_error_403", "description": "description", "created_at":
         "2023-07-27T09:01:37.417151Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e842a635-eb7e-4617-8984-ac57fe909ef7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 296618, "revoker_id": null, "creator_api_token_id":
         "cbdcad40-a7af-43b6-905d-bbd8ca891eeb", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "521efd01-bbcc-4380-b548-ed7242c017ea",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "521efd01-bbcc-4380-b548-ed7242c017ea",
         "name": "ggshield-HLZpiznn", "description": null, "created_at": "2023-07-27T14:54:03.198466Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/521efd01-bbcc-4380-b548-ed7242c017ea",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5670c657-618f-41d7-984b-d59656d905e4",
-        "name": "ggshield-3KTmbo8u", "description": null, "created_at": "2023-07-27T15:44:43.238742Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5670c657-618f-41d7-984b-d59656d905e4",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5670c657-618f-41d7-984b-d59656d905e4", "name": "ggshield-3KTmbo8u",
+        "description": null, "created_at": "2023-07-27T15:44:43.238742Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/5670c657-618f-41d7-984b-d59656d905e4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "a11570c6-f472-4fda-a493-30d65fd8e651",
-        "name": "test Antonin 2", "description": "", "created_at": "2023-08-03T14:09:46.046004Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "a11570c6-f472-4fda-a493-30d65fd8e651", "name": "test
+        Antonin 2", "description": "", "created_at": "2023-08-03T14:09:46.046004Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a11570c6-f472-4fda-a493-30d65fd8e651",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
-        "name": "vBOY test segment 2", "description": "sdqsdqsd", "created_at": "2023-08-07T12:47:49.515448Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2f70f68f-0c38-4e1e-a921-f40b21fd97f7", "name": "vBOY
+        test segment 2", "description": "sdqsdqsd", "created_at": "2023-08-07T12:47:49.515448Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2f70f68f-0c38-4e1e-a921-f40b21fd97f7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "86670f84-e117-4f96-aa16-e399a0bb2cf2",
-        "name": "juuj", "description": "", "created_at": "2023-08-08T15:53:23.097840Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/86670f84-e117-4f96-aa16-e399a0bb2cf2",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "86670f84-e117-4f96-aa16-e399a0bb2cf2", "name": "juuj",
+        "description": "", "created_at": "2023-08-08T15:53:23.097840Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/86670f84-e117-4f96-aa16-e399a0bb2cf2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "90d4c2b6-ecae-4ef9-a754-4561929b9e38",
-        "name": "ggshield-mpkTH5jF", "description": "description", "created_at": "2023-08-16T08:28:18.684517Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "90d4c2b6-ecae-4ef9-a754-4561929b9e38", "name": "ggshield-mpkTH5jF",
+        "description": "description", "created_at": "2023-08-16T08:28:18.684517Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/90d4c2b6-ecae-4ef9-a754-4561929b9e38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
         "name": "ggshield-mzO8qHEz", "description": "description", "created_at": "2023-08-22T08:19:03.821471Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dc69f522-32ec-4f5f-b6be-516fb00a2bcd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "89585e19-1cca-42fc-add0-65cfc24d2fd8", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
         "name": "testket ", "description": "eew", "created_at": "2023-08-29T10:21:29.956291Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7c4ce80a-c28e-40b3-ae47-3656f2be4a51",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "137c9fee-4b3c-4231-92fd-98debf6557c2",
-        "name": "BSides ATL demo for session", "description": "This one will be triggered
-        from 2 different spots online", "created_at": "2023-10-14T12:28:51.206659Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/137c9fee-4b3c-4231-92fd-98debf6557c2",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "137c9fee-4b3c-4231-92fd-98debf6557c2", "name": "BSides
+        ATL demo for session", "description": "This one will be triggered from 2 different
+        spots online", "created_at": "2023-10-14T12:28:51.206659Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/137c9fee-4b3c-4231-92fd-98debf6557c2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 354585, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "48f7c567-93d1-4925-9f77-d3919f120b88",
-        "name": "ggshield-KlAkKRtE", "description": "description", "created_at": "2023-10-16T19:49:08.588391Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "48f7c567-93d1-4925-9f77-d3919f120b88", "name": "ggshield-KlAkKRtE",
+        "description": "description", "created_at": "2023-10-16T19:49:08.588391Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/48f7c567-93d1-4925-9f77-d3919f120b88",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f8e0968-664a-49f3-af85-9cc468b960ab",
         "name": "Jason test", "description": "Token for Test ", "created_at": "2023-10-24T13:45:31.371710Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f8e0968-664a-49f3-af85-9cc468b960ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "8df388e2-aeb5-42ca-b6d5-221a54a40339",
-        "name": "ggshield-P47kTh7j", "description": null, "created_at": "2023-11-09T15:44:33.671666Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8df388e2-aeb5-42ca-b6d5-221a54a40339",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "8df388e2-aeb5-42ca-b6d5-221a54a40339", "name": "ggshield-P47kTh7j",
+        "description": null, "created_at": "2023-11-09T15:44:33.671666Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/8df388e2-aeb5-42ca-b6d5-221a54a40339",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "ecb3d61d-bdab-4636-a436-bef8079a005d",
-        "name": "ggshield-ObfCUUCA", "description": "description", "created_at": "2023-11-28T08:50:32.130230Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "ecb3d61d-bdab-4636-a436-bef8079a005d", "name": "ggshield-ObfCUUCA",
+        "description": "description", "created_at": "2023-11-28T08:50:32.130230Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ecb3d61d-bdab-4636-a436-bef8079a005d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4046ccf5-7821-47f4-be7d-8240be69631b",
-        "name": "ideal-journey-lena", "description": "", "created_at": "2023-12-11T16:29:20.759489Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4046ccf5-7821-47f4-be7d-8240be69631b",
-        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
-        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "52903632-f6ff-460e-8a68-80a942349979",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "52903632-f6ff-460e-8a68-80a942349979",
         "name": "Network Honeytoken", "description": "Aws Honeytoken on Network",
         "created_at": "2023-12-18T13:47:39.151311Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/52903632-f6ff-460e-8a68-80a942349979",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
-        "key": "network", "value": "directory"}], "custom_tags": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "3bba2be8-516e-4951-99f7-eb0d4018ac5b",
         "key": "network", "value": "directory"}], "token": "[REDACTED]"}, {"id": "2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
         "name": "ggshield-JZV5XT71", "description": "description", "created_at": "2024-01-09T09:39:34.421404Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2d8cd946-42d0-4b1f-a3b3-a6a7e731bc7c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "name": "sss", "description": "test", "created_at": "2024-01-09T14:24:10.741214Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/cc9b33c2-2171-4070-a09a-9d4a442fb6cb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a",
-        "name": "BK Test Paris", "description": "Brandon while in Paris office", "created_at":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "34d5205b-accd-429c-9efa-eda48989c83a", "name": "BK
+        Test Paris", "description": "Brandon while in Paris office", "created_at":
         "2024-01-17T11:12:14.759334Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/34d5205b-accd-429c-9efa-eda48989c83a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
-        "name": "Lauren Testing", "description": "Lauren wuz here", "created_at":
-        "2024-01-29T17:37:45.379096Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "571bd68e-e439-423b-a40c-e1ffc6ab7ea4", "name": "Lauren
+        Testing", "description": "Lauren wuz here", "created_at": "2024-01-29T17:37:45.379096Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/571bd68e-e439-423b-a40c-e1ffc6ab7ea4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 637596, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}], "token": "[REDACTED]"}, {"id": "6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
         "name": "solid-octo", "description": "", "created_at": "2024-02-19T13:06:26.880374Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/6fcc5cf2-4b47-497d-9a80-c2d794b96ebc",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
-        "key": "team", "value": "octo"}], "custom_tags": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "77143a81-2b90-45a2-b152-ca4b72ef9d64",
         "key": "team", "value": "octo"}], "token": "[REDACTED]"}, {"id": "1592023a-2f39-4ba6-a503-4c07132f1eb0",
         "name": "GGnikalston/rock-paper-scissors-f4c01375", "description": "", "created_at":
         "2024-02-20T13:32:45.163630Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1592023a-2f39-4ba6-a503-4c07132f1eb0",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d024b464-cd1e-4daf-9b1d-863dcf517a7a",
-        "name": "Demo -2024-02-22", "description": "", "created_at": "2024-02-22T18:53:26.142516Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d024b464-cd1e-4daf-9b1d-863dcf517a7a", "name": "Demo
+        -2024-02-22", "description": "", "created_at": "2024-02-22T18:53:26.142516Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d024b464-cd1e-4daf-9b1d-863dcf517a7a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 354585, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "1bba091c-fc4c-48b5-b558-46c191f67103",
-        "name": "ggshield-ldC5hqqo", "description": "description", "created_at": "2024-02-27T13:42:36.686028Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "1bba091c-fc4c-48b5-b558-46c191f67103", "name": "ggshield-ldC5hqqo",
+        "description": "description", "created_at": "2024-02-27T13:42:36.686028Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1bba091c-fc4c-48b5-b558-46c191f67103",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "d7764013-fdd5-4b08-b195-dff5a338906d",
-        "name": "ggshield-LRYYnjOa", "description": "description", "created_at": "2024-02-27T13:42:37.569678Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "d7764013-fdd5-4b08-b195-dff5a338906d", "name": "ggshield-LRYYnjOa",
+        "description": "description", "created_at": "2024-02-27T13:42:37.569678Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d7764013-fdd5-4b08-b195-dff5a338906d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "def4a23d-3d12-4fe1-b8e0-02250e74e47a",
-        "name": "ggshield-itglxnie", "description": "description", "created_at": "2024-02-27T13:58:30.205444Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "def4a23d-3d12-4fe1-b8e0-02250e74e47a", "name": "ggshield-itglxnie",
+        "description": "description", "created_at": "2024-02-27T13:58:30.205444Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/def4a23d-3d12-4fe1-b8e0-02250e74e47a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "33d149f1-68f4-4446-ae4f-def0ce962724",
-        "name": "ggshield-2Mf02eVA", "description": "description", "created_at": "2024-02-27T13:58:31.125075Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "33d149f1-68f4-4446-ae4f-def0ce962724", "name": "ggshield-2Mf02eVA",
+        "description": "description", "created_at": "2024-02-27T13:58:31.125075Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/33d149f1-68f4-4446-ae4f-def0ce962724",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5ff5eee1-fc18-4474-86fa-c46321c903c8",
-        "name": "ggshield-rmnfzrW2", "description": "description", "created_at": "2024-02-27T14:02:45.009113Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5ff5eee1-fc18-4474-86fa-c46321c903c8", "name": "ggshield-rmnfzrW2",
+        "description": "description", "created_at": "2024-02-27T14:02:45.009113Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5ff5eee1-fc18-4474-86fa-c46321c903c8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "4dd6c06e-e2c0-4593-9be0-b0418ba7a370",
-        "name": "ggshield-5YTKZZTB", "description": "description", "created_at": "2024-02-27T14:02:45.717261Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "4dd6c06e-e2c0-4593-9be0-b0418ba7a370", "name": "ggshield-5YTKZZTB",
+        "description": "description", "created_at": "2024-02-27T14:02:45.717261Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4dd6c06e-e2c0-4593-9be0-b0418ba7a370",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "eba79796-4f46-4e10-b876-280f75138cc9",
-        "name": "ggshield-z3Y6zgih", "description": "description", "created_at": "2024-02-27T14:06:02.196977Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "eba79796-4f46-4e10-b876-280f75138cc9", "name": "ggshield-z3Y6zgih",
+        "description": "description", "created_at": "2024-02-27T14:06:02.196977Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/eba79796-4f46-4e10-b876-280f75138cc9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "0ebc8091-454b-461e-a6f8-fd17bf412c76",
-        "name": "ggshield-jqk54PrI", "description": "description", "created_at": "2024-02-27T14:06:03.018091Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "0ebc8091-454b-461e-a6f8-fd17bf412c76", "name": "ggshield-jqk54PrI",
+        "description": "description", "created_at": "2024-02-27T14:06:03.018091Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ebc8091-454b-461e-a6f8-fd17bf412c76",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "664af568-cfc7-4726-9fb4-0b61606b7386",
-        "name": "ggshield-horgQNnR", "description": "description", "created_at": "2024-02-27T14:19:39.357690Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "664af568-cfc7-4726-9fb4-0b61606b7386", "name": "ggshield-horgQNnR",
+        "description": "description", "created_at": "2024-02-27T14:19:39.357690Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/664af568-cfc7-4726-9fb4-0b61606b7386",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5d915aca-6f6f-4b4e-a996-2c1f53016114",
-        "name": "ggshield-LNgN8R1S", "description": "description", "created_at": "2024-02-27T14:19:40.283320Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5d915aca-6f6f-4b4e-a996-2c1f53016114", "name": "ggshield-LNgN8R1S",
+        "description": "description", "created_at": "2024-02-27T14:19:40.283320Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5d915aca-6f6f-4b4e-a996-2c1f53016114",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245",
-        "name": "Test key ", "description": "ss", "created_at": "2024-02-29T13:49:52.467489Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2e904370-faa8-4842-8e5e-552902fdd245", "name": "Test
+        key ", "description": "ss", "created_at": "2024-02-29T13:49:52.467489Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/2e904370-faa8-4842-8e5e-552902fdd245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
-        "name": "ggshield-Psfrcoxl", "description": "description", "created_at": "2024-03-27T08:48:20.857237Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "9562dc6a-c0e3-4877-b72b-8bb39d27d6cd", "name": "ggshield-Psfrcoxl",
+        "description": "description", "created_at": "2024-03-27T08:48:20.857237Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9562dc6a-c0e3-4877-b72b-8bb39d27d6cd",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5a01f826-4f8f-4235-8867-ce58ac88ce1c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "5a01f826-4f8f-4235-8867-ce58ac88ce1c",
         "name": "ggshield-inUFY47O", "description": "description", "created_at": "2024-03-27T08:48:21.791104Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5a01f826-4f8f-4235-8867-ce58ac88ce1c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 104544, "revoker_id": null, "creator_api_token_id":
         "941124f7-5937-4f91-bea2-3cc0c42d9907", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d72113d0-c346-42c7-bd88-fd5fe0e716f3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d72113d0-c346-42c7-bd88-fd5fe0e716f3",
         "name": "ggshield-eY0ZOlXS", "description": "description", "created_at": "2024-04-30T09:25:38.689800Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d72113d0-c346-42c7-bd88-fd5fe0e716f3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "7f2873cd-3759-4727-a683-31cac57fe5d8",
-        "name": "ggshield-TvlX76OG", "description": "description", "created_at": "2024-04-30T09:25:39.573115Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "7f2873cd-3759-4727-a683-31cac57fe5d8", "name": "ggshield-TvlX76OG",
+        "description": "description", "created_at": "2024-04-30T09:25:39.573115Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7f2873cd-3759-4727-a683-31cac57fe5d8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "72e98633-9179-4a3e-8908-ea2319d19b3b",
-        "name": "ggshield-XYKDhLUY", "description": "description", "created_at": "2024-04-30T10:19:12.369644Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "72e98633-9179-4a3e-8908-ea2319d19b3b", "name": "ggshield-XYKDhLUY",
+        "description": "description", "created_at": "2024-04-30T10:19:12.369644Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72e98633-9179-4a3e-8908-ea2319d19b3b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
         "name": "ggshield-HRoZzrBq", "description": "description", "created_at": "2024-04-30T10:19:13.126568Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/005c847b-caaf-4fc1-97b8-f3b3b3f5b01f",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c7101eaa-ea38-495d-b3b4-c016db23e859",
         "name": "Test key", "description": "Access key", "created_at": "2024-05-22T12:16:55.833940Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c7101eaa-ea38-495d-b3b4-c016db23e859",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
-        "key": "vcs", "value": "github"}], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "ac185e45-281a-4652-bcd2-a01aa8c16327",
         "key": "vcs", "value": "github"}], "token": "[REDACTED]"}, {"id": "a67f962c-9dde-40c2-b404-e7cd4449cc82",
         "name": "pouet", "description": "", "created_at": "2024-05-22T12:19:03.143437Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a67f962c-9dde-40c2-b404-e7cd4449cc82",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582717, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
-        "key": "place", "value": "codebase"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
-        "key": "user", "value": "leakymcgee"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
-        "key": "visability", "value": "public"}], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "75e08b81-a5b1-4829-8c95-07aa2816a432",
         "key": "place", "value": "codebase"}, {"id": "7f6891c2-d895-422a-b6b2-ebe9c5e3f513",
         "key": "user", "value": "leakymcgee"}, {"id": "717dc346-ffc5-4a05-8ebe-d9196d05f9bb",
         "key": "visability", "value": "public"}], "token": "[REDACTED]"}, {"id": "9cca01c5-535f-4f89-a214-6c4c5579fd07",
@@ -402,396 +384,392 @@ interactions:
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9cca01c5-535f-4f89-a214-6c4c5579fd07",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "a411fa2c-a465-4099-8353-3c42365aca50",
-        "name": "test MINT", "description": "test MINT", "created_at": "2024-06-10T14:40:08.522247Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a411fa2c-a465-4099-8353-3c42365aca50",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "e157a0f9-b2eb-4710-8867-2c84e2d6bf99", "name": "test
+        lena", "description": "", "created_at": "2024-06-06T08:18:16.546654Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e157a0f9-b2eb-4710-8867-2c84e2d6bf99",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 319222, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "895b5481-8f72-418f-84de-cd41575d80ca",
+        "key": "machine", "value": "ggprdgim01"}], "token": "[REDACTED]"}, {"id":
+        "a411fa2c-a465-4099-8353-3c42365aca50", "name": "test MINT", "description":
+        "test MINT", "created_at": "2024-06-10T14:40:08.522247Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/a411fa2c-a465-4099-8353-3c42365aca50",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "12c4562e-deb8-4d14-bb23-e344e79b6f04",
-        "name": "ggshield-Wq4EyTMI", "description": "description", "created_at": "2024-06-25T08:36:52.179380Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "12c4562e-deb8-4d14-bb23-e344e79b6f04", "name": "ggshield-Wq4EyTMI",
+        "description": "description", "created_at": "2024-06-25T08:36:52.179380Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/12c4562e-deb8-4d14-bb23-e344e79b6f04",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3407738b-2095-47bb-9cbd-dd16de158d67",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3407738b-2095-47bb-9cbd-dd16de158d67",
         "name": "ggshield-65KCwJls", "description": "description", "created_at": "2024-06-25T08:36:52.873146Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3407738b-2095-47bb-9cbd-dd16de158d67",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
         "name": "ggshield-fb77weow", "description": "description", "created_at": "2024-06-26T09:27:38.724573Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c5c4d338-4b7a-4a8e-9b1b-a3351539b1a4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9223e352-43b6-4e06-8d12-682d669cedd7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9223e352-43b6-4e06-8d12-682d669cedd7",
         "name": "ggshield-TRO3H56N", "description": "description", "created_at": "2024-06-26T09:27:39.479744Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9223e352-43b6-4e06-8d12-682d669cedd7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "17e088b8-2463-48f8-957b-41d017f1dc83",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "17e088b8-2463-48f8-957b-41d017f1dc83",
         "name": "ggshield-s7IOqS0q", "description": "description", "created_at": "2024-06-26T09:42:26.454643Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/17e088b8-2463-48f8-957b-41d017f1dc83",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e332d717-641d-4ea4-81fc-e98115178454",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e332d717-641d-4ea4-81fc-e98115178454",
         "name": "ggshield-JaAf9b0W", "description": "description", "created_at": "2024-06-26T09:42:27.174527Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e332d717-641d-4ea4-81fc-e98115178454",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26514e1f-4237-474b-b907-037b88427f29",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "26514e1f-4237-474b-b907-037b88427f29",
         "name": "ggshield-Uuc8EiUn", "description": "description", "created_at": "2024-06-26T11:51:19.747630Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/26514e1f-4237-474b-b907-037b88427f29",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
         "name": "ggshield-GL7wc5WW", "description": "description", "created_at": "2024-06-26T11:51:20.402145Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8a9e0e65-7f2f-4a85-99fb-cedd7ebe8b83",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a507d04c-bb61-4f2a-93ea-601b8aa27940",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a507d04c-bb61-4f2a-93ea-601b8aa27940",
         "name": "ggshield-w1cOSspy", "description": "description", "created_at": "2024-07-31T15:31:09.349255Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a507d04c-bb61-4f2a-93ea-601b8aa27940",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dafa04c5-299a-4a13-9c35-c523e51763f3",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dafa04c5-299a-4a13-9c35-c523e51763f3",
         "name": "ggshield-b7VHMqbK", "description": "description", "created_at": "2024-07-31T15:31:10.071786Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dafa04c5-299a-4a13-9c35-c523e51763f3",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
         "name": "ggshield-Fu1nGsc9", "description": "description", "created_at": "2024-08-05T09:03:52.745860Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ef580198-cfb2-4bdd-a2bb-e1b8b9e37ea2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "83888e42-dc57-471c-9a08-f023e3dc2949",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "83888e42-dc57-471c-9a08-f023e3dc2949",
         "name": "ggshield-5suF2vRt", "description": "description", "created_at": "2024-08-05T09:03:53.434873Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/83888e42-dc57-471c-9a08-f023e3dc2949",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e8aad547-96a7-40a4-a05d-710cf536f3a7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e8aad547-96a7-40a4-a05d-710cf536f3a7",
         "name": "ggshield-Vqz4LULC", "description": "description", "created_at": "2024-08-05T09:21:25.593516Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e8aad547-96a7-40a4-a05d-710cf536f3a7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
         "name": "ggshield-lqX7PlwI", "description": "description", "created_at": "2024-08-05T09:21:26.211228Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/88c38ccf-471f-4e32-bf58-b1c2ebeb25bb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b144b1fd-dc5f-4a36-abc7-a95d05331245",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b144b1fd-dc5f-4a36-abc7-a95d05331245",
         "name": "ggshield-uZr6LNDv", "description": "description", "created_at": "2024-08-27T07:44:46.267249Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b144b1fd-dc5f-4a36-abc7-a95d05331245",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "903bf588-2a03-4318-be6c-b9e3198d1fd6",
-        "name": "ggshield-5Ty2Hu4r", "description": "description", "created_at": "2024-08-27T07:44:46.871854Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "903bf588-2a03-4318-be6c-b9e3198d1fd6", "name": "ggshield-5Ty2Hu4r",
+        "description": "description", "created_at": "2024-08-27T07:44:46.871854Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/903bf588-2a03-4318-be6c-b9e3198d1fd6",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "11222b98-7705-4180-99d1-6e719d8a05a9",
-        "name": "ggshield-qnLief7n", "description": "description", "created_at": "2024-08-27T08:20:15.846360Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "11222b98-7705-4180-99d1-6e719d8a05a9", "name": "ggshield-qnLief7n",
+        "description": "description", "created_at": "2024-08-27T08:20:15.846360Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/11222b98-7705-4180-99d1-6e719d8a05a9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "707b35fb-685b-4577-88b9-94cccc10e165",
-        "name": "ggshield-wqYwwgeK", "description": "description", "created_at": "2024-08-27T08:20:16.467770Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "707b35fb-685b-4577-88b9-94cccc10e165", "name": "ggshield-wqYwwgeK",
+        "description": "description", "created_at": "2024-08-27T08:20:16.467770Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/707b35fb-685b-4577-88b9-94cccc10e165",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "01c7668d-1467-4cac-a395-4b50fc278407",
-        "name": "ggshield-QkzL5Vyb", "description": "description", "created_at": "2024-09-24T08:50:15.865165Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "01c7668d-1467-4cac-a395-4b50fc278407", "name": "ggshield-QkzL5Vyb",
+        "description": "description", "created_at": "2024-09-24T08:50:15.865165Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/01c7668d-1467-4cac-a395-4b50fc278407",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
         "name": "ggshield-kkpkfk1s", "description": "description", "created_at": "2024-09-24T08:50:16.667172Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ca8f3cd3-b83d-43ac-9a81-fda469c6bd32",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "730bdd87-31b2-4b42-a32a-5750bc595c9c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "730bdd87-31b2-4b42-a32a-5750bc595c9c",
         "name": "ggshield-dtxlZtWH", "description": "description", "created_at": "2024-10-01T13:18:29.918337Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/730bdd87-31b2-4b42-a32a-5750bc595c9c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b42c6945-05fc-4c5b-af83-e60478cd9db5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b42c6945-05fc-4c5b-af83-e60478cd9db5",
         "name": "ggshield-WPIELIcW", "description": "description", "created_at": "2024-10-01T13:18:30.820570Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b42c6945-05fc-4c5b-af83-e60478cd9db5",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
         "name": "ggshield-B8LwcRR0", "description": "description", "created_at": "2024-10-16T13:47:50.239094Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e7bf9401-f90a-45bc-8afb-c2cf3b8c5096",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "81d30531-a54e-4f67-a46b-a7bac5783995",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "81d30531-a54e-4f67-a46b-a7bac5783995",
         "name": "ggshield-IjJFdqDS", "description": "description", "created_at": "2024-10-16T13:47:51.425195Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/81d30531-a54e-4f67-a46b-a7bac5783995",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "50e53ab6-4950-48e6-9350-b5aaa88fafea",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "50e53ab6-4950-48e6-9350-b5aaa88fafea",
         "name": "Demo", "description": "Dev team 1", "created_at": "2024-10-27T21:01:47.725365Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/50e53ab6-4950-48e6-9350-b5aaa88fafea",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582569, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
-        "key": "confrence test", "value": "hacktivity"}], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "2cade8a1-71ff-46d2-bbe3-c2bf71437ae7",
         "key": "confrence test", "value": "hacktivity"}], "token": "[REDACTED]"},
         {"id": "795decd4-4703-4073-9b3c-3ec2157f6182", "name": "Demo token", "description":
         "Take a look", "created_at": "2024-10-28T00:34:48.214122Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/795decd4-4703-4073-9b3c-3ec2157f6182",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 582569, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
-        "name": "ggshield-c6YSc2Ie", "description": "description", "created_at": "2024-10-29T14:36:27.096968Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "c43ee48d-4646-40e8-bd12-3dfa30a6b3db", "name": "ggshield-c6YSc2Ie",
+        "description": "description", "created_at": "2024-10-29T14:36:27.096968Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c43ee48d-4646-40e8-bd12-3dfa30a6b3db",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
         "name": "ggshield-E6IPnu0f", "description": "description", "created_at": "2024-10-29T14:36:28.513178Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c58f768c-c1dc-453b-a33c-ed44a5aa32a2",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a454c002-679b-4250-aacf-28b5207543a4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "a454c002-679b-4250-aacf-28b5207543a4",
         "name": "ggshield-HjwRkUAT", "description": "description", "created_at": "2024-11-27T12:32:44.877048Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a454c002-679b-4250-aacf-28b5207543a4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5af2ae0-f3f6-4301-82bc-b49108bd782b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c5af2ae0-f3f6-4301-82bc-b49108bd782b",
         "name": "ggshield-hIlrbyRm", "description": "description", "created_at": "2024-11-27T12:32:45.728067Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c5af2ae0-f3f6-4301-82bc-b49108bd782b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
         "name": "ggshield-AAcFXCwl", "description": "description", "created_at": "2025-02-27T10:23:31.621722Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7dfdb8ee-56fc-486e-9b7a-e6ff248107fa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "97877334-808d-48c7-8802-2c54e9f43661",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "97877334-808d-48c7-8802-2c54e9f43661",
         "name": "ggshield-srahH0o3", "description": "description", "created_at": "2025-02-27T10:23:32.385844Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/97877334-808d-48c7-8802-2c54e9f43661",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ca642fe-2ce4-42b2-9097-5904093935c1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ca642fe-2ce4-42b2-9097-5904093935c1",
         "name": "ggshield-5Vx0aaQd", "description": "description", "created_at": "2025-02-27T10:31:34.080183Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ca642fe-2ce4-42b2-9097-5904093935c1",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d8590557-764f-4618-9b2e-277d536bd111",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d8590557-764f-4618-9b2e-277d536bd111",
         "name": "ggshield-QYqCVZ4i", "description": "description", "created_at": "2025-02-27T10:31:34.798380Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d8590557-764f-4618-9b2e-277d536bd111",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84b08c90-12f5-48ef-baee-ab8d8b15588c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84b08c90-12f5-48ef-baee-ab8d8b15588c",
         "name": "ggshield-4sJy2SkE", "description": "description", "created_at": "2025-02-27T10:53:01.890617Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84b08c90-12f5-48ef-baee-ab8d8b15588c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72204c1e-12c1-445f-b106-09488214d610",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "72204c1e-12c1-445f-b106-09488214d610",
         "name": "ggshield-eqoLjiAS", "description": "description", "created_at": "2025-02-27T10:53:02.563136Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/72204c1e-12c1-445f-b106-09488214d610",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
         "name": "ggshield-yaqMNJFA", "description": "description", "created_at": "2025-02-27T11:24:20.630794Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ece311db-7d5b-44e3-b18b-7e1aae1e32d8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a5d5ca0-000f-4011-aaf2-b4f627c19649",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "8a5d5ca0-000f-4011-aaf2-b4f627c19649",
         "name": "ggshield-x12c7zPc", "description": "description", "created_at": "2025-02-27T11:24:21.465056Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8a5d5ca0-000f-4011-aaf2-b4f627c19649",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c823f31a-73a8-46cc-be4a-029d6d081793",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c823f31a-73a8-46cc-be4a-029d6d081793",
         "name": "ggshield-9Mq5rTUV", "description": "description", "created_at": "2025-02-27T16:44:10.862683Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c823f31a-73a8-46cc-be4a-029d6d081793",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49f1055b-b505-402b-8b79-e4b2c6cf2041",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49f1055b-b505-402b-8b79-e4b2c6cf2041",
         "name": "ggshield-4MmSKBvx", "description": "description", "created_at": "2025-02-27T16:44:11.663957Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/49f1055b-b505-402b-8b79-e4b2c6cf2041",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be8e40e8-b204-40de-8d37-247ac6ef7077",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "be8e40e8-b204-40de-8d37-247ac6ef7077",
         "name": "ggshield-DBuxWn0n", "description": "description", "created_at": "2025-02-27T16:57:21.290157Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/be8e40e8-b204-40de-8d37-247ac6ef7077",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d10551f8-36f0-4966-a684-d5f9eca89e8d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d10551f8-36f0-4966-a684-d5f9eca89e8d",
         "name": "ggshield-bukJ4Md2", "description": "description", "created_at": "2025-02-27T16:57:22.079317Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d10551f8-36f0-4966-a684-d5f9eca89e8d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d5385824-6a93-47cb-81f3-e818e64371d7",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d5385824-6a93-47cb-81f3-e818e64371d7",
         "name": "ggshield-vI1CTIm2", "description": "description", "created_at": "2025-02-27T17:24:28.533666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d5385824-6a93-47cb-81f3-e818e64371d7",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
         "name": "ggshield-C519GYI9", "description": "description", "created_at": "2025-02-27T17:24:29.231126Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/38caae6b-c07e-4ff8-8d7d-5a5287cdc454",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
         "name": "ggshield-i8zN7WRH", "description": "description", "created_at": "2025-02-27T17:27:14.478281Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/dce0dffd-6ef6-4c29-b1a5-610118f9b77d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "661dae4d-5944-4a20-b7f7-f74913356479",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "661dae4d-5944-4a20-b7f7-f74913356479",
         "name": "ggshield-IX7GxSIs", "description": "description", "created_at": "2025-02-27T17:27:15.226298Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/661dae4d-5944-4a20-b7f7-f74913356479",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
         "name": "ggshield-jdbeH3gE", "description": "description", "created_at": "2025-03-03T09:15:27.049176Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/da9d6ce8-b5c6-4a4e-aad3-7c22560ad42c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22", "key": "env",
-        "value": "production"}], "custom_tags": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22",
-        "key": "env", "value": "production"}], "token": "[REDACTED]"}, {"id": "1f4708b2-0e51-458c-abca-c03e502b4a5a",
+        [], "custom_tags": [{"id": "8927320a-6eac-486b-bc8b-d0e0433a7a22", "key":
+        "env", "value": "production"}], "token": "[REDACTED]"}, {"id": "1f4708b2-0e51-458c-abca-c03e502b4a5a",
         "name": "ggshield-QgwFEPjx", "description": "description", "created_at": "2025-03-27T15:12:18.744612Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/1f4708b2-0e51-458c-abca-c03e502b4a5a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "a4ced9be-6ad5-4d8a-b188-65a117bc0eba",
-        "name": "ggshield-44tVmSvF", "description": "description", "created_at": "2025-03-27T15:12:19.507492Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "a4ced9be-6ad5-4d8a-b188-65a117bc0eba", "name": "ggshield-44tVmSvF",
+        "description": "description", "created_at": "2025-03-27T15:12:19.507492Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/a4ced9be-6ad5-4d8a-b188-65a117bc0eba",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5710ee7d-6428-4074-a9ff-09399782242d",
-        "name": "ggshield-bF87lDBl", "description": "description", "created_at": "2025-03-27T15:21:17.135616Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5710ee7d-6428-4074-a9ff-09399782242d", "name": "ggshield-bF87lDBl",
+        "description": "description", "created_at": "2025-03-27T15:21:17.135616Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5710ee7d-6428-4074-a9ff-09399782242d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
-        "name": "ggshield-LbIDqGyA", "description": "description", "created_at": "2025-03-27T15:21:17.953340Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "4cbf7af9-9989-4185-8ef8-0f39e6f3d145", "name": "ggshield-LbIDqGyA",
+        "description": "description", "created_at": "2025-03-27T15:21:17.953340Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4cbf7af9-9989-4185-8ef8-0f39e6f3d145",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "2dfa1936-f53f-4d0c-8a69-ae9bab297021",
-        "name": "ggshield-qz84En8W", "description": "description", "created_at": "2025-03-27T15:24:16.907610Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2dfa1936-f53f-4d0c-8a69-ae9bab297021", "name": "ggshield-qz84En8W",
+        "description": "description", "created_at": "2025-03-27T15:24:16.907610Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2dfa1936-f53f-4d0c-8a69-ae9bab297021",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "11213dc7-118d-4997-a96b-714640c3ad0b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "11213dc7-118d-4997-a96b-714640c3ad0b",
         "name": "ggshield-CSF39jm8", "description": "description", "created_at": "2025-03-27T15:24:17.721006Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/11213dc7-118d-4997-a96b-714640c3ad0b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "899dd0b0-20b2-45d2-b779-0331cc448935",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "899dd0b0-20b2-45d2-b779-0331cc448935",
         "name": "toto", "description": "tata", "created_at": "2025-05-12T09:58:35.161641Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/899dd0b0-20b2-45d2-b779-0331cc448935",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9fcf0732-6b8d-41d3-ae98-727bd5dde585",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9fcf0732-6b8d-41d3-ae98-727bd5dde585",
         "name": "achille-hackathon", "description": "achille hackathon", "created_at":
         "2025-05-12T12:01:23.542568Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9fcf0732-6b8d-41d3-ae98-727bd5dde585",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b0ddbd44-4054-4127-aa00-cd6727e70d38",
         "name": "TestHoneytoken", "description": "Testing GitGuardian API connectivity",
         "created_at": "2025-05-12T12:19:05.294638Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b0ddbd44-4054-4127-aa00-cd6727e70d38",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b65d42a4-587f-4701-a595-8429cbcda70b",
-        "name": "gg-mcp-server-honeytoken", "description": "Honeytoken for security
-        monitoring in the gg-mcp-server project.", "created_at": "2025-05-12T12:54:44.402023Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b65d42a4-587f-4701-a595-8429cbcda70b",
-        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
-        "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
-        "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3fe4aa4f-49f6-42ad-a34a-0c108b544215",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "3fe4aa4f-49f6-42ad-a34a-0c108b544215",
         "name": "default-honeytoken", "description": "General purpose honeytoken for
         security monitoring", "created_at": "2025-05-12T13:07:52.676810Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/3fe4aa4f-49f6-42ad-a34a-0c108b544215",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 269050, "revoker_id": null, "creator_api_token_id":
         "4652a0d2-6083-4ffc-99cf-d21432584b62", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9844e55d-982c-4458-b65b-592ad99ce77a",
         "name": "test", "description": "test", "created_at": "2025-05-12T13:09:38.965752Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9844e55d-982c-4458-b65b-592ad99ce77a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1026550, "revoker_id": null, "creator_api_token_id":
         "347a103b-d95c-4bc6-baad-f470235759c6", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "b2a7e759-81ab-465d-a578-e3ce42c18741",
         "name": "Test Honeytoken", "description": "Testing honeytoken generation",
         "created_at": "2025-05-12T14:35:34.295363Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/b2a7e759-81ab-465d-a578-e3ce42c18741",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "fbb93094-9778-4b8b-97d8-de99954a758a",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "fbb93094-9778-4b8b-97d8-de99954a758a",
         "name": "AWS_Honeytoken", "description": "Honeytoken generated via MCP", "created_at":
         "2025-05-12T15:01:37.478675Z", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/fbb93094-9778-4b8b-97d8-de99954a758a",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "34e08af4-59a7-4a3b-b799-65acb8a2019d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "34e08af4-59a7-4a3b-b799-65acb8a2019d",
         "name": "AWS-MCP-Honeytoken", "description": "Honeytoken for monitoring potential
         AWS credential leaks", "created_at": "2025-05-12T15:07:16.157981Z", "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/honeytokens/34e08af4-59a7-4a3b-b799-65acb8a2019d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "16805984-70d6-4049-844a-79bac3054f6f",
         "name": "AwsTestHoneytoken", "description": "Test honeytoken for development
         and monitoring", "created_at": "2025-05-12T15:09:00.390236Z", "gitguardian_url":
@@ -799,10 +777,8 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "0a112323-6906-4bd0-a660-1b45a0fc59ca",
         "name": "NHI-Explorer-Secret", "description": "AWS access key for NHI Explorer
         project", "created_at": "2025-05-13T14:55:28.755591Z", "gitguardian_url":
@@ -810,218 +786,321 @@ interactions:
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 270722, "revoker_id": null, "creator_api_token_id":
         "fab65f5d-637c-41ff-83a5-a96f5a67ca6d", "revoker_api_token_id": null, "tags":
-        [], "labels": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key": "source",
-        "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
-        "key": "type", "value": "aws"}], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55",
-        "key": "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
+        [], "custom_tags": [{"id": "60d0313d-9096-41a7-8579-9523bfd8cc55", "key":
+        "source", "value": "auto-generated"}, {"id": "07359853-8918-4881-9d88-1df72e80ad15",
         "key": "type", "value": "aws"}], "token": "[REDACTED]"}, {"id": "69dbbe3c-2dfc-4c93-916c-f70c42f4e2af",
         "name": "ggshield-Leb9CGys", "description": "description", "created_at": "2025-05-27T08:18:31.020533Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/69dbbe3c-2dfc-4c93-916c-f70c42f4e2af",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
         "name": "ggshield-U8JeiAjO", "description": "description", "created_at": "2025-06-24T13:04:20.196705Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/c77d47b6-8d61-46a7-b6a1-1715fc47c7eb",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab",
-        "name": "ggshield-NiJSM24s", "description": "description", "created_at": "2025-06-24T13:04:21.255669Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab", "name": "ggshield-NiJSM24s",
+        "description": "description", "created_at": "2025-06-24T13:04:21.255669Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/8f9db3aa-133c-4c63-b14b-82cf7a8dd0ab",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "5692a982-6603-443e-bdb4-5ea1a5de6f64",
-        "name": "ggshield-JKhVuHaW", "description": "description", "created_at": "2025-06-24T13:06:56.046343Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "5692a982-6603-443e-bdb4-5ea1a5de6f64", "name": "ggshield-JKhVuHaW",
+        "description": "description", "created_at": "2025-06-24T13:06:56.046343Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/5692a982-6603-443e-bdb4-5ea1a5de6f64",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "17925c95-1df7-4e86-9c42-aabb5dbdea69",
-        "name": "ggshield-vfjAXCfY", "description": "description", "created_at": "2025-06-24T13:06:57.033247Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "17925c95-1df7-4e86-9c42-aabb5dbdea69", "name": "ggshield-vfjAXCfY",
+        "description": "description", "created_at": "2025-06-24T13:06:57.033247Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/17925c95-1df7-4e86-9c42-aabb5dbdea69",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "631ef101-122f-4592-9de1-2d6cb5becafa",
-        "name": "ggshield-dbhOtleP", "description": "description", "created_at": "2025-06-24T13:13:01.219899Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "631ef101-122f-4592-9de1-2d6cb5becafa", "name": "ggshield-dbhOtleP",
+        "description": "description", "created_at": "2025-06-24T13:13:01.219899Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/631ef101-122f-4592-9de1-2d6cb5becafa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "bebc1ca8-933d-45ca-b201-fbabc4eab464",
-        "name": "ggshield-7pQLMJYV", "description": "description", "created_at": "2025-06-24T13:13:01.978212Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "bebc1ca8-933d-45ca-b201-fbabc4eab464", "name": "ggshield-7pQLMJYV",
+        "description": "description", "created_at": "2025-06-24T13:13:01.978212Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bebc1ca8-933d-45ca-b201-fbabc4eab464",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "3983e8ff-7fd6-4fde-9117-9612d4258052",
-        "name": "ggshield-phDsJ9wy", "description": "description", "created_at": "2025-06-24T13:29:15.096198Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "3983e8ff-7fd6-4fde-9117-9612d4258052", "name": "ggshield-phDsJ9wy",
+        "description": "description", "created_at": "2025-06-24T13:29:15.096198Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3983e8ff-7fd6-4fde-9117-9612d4258052",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "9340e7fe-f79c-467e-9dcd-43ddaa77dc0c",
-        "name": "ggshield-Md0MBV0B", "description": "description", "created_at": "2025-06-24T13:29:16.049584Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "9340e7fe-f79c-467e-9dcd-43ddaa77dc0c", "name": "ggshield-Md0MBV0B",
+        "description": "description", "created_at": "2025-06-24T13:29:16.049584Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9340e7fe-f79c-467e-9dcd-43ddaa77dc0c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "08b51a6e-dd6c-4a4b-93f9-b955663c6524",
-        "name": "ggshield-ZoWflf5b", "description": "description", "created_at": "2025-06-24T13:31:49.045062Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "08b51a6e-dd6c-4a4b-93f9-b955663c6524", "name": "ggshield-ZoWflf5b",
+        "description": "description", "created_at": "2025-06-24T13:31:49.045062Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/08b51a6e-dd6c-4a4b-93f9-b955663c6524",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "96da938d-d6fa-4e44-9254-c568a27be484",
-        "name": "ggshield-PirK5h1Q", "description": "description", "created_at": "2025-06-24T13:31:49.827284Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "96da938d-d6fa-4e44-9254-c568a27be484", "name": "ggshield-PirK5h1Q",
+        "description": "description", "created_at": "2025-06-24T13:31:49.827284Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/96da938d-d6fa-4e44-9254-c568a27be484",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f2c61b85-e11d-4db0-a8af-7fc327310b39",
-        "name": "ggshield-ZQ4jUtQr", "description": "description", "created_at": "2025-06-24T13:45:17.477850Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f2c61b85-e11d-4db0-a8af-7fc327310b39", "name": "ggshield-ZQ4jUtQr",
+        "description": "description", "created_at": "2025-06-24T13:45:17.477850Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f2c61b85-e11d-4db0-a8af-7fc327310b39",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f99173ff-9ffe-492c-b8ae-54157df89bac",
-        "name": "ggshield-5uK6KYFh", "description": "description", "created_at": "2025-06-24T13:45:18.309642Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f99173ff-9ffe-492c-b8ae-54157df89bac", "name": "ggshield-5uK6KYFh",
+        "description": "description", "created_at": "2025-06-24T13:45:18.309642Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f99173ff-9ffe-492c-b8ae-54157df89bac",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768",
-        "name": "ggshield-MGXkbqc7", "description": "description", "created_at": "2025-06-24T13:50:43.295521Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768", "name": "ggshield-MGXkbqc7",
+        "description": "description", "created_at": "2025-06-24T13:50:43.295521Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/3e4cd78b-4b95-4f2e-8ca6-fa0e6d385768",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "f3252f2c-16a9-45e4-97e8-bed4b5752415",
-        "name": "ggshield-YJd3rq9q", "description": "description", "created_at": "2025-06-24T13:50:44.165951Z",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "f3252f2c-16a9-45e4-97e8-bed4b5752415", "name": "ggshield-YJd3rq9q",
+        "description": "description", "created_at": "2025-06-24T13:50:44.165951Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/f3252f2c-16a9-45e4-97e8-bed4b5752415",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": null, "revoker_id": null, "creator_api_token_id":
-        null, "revoker_api_token_id": null, "tags": [], "labels": [], "custom_tags":
-        [], "token": "[REDACTED]"}, {"id": "e22705f1-5497-449b-9614-3c2d89e3b705",
-        "name": "ggshield-l4abwnpa", "description": null, "created_at": "2025-06-26T12:32:05.993896Z",
-        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e22705f1-5497-449b-9614-3c2d89e3b705",
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "e22705f1-5497-449b-9614-3c2d89e3b705", "name": "ggshield-l4abwnpa",
+        "description": null, "created_at": "2025-06-26T12:32:05.993896Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/e22705f1-5497-449b-9614-3c2d89e3b705",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
         "4ff03654-f280-4c31-8eef-5295d2b75a50", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7691445a-2cb0-4093-94ca-f2c5de877075",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "7691445a-2cb0-4093-94ca-f2c5de877075",
         "name": "ggshield-Lwhu1Nax", "description": "description", "created_at": "2025-07-29T10:34:41.534666Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/7691445a-2cb0-4093-94ca-f2c5de877075",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "951e1f19-5804-444a-b275-b51dc5bf68ee",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "951e1f19-5804-444a-b275-b51dc5bf68ee",
         "name": "ggshield-u9ltlEmT", "description": "description", "created_at": "2025-07-29T10:34:42.385215Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/951e1f19-5804-444a-b275-b51dc5bf68ee",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
         "name": "ggshield-CC0Lj0vS", "description": "description", "created_at": "2025-07-29T10:40:27.317817Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/9f6ec004-4e6b-4a33-8c9e-1e3b7792cea8",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
         "name": "ggshield-ncOpkfP8", "description": "description", "created_at": "2025-08-27T11:43:11.666517Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/49e4fce7-aa48-42b0-9fc4-e16105ae08e5",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2b15518b-3100-4736-bee6-b47fe8d26fc1",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "2b15518b-3100-4736-bee6-b47fe8d26fc1",
         "name": "ggshield-H2eDvilF", "description": "description", "created_at": "2025-08-27T11:43:12.618589Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/2b15518b-3100-4736-bee6-b47fe8d26fc1",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "368a90bf-269b-4a60-95c2-1c77c86f7fd4",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "368a90bf-269b-4a60-95c2-1c77c86f7fd4",
         "name": "ggshield-V6RzZJGL", "description": "description", "created_at": "2025-11-14T16:54:30.227288Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/368a90bf-269b-4a60-95c2-1c77c86f7fd4",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "eae1aaaf-d700-475d-b65a-ffd79f84806d",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "eae1aaaf-d700-475d-b65a-ffd79f84806d",
         "name": "ggshield-Pya2g1xF", "description": "description", "created_at": "2025-11-14T16:54:30.933576Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/eae1aaaf-d700-475d-b65a-ffd79f84806d",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 160089, "revoker_id": null, "creator_api_token_id":
         "c5b1d824-a6c0-46cc-89a8-bd0789dec2a5", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
         "name": "ggshield-Z2Ji3PxX", "description": "description", "created_at": "2026-03-31T13:26:20.710346Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/43fe49e2-a4e9-4050-9eb5-e89bacc45ba9",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
         "name": "ggshield-FsL9dCzu", "description": "description", "created_at": "2026-03-31T13:26:21.681383Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e3f3ff14-a413-415e-a7c1-b91ea1f8ba40",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7daed77-1fa4-416d-88e2-473200b810aa",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "e7daed77-1fa4-416d-88e2-473200b810aa",
         "name": "ggshield-dqv39cn2", "description": "description", "created_at": "2026-03-31T13:32:28.824725Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/e7daed77-1fa4-416d-88e2-473200b810aa",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "601c59d9-7579-402e-90c4-59da055a8d3b",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "601c59d9-7579-402e-90c4-59da055a8d3b",
         "name": "ggshield-YpbVgsRl", "description": "description", "created_at": "2026-03-31T13:32:29.820990Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/601c59d9-7579-402e-90c4-59da055a8d3b",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "54e52712-a036-4e80-899b-c1a200610339",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "54e52712-a036-4e80-899b-c1a200610339",
         "name": "ggshield-DZ5zVj1p", "description": "description", "created_at": "2026-03-31T13:37:32.513332Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/54e52712-a036-4e80-899b-c1a200610339",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51dc5671-8053-4b87-8174-975ccf7f249c",
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "51dc5671-8053-4b87-8174-975ccf7f249c",
         "name": "ggshield-DXGKK2gC", "description": "description", "created_at": "2026-03-31T13:37:33.559937Z",
         "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/51dc5671-8053-4b87-8174-975ccf7f249c",
         "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
         "open_events_count": 0, "creator_id": 1094429, "revoker_id": null, "creator_api_token_id":
         "8467d408-fe6a-4e53-bb63-ef439161d621", "revoker_api_token_id": null, "tags":
-        [], "labels": [], "custom_tags": [], "token": "[REDACTED]"}]'
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "name": "test Pierre", "description": "", "created_at": "2026-04-07T18:38:38.199572Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/84dad31e-2dea-46c9-9ae8-8077d108b74c",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 309802, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "2a72f662-2357-4b93-b48a-00028e36cfff", "name": "test1",
+        "description": "tEST 2", "created_at": "2026-04-30T09:12:55.584248Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/2a72f662-2357-4b93-b48a-00028e36cfff",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "963fbabe-3d2c-4154-8281-2f13be7c06f7", "name": "test121",
+        "description": "testing 12", "created_at": "2026-04-30T11:31:57.689130Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/963fbabe-3d2c-4154-8281-2f13be7c06f7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "bb1adf06-28ea-4daf-b338-59d5ef094f67", "name": "TheBigHoney",
+        "description": "Big Honey Pot for our core secrets", "created_at": "2026-05-19T11:51:12.957707Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/bb1adf06-28ea-4daf-b338-59d5ef094f67",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754656, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "8409c955-f217-47c9-9cf1-3a6b557c65c9", "name": "Test",
+        "description": "", "created_at": "2026-05-26T14:12:05.347374Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/8409c955-f217-47c9-9cf1-3a6b557c65c9",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1754650, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [], "token":
+        "[REDACTED]"}, {"id": "82f00514-d9d3-442c-b575-c40ff77db387", "name": "test-plc2",
+        "description": "", "created_at": "2026-05-27T13:13:33.943814Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/82f00514-d9d3-442c-b575-c40ff77db387",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 701514, "revoker_id": null, "creator_api_token_id":
+        null, "revoker_api_token_id": null, "tags": [], "custom_tags": [{"id": "86303a62-9be9-4866-8961-9b245ff98c20",
+        "key": "squad-honeytoken", "value": null}], "token": "[REDACTED]"}, {"id":
+        "86344c0b-c360-4709-bb6b-fce628ace1d7", "name": "honeytoken-toot-991c4137",
+        "description": "", "created_at": "2026-06-05T17:59:07.240726Z", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/honeytokens/86344c0b-c360-4709-bb6b-fce628ace1d7",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
+        "97c1b533-d768-4054-94de-ae3d967a5128", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "949d59d0-c3c2-4d5e-ae3c-4f365b9b8456",
+        "name": "honeytoken-toot-0fefb095", "description": "", "created_at": "2026-06-05T17:59:07.748651Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/949d59d0-c3c2-4d5e-ae3c-4f365b9b8456",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 113168, "revoker_id": null, "creator_api_token_id":
+        "97c1b533-d768-4054-94de-ae3d967a5128", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "0ab5965c-8f7e-44ec-b64e-1111e140586f",
+        "name": "ggshield-WOmcC4wM", "description": "description", "created_at": "2026-06-15T15:05:19.990102Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/0ab5965c-8f7e-44ec-b64e-1111e140586f",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "95786b03-4165-4245-8aef-fac41ff6a1de",
+        "name": "ggshield-E2HxYogl", "description": "description", "created_at": "2026-06-15T15:05:20.446208Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/95786b03-4165-4245-8aef-fac41ff6a1de",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "98271cf2-3025-4e7d-b120-afd29fe20c8f",
+        "name": "ggshield-32Xli2ct", "description": "description", "created_at": "2026-06-15T15:13:44.456933Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/98271cf2-3025-4e7d-b120-afd29fe20c8f",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "68f09d33-1cab-4b93-84a5-2861a7a01fbc",
+        "name": "ggshield-o2ocvFQZ", "description": "description", "created_at": "2026-06-15T15:13:45.228488Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/68f09d33-1cab-4b93-84a5-2861a7a01fbc",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "ee69dfd0-fa9c-451d-947e-261c2edd4355",
+        "name": "ggshield-rGxN1k4I", "description": "description", "created_at": "2026-06-15T15:46:58.088837Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/ee69dfd0-fa9c-451d-947e-261c2edd4355",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4f91525c-02bd-4a0f-9c5d-c9949f7196f4",
+        "name": "ggshield-bZoVll0H", "description": "description", "created_at": "2026-06-15T15:46:58.839510Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4f91525c-02bd-4a0f-9c5d-c9949f7196f4",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "c347a1bb-6f96-42bc-8a51-592c237b18d9", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "4a3a3699-fb2e-4e0f-ae02-4905fe8228ec",
+        "name": "ggshield-VuSeELel", "description": "description", "created_at": "2026-06-17T13:23:52.166183Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/4a3a3699-fb2e-4e0f-ae02-4905fe8228ec",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "dd2d3e47-d804-41c5-b8b8-f640e6292096", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}, {"id": "d82dc520-9ea5-4a38-a9d8-84bf2f94975b",
+        "name": "ggshield-yQlAvTpn", "description": "description", "created_at": "2026-06-17T13:23:52.682610Z",
+        "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/honeytokens/d82dc520-9ea5-4a38-a9d8-84bf2f94975b",
+        "status": "active", "triggered_at": null, "revoked_at": null, "type": "AWS",
+        "open_events_count": 0, "creator_id": 1306742, "revoker_id": null, "creator_api_token_id":
+        "dd2d3e47-d804-41c5-b8b8-f640e6292096", "revoker_api_token_id": null, "tags":
+        [], "custom_tags": [], "token": "[REDACTED]"}]'
     headers:
+      CF-RAY:
+      - a103978119b7d808-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:47 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, POST, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '82803'
+      - '86935'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:42 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '129'
+      - '120'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_incident_members_basic.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incident_members_basic.yaml
@@ -13,7 +13,9 @@ interactions:
       Host:
       - api.gitguardian.com
       User-Agent:
-      - GitGuardian-MCP-Server/1.0
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
     method: GET
     uri: https://api.gitguardian.com/v1/incidents/secrets/21460/members?per_page=5
   response:
@@ -21,53 +23,61 @@ interactions:
       string: '[{"id": 10, "member_id": 10, "role": "manager", "name": "Bruce Wayne",
         "email": "bruce-wayne-gg@protonmail.com", "incident_id": 21460, "incident_permission":
         "full_access"}, {"id": 13, "member_id": 13, "role": "manager", "name": "Aymeric
-        Sicard", "email": "aymeric.sicard@gitguardian.com", "incident_id": 21460,
+        SICARD", "email": "aymeric.sicard@gitguardian.com", "incident_id": 21460,
         "incident_permission": "full_access"}, {"id": 2508, "member_id": 2508, "role":
-        "manager", "name": "Guillaume Charpiat", "email": "guillaume.charpiat@gitguardian.com",
+        "manager", "name": "Guillaume CHARPIAT", "email": "guillaume.charpiat@gitguardian.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 37699,
-        "member_id": 37699, "role": "manager", "name": "Alexis Larnaud", "email":
+        "member_id": 37699, "role": "manager", "name": "Alexis LARNAUD", "email":
         "alexis.larnaud@gitguardian.com", "incident_id": 21460, "incident_permission":
         "full_access"}, {"id": 63809, "member_id": 63809, "role": "manager", "name":
-        "Orian Roturier", "email": "orian.roturier@gitguardian.com", "incident_id":
+        "Orian ROTURIER", "email": "orian.roturier@gitguardian.com", "incident_id":
         21460, "incident_permission": "full_access"}]'
     headers:
+      CF-RAY:
+      - a10397acfd17d343-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:54 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '836'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Wed, 04 Mar 2026 11:39:06 GMT
       link:
       - <https://api.gitguardian.com/v1/incidents/secrets/21460/members?cursor=cD02MzgwOQ%3D%3D&per_page=5>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.404.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '47'
+      - '42'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.157.1
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_incident_members_with_access_level.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incident_members_with_access_level.yaml
@@ -13,7 +13,9 @@ interactions:
       Host:
       - api.gitguardian.com
       User-Agent:
-      - GitGuardian-MCP-Server/1.0
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
     method: GET
     uri: https://api.gitguardian.com/v1/incidents/secrets/21460/members?per_page=10&access_level=owner
   response:
@@ -21,64 +23,72 @@ interactions:
       string: '[{"id": 10, "member_id": 10, "role": "manager", "name": "Bruce Wayne",
         "email": "bruce-wayne-gg@protonmail.com", "incident_id": 21460, "incident_permission":
         "full_access"}, {"id": 13, "member_id": 13, "role": "manager", "name": "Aymeric
-        Sicard", "email": "aymeric.sicard@gitguardian.com", "incident_id": 21460,
+        SICARD", "email": "aymeric.sicard@gitguardian.com", "incident_id": 21460,
         "incident_permission": "full_access"}, {"id": 2508, "member_id": 2508, "role":
-        "manager", "name": "Guillaume Charpiat", "email": "guillaume.charpiat@gitguardian.com",
+        "manager", "name": "Guillaume CHARPIAT", "email": "guillaume.charpiat@gitguardian.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 37699,
-        "member_id": 37699, "role": "manager", "name": "Alexis Larnaud", "email":
+        "member_id": 37699, "role": "manager", "name": "Alexis LARNAUD", "email":
         "alexis.larnaud@gitguardian.com", "incident_id": 21460, "incident_permission":
         "full_access"}, {"id": 63809, "member_id": 63809, "role": "manager", "name":
-        "Orian Roturier", "email": "orian.roturier@gitguardian.com", "incident_id":
+        "Orian ROTURIER", "email": "orian.roturier@gitguardian.com", "incident_id":
         21460, "incident_permission": "full_access"}, {"id": 69474, "member_id": 69474,
         "role": "member", "name": "Eric", "email": "elacaille0@gmail.com", "incident_id":
         21460, "incident_permission": "can_edit"}, {"id": 104544, "member_id": 104544,
-        "role": "manager", "name": "Pierre Lalanne", "email": "pierre.lalanne@gitguardian.com",
+        "role": "manager", "name": "Pierre LALANNE", "email": "pierre.lalanne@gitguardian.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 104916,
-        "member_id": 104916, "role": "manager", "name": "wassim hana", "email": "wassim.hana@gitguardian.com",
+        "member_id": 104916, "role": "manager", "name": "Wassim HANA", "email": "wassim.hana@gitguardian.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 113168,
-        "member_id": 113168, "role": "owner", "name": "Henri Hubert", "email": "henri.hubert@gitguardian.com",
+        "member_id": 113168, "role": "owner", "name": "Henri HUBERT", "email": "henri.hubert@gitguardian.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 136170,
-        "member_id": 136170, "role": "manager", "name": "Eric Fourrier", "email":
+        "member_id": 136170, "role": "manager", "name": "Eric FOURRIER", "email":
         "eric.fourrier@gitguardian.com", "incident_id": 21460, "incident_permission":
         "full_access"}]'
     headers:
+      CF-RAY:
+      - a10397b0aa709dae-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:54 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '1651'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Wed, 04 Mar 2026 11:39:07 GMT
       link:
       - <https://api.gitguardian.com/v1/incidents/secrets/21460/members?access_level=owner&cursor=cD0xMzYxNzA%3D&per_page=10>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.404.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '36'
+      - '33'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.157.1
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_incident_members_with_direct_access.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incident_members_with_direct_access.yaml
@@ -13,7 +13,9 @@ interactions:
       Host:
       - api.gitguardian.com
       User-Agent:
-      - GitGuardian-MCP-Server/1.0
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
     method: GET
     uri: https://api.gitguardian.com/v1/incidents/secrets/21460/members?per_page=10&direct_access=true
   response:
@@ -21,64 +23,72 @@ interactions:
       string: '[{"id": 10, "member_id": 10, "role": "manager", "name": "Bruce Wayne",
         "email": "bruce-wayne-gg@protonmail.com", "incident_id": 21460, "incident_permission":
         "full_access"}, {"id": 13, "member_id": 13, "role": "manager", "name": "Aymeric
-        Sicard", "email": "aymeric.sicard@gitguardian.com", "incident_id": 21460,
+        SICARD", "email": "aymeric.sicard@gitguardian.com", "incident_id": 21460,
         "incident_permission": "full_access"}, {"id": 2508, "member_id": 2508, "role":
-        "manager", "name": "Guillaume Charpiat", "email": "guillaume.charpiat@gitguardian.com",
+        "manager", "name": "Guillaume CHARPIAT", "email": "guillaume.charpiat@gitguardian.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 37699,
-        "member_id": 37699, "role": "manager", "name": "Alexis Larnaud", "email":
+        "member_id": 37699, "role": "manager", "name": "Alexis LARNAUD", "email":
         "alexis.larnaud@gitguardian.com", "incident_id": 21460, "incident_permission":
         "full_access"}, {"id": 63809, "member_id": 63809, "role": "manager", "name":
-        "Orian Roturier", "email": "orian.roturier@gitguardian.com", "incident_id":
+        "Orian ROTURIER", "email": "orian.roturier@gitguardian.com", "incident_id":
         21460, "incident_permission": "full_access"}, {"id": 69474, "member_id": 69474,
         "role": "member", "name": "Eric", "email": "elacaille0@gmail.com", "incident_id":
         21460, "incident_permission": "can_edit"}, {"id": 104544, "member_id": 104544,
-        "role": "manager", "name": "Pierre Lalanne", "email": "pierre.lalanne@gitguardian.com",
+        "role": "manager", "name": "Pierre LALANNE", "email": "pierre.lalanne@gitguardian.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 104916,
-        "member_id": 104916, "role": "manager", "name": "wassim hana", "email": "wassim.hana@gitguardian.com",
+        "member_id": 104916, "role": "manager", "name": "Wassim HANA", "email": "wassim.hana@gitguardian.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 113168,
-        "member_id": 113168, "role": "owner", "name": "Henri Hubert", "email": "henri.hubert@gitguardian.com",
+        "member_id": 113168, "role": "owner", "name": "Henri HUBERT", "email": "henri.hubert@gitguardian.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 136170,
-        "member_id": 136170, "role": "manager", "name": "Eric Fourrier", "email":
+        "member_id": 136170, "role": "manager", "name": "Eric FOURRIER", "email":
         "eric.fourrier@gitguardian.com", "incident_id": 21460, "incident_permission":
         "full_access"}]'
     headers:
+      CF-RAY:
+      - a10397b40d96d10c-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:55 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '1651'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Wed, 04 Mar 2026 11:39:09 GMT
       link:
       - <https://api.gitguardian.com/v1/incidents/secrets/21460/members?cursor=cD0xMzYxNzA%3D&direct_access=true&per_page=10>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.404.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '32'
+      - '41'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.157.1
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_incident_members_with_ordering.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incident_members_with_ordering.yaml
@@ -13,7 +13,9 @@ interactions:
       Host:
       - api.gitguardian.com
       User-Agent:
-      - GitGuardian-MCP-Server/1.0
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
     method: GET
     uri: https://api.gitguardian.com/v1/incidents/secrets/21460/members?per_page=10&ordering=-created_at
   response:
@@ -21,64 +23,72 @@ interactions:
       string: '[{"id": 10, "member_id": 10, "role": "manager", "name": "Bruce Wayne",
         "email": "bruce-wayne-gg@protonmail.com", "incident_id": 21460, "incident_permission":
         "full_access"}, {"id": 13, "member_id": 13, "role": "manager", "name": "Aymeric
-        Sicard", "email": "aymeric.sicard@gitguardian.com", "incident_id": 21460,
+        SICARD", "email": "aymeric.sicard@gitguardian.com", "incident_id": 21460,
         "incident_permission": "full_access"}, {"id": 2508, "member_id": 2508, "role":
-        "manager", "name": "Guillaume Charpiat", "email": "guillaume.charpiat@gitguardian.com",
+        "manager", "name": "Guillaume CHARPIAT", "email": "guillaume.charpiat@gitguardian.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 37699,
-        "member_id": 37699, "role": "manager", "name": "Alexis Larnaud", "email":
+        "member_id": 37699, "role": "manager", "name": "Alexis LARNAUD", "email":
         "alexis.larnaud@gitguardian.com", "incident_id": 21460, "incident_permission":
         "full_access"}, {"id": 63809, "member_id": 63809, "role": "manager", "name":
-        "Orian Roturier", "email": "orian.roturier@gitguardian.com", "incident_id":
+        "Orian ROTURIER", "email": "orian.roturier@gitguardian.com", "incident_id":
         21460, "incident_permission": "full_access"}, {"id": 69474, "member_id": 69474,
         "role": "member", "name": "Eric", "email": "elacaille0@gmail.com", "incident_id":
         21460, "incident_permission": "can_edit"}, {"id": 104544, "member_id": 104544,
-        "role": "manager", "name": "Pierre Lalanne", "email": "pierre.lalanne@gitguardian.com",
+        "role": "manager", "name": "Pierre LALANNE", "email": "pierre.lalanne@gitguardian.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 104916,
-        "member_id": 104916, "role": "manager", "name": "wassim hana", "email": "wassim.hana@gitguardian.com",
+        "member_id": 104916, "role": "manager", "name": "Wassim HANA", "email": "wassim.hana@gitguardian.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 113168,
-        "member_id": 113168, "role": "owner", "name": "Henri Hubert", "email": "henri.hubert@gitguardian.com",
+        "member_id": 113168, "role": "owner", "name": "Henri HUBERT", "email": "henri.hubert@gitguardian.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 136170,
-        "member_id": 136170, "role": "manager", "name": "Eric Fourrier", "email":
+        "member_id": 136170, "role": "manager", "name": "Eric FOURRIER", "email":
         "eric.fourrier@gitguardian.com", "incident_id": 21460, "incident_permission":
         "full_access"}]'
     headers:
+      CF-RAY:
+      - a10397b25a4dd146-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:55 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '1651'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Wed, 04 Mar 2026 11:39:08 GMT
       link:
       - <https://api.gitguardian.com/v1/incidents/secrets/21460/members?cursor=cD0xMzYxNzA%3D&ordering=-created_at&per_page=10>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.404.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '36'
+      - '32'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.157.1
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_incident_members_with_search.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incident_members_with_search.yaml
@@ -13,62 +13,72 @@ interactions:
       Host:
       - api.gitguardian.com
       User-Agent:
-      - GitGuardian-MCP-Server/1.0
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
     method: GET
     uri: https://api.gitguardian.com/v1/incidents/secrets/21460/members?per_page=10&search=gitguardian
   response:
     body:
-      string: '[{"id": 13, "member_id": 13, "role": "manager", "name": "Aymeric Sicard",
+      string: '[{"id": 13, "member_id": 13, "role": "manager", "name": "Aymeric SICARD",
         "email": "aymeric.sicard@gitguardian.com", "incident_id": 21460, "incident_permission":
         "full_access"}, {"id": 2508, "member_id": 2508, "role": "manager", "name":
-        "Guillaume Charpiat", "email": "guillaume.charpiat@gitguardian.com", "incident_id":
+        "Guillaume CHARPIAT", "email": "guillaume.charpiat@gitguardian.com", "incident_id":
         21460, "incident_permission": "full_access"}, {"id": 37699, "member_id": 37699,
-        "role": "manager", "name": "Alexis Larnaud", "email": "alexis.larnaud@gitguardian.com",
+        "role": "manager", "name": "Alexis LARNAUD", "email": "alexis.larnaud@gitguardian.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 63809,
-        "member_id": 63809, "role": "manager", "name": "Orian Roturier", "email":
+        "member_id": 63809, "role": "manager", "name": "Orian ROTURIER", "email":
         "orian.roturier@gitguardian.com", "incident_id": 21460, "incident_permission":
         "full_access"}, {"id": 104544, "member_id": 104544, "role": "manager", "name":
-        "Pierre Lalanne", "email": "pierre.lalanne@gitguardian.com", "incident_id":
+        "Pierre LALANNE", "email": "pierre.lalanne@gitguardian.com", "incident_id":
         21460, "incident_permission": "full_access"}, {"id": 104916, "member_id":
-        104916, "role": "manager", "name": "wassim hana", "email": "wassim.hana@gitguardian.com",
+        104916, "role": "manager", "name": "Wassim HANA", "email": "wassim.hana@gitguardian.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 113168,
-        "member_id": 113168, "role": "owner", "name": "Henri Hubert", "email": "henri.hubert@gitguardian.com",
+        "member_id": 113168, "role": "owner", "name": "Henri HUBERT", "email": "henri.hubert@gitguardian.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 136170,
-        "member_id": 136170, "role": "manager", "name": "Eric Fourrier", "email":
+        "member_id": 136170, "role": "manager", "name": "Eric FOURRIER", "email":
         "eric.fourrier@gitguardian.com", "incident_id": 21460, "incident_permission":
         "full_access"}, {"id": 160089, "member_id": 160089, "role": "manager", "name":
-        "Aur\u00e9lien G\u00e2teau", "email": "aurelien.gateau@gitguardian.com", "incident_id":
+        "Aur\u00e9lien G\u00c2TEAU", "email": "aurelien.gateau@gitguardian.com", "incident_id":
         21460, "incident_permission": "full_access"}, {"id": 166199, "member_id":
-        166199, "role": "manager", "name": "Stanislas Cr\u00e9pin", "email": "stanislas.crepin@gitguardian.com",
+        166199, "role": "manager", "name": "Stanislas CR\u00c9PIN", "email": "stanislas.crepin@gitguardian.com",
         "incident_id": 21460, "incident_permission": "full_access"}]'
     headers:
+      CF-RAY:
+      - a10397aeeb3fd8d2-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:54 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '1698'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Wed, 04 Mar 2026 11:39:07 GMT
       link:
       - <https://api.gitguardian.com/v1/incidents/secrets/21460/members?cursor=cD0xNjYxOTk%3D&per_page=10&search=gitguardian>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.404.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
@@ -78,7 +88,7 @@ interactions:
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.157.1
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_incident_teams_basic.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incident_teams_basic.yaml
@@ -13,7 +13,9 @@ interactions:
       Host:
       - api.gitguardian.com
       User-Agent:
-      - GitGuardian-MCP-Server/1.0
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
     method: GET
     uri: https://api.gitguardian.com/v1/incidents/secrets/21460/teams?per_page=5
   response:
@@ -21,44 +23,54 @@ interactions:
       string: '[{"team_id": 304856, "incident_id": 21460, "incident_permission": "full_access"},
         {"team_id": 305252, "incident_id": 21460, "incident_permission": "full_access"},
         {"team_id": 306598, "incident_id": 21460, "incident_permission": "full_access"},
-        {"team_id": 337146, "incident_id": 21460, "incident_permission": "full_access"}]'
+        {"team_id": 337146, "incident_id": 21460, "incident_permission": "full_access"},
+        {"team_id": 470245, "incident_id": 21460, "incident_permission": "full_access"}]'
     headers:
+      CF-RAY:
+      - a10397b5bf65b843-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:55 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '301'
+      - '376'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Wed, 04 Mar 2026 11:39:09 GMT
       link:
-      - ''
+      - <https://api.gitguardian.com/v1/incidents/secrets/21460/teams?cursor=cD00NzAyNDU%3D&per_page=5>;
+        rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.404.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '97'
+      - '264'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.157.1
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_incident_teams_with_direct_access.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incident_teams_with_direct_access.yaml
@@ -13,7 +13,9 @@ interactions:
       Host:
       - api.gitguardian.com
       User-Agent:
-      - GitGuardian-MCP-Server/1.0
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
     method: GET
     uri: https://api.gitguardian.com/v1/incidents/secrets/21460/teams?per_page=10&direct_access=true
   response:
@@ -21,44 +23,56 @@ interactions:
       string: '[{"team_id": 304856, "incident_id": 21460, "incident_permission": "full_access"},
         {"team_id": 305252, "incident_id": 21460, "incident_permission": "full_access"},
         {"team_id": 306598, "incident_id": 21460, "incident_permission": "full_access"},
-        {"team_id": 337146, "incident_id": 21460, "incident_permission": "full_access"}]'
+        {"team_id": 337146, "incident_id": 21460, "incident_permission": "full_access"},
+        {"team_id": 470245, "incident_id": 21460, "incident_permission": "full_access"},
+        {"team_id": 491687, "incident_id": 21460, "incident_permission": "full_access"},
+        {"team_id": 574615, "incident_id": 21460, "incident_permission": "full_access"},
+        {"team_id": 931424, "incident_id": 21460, "incident_permission": "full_access"}]'
     headers:
+      CF-RAY:
+      - a10397bac9b1d578-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:56 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '301'
+      - '601'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Wed, 04 Mar 2026 11:39:11 GMT
       link:
       - ''
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.404.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '38'
+      - '48'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.157.1
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_incident_teams_with_search.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incident_teams_with_search.yaml
@@ -13,7 +13,9 @@ interactions:
       Host:
       - api.gitguardian.com
       User-Agent:
-      - GitGuardian-MCP-Server/1.0
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
     method: GET
     uri: https://api.gitguardian.com/v1/incidents/secrets/21460/teams?per_page=10&search=feature
   response:
@@ -21,44 +23,56 @@ interactions:
       string: '[{"team_id": 304856, "incident_id": 21460, "incident_permission": "full_access"},
         {"team_id": 305252, "incident_id": 21460, "incident_permission": "full_access"},
         {"team_id": 306598, "incident_id": 21460, "incident_permission": "full_access"},
-        {"team_id": 337146, "incident_id": 21460, "incident_permission": "full_access"}]'
+        {"team_id": 337146, "incident_id": 21460, "incident_permission": "full_access"},
+        {"team_id": 470245, "incident_id": 21460, "incident_permission": "full_access"},
+        {"team_id": 491687, "incident_id": 21460, "incident_permission": "full_access"},
+        {"team_id": 574615, "incident_id": 21460, "incident_permission": "full_access"},
+        {"team_id": 931424, "incident_id": 21460, "incident_permission": "full_access"}]'
     headers:
+      CF-RAY:
+      - a10397b8ff449816-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:56 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '301'
+      - '601'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Wed, 04 Mar 2026 11:39:10 GMT
       link:
       - ''
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.404.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '37'
+      - '51'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.157.1
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_incidents_coerce_multiple_single_values.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incidents_coerce_multiple_single_values.yaml
@@ -21,8 +21,55 @@ interactions:
   response:
     body:
       string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?ordering=-date&page=2&page_size=5&severity__in=10&status__in=TRIGGERED&tags__nin=TEST_FILE&validity__in=valid",
-        "previous": null, "results": [{"id": 22515404, "account": 8, "criterion":
-        "AWS Keys", "date": "2025-11-17T17:16:25Z", "last_trigger_published_at": "2025-11-17T17:16:25Z",
+        "previous": null, "results": [{"id": 32985083, "account": 8, "criterion":
+        "Google API Key", "date": "2026-05-19T09:33:23Z", "last_trigger_published_at":
+        "2026-05-19T09:33:23Z", "last_triggered_at": "2026-05-19T09:36:55.570755Z",
+        "last_trigger_detected_at": "2026-05-19T09:36:55.570755Z", "hash": "pHE0O7zGgt2lhT0TLQzB2cwgMuZgrhqH4vSIGV5fw5ao1EL3iwQ5Z8PP16EaJtIX",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Google API Key", "severity_rule_config": {"id": 11883, "gg_created_at": "2026-05-20T08:56:10.055321Z",
+        "gg_updated_at": "2026-05-20T08:56:10.055331Z", "index": 10, "severity": 10,
+        "rule": {"id": 745, "gg_created_at": "2026-02-12T15:13:36.079495Z", "gg_updated_at":
+        "2026-02-12T15:13:36.079508Z", "name": "Publicly leaked secrets", "description":
+        "Publicly leaked secrets outside perimeter", "json_rule": {"operator": "AND",
+        "args": [{"operator": "NOT", "arg1": {"operator": "EQ", "arg1": {"path": "issue.public_leak_range",
+        "default": null}, "arg2": {"value": "0"}}}, {"operator": "NOT", "arg1": {"operator":
+        "EQ", "arg1": {"path": "issue.secret.validity_status", "default": null}, "arg2":
+        {"value": "invalid"}}}]}, "is_global": false, "scope": "private", "author":
+        520858}}, "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com",
+        "name": "dev"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 16218896, "name": "qa / test-nriv", "type": "gl_project", "path":
+        "qa1/test-nriv", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 0, "score": 64, "displayed_occurrence": {"id":
+        268288466, "issue": 32985083, "account": 8, "kind": "RLTM", "element": "9181621d49e910c3d2393f2373e52c04b26c7adb",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "y0o7bgCt8InKo3/G0QE6WaG+gU32WlUdYH0N4oUFXredK2KoKwrhfI+hoCMCs6v6",
+        "published_at": "2026-05-19T09:33:23Z", "date": "2026-05-19T09:33:23Z", "detected_at":
+        "2026-05-19T09:36:53.339083Z", "is_vcs_type": true, "last_detected_at": "2026-05-19T09:33:23Z",
+        "last_seen_at": "2026-05-19T09:33:23Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa1/test-nriv/commit/9181621d49e910c3d2393f2373e52c04b26c7adb#a290632bbcae192e53c54337b3238d835c97e8a9_5_4",
+        "source": {"id": 16218896, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa1/test-nriv",
+        "type": "gl_project", "display_name": "qa / test-nriv", "visibility": "internal",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 162813398,
+        "secrets_engine_version": "2.162.0", "matches": [{"name": "apikey", "string_matched":
+        "[REDACTED]", "indice_start": 307, "indice_end": 346, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 4, "post_line_end": 4}], "most_sensitive_match_name":
+        "apikey", "insights": [], "filepath": ".envrc", "filename": ".envrc", "presence":
+        "visible", "last_presence_seen_at": "2026-05-19T09:36:55.598741Z", "last_presence_check_at":
+        "2026-05-19T09:36:55.598741Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        true, "change_type": "addition", "full_tags": [{"type": "DEFAULT_BRANCH",
+        "metadata": null, "field": "content"}]}, "has_dropped_occurrences": false,
+        "tags": ["DEFAULT_BRANCH", "PUBLICLY_LEAKED"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": true},
+        "occurrences_count": 2}, {"id": 22515404, "account": 8, "criterion": "AWS
+        Keys", "date": "2025-11-17T17:16:25Z", "last_trigger_published_at": "2025-11-17T17:16:25Z",
         "last_triggered_at": "2025-11-17T17:18:18.706440Z", "last_trigger_detected_at":
         "2025-11-17T17:18:18.706440Z", "hash": "6y4trbQi60aNmDEFQe0tJH3jke+8j18I9t2sKfgaunTYEUdZL4Qc71cZRqNcojMG",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
@@ -30,8 +77,8 @@ interactions:
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "AWS IAM Keys", "severity_rule_config": {"id": 10860, "gg_created_at": "2026-02-12T15:13:37.684167Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684171Z", "index": 30, "severity": 10,
+        "AWS IAM Keys", "severity_rule_config": {"id": 11885, "gg_created_at": "2026-05-20T08:56:10.055362Z",
+        "gg_updated_at": "2026-05-20T08:56:10.055364Z", "index": 30, "severity": 10,
         "rule": {"id": 503, "gg_created_at": "2025-03-18T08:57:54.142008Z", "gg_updated_at":
         "2025-04-02T13:15:43.307296Z", "name": "Valid secrets related to highly sensitive
         detectors", "description": "Secrets related to highly sensitive detectors
@@ -48,44 +95,44 @@ interactions:
         "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
         "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "gim-qa-gitlabSandbox-auto
+        null, "locations_count": 0, "sources": [{"id": 16219056, "name": "gim-qa-gitlabSandbox-auto
         / gim-qa-gitlabSandbox-staging", "type": "gl_project", "path": "gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
-        "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 1, "score": 97, "displayed_occurrence":
-        {"id": 226113779, "issue": 22515404, "account": 8, "kind": "RLTM", "element":
-        "95c8ae28ae02f1182bfa5ae2f6cabb69fab3ece9", "element_type": "GIT_COMMIT",
-        "author_name": "dev", "author_info": "gim+dev@gitguardian.com", "value": null,
-        "value_hash": "yEDhOhQ6p7D5/7TcJR5YtztO3INO1WgqiWd2qPiA0XRele/bong1Td3XczdQcVM3",
+        "source_criticality": "critical", "monitoring_status": "active", "deleted_at":
+        null}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
+        1, "score": 97, "displayed_occurrence": {"id": 226113779, "issue": 22515404,
+        "account": 8, "kind": "RLTM", "element": "95c8ae28ae02f1182bfa5ae2f6cabb69fab3ece9",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "yEDhOhQ6p7D5/7TcJR5YtztO3INO1WgqiWd2qPiA0XRele/bong1Td3XczdQcVM3",
         "published_at": "2025-11-17T17:16:25Z", "date": "2025-11-17T17:16:25Z", "detected_at":
         "2025-11-17T17:18:16.645938Z", "is_vcs_type": true, "last_detected_at": "2025-11-17T17:16:25Z",
         "last_seen_at": "2025-11-17T17:16:25Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging/commit/95c8ae28ae02f1182bfa5ae2f6cabb69fab3ece9#34c8dc1a12161a07003ebd2c3145185257f0cd94_0_3",
         "source": {"id": 16219056, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
         "type": "gl_project", "display_name": "gim-qa-gitlabSandbox-auto / gim-qa-gitlabSandbox-staging",
-        "visibility": "private", "monitored": true, "source_criticality": "unknown",
-        "deleted_at": null, "default_branch": "main"}, "regression": false, "content":
-        105863010, "secrets_engine_version": "2.150.0", "matches": [{"name": "client_id",
-        "string_matched": "[REDACTED]", "indice_start": 45, "indice_end": 65, "pre_line_start":
-        null, "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}, {"name":
-        "client_secret", "string_matched": "[REDACTED]", "indice_start": 82, "indice_end":
-        122, "pre_line_start": null, "pre_line_end": null, "post_line_start": 3, "post_line_end":
-        3}], "most_sensitive_match_name": "client_secret", "insights": [], "filepath":
-        "aws_api_access.yml", "filename": "aws_api_access.yml", "presence": "visible",
-        "last_presence_seen_at": "2026-02-18T22:30:08.818671Z", "last_presence_check_at":
-        "2026-02-18T22:30:08.818671Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        false, "change_type": "addition", "full_tags": []}, "has_dropped_occurrences":
-        false, "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
-        21256874, "account": 8, "criterion": "Google API Key", "date": "2025-09-28T15:22:38.271649Z",
-        "last_trigger_published_at": "2025-09-28T15:22:38.271649Z", "last_triggered_at":
-        "2025-09-28T15:22:38.612424Z", "last_trigger_detected_at": "2025-09-28T15:22:38.612424Z",
-        "hash": "Jxnz5kPob11xLvEtZ86g47aESTtckctpj4bPLy+pvS9PIsSDiwQ5Z8PP16EaJtIX",
+        "visibility": "private", "monitored": true, "source_criticality": "critical",
+        "deleted_at": null, "default_branch": "main", "monitoring_status": "active"},
+        "regression": false, "content": 105863010, "secrets_engine_version": "2.150.0",
+        "matches": [{"name": "client_id", "string_matched": "[REDACTED]", "indice_start":
+        45, "indice_end": 65, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        2, "post_line_end": 2}, {"name": "client_secret", "string_matched": "[REDACTED]",
+        "indice_start": 82, "indice_end": 122, "pre_line_start": null, "pre_line_end":
+        null, "post_line_start": 3, "post_line_end": 3}], "most_sensitive_match_name":
+        "client_secret", "insights": [], "filepath": "aws_api_access.yml", "filename":
+        "aws_api_access.yml", "presence": "visible", "last_presence_seen_at": "2026-06-04T08:10:24.433576Z",
+        "last_presence_check_at": "2026-06-04T08:10:24.433576Z", "first_presence_deleted_at":
+        null, "seen_in_default_branch": false, "change_type": "addition", "full_tags":
+        []}, "has_dropped_occurrences": false, "tags": ["REVOCABLE_BY_GG"], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 1}, {"id": 21256874, "account": 8, "criterion":
+        "Google API Key", "date": "2025-09-28T15:22:38.271649Z", "last_trigger_published_at":
+        "2025-09-28T15:22:38.271649Z", "last_triggered_at": "2025-09-28T15:22:38.612424Z",
+        "last_trigger_detected_at": "2025-09-28T15:22:38.612424Z", "hash": "Jxnz5kPob11xLvEtZ86g47aESTtckctpj4bPLy+pvS9PIsSDiwQ5Z8PP16EaJtIX",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Google API Key", "severity_rule_config": {"id": 10858, "gg_created_at": "2026-02-12T15:13:37.684102Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684119Z", "index": 10, "severity": 10,
+        "Google API Key", "severity_rule_config": {"id": 11883, "gg_created_at": "2026-05-20T08:56:10.055321Z",
+        "gg_updated_at": "2026-05-20T08:56:10.055331Z", "index": 10, "severity": 10,
         "rule": {"id": 745, "gg_created_at": "2026-02-12T15:13:36.079495Z", "gg_updated_at":
         "2026-02-12T15:13:36.079508Z", "name": "Publicly leaked secrets", "description":
         "Publicly leaked secrets outside perimeter", "json_rule": {"operator": "AND",
@@ -98,24 +145,26 @@ interactions:
         "GitGuardian Sandbox [internal]"}], "user_permission": 7, "is_publicly_shared":
         false, "feedbacks_count": 0, "occurrences_presence_seen_count": 3, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "GitHub Gist Public Testing", "type": "custom_source", "path": "GitHub
-        Gist Public Testing", "source_criticality": "unknown"}], "custom_tags": [],
-        "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0, "score":
-        35, "displayed_occurrence": {"id": 217629888, "issue": 21256874, "account":
-        8, "kind": "RLTM", "element": "", "element_type": "CUSTOM_ELEMENT", "author_name":
-        "GitGuardian Sandbox [internal]", "author_info": "", "value": null, "value_hash":
-        "vaoX27XgrGUFeuRDLf1lGhRHkgfeKQkdi/3qMgXMYvxgUYRCJMTAoAK2DALLNEk3", "published_at":
-        "2025-09-28T15:22:38.271649Z", "date": "2025-09-28T15:22:38.271649Z", "detected_at":
-        "2025-09-28T15:22:38.386090Z", "is_vcs_type": false, "last_detected_at": "2025-09-28T15:22:38.271649Z",
-        "last_seen_at": "2025-09-28T15:22:38.271649Z", "data": {}, "url": "", "source":
-        {"id": 22879703, "url": "", "type": "custom_source", "display_name": "GitHub
-        Gist Public Testing", "visibility": "private", "monitored": false, "source_criticality":
-        "unknown", "deleted_at": "2025-09-30T09:36:56.792947Z", "default_branch":
-        null}, "regression": false, "content": 95760168, "secrets_engine_version":
-        "2.148.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 715525, "indice_end": 715564, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "public_github_sagarchittaragi_75a7ce7770d67624fd77656f0d3ad099",
+        [{"id": 22879703, "name": "GitHub Gist Public Testing", "type": "custom_source",
+        "path": "GitHub Gist Public Testing", "source_criticality": "unknown", "monitoring_status":
+        "disabled", "deleted_at": "2025-09-30T09:36:56.792947+00:00"}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 35, "displayed_occurrence": {"id": 217629888, "issue": 21256874,
+        "account": 8, "kind": "RLTM", "element": "", "element_type": "CUSTOM_ELEMENT",
+        "author_name": "GitGuardian Sandbox [internal]", "author_info": "", "value":
+        null, "value_hash": "vaoX27XgrGUFeuRDLf1lGhRHkgfeKQkdi/3qMgXMYvxgUYRCJMTAoAK2DALLNEk3",
+        "published_at": "2025-09-28T15:22:38.271649Z", "date": "2025-09-28T15:22:38.271649Z",
+        "detected_at": "2025-09-28T15:22:38.386090Z", "is_vcs_type": false, "last_detected_at":
+        "2025-09-28T15:22:38.271649Z", "last_seen_at": "2025-09-28T15:22:38.271649Z",
+        "data": {}, "url": "", "source": {"id": 22879703, "url": "", "type": "custom_source",
+        "display_name": "GitHub Gist Public Testing", "visibility": "private", "monitored":
+        false, "source_criticality": "unknown", "deleted_at": "2025-09-30T09:36:56.792947Z",
+        "default_branch": null, "monitoring_status": "disabled"}, "regression": false,
+        "content": 95760168, "secrets_engine_version": "2.148.0", "matches": [{"name":
+        "apikey", "string_matched": "[REDACTED]", "indice_start": 715525, "indice_end":
+        715564, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
+        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
+        [], "filepath": "public_github_sagarchittaragi_75a7ce7770d67624fd77656f0d3ad099",
         "filename": "public_github_sagarchittaragi_75a7ce7770d67624fd77656f0d3ad099",
         "presence": "visible", "last_presence_seen_at": "2025-09-28T15:22:38.645860Z",
         "last_presence_check_at": "2025-09-28T15:22:38.645860Z", "first_presence_deleted_at":
@@ -131,8 +180,8 @@ interactions:
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Google API Key", "severity_rule_config": {"id": 10858, "gg_created_at": "2026-02-12T15:13:37.684102Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684119Z", "index": 10, "severity": 10,
+        "Google API Key", "severity_rule_config": {"id": 11883, "gg_created_at": "2026-05-20T08:56:10.055321Z",
+        "gg_updated_at": "2026-05-20T08:56:10.055331Z", "index": 10, "severity": 10,
         "rule": {"id": 745, "gg_created_at": "2026-02-12T15:13:36.079495Z", "gg_updated_at":
         "2026-02-12T15:13:36.079508Z", "name": "Publicly leaked secrets", "description":
         "Publicly leaked secrets outside perimeter", "json_rule": {"operator": "AND",
@@ -145,24 +194,26 @@ interactions:
         "GitGuardian Sandbox [internal]"}], "user_permission": 7, "is_publicly_shared":
         false, "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "GitHub Gist Public Testing", "type": "custom_source", "path": "GitHub
-        Gist Public Testing", "source_criticality": "unknown"}], "custom_tags": [],
-        "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0, "score":
-        64, "displayed_occurrence": {"id": 217594938, "issue": 21251447, "account":
-        8, "kind": "RLTM", "element": "", "element_type": "CUSTOM_ELEMENT", "author_name":
-        "GitGuardian Sandbox [internal]", "author_info": "", "value": null, "value_hash":
-        "8WalVYdfAy9WWVLzVZBfOXcyF0UCcYGuYQrb3Wdix673pMDZxFC6e51x3UmXyF+6", "published_at":
-        "2025-09-28T04:37:26.780820Z", "date": "2025-09-28T04:37:26.780820Z", "detected_at":
-        "2025-09-28T04:37:26.850787Z", "is_vcs_type": false, "last_detected_at": "2025-09-28T04:37:26.780820Z",
-        "last_seen_at": "2025-09-28T04:37:26.780820Z", "data": {}, "url": "", "source":
-        {"id": 22879703, "url": "", "type": "custom_source", "display_name": "GitHub
-        Gist Public Testing", "visibility": "private", "monitored": false, "source_criticality":
-        "unknown", "deleted_at": "2025-09-30T09:36:56.792947Z", "default_branch":
-        null}, "regression": false, "content": 95670280, "secrets_engine_version":
-        "2.148.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 4660, "indice_end": 4699, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "public_github_youngbee369_a8de7dcd6c0ff078c7f99a4d1622ad45",
+        [{"id": 22879703, "name": "GitHub Gist Public Testing", "type": "custom_source",
+        "path": "GitHub Gist Public Testing", "source_criticality": "unknown", "monitoring_status":
+        "disabled", "deleted_at": "2025-09-30T09:36:56.792947+00:00"}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 64, "displayed_occurrence": {"id": 217594938, "issue": 21251447,
+        "account": 8, "kind": "RLTM", "element": "", "element_type": "CUSTOM_ELEMENT",
+        "author_name": "GitGuardian Sandbox [internal]", "author_info": "", "value":
+        null, "value_hash": "8WalVYdfAy9WWVLzVZBfOXcyF0UCcYGuYQrb3Wdix673pMDZxFC6e51x3UmXyF+6",
+        "published_at": "2025-09-28T04:37:26.780820Z", "date": "2025-09-28T04:37:26.780820Z",
+        "detected_at": "2025-09-28T04:37:26.850787Z", "is_vcs_type": false, "last_detected_at":
+        "2025-09-28T04:37:26.780820Z", "last_seen_at": "2025-09-28T04:37:26.780820Z",
+        "data": {}, "url": "", "source": {"id": 22879703, "url": "", "type": "custom_source",
+        "display_name": "GitHub Gist Public Testing", "visibility": "private", "monitored":
+        false, "source_criticality": "unknown", "deleted_at": "2025-09-30T09:36:56.792947Z",
+        "default_branch": null, "monitoring_status": "disabled"}, "regression": false,
+        "content": 95670280, "secrets_engine_version": "2.148.0", "matches": [{"name":
+        "apikey", "string_matched": "[REDACTED]", "indice_start": 4660, "indice_end":
+        4699, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
+        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
+        [], "filepath": "public_github_youngbee369_a8de7dcd6c0ff078c7f99a4d1622ad45",
         "filename": "public_github_youngbee369_a8de7dcd6c0ff078c7f99a4d1622ad45",
         "presence": "visible", "last_presence_seen_at": "2025-09-28T04:37:27.121112Z",
         "last_presence_check_at": "2025-09-28T04:37:27.121112Z", "first_presence_deleted_at":
@@ -178,8 +229,8 @@ interactions:
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "DeepSeek API Key", "severity_rule_config": {"id": 10858, "gg_created_at":
-        "2026-02-12T15:13:37.684102Z", "gg_updated_at": "2026-02-12T15:13:37.684119Z",
+        "DeepSeek API Key", "severity_rule_config": {"id": 11883, "gg_created_at":
+        "2026-05-20T08:56:10.055321Z", "gg_updated_at": "2026-05-20T08:56:10.055331Z",
         "index": 10, "severity": 10, "rule": {"id": 745, "gg_created_at": "2026-02-12T15:13:36.079495Z",
         "gg_updated_at": "2026-02-12T15:13:36.079508Z", "name": "Publicly leaked secrets",
         "description": "Publicly leaked secrets outside perimeter", "json_rule": {"operator":
@@ -192,111 +243,74 @@ interactions:
         100, "authors": [{"info": "", "name": "GitGuardian Sandbox [internal]"}],
         "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "GitHub Gist Public Testing",
-        "type": "custom_source", "path": "GitHub Gist Public Testing", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 0, "score": 91, "displayed_occurrence": {"id": 217590276,
-        "issue": 21250826, "account": 8, "kind": "RLTM", "element": "", "element_type":
-        "CUSTOM_ELEMENT", "author_name": "GitGuardian Sandbox [internal]", "author_info":
-        "", "value": null, "value_hash": "S9J90cfgfIz9/1KiWTklsCZsShVgIHiSFM0yUQf2i7lzzzxGfAxs12u2O6U6+pg/",
+        null, "locations_count": 0, "sources": [{"id": 22879703, "name": "GitHub Gist
+        Public Testing", "type": "custom_source", "path": "GitHub Gist Public Testing",
+        "source_criticality": "unknown", "monitoring_status": "disabled", "deleted_at":
+        "2025-09-30T09:36:56.792947+00:00"}], "custom_tags": [], "vault_metadata":
+        null, "is_vaulted": false, "similar_issue_count": 0, "score": 91, "displayed_occurrence":
+        {"id": 217590276, "issue": 21250826, "account": 8, "kind": "RLTM", "element":
+        "", "element_type": "CUSTOM_ELEMENT", "author_name": "GitGuardian Sandbox
+        [internal]", "author_info": "", "value": null, "value_hash": "S9J90cfgfIz9/1KiWTklsCZsShVgIHiSFM0yUQf2i7lzzzxGfAxs12u2O6U6+pg/",
         "published_at": "2025-09-28T02:34:55.156736Z", "date": "2025-09-28T02:34:55.156736Z",
         "detected_at": "2025-09-28T02:34:55.601861Z", "is_vcs_type": false, "last_detected_at":
         "2025-09-28T02:34:55.156736Z", "last_seen_at": "2025-09-28T02:34:55.156736Z",
         "data": {}, "url": "", "source": {"id": 22879703, "url": "", "type": "custom_source",
         "display_name": "GitHub Gist Public Testing", "visibility": "private", "monitored":
         false, "source_criticality": "unknown", "deleted_at": "2025-09-30T09:36:56.792947Z",
-        "default_branch": null}, "regression": false, "content": 95659566, "secrets_engine_version":
-        "2.148.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 52030, "indice_end": 52065, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "public_github_HugsLibRecordKeeper_e0e10d04d64bf1543f67a3abf9816cab",
+        "default_branch": null, "monitoring_status": "disabled"}, "regression": false,
+        "content": 95659566, "secrets_engine_version": "2.148.0", "matches": [{"name":
+        "apikey", "string_matched": "[REDACTED]", "indice_start": 52030, "indice_end":
+        52065, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
+        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
+        [], "filepath": "public_github_HugsLibRecordKeeper_e0e10d04d64bf1543f67a3abf9816cab",
         "filename": "public_github_HugsLibRecordKeeper_e0e10d04d64bf1543f67a3abf9816cab",
         "presence": "visible", "last_presence_seen_at": "2025-09-28T02:34:55.830969Z",
         "last_presence_check_at": "2025-09-28T02:34:55.830969Z", "first_presence_deleted_at":
         null, "seen_in_default_branch": null, "change_type": null, "full_tags": []},
         "has_dropped_occurrences": false, "tags": ["PUBLICLY_LEAKED"], "public_exposure":
         {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        true}, "occurrences_count": 1}, {"id": 21249986, "account": 8, "criterion":
-        "OpenWeatherMap Token", "date": "2025-09-28T00:51:42.265003Z", "last_trigger_published_at":
-        "2025-09-28T00:51:42.265003Z", "last_triggered_at": "2025-09-28T00:51:42.545593Z",
-        "last_trigger_detected_at": "2025-09-28T00:51:42.545593Z", "hash": "G+55CfHB8Ki7BeVzFjhNlgKGGKJH6+kZro1WRqPtPL10DyCT55bBE6WEo9rNnqWB",
-        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
-        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
-        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
-        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
-        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "OpenWeatherMap Token", "severity_rule_config": {"id": 10858, "gg_created_at":
-        "2026-02-12T15:13:37.684102Z", "gg_updated_at": "2026-02-12T15:13:37.684119Z",
-        "index": 10, "severity": 10, "rule": {"id": 745, "gg_created_at": "2026-02-12T15:13:36.079495Z",
-        "gg_updated_at": "2026-02-12T15:13:36.079508Z", "name": "Publicly leaked secrets",
-        "description": "Publicly leaked secrets outside perimeter", "json_rule": {"operator":
-        "AND", "args": [{"operator": "NOT", "arg1": {"operator": "EQ", "arg1": {"path":
-        "issue.public_leak_range", "default": null}, "arg2": {"value": "0"}}}, {"operator":
-        "NOT", "arg1": {"operator": "EQ", "arg1": {"path": "issue.secret.validity_status",
-        "default": null}, "arg2": {"value": "invalid"}}}]}, "is_global": false, "scope":
-        "private", "author": 520858}}, "declarative_secret_status": null, "assignee":
-        null, "last_presence_check_at": null, "secret": "[REDACTED]", "severity":
-        100, "authors": [{"info": "", "name": "GitGuardian Sandbox [internal]"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "GitHub Gist Public Testing",
-        "type": "custom_source", "path": "GitHub Gist Public Testing", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 0, "score": 54, "displayed_occurrence": {"id": 217585090,
-        "issue": 21249986, "account": 8, "kind": "RLTM", "element": "", "element_type":
-        "CUSTOM_ELEMENT", "author_name": "GitGuardian Sandbox [internal]", "author_info":
-        "", "value": null, "value_hash": "osEp3GKX4ftrxTM5lNGzTdef2z+j0tc2XJHHJF2v91JTdYxPw5c2j2dU7D4EWOPl",
-        "published_at": "2025-09-28T00:51:42.265003Z", "date": "2025-09-28T00:51:42.265003Z",
-        "detected_at": "2025-09-28T00:51:42.321226Z", "is_vcs_type": false, "last_detected_at":
-        "2025-09-28T00:51:42.265003Z", "last_seen_at": "2025-09-28T00:51:42.265003Z",
-        "data": {}, "url": "", "source": {"id": 22879703, "url": "", "type": "custom_source",
-        "display_name": "GitHub Gist Public Testing", "visibility": "private", "monitored":
-        false, "source_criticality": "unknown", "deleted_at": "2025-09-30T09:36:56.792947Z",
-        "default_branch": null}, "regression": false, "content": 95649476, "secrets_engine_version":
-        "2.148.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 712505, "indice_end": 712537, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "public_github_mitch1490_ee46d407faf56d69d50085548e31ebfb",
-        "filename": "public_github_mitch1490_ee46d407faf56d69d50085548e31ebfb", "presence":
-        "visible", "last_presence_seen_at": "2025-09-28T00:51:42.568747Z", "last_presence_check_at":
-        "2025-09-28T00:51:42.568747Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": ["PUBLICLY_LEAKED"], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": true},
-        "occurrences_count": 1}]}'
+        true}, "occurrences_count": 1}]}'
     headers:
+      CF-RAY:
+      - a10397c8683b6f66-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:58 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '27736'
+      - '28403'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:52 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '158'
+      - '199'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_incidents_coerce_single_severity.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incidents_coerce_single_severity.yaml
@@ -21,171 +21,199 @@ interactions:
   response:
     body:
       string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?ordering=-date&page=2&page_size=5&severity__in=10&status__in=TRIGGERED%2CASSIGNED%2CRESOLVED&tags__nin=TEST_FILE%2CFALSE_POSITIVE%2CCHECK_RUN_SKIP_FALSE_POSITIVE%2CCHECK_RUN_SKIP_LOW_RISK%2CCHECK_RUN_SKIP_TEST_CRED&validity__in=valid%2Cfailed_to_check%2Cno_checker%2Cnot_checked",
-        "previous": null, "results": [{"id": 26879946, "account": 8, "criterion":
-        "AWS Keys", "date": "2026-02-05T16:48:19Z", "last_trigger_published_at": "2026-02-05T16:48:19Z",
-        "last_triggered_at": "2026-02-05T16:51:59.912161Z", "last_trigger_detected_at":
-        "2026-02-05T16:51:59.912161Z", "hash": "BPRo0pF0ZesUJFhK1FAEiWQsj9wNtT2WYZ15WbzmXjC7vE/VL4Qc71cZRqNcojMG",
+        "previous": null, "results": [{"id": 32985083, "account": 8, "criterion":
+        "Google API Key", "date": "2026-05-19T09:33:23Z", "last_trigger_published_at":
+        "2026-05-19T09:33:23Z", "last_triggered_at": "2026-05-19T09:36:55.570755Z",
+        "last_trigger_detected_at": "2026-05-19T09:36:55.570755Z", "hash": "pHE0O7zGgt2lhT0TLQzB2cwgMuZgrhqH4vSIGV5fw5ao1EL3iwQ5Z8PP16EaJtIX",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
-        "none", "manual_severity_setter_type": "none", "status": "ASSIGNED", "issue_name":
-        "AWS IAM Keys", "severity_rule_config": {"id": 10860, "gg_created_at": "2026-02-12T15:13:37.684167Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684171Z", "index": 30, "severity": 10,
-        "rule": {"id": 503, "gg_created_at": "2025-03-18T08:57:54.142008Z", "gg_updated_at":
-        "2025-04-02T13:15:43.307296Z", "name": "Valid secrets related to highly sensitive
-        detectors", "description": "Secrets related to highly sensitive detectors
-        were valid when the incident was discovered. You can edit this rule to create
-        your own list of sensitive detectors", "json_rule": {"operator": "AND", "args":
-        [{"operator": "EQ", "arg1": {"path": "issue.secret.validity_status", "default":
-        null}, "arg2": {"value": "valid"}}, {"operator": "IN", "arg1": {"path": "issue.secret.detector.detector_group_name",
-        "default": null}, "arg2": {"value": ["github_app_token", "ldap_credentials",
-        "github_oauth_token", "googlecloud_keys", "jira_basic_auth", "python_package_index_key",
-        "aws_iam_sts", "npm_token", "gitlab_token", "smtp_credentials", "github_fine_grained_pat",
-        "gitlab_enterprise_token", "github_access_token", "aws_iam"]}}]}, "is_global":
-        true, "scope": "any", "author": null}}, "declarative_secret_status": null,
-        "assignee": 581873, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        8, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "gim-qa-gitlabSandbox-auto
-        / gim-qa-gitlabSandbox-staging", "type": "gl_project", "path": "gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
-        "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
-        {"id": 242021853, "issue": 26879946, "account": 8, "kind": "RLTM", "element":
-        "e2cbc193a76a13b94e135c12a055d2083a233a89", "element_type": "GIT_COMMIT",
-        "author_name": "dev", "author_info": "gim+dev@gitguardian.com", "value": null,
-        "value_hash": "7AkVngiwT5n4ZZihQovCHs2qrlx0MOfD853AYv4HHS0DiM0Vk9YtctC+FFM1Iw+v",
-        "published_at": "2026-02-05T16:48:19Z", "date": "2026-02-05T16:48:19Z", "detected_at":
-        "2026-02-05T16:51:53.166126Z", "is_vcs_type": true, "last_detected_at": "2026-02-05T16:48:19Z",
-        "last_seen_at": "2026-02-05T16:48:19Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging/commit/e2cbc193a76a13b94e135c12a055d2083a233a89#2dd906314026edd7e5fa25025afd4353424625a7_0_19",
-        "source": {"id": 16219056, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
-        "type": "gl_project", "display_name": "gim-qa-gitlabSandbox-auto / gim-qa-gitlabSandbox-staging",
-        "visibility": "private", "monitored": true, "source_criticality": "unknown",
-        "deleted_at": null, "default_branch": "main"}, "regression": false, "content":
-        130291193, "secrets_engine_version": "2.156.0", "matches": [{"name": "client_id",
-        "string_matched": "[REDACTED]", "indice_start": 124, "indice_end": 144, "pre_line_start":
-        null, "pre_line_end": null, "post_line_start": 4, "post_line_end": 4}, {"name":
-        "client_secret", "string_matched": "[REDACTED]", "indice_start": 981, "indice_end":
-        1021, "pre_line_start": null, "pre_line_end": null, "post_line_start": 19,
-        "post_line_end": 19}], "most_sensitive_match_name": "client_secret", "insights":
-        [], "filepath": "ec2_instance_management.py", "filename": "ec2_instance_management.py",
-        "presence": "visible", "last_presence_seen_at": "2026-02-18T22:30:08.818671Z",
-        "last_presence_check_at": "2026-02-18T22:30:08.818671Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": false, "change_type": "addition", "full_tags":
-        []}, "has_dropped_occurrences": false, "tags": [], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 8}, {"id": 26155836, "account": 8, "criterion": "Artifactory
-        Token", "date": "2026-01-21T10:36:57.655878Z", "last_trigger_published_at":
-        "2026-01-21T10:36:57.655878Z", "last_triggered_at": "2026-01-21T10:36:58.397779Z",
-        "last_trigger_detected_at": "2026-01-21T10:36:58.397779Z", "hash": "sb5IGg6qhGHwZ7DbBySx1FRi53wnsGUfGCxJpN/LR7YhaCe/mfERIIoosvzjJs1k",
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Google API Key", "severity_rule_config": {"id": 11883, "gg_created_at": "2026-05-20T08:56:10.055321Z",
+        "gg_updated_at": "2026-05-20T08:56:10.055331Z", "index": 10, "severity": 10,
+        "rule": {"id": 745, "gg_created_at": "2026-02-12T15:13:36.079495Z", "gg_updated_at":
+        "2026-02-12T15:13:36.079508Z", "name": "Publicly leaked secrets", "description":
+        "Publicly leaked secrets outside perimeter", "json_rule": {"operator": "AND",
+        "args": [{"operator": "NOT", "arg1": {"operator": "EQ", "arg1": {"path": "issue.public_leak_range",
+        "default": null}, "arg2": {"value": "0"}}}, {"operator": "NOT", "arg1": {"operator":
+        "EQ", "arg1": {"path": "issue.secret.validity_status", "default": null}, "arg2":
+        {"value": "invalid"}}}]}, "is_global": false, "scope": "private", "author":
+        520858}}, "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com",
+        "name": "dev"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 16218896, "name": "qa / test-nriv", "type": "gl_project", "path":
+        "qa1/test-nriv", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 0, "score": 64, "displayed_occurrence": {"id":
+        268288466, "issue": 32985083, "account": 8, "kind": "RLTM", "element": "9181621d49e910c3d2393f2373e52c04b26c7adb",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "y0o7bgCt8InKo3/G0QE6WaG+gU32WlUdYH0N4oUFXredK2KoKwrhfI+hoCMCs6v6",
+        "published_at": "2026-05-19T09:33:23Z", "date": "2026-05-19T09:33:23Z", "detected_at":
+        "2026-05-19T09:36:53.339083Z", "is_vcs_type": true, "last_detected_at": "2026-05-19T09:33:23Z",
+        "last_seen_at": "2026-05-19T09:33:23Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa1/test-nriv/commit/9181621d49e910c3d2393f2373e52c04b26c7adb#a290632bbcae192e53c54337b3238d835c97e8a9_5_4",
+        "source": {"id": 16218896, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa1/test-nriv",
+        "type": "gl_project", "display_name": "qa / test-nriv", "visibility": "internal",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 162813398,
+        "secrets_engine_version": "2.162.0", "matches": [{"name": "apikey", "string_matched":
+        "[REDACTED]", "indice_start": 307, "indice_end": 346, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 4, "post_line_end": 4}], "most_sensitive_match_name":
+        "apikey", "insights": [], "filepath": ".envrc", "filename": ".envrc", "presence":
+        "visible", "last_presence_seen_at": "2026-05-19T09:36:55.598741Z", "last_presence_check_at":
+        "2026-05-19T09:36:55.598741Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        true, "change_type": "addition", "full_tags": [{"type": "DEFAULT_BRANCH",
+        "metadata": null, "field": "content"}]}, "has_dropped_occurrences": false,
+        "tags": ["DEFAULT_BRANCH", "PUBLICLY_LEAKED"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": true},
+        "occurrences_count": 2}, {"id": 33596487, "account": 8, "criterion": "Crates.io
+        Key", "date": "2026-04-23T07:03:59Z", "last_trigger_published_at": "2026-04-23T07:03:59Z",
+        "last_triggered_at": "2026-06-03T06:07:40.264252Z", "last_trigger_detected_at":
+        "2026-06-03T06:07:40.264252Z", "hash": "7eMsZPo8NYvdQprGPmJvhmha71pPOf1TQ5jiVU0F67VXPtdQqnKJPm3m46v5MSqC",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
-        "resolved": true, "resolved_at": "2026-02-27T12:28:45.159703Z", "resolver":
-        353104, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "none", "ignorer_type": "none", "resolver_display_name": "jean.ramirez@gitguardian.com",
-        "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
-        "none", "status": "RESOLVED", "issue_name": "Artifactory Token", "severity_rule_config":
-        {"id": 10870, "gg_created_at": "2026-02-12T15:13:37.684322Z", "gg_updated_at":
-        "2026-02-12T15:13:37.684326Z", "index": 130, "severity": 10, "rule": {"id":
-        513, "gg_created_at": "2025-03-18T08:57:54.142453Z", "gg_updated_at": "2025-03-18T08:57:54.142456Z",
-        "name": "Package manager related secret", "description": "The detector relates
-        to a package manager", "json_rule": {"operator": "EQ", "arg1": {"path": "issue.secret.detector.metadata.category",
-        "default": null}, "arg2": {"value": "package_registry"}}, "is_global": true,
-        "scope": "private", "author": null}}, "declarative_secret_status": "revoked",
-        "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gg-tools@gitguardian.com", "name":
-        "gg-tools"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Crates.io Key", "severity_rule_config": {"id": 11895, "gg_created_at": "2026-05-20T08:56:10.055460Z",
+        "gg_updated_at": "2026-05-20T08:56:10.055463Z", "index": 130, "severity":
+        10, "rule": {"id": 513, "gg_created_at": "2025-03-18T08:57:54.142453Z", "gg_updated_at":
+        "2025-03-18T08:57:54.142456Z", "name": "Package manager related secret", "description":
+        "The detector relates to a package manager", "json_rule": {"operator": "EQ",
+        "arg1": {"path": "issue.secret.detector.metadata.category", "default": null},
+        "arg2": {"value": "package_registry"}}, "is_global": true, "scope": "private",
+        "author": null}}, "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "gg-tools@gitguardian.com",
+        "name": "gim-dev"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
         0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "jira-data-center.do.gitguardian.dev / ChangingGCAM", "type": "jira_data_center_project",
-        "path": "jira-data-center.do.gitguardian.dev / ChangingGCAM", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 0, "score": 86, "displayed_occurrence": {"id": 238634588,
-        "issue": 26155836, "account": 8, "kind": "RLTM", "element": "https://jira-data-center.do.gitguardian.dev/browse/GCAM-2?focusedCommentId=11020#comment-11020",
-        "element_type": "JIRA_COMMENT", "author_name": "gg-tools", "author_info":
-        "gg-tools@gitguardian.com", "value": null, "value_hash": "eQvUyYdyG+FGWUNR0idFck7aRQRzU9rBJuNONSFQNBc/68hbESiZedNRnCS6CqCj",
-        "published_at": "2026-01-21T10:36:57.655878Z", "date": "2026-01-21T10:36:57.655878Z",
-        "detected_at": "2026-01-21T10:36:55.769000Z", "is_vcs_type": false, "last_detected_at":
-        "2026-01-21T10:47:47.663607Z", "last_seen_at": "2026-01-21T10:47:47.663607Z",
-        "data": {}, "url": "https://jira-data-center.do.gitguardian.dev/browse/GCAM-2?focusedCommentId=11020#comment-11020",
-        "source": {"id": 24381556, "url": "https://jira-data-center.do.gitguardian.dev/browse/GCAM/",
-        "type": "jira_data_center_project", "display_name": "jira-data-center.do.gitguardian.dev
-        / ChangingGCAM", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 125057751, "secrets_engine_version": "2.155.2", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 925, "indice_end":
-        998, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
-        "2026-02-26T14:27:22.357606Z", "last_presence_check_at": "2026-02-26T14:27:22.357606Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 27907812, "name": "gim-dev/ra24091", "type": "ghe_repository", "path":
+        "gim-dev/ra24091", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 0, "score": 86, "displayed_occurrence": {"id":
+        271124127, "issue": 33596487, "account": 8, "kind": "HIST", "element": "726d6e14f4865b2ae7fa5d03972347e479880620",
+        "element_type": "GIT_COMMIT", "author_name": "gim-dev", "author_info": "gg-tools@gitguardian.com",
+        "value": null, "value_hash": "bopfgjC9/ZqBM1Kl5mY7IsWivqih2CFAsisDVRqeRik1/8IJmhFA3PTcIootBtrN",
+        "published_at": "2026-04-23T07:03:59Z", "date": "2026-04-23T07:03:59Z", "detected_at":
+        "2026-06-03T06:07:39.990226Z", "is_vcs_type": true, "last_detected_at": "2026-04-23T07:03:59Z",
+        "last_seen_at": "2026-04-23T07:03:59Z", "data": {}, "url": "https://ghe-01.aws-qa-gitguardian.com/gim-dev/ra24091/commit/726d6e14f4865b2ae7fa5d03972347e479880620#diff-a8f520d6712a82ea3d0013a99d2a9dd590c10c78a334a1933e7a553458799877R4",
+        "source": {"id": 27907812, "url": "https://ghe-01.aws-qa-gitguardian.com/gim-dev/ra24091",
+        "type": "ghe_repository", "display_name": "gim-dev/ra24091", "visibility":
+        "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
+        null, "default_branch": "main", "monitoring_status": "active"}, "regression":
+        false, "content": 166434270, "secrets_engine_version": "2.164.0", "matches":
+        [{"name": "apikey", "string_matched": "[REDACTED]", "indice_start": 183, "indice_end":
+        218, "pre_line_start": null, "pre_line_end": null, "post_line_start": 4, "post_line_end":
+        4}], "most_sensitive_match_name": "apikey", "insights": [], "filepath": "toto.py",
+        "filename": "toto.py", "presence": "visible", "last_presence_seen_at": "2026-06-03T06:07:40.296212Z",
+        "last_presence_check_at": "2026-06-03T06:07:40.296212Z", "first_presence_deleted_at":
+        null, "seen_in_default_branch": null, "change_type": "addition", "full_tags":
+        [{"type": "FROM_HISTORICAL_SCAN", "metadata": null, "field": "content"}]},
+        "has_dropped_occurrences": false, "tags": ["FROM_HISTORICAL_SCAN"], "public_exposure":
         {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 1}, {"id": 22515404, "account": 8, "criterion":
-        "AWS Keys", "date": "2025-11-17T17:16:25Z", "last_trigger_published_at": "2025-11-17T17:16:25Z",
-        "last_triggered_at": "2025-11-17T17:18:18.706440Z", "last_trigger_detected_at":
-        "2025-11-17T17:18:18.706440Z", "hash": "6y4trbQi60aNmDEFQe0tJH3jke+8j18I9t2sKfgaunTYEUdZL4Qc71cZRqNcojMG",
+        false}, "occurrences_count": 1}, {"id": 33596488, "account": 8, "criterion":
+        "Crates.io Key", "date": "2026-04-23T07:01:34Z", "last_trigger_published_at":
+        "2026-04-23T07:01:34Z", "last_triggered_at": "2026-06-03T06:07:40.264351Z",
+        "last_trigger_detected_at": "2026-06-03T06:07:40.264351Z", "hash": "9n9tdaRAuAdxkvvw3A+ANdmW41uhktmL5Fv2QzYmHCcMYFLLqnKJPm3m46v5MSqC",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "AWS IAM Keys", "severity_rule_config": {"id": 10860, "gg_created_at": "2026-02-12T15:13:37.684167Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684171Z", "index": 30, "severity": 10,
-        "rule": {"id": 503, "gg_created_at": "2025-03-18T08:57:54.142008Z", "gg_updated_at":
-        "2025-04-02T13:15:43.307296Z", "name": "Valid secrets related to highly sensitive
-        detectors", "description": "Secrets related to highly sensitive detectors
-        were valid when the incident was discovered. You can edit this rule to create
-        your own list of sensitive detectors", "json_rule": {"operator": "AND", "args":
-        [{"operator": "EQ", "arg1": {"path": "issue.secret.validity_status", "default":
-        null}, "arg2": {"value": "valid"}}, {"operator": "IN", "arg1": {"path": "issue.secret.detector.detector_group_name",
-        "default": null}, "arg2": {"value": ["github_app_token", "ldap_credentials",
-        "github_oauth_token", "googlecloud_keys", "jira_basic_auth", "python_package_index_key",
-        "aws_iam_sts", "npm_token", "gitlab_token", "smtp_credentials", "github_fine_grained_pat",
-        "gitlab_enterprise_token", "github_access_token", "aws_iam"]}}]}, "is_global":
-        true, "scope": "any", "author": null}}, "declarative_secret_status": null,
-        "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "gim-qa-gitlabSandbox-auto
-        / gim-qa-gitlabSandbox-staging", "type": "gl_project", "path": "gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
-        "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 1, "score": 97, "displayed_occurrence":
-        {"id": 226113779, "issue": 22515404, "account": 8, "kind": "RLTM", "element":
-        "95c8ae28ae02f1182bfa5ae2f6cabb69fab3ece9", "element_type": "GIT_COMMIT",
-        "author_name": "dev", "author_info": "gim+dev@gitguardian.com", "value": null,
-        "value_hash": "yEDhOhQ6p7D5/7TcJR5YtztO3INO1WgqiWd2qPiA0XRele/bong1Td3XczdQcVM3",
-        "published_at": "2025-11-17T17:16:25Z", "date": "2025-11-17T17:16:25Z", "detected_at":
-        "2025-11-17T17:18:16.645938Z", "is_vcs_type": true, "last_detected_at": "2025-11-17T17:16:25Z",
-        "last_seen_at": "2025-11-17T17:16:25Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging/commit/95c8ae28ae02f1182bfa5ae2f6cabb69fab3ece9#34c8dc1a12161a07003ebd2c3145185257f0cd94_0_3",
-        "source": {"id": 16219056, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
-        "type": "gl_project", "display_name": "gim-qa-gitlabSandbox-auto / gim-qa-gitlabSandbox-staging",
-        "visibility": "private", "monitored": true, "source_criticality": "unknown",
-        "deleted_at": null, "default_branch": "main"}, "regression": false, "content":
-        105863010, "secrets_engine_version": "2.150.0", "matches": [{"name": "client_id",
-        "string_matched": "[REDACTED]", "indice_start": 45, "indice_end": 65, "pre_line_start":
-        null, "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}, {"name":
-        "client_secret", "string_matched": "[REDACTED]", "indice_start": 82, "indice_end":
-        122, "pre_line_start": null, "pre_line_end": null, "post_line_start": 3, "post_line_end":
-        3}], "most_sensitive_match_name": "client_secret", "insights": [], "filepath":
-        "aws_api_access.yml", "filename": "aws_api_access.yml", "presence": "visible",
-        "last_presence_seen_at": "2026-02-18T22:30:08.818671Z", "last_presence_check_at":
-        "2026-02-18T22:30:08.818671Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        false, "change_type": "addition", "full_tags": []}, "has_dropped_occurrences":
-        false, "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
-        21857830, "account": 8, "criterion": "Generic Private Key", "date": "2025-10-21T15:12:04Z",
-        "last_trigger_published_at": "2025-10-21T15:12:04Z", "last_triggered_at":
-        "2025-10-24T14:00:09.175001Z", "last_trigger_detected_at": "2025-10-24T14:00:09.175001Z",
-        "hash": "Zd93zYw/R/gWlrzFtbVCB8yjZSdccT/b0NvSLGeof/3dmYqVVYcK62ozICbL8rB3",
+        "Crates.io Key", "severity_rule_config": {"id": 11895, "gg_created_at": "2026-05-20T08:56:10.055460Z",
+        "gg_updated_at": "2026-05-20T08:56:10.055463Z", "index": 130, "severity":
+        10, "rule": {"id": 513, "gg_created_at": "2025-03-18T08:57:54.142453Z", "gg_updated_at":
+        "2025-03-18T08:57:54.142456Z", "name": "Package manager related secret", "description":
+        "The detector relates to a package manager", "json_rule": {"operator": "EQ",
+        "arg1": {"path": "issue.secret.detector.metadata.category", "default": null},
+        "arg2": {"value": "package_registry"}}, "is_global": true, "scope": "private",
+        "author": null}}, "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "gg-tools@gitguardian.com",
+        "name": "gim-dev"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 27907812, "name": "gim-dev/ra24091", "type": "ghe_repository", "path":
+        "gim-dev/ra24091", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 0, "score": 86, "displayed_occurrence": {"id":
+        271124128, "issue": 33596488, "account": 8, "kind": "HIST", "element": "aa11f9f443e865a8ec50290ee90fe169c21aef9b",
+        "element_type": "GIT_COMMIT", "author_name": "gim-dev", "author_info": "gg-tools@gitguardian.com",
+        "value": null, "value_hash": "dukMeDq1taBlF0eO3eWtf2S+5XlcRbPvGW2jrR30ibxFu9h2SqU+DWCwq6Cxp/hP",
+        "published_at": "2026-04-23T07:01:34Z", "date": "2026-04-23T07:01:34Z", "detected_at":
+        "2026-06-03T06:07:39.990226Z", "is_vcs_type": true, "last_detected_at": "2026-04-23T07:01:34Z",
+        "last_seen_at": "2026-04-23T07:01:34Z", "data": {}, "url": "https://ghe-01.aws-qa-gitguardian.com/gim-dev/ra24091/commit/aa11f9f443e865a8ec50290ee90fe169c21aef9b#diff-a8f520d6712a82ea3d0013a99d2a9dd590c10c78a334a1933e7a553458799877R3",
+        "source": {"id": 27907812, "url": "https://ghe-01.aws-qa-gitguardian.com/gim-dev/ra24091",
+        "type": "ghe_repository", "display_name": "gim-dev/ra24091", "visibility":
+        "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
+        null, "default_branch": "main", "monitoring_status": "active"}, "regression":
+        false, "content": 166434269, "secrets_engine_version": "2.164.0", "matches":
+        [{"name": "apikey", "string_matched": "[REDACTED]", "indice_start": 88, "indice_end":
+        123, "pre_line_start": null, "pre_line_end": null, "post_line_start": 3, "post_line_end":
+        3}], "most_sensitive_match_name": "apikey", "insights": [], "filepath": "toto.py",
+        "filename": "toto.py", "presence": "visible", "last_presence_seen_at": "2026-06-03T06:07:40.296212Z",
+        "last_presence_check_at": "2026-06-03T06:07:40.296212Z", "first_presence_deleted_at":
+        null, "seen_in_default_branch": null, "change_type": "addition", "full_tags":
+        [{"type": "FROM_HISTORICAL_SCAN", "metadata": null, "field": "content"}]},
+        "has_dropped_occurrences": false, "tags": ["FROM_HISTORICAL_SCAN"], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 2}, {"id": 33596489, "account": 8, "criterion":
+        "Crates.io Key", "date": "2026-04-23T07:01:34Z", "last_trigger_published_at":
+        "2026-04-23T07:01:34Z", "last_triggered_at": "2026-06-03T06:07:40.264398Z",
+        "last_trigger_detected_at": "2026-06-03T06:07:40.264398Z", "hash": "p+1AOmmSi7EjUgFDneZ99ZOqsN8Zh7oiZa/V9dwYv5mnrw9eqnKJPm3m46v5MSqC",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Generic Private Key", "severity_rule_config": {"id": 10858, "gg_created_at":
-        "2026-02-12T15:13:37.684102Z", "gg_updated_at": "2026-02-12T15:13:37.684119Z",
+        "Crates.io Key", "severity_rule_config": {"id": 11895, "gg_created_at": "2026-05-20T08:56:10.055460Z",
+        "gg_updated_at": "2026-05-20T08:56:10.055463Z", "index": 130, "severity":
+        10, "rule": {"id": 513, "gg_created_at": "2025-03-18T08:57:54.142453Z", "gg_updated_at":
+        "2025-03-18T08:57:54.142456Z", "name": "Package manager related secret", "description":
+        "The detector relates to a package manager", "json_rule": {"operator": "EQ",
+        "arg1": {"path": "issue.secret.detector.metadata.category", "default": null},
+        "arg2": {"value": "package_registry"}}, "is_global": true, "scope": "private",
+        "author": null}}, "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "gg-tools@gitguardian.com",
+        "name": "gim-dev"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
+        [{"id": 27907812, "name": "gim-dev/ra24091", "type": "ghe_repository", "path":
+        "gim-dev/ra24091", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 0, "score": 86, "displayed_occurrence": {"id":
+        271124122, "issue": 33596489, "account": 8, "kind": "HIST", "element": "aa11f9f443e865a8ec50290ee90fe169c21aef9b",
+        "element_type": "GIT_COMMIT", "author_name": "gim-dev", "author_info": "gg-tools@gitguardian.com",
+        "value": null, "value_hash": "72AJ4l7ikuNODzwNuaxjTIxDURGLw+/dPaAUz7IaWGID7D5e7+TNTxbhgBuHYpK2",
+        "published_at": "2026-04-23T07:01:34Z", "date": "2026-04-23T07:01:34Z", "detected_at":
+        "2026-06-03T06:07:39.990226Z", "is_vcs_type": true, "last_detected_at": "2026-04-23T07:01:34Z",
+        "last_seen_at": "2026-04-23T07:01:34Z", "data": {}, "url": "https://ghe-01.aws-qa-gitguardian.com/gim-dev/ra24091/commit/aa11f9f443e865a8ec50290ee90fe169c21aef9b#diff-a8f520d6712a82ea3d0013a99d2a9dd590c10c78a334a1933e7a553458799877R4",
+        "source": {"id": 27907812, "url": "https://ghe-01.aws-qa-gitguardian.com/gim-dev/ra24091",
+        "type": "ghe_repository", "display_name": "gim-dev/ra24091", "visibility":
+        "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
+        null, "default_branch": "main", "monitoring_status": "active"}, "regression":
+        false, "content": 166434269, "secrets_engine_version": "2.164.0", "matches":
+        [{"name": "apikey", "string_matched": "[REDACTED]", "indice_start": 135, "indice_end":
+        170, "pre_line_start": null, "pre_line_end": null, "post_line_start": 4, "post_line_end":
+        4}], "most_sensitive_match_name": "apikey", "insights": [], "filepath": "toto.py",
+        "filename": "toto.py", "presence": "visible", "last_presence_seen_at": "2026-06-03T06:07:40.296212Z",
+        "last_presence_check_at": "2026-06-03T06:07:40.296212Z", "first_presence_deleted_at":
+        null, "seen_in_default_branch": null, "change_type": "addition", "full_tags":
+        [{"type": "FROM_HISTORICAL_SCAN", "metadata": null, "field": "content"}]},
+        "has_dropped_occurrences": false, "tags": ["FROM_HISTORICAL_SCAN"], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 2}, {"id": 30544091, "account": 8, "criterion":
+        "Generic Password", "date": "2026-04-21T13:50:33Z", "last_trigger_published_at":
+        "2026-04-21T13:50:33Z", "last_triggered_at": "2026-04-21T13:51:51.903700Z",
+        "last_trigger_detected_at": "2026-04-21T13:51:51.903700Z", "hash": "4PzpgFt47Giz2Rc65HRXDbWN+5eN4xW6krfNc4FSo9llmZnwfma8ieOEhD7igl+v",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "PostgreSQL Credentials", "severity_rule_config": {"id": 11883, "gg_created_at":
+        "2026-05-20T08:56:10.055321Z", "gg_updated_at": "2026-05-20T08:56:10.055331Z",
         "index": 10, "severity": 10, "rule": {"id": 745, "gg_created_at": "2026-02-12T15:13:36.079495Z",
         "gg_updated_at": "2026-02-12T15:13:36.079508Z", "name": "Publicly leaked secrets",
         "description": "Publicly leaked secrets outside perimeter", "json_rule": {"operator":
@@ -195,114 +223,78 @@ interactions:
         "default": null}, "arg2": {"value": "invalid"}}}]}, "is_global": false, "scope":
         "private", "author": 520858}}, "declarative_secret_status": null, "assignee":
         null, "last_presence_check_at": null, "secret": "[REDACTED]", "severity":
-        100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}], "user_permission":
-        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        2, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"name": "kevin-nedelec / Rayn-private",
-        "type": "gl_project", "path": "kevin-nedelec/rayn-private", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 0, "score": 79, "displayed_occurrence": {"id": 222656411,
-        "issue": 21857830, "account": 8, "kind": "HIST", "element": "4334fd4d0902e960583a2f0f578dd7cb0c1f691f",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
-        "value": null, "value_hash": "4elueXyOgrNYPQ5m+XbCLfjEyoDQgvVA5a9sk8YsKVuGk7K+MSCwVESEtIRCtWCk",
-        "published_at": "2025-10-21T15:12:04Z", "date": "2025-10-21T15:12:04Z", "detected_at":
-        "2025-10-24T14:00:01.744927Z", "is_vcs_type": true, "last_detected_at": "2025-10-21T15:12:04Z",
-        "last_seen_at": "2025-10-21T15:12:04Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/kevin-nedelec/rayn-private/commit/4334fd4d0902e960583a2f0f578dd7cb0c1f691f#53585a096fe3a3b96321113856ae62602995a33b_None_2624",
-        "source": {"id": 23657440, "url": "https://gitlab-01.aws-qa-gitguardian.com/kevin-nedelec/rayn-private",
-        "type": "gl_project", "display_name": "kevin-nedelec / Rayn-private", "visibility":
+        100, "authors": [{"info": "alina.tuholukova@gitguardian.com", "name": "Alina
+        Tuholukova"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 24066096, "name": "group3 / Guillaume testing", "type": "gl_project",
+        "path": "group2/guillaume-testing", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 55, "displayed_occurrence":
+        {"id": 261408101, "issue": 30544091, "account": 8, "kind": "RLTM", "element":
+        "5e35304d12f5207f72dc3da8e7033494e3d49a90", "element_type": "GIT_COMMIT",
+        "author_name": "Alina Tuholukova", "author_info": "alina.tuholukova@gitguardian.com",
+        "value": null, "value_hash": "dmdGBLQCcXWDEKckkQGMvXTikhk7Qkpaml86yoY9X4Xmx+Oc7u2brhHr47K73UWF",
+        "published_at": "2026-04-21T13:50:33Z", "date": "2026-04-21T13:50:33Z", "detected_at":
+        "2026-04-21T13:51:50.123829Z", "is_vcs_type": true, "last_detected_at": "2026-04-21T13:50:33Z",
+        "last_seen_at": "2026-04-21T13:50:33Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/group2/guillaume-testing/commit/5e35304d12f5207f72dc3da8e7033494e3d49a90#1a1b9769344cb239f2e540e1e6ee1efa2d3034ea_0_8",
+        "source": {"id": 24066096, "url": "https://gitlab-01.aws-qa-gitguardian.com/group2/guillaume-testing",
+        "type": "gl_project", "display_name": "group3 / Guillaume testing", "visibility":
         "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
-        null, "default_branch": "master"}, "regression": false, "content": 100719616,
-        "secrets_engine_version": "2.149.1", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 167202, "indice_end": 167635, "pre_line_start":
-        null, "pre_line_end": null, "post_line_start": 2624, "post_line_end": 2624}],
-        "most_sensitive_match_name": "apikey", "insights": [], "filepath": "yarn.lock",
-        "filename": "yarn.lock", "presence": "visible", "last_presence_seen_at": "2026-02-18T22:33:19.975686Z",
-        "last_presence_check_at": "2026-02-18T22:33:19.975686Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": "addition", "full_tags":
-        [{"type": "FROM_HISTORICAL_SCAN", "metadata": null}]}, "has_dropped_occurrences":
-        false, "tags": ["FROM_HISTORICAL_SCAN", "PUBLICLY_LEAKED"], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": true, "leaked_outside_perimeter":
-        false}, "occurrences_count": 2}, {"id": 21857831, "account": 8, "criterion":
-        "RSA Private Key", "date": "2025-10-21T15:12:04Z", "last_trigger_published_at":
-        "2025-10-21T15:12:04Z", "last_triggered_at": "2025-10-24T14:00:09.175160Z",
-        "last_trigger_detected_at": "2025-10-24T14:00:09.175160Z", "hash": "naEqgN/D9qNsk8WifuluDLW5hbScH3ENkz1s6aH+bJgJ5zvw7vN5xZFHxYj+duJV",
-        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
-        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
-        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
-        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
-        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "RSA Private Key", "severity_rule_config": {"id": 10858, "gg_created_at":
-        "2026-02-12T15:13:37.684102Z", "gg_updated_at": "2026-02-12T15:13:37.684119Z",
-        "index": 10, "severity": 10, "rule": {"id": 745, "gg_created_at": "2026-02-12T15:13:36.079495Z",
-        "gg_updated_at": "2026-02-12T15:13:36.079508Z", "name": "Publicly leaked secrets",
-        "description": "Publicly leaked secrets outside perimeter", "json_rule": {"operator":
-        "AND", "args": [{"operator": "NOT", "arg1": {"operator": "EQ", "arg1": {"path":
-        "issue.public_leak_range", "default": null}, "arg2": {"value": "0"}}}, {"operator":
-        "NOT", "arg1": {"operator": "EQ", "arg1": {"path": "issue.secret.validity_status",
-        "default": null}, "arg2": {"value": "invalid"}}}]}, "is_global": false, "scope":
-        "private", "author": 520858}}, "declarative_secret_status": null, "assignee":
-        null, "last_presence_check_at": null, "secret": "[REDACTED]", "severity":
-        100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}], "user_permission":
-        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        2, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "kevin-nedelec / Rayn-private",
-        "type": "gl_project", "path": "kevin-nedelec/rayn-private", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 0, "score": 75, "displayed_occurrence": {"id": 222656412,
-        "issue": 21857831, "account": 8, "kind": "HIST", "element": "49f8942dcaf2c9a180f5eb090270ffafe9ef813a",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
-        "value": null, "value_hash": "SQILbjvj8BY3EDFcUQtxuDQpSUDpcSrXrwvgmYepHQyiruiBfTTU7gIYYCLw5Cwr",
-        "published_at": "2025-10-21T15:12:04Z", "date": "2025-10-21T15:12:04Z", "detected_at":
-        "2025-10-24T14:00:01.744927Z", "is_vcs_type": true, "last_detected_at": "2025-10-21T15:12:04Z",
-        "last_seen_at": "2025-10-21T15:12:04Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/kevin-nedelec/rayn-private/commit/49f8942dcaf2c9a180f5eb090270ffafe9ef813a#53585a096fe3a3b96321113856ae62602995a33b_None_2477",
-        "source": {"id": 23657440, "url": "https://gitlab-01.aws-qa-gitguardian.com/kevin-nedelec/rayn-private",
-        "type": "gl_project", "display_name": "kevin-nedelec / Rayn-private", "visibility":
-        "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
-        null, "default_branch": "master"}, "regression": false, "content": 100719617,
-        "secrets_engine_version": "2.149.1", "matches": [{"name": "apikey", "string_matched":
-        "[REDACTED]", "indice_start": 160887, "indice_end": 161787, "pre_line_start":
-        null, "pre_line_end": null, "post_line_start": 2477, "post_line_end": 2491}],
-        "most_sensitive_match_name": "apikey", "insights": [], "filepath": "yarn.lock",
-        "filename": "yarn.lock", "presence": "visible", "last_presence_seen_at": "2026-02-18T22:33:19.975686Z",
-        "last_presence_check_at": "2026-02-18T22:33:19.975686Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": "addition", "full_tags":
-        [{"type": "FROM_HISTORICAL_SCAN", "metadata": null}]}, "has_dropped_occurrences":
-        false, "tags": ["FROM_HISTORICAL_SCAN", "PUBLICLY_LEAKED"], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": true, "leaked_outside_perimeter":
-        false}, "occurrences_count": 2}]}'
+        null, "default_branch": "main", "monitoring_status": "active"}, "regression":
+        false, "content": 154593141, "secrets_engine_version": "2.161.0", "matches":
+        [{"name": "password", "string_matched": "[REDACTED]", "indice_start": 168,
+        "indice_end": 188, "pre_line_start": null, "pre_line_end": null, "post_line_start":
+        8, "post_line_end": 8}], "most_sensitive_match_name": "password", "insights":
+        [], "filepath": "config.py", "filename": "config.py", "presence": "visible",
+        "last_presence_seen_at": "2026-04-21T13:51:51.947249Z", "last_presence_check_at":
+        "2026-04-21T13:51:51.947249Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        true, "change_type": "addition", "full_tags": [{"type": "DEFAULT_BRANCH",
+        "metadata": null, "field": "content"}]}, "has_dropped_occurrences": false,
+        "tags": ["DEFAULT_BRANCH", "PUBLICLY_LEAKED"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": true},
+        "occurrences_count": 1}]}'
     headers:
+      CF-RAY:
+      - a10397c09fb5343a-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:57 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '27675'
+      - '26186'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:51 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '125'
+      - '199'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_incidents_coerce_single_status.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incidents_coerce_single_status.yaml
@@ -21,49 +21,49 @@ interactions:
   response:
     body:
       string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?ordering=-date&page=2&page_size=5&severity__in=10%2C20%2C30%2C100&status__in=TRIGGERED&tags__nin=TEST_FILE%2CFALSE_POSITIVE%2CCHECK_RUN_SKIP_FALSE_POSITIVE%2CCHECK_RUN_SKIP_LOW_RISK%2CCHECK_RUN_SKIP_TEST_CRED&validity__in=valid%2Cfailed_to_check%2Cno_checker%2Cnot_checked",
-        "previous": null, "results": [{"id": 29487335, "account": 8, "criterion":
-        "Stripe Webhook Secret", "date": "2026-04-02T16:22:33.518000Z", "last_trigger_published_at":
-        "2026-04-02T16:22:33.518000Z", "last_triggered_at": "2026-04-02T16:22:34.233032Z",
-        "last_trigger_detected_at": "2026-04-02T16:22:34.233032Z", "hash": "JquJu98wTd0k40t3UsNgP22P+ywFCrsGM1VDRg3oZBdGXhRWbjOMbKAG+JtXZUOK",
+        "previous": null, "results": [{"id": 34205503, "account": 8, "criterion":
+        "microsoft_azure_storage_connection_string", "date": "2026-06-23T11:13:31.325324Z",
+        "last_trigger_published_at": "2026-06-23T11:13:31.325324Z", "last_triggered_at":
+        "2026-06-23T11:13:31.343453Z", "last_trigger_detected_at": "2026-06-23T11:13:31.343453Z",
+        "hash": "HdPZ4cjZuziAqsakdlsUnJDapTz3ns5pX8vPzfhvGQvpWWWX25LITKmJimoqGr3z",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Stripe Webhook Secret", "severity_rule_config": null, "declarative_secret_status":
-        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}], "user_permission": 7, "is_publicly_shared": true,
-        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "gg-test-integrations / My Kanban Space", "type": "jira_cloud_project",
-        "path": "gg-test-integrations / My Kanban Space", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 62, "displayed_occurrence": {"id": 256867982, "issue": 29487335,
-        "account": 8, "kind": "RLTM", "element": "KAN-8?focusedCommentId=10014", "element_type":
-        "JIRA_COMMENT", "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "o40+pCpgMCFgcapQEEdZ3imjEpSONYcgy0J+gLe5ygKDJctj7Ro4REsJrqbUl0yj",
-        "published_at": "2026-04-02T16:22:33.518000Z", "date": "2026-04-02T16:22:33.518000Z",
-        "detected_at": "2026-04-02T16:22:34.031682Z", "is_vcs_type": false, "last_detected_at":
-        "2026-04-02T16:22:33.518000Z", "last_seen_at": "2026-04-02T16:22:33.518000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/KAN-8?focusedCommentId=10014",
-        "source": {"id": 26780039, "url": "https://gg-test-integrations.atlassian.net/browse/KAN",
-        "type": "jira_cloud_project", "display_name": "gg-test-integrations / My Kanban
-        Space", "visibility": "private", "monitored": true, "source_criticality":
-        "unknown", "deleted_at": null, "default_branch": null}, "regression": false,
-        "content": 148603941, "secrets_engine_version": "2.159.0", "matches": [{"name":
-        "apikey", "string_matched": "[REDACTED]", "indice_start": 25, "indice_end":
-        63, "pre_line_start": null, "pre_line_end": null, "post_line_start": null,
-        "post_line_end": null}], "most_sensitive_match_name": "apikey", "insights":
-        [], "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
-        "2026-04-02T16:22:34.268883Z", "last_presence_check_at": "2026-04-02T16:22:34.268883Z",
-        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
-        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 1}, {"id": 27743219, "account": 8, "criterion":
-        "Generic Password", "date": "2026-03-02T08:03:19Z", "last_trigger_published_at":
-        "2026-03-02T08:03:19Z", "last_triggered_at": "2026-03-02T08:04:40.966599Z",
-        "last_trigger_detected_at": "2026-03-02T08:04:40.966599Z", "hash": "DIhTV8EvZb3qiiqNdZxIdx5KXxPM1+opgvbjqYv9ikr7Xshkfma8ieOEhD7igl+v",
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
+        "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
+        "detected_at": "2026-06-23T11:13:31.325324Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
+        "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
+        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
+        34186239, "account": 8, "criterion": "Generic Password", "date": "2026-06-22T15:14:57Z",
+        "last_trigger_published_at": "2026-06-22T15:14:57Z", "last_triggered_at":
+        "2026-06-22T15:16:49.799821Z", "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z",
+        "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -72,181 +72,191 @@ interactions:
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
         "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        2, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"name": "olaugier / test", "type":
-        "gl_project", "path": "olaugier/test", "source_criticality": "unknown"}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        0, "score": 63, "displayed_occurrence": {"id": 247153722, "issue": 27743219,
-        "account": 8, "kind": "RLTM", "element": "876b995fcda9f3ebacdde3630fe8521c09e88a50",
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
+        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
+        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
         "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
-        "value": null, "value_hash": "kqtDoOt2gXsDpCN6VFM6vvO0PUTxcS7pA+2Yu2AS9t2s4kcdjypyaVpjw9oi8GAg",
-        "published_at": "2026-03-02T08:03:19Z", "date": "2026-03-02T08:03:19Z", "detected_at":
-        "2026-03-02T08:04:26.107138Z", "is_vcs_type": true, "last_detected_at": "2026-03-02T08:03:19Z",
-        "last_seen_at": "2026-03-02T08:03:19Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/876b995fcda9f3ebacdde3630fe8521c09e88a50#dbdb2e6bfc642ed0d0c5033e50062fe3ede15e4e_0_3",
+        "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
+        "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
+        "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
         "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        "main"}, "regression": false, "content": 137431882, "secrets_engine_version":
-        "2.157.1", "matches": [{"name": "password", "string_matched": "[REDACTED]",
-        "indice_start": 67, "indice_end": 143, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 3, "post_line_end": 3}], "most_sensitive_match_name":
-        "password", "insights": [{"name": "minified", "source": "document", "metadata":
-        {"minified_probability": 0.0}}], "filepath": "configuration_15.txt", "filename":
-        "configuration_15.txt", "presence": "visible", "last_presence_seen_at": "2026-03-02T08:04:41.000526Z",
-        "last_presence_check_at": "2026-03-02T08:04:41.000526Z", "first_presence_deleted_at":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 113, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_63.txt", "filename":
+        "configuration_63.txt", "presence": "visible", "last_presence_seen_at": "2026-06-22T15:16:49.824313Z",
+        "last_presence_check_at": "2026-06-22T15:16:49.824313Z", "first_presence_deleted_at":
         null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
-        [{"type": "DEFAULT_BRANCH", "metadata": null}]}, "has_dropped_occurrences":
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
         false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
         false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 2}, {"id": 26805049, "account": 8, "criterion": "Generic
-        High Entropy Secret", "date": "2026-02-04T12:40:14Z", "last_trigger_published_at":
-        "2026-02-04T12:40:14Z", "last_triggered_at": "2026-02-04T13:38:51.993879Z",
-        "last_trigger_detected_at": "2026-02-04T13:38:51.993879Z", "hash": "WTaCT+UniPgL/yRBqvY08cAEfxZM20pDa9wMIFDtfg14lIkIp+KkPCNpyNbtXqJM",
+        "occurrences_count": 1}, {"id": 34122510, "account": 8, "criterion": "Generic
+        Password", "date": "2026-06-19T13:41:03Z", "last_trigger_published_at": "2026-06-19T13:41:03Z",
+        "last_triggered_at": "2026-06-19T13:43:05.020137Z", "last_trigger_detected_at":
+        "2026-06-19T13:43:05.020137Z", "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Square Token", "severity_rule_config": null, "declarative_secret_status":
-        null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "romain.jouhannet@gitguardian.com",
-        "name": "Romain Jouhannet"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "RomainJ / demo", "type": "gl_project", "path": "romain/demo", "source_criticality":
-        "unknown"}], "custom_tags": [{"id": "95d1699b-48cf-4ff6-a63c-fe84962ae3d7",
-        "key": "review-now", "value": null}], "vault_metadata": null, "is_vaulted":
-        false, "similar_issue_count": 2, "score": 29, "displayed_occurrence": {"id":
-        241287705, "issue": 26805049, "account": 8, "kind": "HIST", "element": "5198e8b1dbfceb42a733e2f96a8c737fa8bc5ee8",
-        "element_type": "GIT_COMMIT", "author_name": "Romain Jouhannet", "author_info":
-        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "GhRrj5e1kcvhEll7h1jzMp+OWqSKSo2NolskBvuPoBtWAGgECsEe4zatEBTLXqE2",
-        "published_at": "2026-02-04T12:40:14Z", "date": "2026-02-04T12:40:14Z", "detected_at":
-        "2026-02-04T13:38:46.386256Z", "is_vcs_type": true, "last_detected_at": "2026-02-04T12:40:14Z",
-        "last_seen_at": "2026-02-04T12:40:14Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/5198e8b1dbfceb42a733e2f96a8c737fa8bc5ee8#8b00584865b28d12f057cc2064a51a05b33603f1_None_20",
-        "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
-        "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
-        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        "main"}, "regression": false, "content": 129708170, "secrets_engine_version":
-        "2.155.4", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 901, "indice_end": 963, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 20, "post_line_end": 20}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "bluethroat.py", "filename": "bluethroat.py",
-        "presence": "visible", "last_presence_seen_at": "2026-02-18T22:33:05.054565Z",
-        "last_presence_check_at": "2026-02-18T22:33:05.054565Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": "addition", "full_tags":
-        [{"type": "FROM_HISTORICAL_SCAN", "metadata": null}]}, "has_dropped_occurrences":
-        false, "tags": ["DEFAULT_BRANCH", "FROM_HISTORICAL_SCAN"], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "occurrences_count": 2}, {"id": 27376706, "account": 8, "criterion":
-        "Generic High Entropy Secret", "date": "2026-02-03T18:01:34Z", "last_trigger_published_at":
-        "2026-02-03T18:01:34Z", "last_triggered_at": "2026-02-18T22:30:10.841502Z",
-        "last_trigger_detected_at": "2026-02-18T22:30:10.841502Z", "hash": "ibXkMJV6uTHsJafjczOQ68QAB5+duicw47vYL2RYo1qDXv9hp+KkPCNpyNbtXqJM",
-        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
-        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
-        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
-        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
-        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Generic High Entropy Secret", "severity_rule_config": null, "declarative_secret_status":
+        "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
         "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        2, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"name": "dev / af-test", "type":
-        "gl_project", "path": "dev/af-test", "source_criticality": "unknown"}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 17, "displayed_occurrence": {"id": 244951506, "issue": 27376706,
-        "account": 8, "kind": "HIST", "element": "964cf6ffd1a7394dafa06c6ac2bea9cdbd26e271",
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
+        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
+        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
+        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
         "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
-        "value": null, "value_hash": "yPHhVm3+xgFEqcd3lgG3sU/dBii/3F/OKPNx2tHffffXEO/OIlAnR+7CSJX89j/e",
-        "published_at": "2026-02-03T18:01:34Z", "date": "2026-02-03T18:01:34Z", "detected_at":
-        "2026-02-18T22:30:10.259311Z", "is_vcs_type": true, "last_detected_at": "2026-02-03T18:01:34Z",
-        "last_seen_at": "2026-02-03T18:01:34Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/dev/af-test/commit/964cf6ffd1a7394dafa06c6ac2bea9cdbd26e271#1b22a15539aac2764ebbd49097d6da240d01f70e_None_1",
-        "source": {"id": 16824393, "url": "https://gitlab-01.aws-qa-gitguardian.com/dev/af-test",
-        "type": "gl_project", "display_name": "dev / af-test", "visibility": "private",
+        "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
+        "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
+        "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        "main"}, "regression": false, "content": 134319827, "secrets_engine_version":
-        "2.156.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 30, "indice_end": 80, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 1, "post_line_end": 1}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "leak.py", "filename": "leak.py", "presence":
-        "visible", "last_presence_seen_at": "2026-02-18T22:30:10.880417Z", "last_presence_check_at":
-        "2026-02-18T22:30:10.880417Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": "addition", "full_tags": [{"type": "FROM_HISTORICAL_SCAN",
-        "metadata": null}]}, "has_dropped_occurrences": false, "tags": ["FROM_HISTORICAL_SCAN"],
-        "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 2}, {"id":
-        27376707, "account": 8, "criterion": "Generic High Entropy Secret", "date":
-        "2026-02-03T17:58:58Z", "last_trigger_published_at": "2026-02-03T17:58:58Z",
-        "last_triggered_at": "2026-02-18T22:30:10.841568Z", "last_trigger_detected_at":
-        "2026-02-18T22:30:10.841568Z", "hash": "xAQweN+OlrDmqrwnVOwiDm/jfEeh9TDUfUAcbN8N9t9GT3gZp+KkPCNpyNbtXqJM",
+        "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "password", "string_matched":
+        "[REDACTED]", "indice_start": 67, "indice_end": 129, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "most_sensitive_match_name":
+        "password", "insights": [], "filepath": "configuration_62.txt", "filename":
+        "configuration_62.txt", "presence": "visible", "last_presence_seen_at": "2026-06-19T13:43:05.062490Z",
+        "last_presence_check_at": "2026-06-19T13:43:05.062490Z", "first_presence_deleted_at":
+        null, "seen_in_default_branch": true, "change_type": "addition", "full_tags":
+        [{"type": "DEFAULT_BRANCH", "metadata": null, "field": "content"}]}, "has_dropped_occurrences":
+        false, "tags": ["DEFAULT_BRANCH"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
+        "occurrences_count": 1}, {"id": 34038186, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-16T18:55:43.166667Z", "last_trigger_published_at": "2026-06-16T18:55:43.166667Z",
+        "last_triggered_at": "2026-06-16T18:55:43.185061Z", "last_trigger_detected_at":
+        "2026-06-16T18:55:43.185061Z", "hash": "JFTpQX+4P/dEcXJJ2iw+u54JYDsJnqLtrdws1wjFQ8t9LtHh25LITKmJimoqGr3z",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Generic High Entropy Secret", "severity_rule_config": null, "declarative_secret_status":
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
+        "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
+        "detected_at": "2026-06-16T18:55:43.166667Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
+        "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
+        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
+        33905111, "account": 8, "criterion": "GitLab Deploy Token", "date": "2026-06-11T12:29:43Z",
+        "last_trigger_published_at": "2026-06-11T12:29:43Z", "last_triggered_at":
+        "2026-06-11T12:30:11.342010Z", "last_trigger_detected_at": "2026-06-11T12:30:11.342010Z",
+        "hash": "G0fVu31BJOKtUHJsvHbpcGhXGXhyr2/bQf6zzlhNv+czrK+KrGdxdFLGuJmYhmlq",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "GitLab Deploy Token", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
         "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
         "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "dev / af-test", "type":
-        "gl_project", "path": "dev/af-test", "source_criticality": "unknown"}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 53, "displayed_occurrence": {"id": 244951502, "issue": 27376707,
-        "account": 8, "kind": "HIST", "element": "ebf0a2ce7add36b9d8a0ae67097a30a5e60cf43a",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
-        "value": null, "value_hash": "BVJDQbByiB9ovuJtNn619r8AZGFSwmut5pVKEs7pZRsRXpWprzdNjzDjE4tYBaZ+",
-        "published_at": "2026-02-03T17:58:58Z", "date": "2026-02-03T17:58:58Z", "detected_at":
-        "2026-02-18T22:30:10.259311Z", "is_vcs_type": true, "last_detected_at": "2026-02-03T17:58:58Z",
-        "last_seen_at": "2026-02-03T17:58:58Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/dev/af-test/commit/ebf0a2ce7add36b9d8a0ae67097a30a5e60cf43a#451872b483a0c013a933a253dbb6e06aba019ed5_None_1",
-        "source": {"id": 16824393, "url": "https://gitlab-01.aws-qa-gitguardian.com/dev/af-test",
-        "type": "gl_project", "display_name": "dev / af-test", "visibility": "private",
+        null, "locations_count": 1, "sources": [{"id": 28664611, "name": "dev / plal_test",
+        "type": "gl_project", "path": "dev/plal_test", "source_criticality": "unknown",
+        "monitoring_status": "active", "deleted_at": null}], "custom_tags": [], "vault_metadata":
+        null, "is_vaulted": false, "similar_issue_count": 0, "score": 85, "displayed_occurrence":
+        {"id": 272645187, "issue": 33905111, "account": 8, "kind": "HIST", "element":
+        "0102329ae146f51358cff771dbdf860acbc78ef6", "element_type": "GIT_COMMIT",
+        "author_name": "dev", "author_info": "gim+dev@gitguardian.com", "value": null,
+        "value_hash": "vKgkDXA4NszdEvKqefnQ7tPG4AsADP5uV3carLt96S2ZoMa7KySfdZ9m9HlrAElh",
+        "published_at": "2026-06-11T12:29:43Z", "date": "2026-06-11T12:29:43Z", "detected_at":
+        "2026-06-11T12:30:10.472937Z", "is_vcs_type": true, "last_detected_at": "2026-06-11T12:37:30.541974Z",
+        "last_seen_at": "2026-06-11T12:37:30.541974Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/dev/plal_test/commit/0102329ae146f51358cff771dbdf860acbc78ef6#5a06a4630a05426a25bc162c233d6cf8ed2462a0_None_5",
+        "source": {"id": 28664611, "url": "https://gitlab-01.aws-qa-gitguardian.com/dev/plal_test",
+        "type": "gl_project", "display_name": "dev / plal_test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        "main"}, "regression": false, "content": 134319828, "secrets_engine_version":
-        "2.156.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 123, "indice_end": 173, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 1, "post_line_end": 1}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "file.py", "filename": "file.py", "presence":
-        "visible", "last_presence_seen_at": "2026-02-18T22:30:10.880417Z", "last_presence_check_at":
-        "2026-02-18T22:30:10.880417Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": "addition", "full_tags": [{"type": "FROM_HISTORICAL_SCAN",
-        "metadata": null}]}, "has_dropped_occurrences": false, "tags": ["FROM_HISTORICAL_SCAN"],
-        "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}]}'
+        "main", "monitoring_status": "active"}, "regression": false, "content": 168574637,
+        "secrets_engine_version": "2.165.0", "matches": [{"name": "apikey", "string_matched":
+        "[REDACTED]", "indice_start": 65, "indice_end": 90, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 5, "post_line_end": 5}], "most_sensitive_match_name":
+        "apikey", "insights": [], "filepath": "secret_and_pii.txt", "filename": "secret_and_pii.txt",
+        "presence": "visible", "last_presence_seen_at": "2026-06-11T12:37:30.541974Z",
+        "last_presence_check_at": "2026-06-11T12:37:30.541974Z", "first_presence_deleted_at":
+        null, "seen_in_default_branch": null, "change_type": "addition", "full_tags":
+        [{"type": "FROM_HISTORICAL_SCAN", "metadata": null, "field": "content"}]},
+        "has_dropped_occurrences": false, "tags": ["FROM_HISTORICAL_SCAN"], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 1}]}'
     headers:
+      CF-RAY:
+      - a10397bcbb74dc71-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:57 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '22778'
+      - '22856'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:50 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '130'
+      - '197'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_incidents_coerce_single_validity.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incidents_coerce_single_validity.yaml
@@ -21,125 +21,133 @@ interactions:
   response:
     body:
       string: '{"count": null, "page": 1, "next": "https://api.gitguardian.com/exposed/v1/incidents-for-mcp?ordering=-date&page=2&page_size=5&severity__in=10%2C20%2C30%2C100&status__in=TRIGGERED%2CASSIGNED%2CRESOLVED&tags__nin=TEST_FILE%2CFALSE_POSITIVE%2CCHECK_RUN_SKIP_FALSE_POSITIVE%2CCHECK_RUN_SKIP_LOW_RISK%2CCHECK_RUN_SKIP_TEST_CRED&validity__in=valid",
-        "previous": null, "results": [{"id": 26879946, "account": 8, "criterion":
-        "AWS Keys", "date": "2026-02-05T16:48:19Z", "last_trigger_published_at": "2026-02-05T16:48:19Z",
-        "last_triggered_at": "2026-02-05T16:51:59.912161Z", "last_trigger_detected_at":
-        "2026-02-05T16:51:59.912161Z", "hash": "BPRo0pF0ZesUJFhK1FAEiWQsj9wNtT2WYZ15WbzmXjC7vE/VL4Qc71cZRqNcojMG",
-        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
-        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
-        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
-        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
-        "none", "manual_severity_setter_type": "none", "status": "ASSIGNED", "issue_name":
-        "AWS IAM Keys", "severity_rule_config": {"id": 10860, "gg_created_at": "2026-02-12T15:13:37.684167Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684171Z", "index": 30, "severity": 10,
-        "rule": {"id": 503, "gg_created_at": "2025-03-18T08:57:54.142008Z", "gg_updated_at":
-        "2025-04-02T13:15:43.307296Z", "name": "Valid secrets related to highly sensitive
-        detectors", "description": "Secrets related to highly sensitive detectors
-        were valid when the incident was discovered. You can edit this rule to create
-        your own list of sensitive detectors", "json_rule": {"operator": "AND", "args":
-        [{"operator": "EQ", "arg1": {"path": "issue.secret.validity_status", "default":
-        null}, "arg2": {"value": "valid"}}, {"operator": "IN", "arg1": {"path": "issue.secret.detector.detector_group_name",
-        "default": null}, "arg2": {"value": ["github_app_token", "ldap_credentials",
-        "github_oauth_token", "googlecloud_keys", "jira_basic_auth", "python_package_index_key",
-        "aws_iam_sts", "npm_token", "gitlab_token", "smtp_credentials", "github_fine_grained_pat",
-        "gitlab_enterprise_token", "github_access_token", "aws_iam"]}}]}, "is_global":
-        true, "scope": "any", "author": null}}, "declarative_secret_status": null,
-        "assignee": 581873, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        8, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "gim-qa-gitlabSandbox-auto
-        / gim-qa-gitlabSandbox-staging", "type": "gl_project", "path": "gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
-        "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
-        {"id": 242021853, "issue": 26879946, "account": 8, "kind": "RLTM", "element":
-        "e2cbc193a76a13b94e135c12a055d2083a233a89", "element_type": "GIT_COMMIT",
-        "author_name": "dev", "author_info": "gim+dev@gitguardian.com", "value": null,
-        "value_hash": "7AkVngiwT5n4ZZihQovCHs2qrlx0MOfD853AYv4HHS0DiM0Vk9YtctC+FFM1Iw+v",
-        "published_at": "2026-02-05T16:48:19Z", "date": "2026-02-05T16:48:19Z", "detected_at":
-        "2026-02-05T16:51:53.166126Z", "is_vcs_type": true, "last_detected_at": "2026-02-05T16:48:19Z",
-        "last_seen_at": "2026-02-05T16:48:19Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging/commit/e2cbc193a76a13b94e135c12a055d2083a233a89#2dd906314026edd7e5fa25025afd4353424625a7_0_19",
-        "source": {"id": 16219056, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
-        "type": "gl_project", "display_name": "gim-qa-gitlabSandbox-auto / gim-qa-gitlabSandbox-staging",
-        "visibility": "private", "monitored": true, "source_criticality": "unknown",
-        "deleted_at": null, "default_branch": "main"}, "regression": false, "content":
-        130291193, "secrets_engine_version": "2.156.0", "matches": [{"name": "client_id",
-        "string_matched": "[REDACTED]", "indice_start": 124, "indice_end": 144, "pre_line_start":
-        null, "pre_line_end": null, "post_line_start": 4, "post_line_end": 4}, {"name":
-        "client_secret", "string_matched": "[REDACTED]", "indice_start": 981, "indice_end":
-        1021, "pre_line_start": null, "pre_line_end": null, "post_line_start": 19,
-        "post_line_end": 19}], "most_sensitive_match_name": "client_secret", "insights":
-        [], "filepath": "ec2_instance_management.py", "filename": "ec2_instance_management.py",
-        "presence": "visible", "last_presence_seen_at": "2026-02-18T22:30:08.818671Z",
-        "last_presence_check_at": "2026-02-18T22:30:08.818671Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": false, "change_type": "addition", "full_tags":
-        []}, "has_dropped_occurrences": false, "tags": [], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 8}, {"id": 22515404, "account": 8, "criterion": "AWS
-        Keys", "date": "2025-11-17T17:16:25Z", "last_trigger_published_at": "2025-11-17T17:16:25Z",
-        "last_triggered_at": "2025-11-17T17:18:18.706440Z", "last_trigger_detected_at":
-        "2025-11-17T17:18:18.706440Z", "hash": "6y4trbQi60aNmDEFQe0tJH3jke+8j18I9t2sKfgaunTYEUdZL4Qc71cZRqNcojMG",
+        "previous": null, "results": [{"id": 34205503, "account": 8, "criterion":
+        "microsoft_azure_storage_connection_string", "date": "2026-06-23T11:13:31.325324Z",
+        "last_trigger_published_at": "2026-06-23T11:13:31.325324Z", "last_triggered_at":
+        "2026-06-23T11:13:31.343453Z", "last_trigger_detected_at": "2026-06-23T11:13:31.343453Z",
+        "hash": "HdPZ4cjZuziAqsakdlsUnJDapTz3ns5pX8vPzfhvGQvpWWWX25LITKmJimoqGr3z",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "AWS IAM Keys", "severity_rule_config": {"id": 10860, "gg_created_at": "2026-02-12T15:13:37.684167Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684171Z", "index": 30, "severity": 10,
-        "rule": {"id": 503, "gg_created_at": "2025-03-18T08:57:54.142008Z", "gg_updated_at":
-        "2025-04-02T13:15:43.307296Z", "name": "Valid secrets related to highly sensitive
-        detectors", "description": "Secrets related to highly sensitive detectors
-        were valid when the incident was discovered. You can edit this rule to create
-        your own list of sensitive detectors", "json_rule": {"operator": "AND", "args":
-        [{"operator": "EQ", "arg1": {"path": "issue.secret.validity_status", "default":
-        null}, "arg2": {"value": "valid"}}, {"operator": "IN", "arg1": {"path": "issue.secret.detector.detector_group_name",
-        "default": null}, "arg2": {"value": ["github_app_token", "ldap_credentials",
-        "github_oauth_token", "googlecloud_keys", "jira_basic_auth", "python_package_index_key",
-        "aws_iam_sts", "npm_token", "gitlab_token", "smtp_credentials", "github_fine_grained_pat",
-        "gitlab_enterprise_token", "github_access_token", "aws_iam"]}}]}, "is_global":
-        true, "scope": "any", "author": null}}, "declarative_secret_status": null,
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
+        "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
+        "detected_at": "2026-06-23T11:13:31.325324Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
+        "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
+        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
+        34181686, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-22T11:25:45.739149Z", "last_trigger_published_at": "2026-06-22T11:25:45.739149Z",
+        "last_triggered_at": "2026-06-22T11:25:45.762592Z", "last_trigger_detected_at":
+        "2026-06-22T11:25:45.762592Z", "hash": "gVrL/pjjFLo7sSikPS1pWtPJbr+oWSSVz8IB6+2ViJDSJKiK25LITKmJimoqGr3z",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": true, "resolved_at": "2026-06-22T11:26:52.971214Z", "resolver":
+        1751937, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
+        "none", "ignorer_type": "none", "resolver_display_name": "candidate.playground+eu@gitguardian.com",
+        "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
+        "none", "status": "RESOLVED", "issue_name": "Microsoft Azure Storage Connection
+        String", "severity_rule_config": null, "declarative_secret_status": "revoked",
         "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
+        "severity": 100, "authors": [{"info": "", "name": "Kashyapa P.A. Jayasekera"}],
         "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "gim-qa-gitlabSandbox-auto
-        / gim-qa-gitlabSandbox-staging", "type": "gl_project", "path": "gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
-        "source_criticality": "unknown"}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 1, "score": 97, "displayed_occurrence":
-        {"id": 226113779, "issue": 22515404, "account": 8, "kind": "RLTM", "element":
-        "95c8ae28ae02f1182bfa5ae2f6cabb69fab3ece9", "element_type": "GIT_COMMIT",
-        "author_name": "dev", "author_info": "gim+dev@gitguardian.com", "value": null,
-        "value_hash": "yEDhOhQ6p7D5/7TcJR5YtztO3INO1WgqiWd2qPiA0XRele/bong1Td3XczdQcVM3",
-        "published_at": "2025-11-17T17:16:25Z", "date": "2025-11-17T17:16:25Z", "detected_at":
-        "2025-11-17T17:18:16.645938Z", "is_vcs_type": true, "last_detected_at": "2025-11-17T17:16:25Z",
-        "last_seen_at": "2025-11-17T17:16:25Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging/commit/95c8ae28ae02f1182bfa5ae2f6cabb69fab3ece9#34c8dc1a12161a07003ebd2c3145185257f0cd94_0_3",
-        "source": {"id": 16219056, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
-        "type": "gl_project", "display_name": "gim-qa-gitlabSandbox-auto / gim-qa-gitlabSandbox-staging",
-        "visibility": "private", "monitored": true, "source_criticality": "unknown",
-        "deleted_at": null, "default_branch": "main"}, "regression": false, "content":
-        105863010, "secrets_engine_version": "2.150.0", "matches": [{"name": "client_id",
-        "string_matched": "[REDACTED]", "indice_start": 45, "indice_end": 65, "pre_line_start":
-        null, "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}, {"name":
-        "client_secret", "string_matched": "[REDACTED]", "indice_start": 82, "indice_end":
-        122, "pre_line_start": null, "pre_line_end": null, "post_line_start": 3, "post_line_end":
-        3}], "most_sensitive_match_name": "client_secret", "insights": [], "filepath":
-        "aws_api_access.yml", "filename": "aws_api_access.yml", "presence": "visible",
-        "last_presence_seen_at": "2026-02-18T22:30:08.818671Z", "last_presence_check_at":
-        "2026-02-18T22:30:08.818671Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        false, "change_type": "addition", "full_tags": []}, "has_dropped_occurrences":
-        false, "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}, {"id":
-        21256874, "account": 8, "criterion": "Google API Key", "date": "2025-09-28T15:22:38.271649Z",
-        "last_trigger_published_at": "2025-09-28T15:22:38.271649Z", "last_triggered_at":
-        "2025-09-28T15:22:38.612424Z", "last_trigger_detected_at": "2025-09-28T15:22:38.612424Z",
-        "hash": "Jxnz5kPob11xLvEtZ86g47aESTtckctpj4bPLy+pvS9PIsSDiwQ5Z8PP16EaJtIX",
+        6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "GGFRLTA127
+        \u2014 kashyapap.jayasekera", "type": "endpoints", "path": "GGFRLTA127 \u2014
+        kashyapap.jayasekera", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274639444, "issue": 34181686, "account": 8, "kind": "RLTM", "element":
+        "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "AAr6ayAj6Hs2pOICdVUlEyuXlsQ78K3HFGOJgWA/yAiQrRuQH9Kv1GxUH36IT99d",
+        "published_at": "2026-06-22T11:25:45.739149Z", "date": "2026-06-22T11:25:45.739149Z",
+        "detected_at": "2026-06-22T11:25:45.739149Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-22T11:25:45.739149Z", "last_seen_at": "2026-06-22T11:25:45.739149Z",
+        "data": {"line": 20, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-22T11:25:45.739149Z", "last_presence_check_at":
+        "2026-06-22T11:25:45.739149Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 6}, {"id":
+        34038186, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
+        "date": "2026-06-16T18:55:43.166667Z", "last_trigger_published_at": "2026-06-16T18:55:43.166667Z",
+        "last_triggered_at": "2026-06-16T18:55:43.185061Z", "last_trigger_detected_at":
+        "2026-06-16T18:55:43.185061Z", "hash": "JFTpQX+4P/dEcXJJ2iw+u54JYDsJnqLtrdws1wjFQ8t9LtHh25LITKmJimoqGr3z",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Google API Key", "severity_rule_config": {"id": 10858, "gg_created_at": "2026-02-12T15:13:37.684102Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684119Z", "index": 10, "severity": 10,
+        "Microsoft Azure Storage Connection String", "severity_rule_config": null,
+        "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
+        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
+        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
+        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
+        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
+        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
+        "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
+        "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
+        "detected_at": "2026-06-16T18:55:43.166667Z", "is_vcs_type": false, "last_detected_at":
+        "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
+        "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
+        "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
+        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
+        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
+        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
+        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
+        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
+        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
+        32985083, "account": 8, "criterion": "Google API Key", "date": "2026-05-19T09:33:23Z",
+        "last_trigger_published_at": "2026-05-19T09:33:23Z", "last_triggered_at":
+        "2026-05-19T09:36:55.570755Z", "last_trigger_detected_at": "2026-05-19T09:36:55.570755Z",
+        "hash": "pHE0O7zGgt2lhT0TLQzB2cwgMuZgrhqH4vSIGV5fw5ao1EL3iwQ5Z8PP16EaJtIX",
+        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
+        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
+        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
+        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
+        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
+        "Google API Key", "severity_rule_config": {"id": 11883, "gg_created_at": "2026-05-20T08:56:10.055321Z",
+        "gg_updated_at": "2026-05-20T08:56:10.055331Z", "index": 10, "severity": 10,
         "rule": {"id": 745, "gg_created_at": "2026-02-12T15:13:36.079495Z", "gg_updated_at":
         "2026-02-12T15:13:36.079508Z", "name": "Publicly leaked secrets", "description":
         "Publicly leaked secrets outside perimeter", "json_rule": {"operator": "AND",
@@ -147,163 +155,123 @@ interactions:
         "default": null}, "arg2": {"value": "0"}}}, {"operator": "NOT", "arg1": {"operator":
         "EQ", "arg1": {"path": "issue.secret.validity_status", "default": null}, "arg2":
         {"value": "invalid"}}}]}, "is_global": false, "scope": "private", "author":
-        520858}}, "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
-        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "GitGuardian Sandbox [internal]"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 3, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "GitHub Gist Public Testing", "type": "custom_source", "path": "GitHub
-        Gist Public Testing", "source_criticality": "unknown"}], "custom_tags": [],
-        "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0, "score":
-        35, "displayed_occurrence": {"id": 217629888, "issue": 21256874, "account":
-        8, "kind": "RLTM", "element": "", "element_type": "CUSTOM_ELEMENT", "author_name":
-        "GitGuardian Sandbox [internal]", "author_info": "", "value": null, "value_hash":
-        "vaoX27XgrGUFeuRDLf1lGhRHkgfeKQkdi/3qMgXMYvxgUYRCJMTAoAK2DALLNEk3", "published_at":
-        "2025-09-28T15:22:38.271649Z", "date": "2025-09-28T15:22:38.271649Z", "detected_at":
-        "2025-09-28T15:22:38.386090Z", "is_vcs_type": false, "last_detected_at": "2025-09-28T15:22:38.271649Z",
-        "last_seen_at": "2025-09-28T15:22:38.271649Z", "data": {}, "url": "", "source":
-        {"id": 22879703, "url": "", "type": "custom_source", "display_name": "GitHub
-        Gist Public Testing", "visibility": "private", "monitored": false, "source_criticality":
-        "unknown", "deleted_at": "2025-09-30T09:36:56.792947Z", "default_branch":
-        null}, "regression": false, "content": 95760168, "secrets_engine_version":
-        "2.148.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 715525, "indice_end": 715564, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "public_github_sagarchittaragi_75a7ce7770d67624fd77656f0d3ad099",
-        "filename": "public_github_sagarchittaragi_75a7ce7770d67624fd77656f0d3ad099",
-        "presence": "visible", "last_presence_seen_at": "2025-09-28T15:22:38.645860Z",
-        "last_presence_check_at": "2025-09-28T15:22:38.645860Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": []},
-        "has_dropped_occurrences": false, "tags": [], "public_exposure": {"source_publicly_visible":
-        false, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "occurrences_count": 3}, {"id": 21251447, "account": 8, "criterion": "Google
-        API Key", "date": "2025-09-28T04:37:26.780820Z", "last_trigger_published_at":
-        "2025-09-28T04:37:26.780820Z", "last_triggered_at": "2025-09-28T04:37:27.086350Z",
-        "last_trigger_detected_at": "2025-09-28T04:37:27.086350Z", "hash": "WalGxMwzVJ87pj8JiS0ZNe3lw3X3qfK3BkEsRZ10l5GkP6wwiwQ5Z8PP16EaJtIX",
+        520858}}, "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com",
+        "name": "dev"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 16218896, "name": "qa / test-nriv", "type": "gl_project", "path":
+        "qa1/test-nriv", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 0, "score": 64, "displayed_occurrence": {"id":
+        268288466, "issue": 32985083, "account": 8, "kind": "RLTM", "element": "9181621d49e910c3d2393f2373e52c04b26c7adb",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "value": null, "value_hash": "y0o7bgCt8InKo3/G0QE6WaG+gU32WlUdYH0N4oUFXredK2KoKwrhfI+hoCMCs6v6",
+        "published_at": "2026-05-19T09:33:23Z", "date": "2026-05-19T09:33:23Z", "detected_at":
+        "2026-05-19T09:36:53.339083Z", "is_vcs_type": true, "last_detected_at": "2026-05-19T09:33:23Z",
+        "last_seen_at": "2026-05-19T09:33:23Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa1/test-nriv/commit/9181621d49e910c3d2393f2373e52c04b26c7adb#a290632bbcae192e53c54337b3238d835c97e8a9_5_4",
+        "source": {"id": 16218896, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa1/test-nriv",
+        "type": "gl_project", "display_name": "qa / test-nriv", "visibility": "internal",
+        "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
+        "main", "monitoring_status": "active"}, "regression": false, "content": 162813398,
+        "secrets_engine_version": "2.162.0", "matches": [{"name": "apikey", "string_matched":
+        "[REDACTED]", "indice_start": 307, "indice_end": 346, "pre_line_start": null,
+        "pre_line_end": null, "post_line_start": 4, "post_line_end": 4}], "most_sensitive_match_name":
+        "apikey", "insights": [], "filepath": ".envrc", "filename": ".envrc", "presence":
+        "visible", "last_presence_seen_at": "2026-05-19T09:36:55.598741Z", "last_presence_check_at":
+        "2026-05-19T09:36:55.598741Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        true, "change_type": "addition", "full_tags": [{"type": "DEFAULT_BRANCH",
+        "metadata": null, "field": "content"}]}, "has_dropped_occurrences": false,
+        "tags": ["DEFAULT_BRANCH", "PUBLICLY_LEAKED"], "public_exposure": {"source_publicly_visible":
+        false, "public_incident_linked": false, "leaked_outside_perimeter": true},
+        "occurrences_count": 2}, {"id": 32971986, "account": 8, "criterion": "GitGuardian
+        Test Token Checked", "date": "2026-05-18T16:46:02.652000Z", "last_trigger_published_at":
+        "2026-05-18T16:46:02.652000Z", "last_triggered_at": "2026-05-18T21:54:00.456840Z",
+        "last_trigger_detected_at": "2026-05-18T21:54:00.456840Z", "hash": "H2xlJHEiSoY9Dp4AAvsp9IUC8tJn5VQnVkxnWdAqDESo7y5ACxpDOKaZihAFaYMH",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "Google API Key", "severity_rule_config": {"id": 10858, "gg_created_at": "2026-02-12T15:13:37.684102Z",
-        "gg_updated_at": "2026-02-12T15:13:37.684119Z", "index": 10, "severity": 10,
-        "rule": {"id": 745, "gg_created_at": "2026-02-12T15:13:36.079495Z", "gg_updated_at":
-        "2026-02-12T15:13:36.079508Z", "name": "Publicly leaked secrets", "description":
-        "Publicly leaked secrets outside perimeter", "json_rule": {"operator": "AND",
-        "args": [{"operator": "NOT", "arg1": {"operator": "EQ", "arg1": {"path": "issue.public_leak_range",
-        "default": null}, "arg2": {"value": "0"}}}, {"operator": "NOT", "arg1": {"operator":
+        "GitGuardian Test Token Checked", "severity_rule_config": {"id": 11901, "gg_created_at":
+        "2026-05-20T08:56:10.055519Z", "gg_updated_at": "2026-05-20T08:56:10.055521Z",
+        "index": 190, "severity": 20, "rule": {"id": 519, "gg_created_at": "2025-03-18T08:57:54.142609Z",
+        "gg_updated_at": "2025-03-18T08:57:54.142612Z", "name": "Valid secret", "description":
+        "The secrets were valid when the incident was discovered", "json_rule": {"operator":
         "EQ", "arg1": {"path": "issue.secret.validity_status", "default": null}, "arg2":
-        {"value": "invalid"}}}]}, "is_global": false, "scope": "private", "author":
-        520858}}, "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
-        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "GitGuardian Sandbox [internal]"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        {"value": "valid"}}, "is_global": true, "scope": "private", "author": null}},
+        "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "<unknown>",
+        "name": "Guy Le Gardien"}], "user_permission": 7, "is_publicly_shared": false,
+        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"name": "GitHub Gist Public Testing", "type": "custom_source", "path": "GitHub
-        Gist Public Testing", "source_criticality": "unknown"}], "custom_tags": [],
-        "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0, "score":
-        64, "displayed_occurrence": {"id": 217594938, "issue": 21251447, "account":
-        8, "kind": "RLTM", "element": "", "element_type": "CUSTOM_ELEMENT", "author_name":
-        "GitGuardian Sandbox [internal]", "author_info": "", "value": null, "value_hash":
-        "8WalVYdfAy9WWVLzVZBfOXcyF0UCcYGuYQrb3Wdix673pMDZxFC6e51x3UmXyF+6", "published_at":
-        "2025-09-28T04:37:26.780820Z", "date": "2025-09-28T04:37:26.780820Z", "detected_at":
-        "2025-09-28T04:37:26.850787Z", "is_vcs_type": false, "last_detected_at": "2025-09-28T04:37:26.780820Z",
-        "last_seen_at": "2025-09-28T04:37:26.780820Z", "data": {}, "url": "", "source":
-        {"id": 22879703, "url": "", "type": "custom_source", "display_name": "GitHub
-        Gist Public Testing", "visibility": "private", "monitored": false, "source_criticality":
-        "unknown", "deleted_at": "2025-09-30T09:36:56.792947Z", "default_branch":
-        null}, "regression": false, "content": 95670280, "secrets_engine_version":
-        "2.148.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 4660, "indice_end": 4699, "pre_line_start": null, "pre_line_end":
+        [{"id": 26936741, "name": "gitguardian-team-vxrpkdpl / Philippe Gablain",
+        "type": "confluence_cloud_space", "path": "gitguardian-team-vxrpkdpl / Philippe
+        Gablain", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 0, "score": 60, "displayed_occurrence": {"id":
+        268216251, "issue": 32971986, "account": 8, "kind": "RLTM", "element": "14057485",
+        "element_type": "CONFLUENCE_PAGE", "author_name": "Guy Le Gardien", "author_info":
+        "<unknown>", "value": null, "value_hash": "aYVfGM8nV/Ld8zHxuyceM8pdmSDxiNAmP9oGIJun9+NtN/xDdpu8LgTD8V+IJb9L",
+        "published_at": "2026-05-18T16:46:02.652000Z", "date": "2026-05-18T16:46:02.652000Z",
+        "detected_at": "2026-05-18T21:53:58.368709Z", "is_vcs_type": false, "last_detected_at":
+        "2026-05-18T16:46:02.652000Z", "last_seen_at": "2026-05-18T16:46:02.652000Z",
+        "data": {}, "url": "https://gitguardian-team-vxrpkdpl.atlassian.net/wiki/spaces/~62a76a05979e6e00690427b5/pages/14057485/test+gg+token",
+        "source": {"id": 26936741, "url": "https://gitguardian-team-vxrpkdpl.atlassian.net/wiki/spaces/~62a76a05979e6e00690427b5",
+        "type": "confluence_cloud_space", "display_name": "gitguardian-team-vxrpkdpl
+        / Philippe Gablain", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 162682107, "secrets_engine_version":
+        "2.162.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
+        "indice_start": 30, "indice_end": 47, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "public_github_youngbee369_a8de7dcd6c0ff078c7f99a4d1622ad45",
-        "filename": "public_github_youngbee369_a8de7dcd6c0ff078c7f99a4d1622ad45",
-        "presence": "visible", "last_presence_seen_at": "2025-09-28T04:37:27.121112Z",
-        "last_presence_check_at": "2025-09-28T04:37:27.121112Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": []},
-        "has_dropped_occurrences": false, "tags": ["PUBLICLY_LEAKED"], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        true}, "occurrences_count": 1}, {"id": 21250826, "account": 8, "criterion":
-        "DeepSeek API Key", "date": "2025-09-28T02:34:55.156736Z", "last_trigger_published_at":
-        "2025-09-28T02:34:55.156736Z", "last_triggered_at": "2025-09-28T02:34:55.812065Z",
-        "last_trigger_detected_at": "2025-09-28T02:34:55.812065Z", "hash": "EmVR5NWRB87CbNgAA1i1CxdMstfwZV3vFmSvEGv3CPvhASlwl9yUgFtNM7Q1m5Uz",
-        "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
-        "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
-        "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
-        "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
-        "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
-        "DeepSeek API Key", "severity_rule_config": {"id": 10858, "gg_created_at":
-        "2026-02-12T15:13:37.684102Z", "gg_updated_at": "2026-02-12T15:13:37.684119Z",
-        "index": 10, "severity": 10, "rule": {"id": 745, "gg_created_at": "2026-02-12T15:13:36.079495Z",
-        "gg_updated_at": "2026-02-12T15:13:36.079508Z", "name": "Publicly leaked secrets",
-        "description": "Publicly leaked secrets outside perimeter", "json_rule": {"operator":
-        "AND", "args": [{"operator": "NOT", "arg1": {"operator": "EQ", "arg1": {"path":
-        "issue.public_leak_range", "default": null}, "arg2": {"value": "0"}}}, {"operator":
-        "NOT", "arg1": {"operator": "EQ", "arg1": {"path": "issue.secret.validity_status",
-        "default": null}, "arg2": {"value": "invalid"}}}]}, "is_global": false, "scope":
-        "private", "author": 520858}}, "declarative_secret_status": null, "assignee":
-        null, "last_presence_check_at": null, "secret": "[REDACTED]", "severity":
-        100, "authors": [{"info": "", "name": "GitGuardian Sandbox [internal]"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"name": "GitHub Gist Public Testing",
-        "type": "custom_source", "path": "GitHub Gist Public Testing", "source_criticality":
-        "unknown"}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false,
-        "similar_issue_count": 0, "score": 91, "displayed_occurrence": {"id": 217590276,
-        "issue": 21250826, "account": 8, "kind": "RLTM", "element": "", "element_type":
-        "CUSTOM_ELEMENT", "author_name": "GitGuardian Sandbox [internal]", "author_info":
-        "", "value": null, "value_hash": "S9J90cfgfIz9/1KiWTklsCZsShVgIHiSFM0yUQf2i7lzzzxGfAxs12u2O6U6+pg/",
-        "published_at": "2025-09-28T02:34:55.156736Z", "date": "2025-09-28T02:34:55.156736Z",
-        "detected_at": "2025-09-28T02:34:55.601861Z", "is_vcs_type": false, "last_detected_at":
-        "2025-09-28T02:34:55.156736Z", "last_seen_at": "2025-09-28T02:34:55.156736Z",
-        "data": {}, "url": "", "source": {"id": 22879703, "url": "", "type": "custom_source",
-        "display_name": "GitHub Gist Public Testing", "visibility": "private", "monitored":
-        false, "source_criticality": "unknown", "deleted_at": "2025-09-30T09:36:56.792947Z",
-        "default_branch": null}, "regression": false, "content": 95659566, "secrets_engine_version":
-        "2.148.0", "matches": [{"name": "apikey", "string_matched": "[REDACTED]",
-        "indice_start": 52030, "indice_end": 52065, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": null, "post_line_end": null}], "most_sensitive_match_name":
-        "apikey", "insights": [], "filepath": "public_github_HugsLibRecordKeeper_e0e10d04d64bf1543f67a3abf9816cab",
-        "filename": "public_github_HugsLibRecordKeeper_e0e10d04d64bf1543f67a3abf9816cab",
-        "presence": "visible", "last_presence_seen_at": "2025-09-28T02:34:55.830969Z",
-        "last_presence_check_at": "2025-09-28T02:34:55.830969Z", "first_presence_deleted_at":
-        null, "seen_in_default_branch": null, "change_type": null, "full_tags": []},
-        "has_dropped_occurrences": false, "tags": ["PUBLICLY_LEAKED"], "public_exposure":
-        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
-        true}, "occurrences_count": 1}]}'
+        "apikey", "insights": [], "filepath": null, "filename": null, "presence":
+        "visible", "last_presence_seen_at": "2026-05-18T21:54:00.520852Z", "last_presence_check_at":
+        "2026-05-18T21:54:00.520852Z", "first_presence_deleted_at": null, "seen_in_default_branch":
+        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
+        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "occurrences_count": 1}]}'
     headers:
+      CF-RAY:
+      - a10397c45da5f6b5-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:45:58 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '28635'
+      - '24252'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:51 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '135'
+      - '251'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_members.yaml
+++ b/tests/cassettes/tools/vcr/test_list_members.yaml
@@ -25,54 +25,62 @@ interactions:
         "last_login": "2020-09-30T12:21:19.319487Z", "active": true}, {"id": 13, "role":
         "manager", "access_level": "manager", "email": "aymeric.sicard@gitguardian.com",
         "name": "Aymeric SICARD", "created_at": "2020-01-21T09:35:47.907207Z", "last_login":
-        "2026-04-02T08:21:40.877924Z", "active": true}, {"id": 2508, "role": "manager",
+        "2026-06-22T14:20:46.680540Z", "active": true}, {"id": 2508, "role": "manager",
         "access_level": "manager", "email": "guillaume.charpiat@gitguardian.com",
         "name": "Guillaume CHARPIAT", "created_at": "2020-03-23T17:53:57.158457Z",
-        "last_login": "2026-03-25T10:56:33.130265Z", "active": true}, {"id": 37699,
+        "last_login": "2026-06-10T11:29:54.420261Z", "active": true}, {"id": 37699,
         "role": "manager", "access_level": "manager", "email": "alexis.larnaud@gitguardian.com",
         "name": "Alexis LARNAUD", "created_at": "2020-09-03T11:16:05.980606Z", "last_login":
-        "2026-03-31T09:14:08.791897Z", "active": true}, {"id": 63809, "role": "manager",
+        "2026-06-22T09:33:43.124144Z", "active": true}, {"id": 63809, "role": "manager",
         "access_level": "manager", "email": "orian.roturier@gitguardian.com", "name":
         "Orian ROTURIER", "created_at": "2020-11-25T14:01:01.749542Z", "last_login":
         "2025-08-05T08:47:38.723615Z", "active": true}]'
     headers:
+      CF-RAY:
+      - a10398c8de77e8c9-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:46:39 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '1098'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:44:53 GMT
       link:
       - <https://api.gitguardian.com/v1/members?cursor=cD02MzgwOQ%3D%3D&per_page=5>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '36'
+      - '41'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_public_incidents_basic.yaml
+++ b/tests/cassettes/tools/vcr/test_list_public_incidents_basic.yaml
@@ -20,91 +20,89 @@ interactions:
     uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=5&ordering=-date
   response:
     body:
-      string: '[{"id": 1656322, "detector": {"name": "generic_password", "display_name":
-        "Generic Password", "nature": "generic", "family": "other", "category": "other",
-        "detector_group_name": "generic_password", "detector_group_display_name":
-        "Generic Password"}, "date": "2026-04-08T13:57:02Z", "secret_id": 30877010,
-        "secret_hash": "xHPjwUsmqt6eA7ncYDxRlt7kV7BnCq1drlnSRHGknhfkmcDLfma8ieOEhD7igl+v",
-        "hmsl_hash": "7c3d0e84bbd9229c2997872cb4d17c04c6ff7220fd5f2812bbd1d1dbe6f5947a",
-        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2026-04-08T14:03:21.364805Z",
+      string: '[{"id": 2954877, "detector": {"name": "json_web_token", "display_name":
+        "JSON Web Token", "nature": "generic", "family": "other", "category": "other",
+        "detector_group_name": "json_web_token", "detector_group_display_name": "JSON
+        Web Token"}, "date": "2026-06-23T11:45:26Z", "secret_id": 34904128, "secret_hash":
+        "/uKNK09tzkxmPoFf3vj8jPyGxmvpayFjCCdnow7p0/fzFIUob/zCaMfAAG3RGpZN", "hmsl_hash":
+        "86b53de471f9bd2633d5bf47c107c028f8a42913d47262d64938e9a9a8495fb9", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2026-06-23T11:50:44.799930Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "no_checker", "severity": "high", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 53, "severity_rule_id":
+        11902, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/2954877",
+        "tags": ["JWT_PROPERTIES", "SENSITIVE_FILE"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "JSON Web Token"}, {"id": 2954259, "detector": {"name":
+        "json_web_token", "display_name": "JSON Web Token", "nature": "generic", "family":
+        "other", "category": "other", "detector_group_name": "json_web_token", "detector_group_display_name":
+        "JSON Web Token"}, "date": "2026-06-23T09:41:00Z", "secret_id": 34901242,
+        "secret_hash": "u+QTBcREJHTV9cQ9/lVIB9JNmoOEzac1Rnf97fSMIuFU/IrSb/zCaMfAAG3RGpZN",
+        "hmsl_hash": "25bc965e6d4fc75bf9d067ab4879f2d4d6b9782e3eb282e24428b239b225e60d",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2026-06-23T09:46:08.920156Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        false, "validity": "no_checker", "severity": "high", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        52, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        53, "severity_rule_id": 11902, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1656322",
-        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "Generic Password"}, {"id": 1622340, "detector": {"name": "generic_password",
-        "display_name": "Generic Password", "nature": "generic", "family": "other",
-        "category": "other", "detector_group_name": "generic_password", "detector_group_display_name":
-        "Generic Password"}, "date": "2026-04-07T20:07:53Z", "secret_id": 30795205,
-        "secret_hash": "kB4u8+jrFoS2fxB1eoQxTY0F3Lh+PlC371M42NbxwiiCVuU9fma8ieOEhD7igl+v",
-        "hmsl_hash": "e6b9fe4ea6d7ad7257e228bc4c6040fe7d23c5a0c5872b80ec42bf08648876a1",
-        "occurrences_count": 8, "status": "TRIGGERED", "triggered_at": "2026-04-07T20:12:57.950362Z",
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2954259",
+        "tags": ["JWT_PROPERTIES", "SENSITIVE_FILE"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "JSON Web Token"}, {"id": 2949307, "detector": {"name":
+        "openai_apikey", "display_name": "OpenAI API Key", "nature": "specific", "family":
+        "token", "category": "ai", "detector_group_name": "openai_apikey", "detector_group_display_name":
+        "OpenAI API Key"}, "date": "2026-06-23T05:04:48Z", "secret_id": 34891713,
+        "secret_hash": "+V9R4W4h7xf8KvRB9RQ2AodNfidCwS1ycVkWB6rrrdK45ZnH95GRLqiXIWrK60u6",
+        "hmsl_hash": "c391a648c624e1acd6546268b1e376f91a99e40353834b3339c077f1c79b8af3",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2026-06-23T05:09:52.427805Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        38, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        6, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1622340",
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2949307",
         "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "Generic Password"}, {"id": 1565465, "detector": {"name": "generic_high_entropy_secret",
-        "display_name": "Generic High Entropy Secret", "nature": "generic", "family":
-        "other", "category": "other", "detector_group_name": "generic_high_entropy_secret",
-        "detector_group_display_name": "Generic High Entropy Secret"}, "date": "2026-03-29T19:45:49Z",
-        "secret_id": 30242300, "secret_hash": "4U/oBUMl1qh7Srz5W44PGp28+z79LJdZ6yTv1DCbpNbOcxetp+KkPCNpyNbtXqJM",
-        "hmsl_hash": "945925d9c2d7d630159586c5cbf7edb6074e906dd69a7eabaa804e365857cab0",
-        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2026-03-29T19:50:52.892358Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        "OpenAI API Key"}, {"id": 2944806, "detector": {"name": "aws_iam", "display_name":
+        "AWS IAM Keys", "nature": "specific", "family": "credentials", "category":
+        "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2026-06-22T05:03:49Z", "secret_id": 34862311, "secret_hash":
+        "v7ek1CGclYHnQemR/t8Pdr5CWuNYcBi4dJ9OgMye/a2P1zFuL4Qc71cZRqNcojMG", "hmsl_hash":
+        "12d9ae9e4002624a9444428efc0c98cc5d2a47bb77d9922be27e15070f798dd0", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2026-06-22T05:09:25.512641Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/2944806",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "AWS IAM Keys"}, {"id": 2939331, "detector": {"name": "slackbototken", "display_name":
+        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2026-06-21T05:04:43Z", "secret_id": 34837770, "secret_hash":
+        "W6DrKdeBG5AAks4Oy0RD+6KCgSgAyXYRmVLoAlgzsIJ8mB78OMgPzYhV28m6OGG4", "hmsl_hash":
+        "5eb6c32e69404e85f4a18d4eb7228b47173c1820266b52c860cffca4fdd539d4", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2026-06-21T05:10:05.366593Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        53, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        22, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1565465",
-        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "Generic High Entropy Secret"}, {"id": 1559615, "detector": {"name": "smtp_assignment",
-        "display_name": "SMTP credentials", "nature": "specific", "family": "identifiers",
-        "category": "messaging_system", "detector_group_name": "smtp_credentials",
-        "detector_group_display_name": "SMTP credentials"}, "date": "2026-03-28T23:24:10Z",
-        "secret_id": 30206041, "secret_hash": "8Kighb5RJJlUPfc3hkc6LGHKUPKBoGmqxqHjr7CUQ07ZiAyAnUgJKbY5bDWilWBS",
-        "hmsl_hash": "1b52928ad2792d1bad89e2a5e837ad513a4b50ced14971df92e46f8bf2764d10",
-        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2026-03-28T23:29:58.247999Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        63, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
-        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1559615",
-        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "SMTP credentials"}, {"id": 1554830, "detector": {"name": "generic_high_entropy_secret",
-        "display_name": "Generic High Entropy Secret", "nature": "generic", "family":
-        "other", "category": "other", "detector_group_name": "generic_high_entropy_secret",
-        "detector_group_display_name": "Generic High Entropy Secret"}, "date": "2026-03-27T18:11:26Z",
-        "secret_id": 30166297, "secret_hash": "PGGOlbTiQZGqXXA3Vj88RduN0f+72Aha3hUU4MwsiKW7Qj8dp+KkPCNpyNbtXqJM",
-        "hmsl_hash": "e2d81242e3b11cd65b823f92e2dde252dadd99821d401c06f00a8b08994d6e54",
-        "occurrences_count": 15, "status": "IGNORED", "triggered_at": "2026-03-27T18:16:57.754167Z",
-        "ignored_at": "2026-03-27T18:17:37.519114Z", "ignorer_id": 492181, "ignorer_api_token_id":
-        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
-        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
-        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
-        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1554830",
-        "tags": ["FALSE_POSITIVE"], "custom_tags": [], "destination_tickets": [],
-        "incident_name": "Generic High Entropy Secret"}]'
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2939331",
+        "tags": ["IS_COMPANY_CONTEXT", "TEST_FILE"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Slack Bot Token"}]'
     headers:
       CF-RAY:
-      - 9efb1c598856700e-CDG
+      - a10397cc18b88ce7-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 08:45:07 GMT
+      - Tue, 23 Jun 2026 12:45:59 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -116,13 +114,13 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '5802'
+      - '5673'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
       - same-origin
       link:
-      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=bz0xJnA9MjAyNi0wMy0yOCsyMyUzQTI0JTNBMTAlMkIwMCUzQTAw&ordering=-date&per_page=5>;
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0yMDI2LTA2LTIxKzA1JTNBMDQlM0E0MyUyQjAwJTNBMDA%3D&ordering=-date&per_page=5>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
@@ -131,17 +129,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '97'
+      - '92'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_public_incidents_with_date_and_risk_score_bounds.yaml
+++ b/tests/cassettes/tools/vcr/test_list_public_incidents_with_date_and_risk_score_bounds.yaml
@@ -31,7 +31,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 100, "severity_rule_id":
-        10861, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11886, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/5207",
         "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
         [], "incident_name": "DigitalOcean Token"}, {"id": 5208, "detector": {"name":
@@ -45,7 +45,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 100, "severity_rule_id":
-        10861, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11886, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/5208",
         "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
         [], "incident_name": "DigitalOcean Token"}, {"id": 1142573, "detector": {"name":
@@ -74,7 +74,7 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 99, "severity_rule_id":
-        10862, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11887, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/6431",
         "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
         [], "incident_name": "GitHub OAuth App Keys"}, {"id": 6430, "detector": {"name":
@@ -88,68 +88,70 @@ interactions:
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 99, "severity_rule_id":
-        10862, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        11887, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
         null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/6430",
         "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
-        [], "incident_name": "Bitbucket Keys"}, {"id": 120, "detector": {"name": "aws_iam",
-        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
-        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
-        "AWS IAM Keys"}, "date": "2022-09-21T07:47:10Z", "secret_id": 14592936, "secret_hash":
-        "HCWrG3nEt9czkeRivsO5t2mdGFXFrkwOSPchO87xypH14P2ML4Qc71cZRqNcojMG", "hmsl_hash":
-        "44126737df445f6b9468541f77e5c5bdac71b057644a7fe1c8c219940948acc4", "occurrences_count":
-        1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:03.840266Z", "ignored_at":
-        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
-        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
-        "validity": "invalid", "severity": "critical", "assignee_id": null, "assignee_email":
+        [], "incident_name": "Bitbucket Keys"}, {"id": 4956, "detector": {"name":
+        "google_oauth2", "display_name": "Google OAuth2 Keys", "nature": "specific",
+        "family": "credentials", "category": "cloud_provider", "detector_group_name":
+        "google_oauth2_keys", "detector_group_display_name": "Google OAuth2 Keys"},
+        "date": "2023-03-06T00:16:20Z", "secret_id": 14597586, "secret_hash": "GzQ+h5u2VDpOURkCJwl8sXStbutRBP4wCnMlY8GovIWXb3NNGNXwbhGU7EDDkdC0",
+        "hmsl_hash": "7aede9f1814164ead51a330256a4189cc72ec3cc07e12b4b2f9403f691ce1690",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:09:54.854532Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "valid", "severity": "unknown", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
-        7263, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/120",
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/4956",
         "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
-        [], "incident_name": "AWS IAM Keys"}, {"id": 1112, "detector": {"name": "aws_iam",
-        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
-        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
-        "AWS IAM Keys"}, "date": "2022-09-14T07:50:20Z", "secret_id": 14593846, "secret_hash":
-        "dEfda3BVSUK9yc1JYPEqSufAdUxQUQ9AqXCVJ1nQKyznAYCnL4Qc71cZRqNcojMG", "hmsl_hash":
-        "0847969d69f0208c61843d6e844e9a0aec67df7d818ac44b906f5671dd538794", "occurrences_count":
-        1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:39.804910Z", "ignored_at":
-        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
-        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
-        "validity": "invalid", "severity": "critical", "assignee_id": null, "assignee_email":
-        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
-        7263, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1112",
-        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
-        [], "incident_name": "AWS IAM Keys"}, {"id": 6663, "detector": {"name": "aws_iam",
-        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
-        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
-        "AWS IAM Keys"}, "date": "2025-01-14T14:28:59Z", "secret_id": 14663989, "secret_hash":
-        "mKvfyERvoW7Jo+/nDXJ/tcfbWqS4tGEO+1j6vf7vlmpyzHHhL4Qc71cZRqNcojMG", "hmsl_hash":
-        "04d0ef9d0b87b0ad5c9e1da99a7e6015bfab50127cbea8d9ff09356021f65998", "occurrences_count":
-        7, "status": "RESOLVED", "triggered_at": "2025-01-14T14:34:01.621378Z", "ignored_at":
-        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
-        "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
-        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
-        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
-        null, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/6663",
-        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "AWS IAM Keys"}, {"id": 518, "detector": {"name": "aws_iam", "display_name":
+        [], "incident_name": "Google OAuth2 Keys"}, {"id": 1112, "detector": {"name":
+        "aws_iam", "display_name": "AWS IAM Keys", "nature": "specific", "family":
+        "credentials", "category": "cloud_provider", "detector_group_name": "aws_iam",
+        "detector_group_display_name": "AWS IAM Keys"}, "date": "2022-09-14T07:50:20Z",
+        "secret_id": 14593846, "secret_hash": "dEfda3BVSUK9yc1JYPEqSufAdUxQUQ9AqXCVJ1nQKyznAYCnL4Qc71cZRqNcojMG",
+        "hmsl_hash": "0847969d69f0208c61843d6e844e9a0aec67df7d818ac44b906f5671dd538794",
+        "occurrences_count": 1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:39.804910Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        "2026-01-26T14:38:12.774362Z", "resolver_id": 492181, "resolver_api_token_id":
+        null, "secret_revoked": true, "validity": "invalid", "severity": "critical",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 97, "severity_rule_id": 7263, "is_vaulted": false, "declarative_secret_status":
+        "revoked", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1112", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "AWS IAM Keys"}, {"id": 1757, "detector": {"name": "aws_iam", "display_name":
         "AWS IAM Keys", "nature": "specific", "family": "credentials", "category":
         "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
-        "AWS IAM Keys"}, "date": "2023-10-19T12:06:07Z", "secret_id": 14593309, "secret_hash":
-        "aQL+3fwIPTpy/G2vW31cL2nAoP8QUXwn3RsexMv3kL2xtBnKL4Qc71cZRqNcojMG", "hmsl_hash":
-        "c1150af7814de655b6069ae54839018ab8350dec4151a441fa5d40bd0b489fd5", "occurrences_count":
-        9, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:11.066572Z", "ignored_at":
+        "AWS IAM Keys"}, "date": "2022-10-26T17:51:02Z", "secret_id": 5040480, "secret_hash":
+        "9iOcecIDUnwTswf4LBKhEr1f7h+yKuXPUh8Ts6MQ0Em4ZtnDL4Qc71cZRqNcojMG", "hmsl_hash":
+        "9d34dc7a860e4868c3093156278fc8e65f0ceabd9d8fd087022bd09d20f6c6ad", "occurrences_count":
+        1, "status": "RESOLVED", "triggered_at": "2025-01-07T18:07:03.136672Z", "ignored_at":
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-01-26T14:38:12.774362Z",
         "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
         "validity": "invalid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 97, "severity_rule_id":
         7263, "is_vaulted": false, "declarative_secret_status": "revoked", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/518",
-        "tags": ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets":
-        [], "incident_name": "AWS IAM Keys"}, {"id": 385, "detector": {"name": "aws_iam",
-        "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
-        "category": "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1757",
+        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
+        "destination_tickets": [], "incident_name": "AWS IAM Keys"}, {"id": 518, "detector":
+        {"name": "aws_iam", "display_name": "AWS IAM Keys", "nature": "specific",
+        "family": "credentials", "category": "cloud_provider", "detector_group_name":
+        "aws_iam", "detector_group_display_name": "AWS IAM Keys"}, "date": "2023-10-19T12:06:07Z",
+        "secret_id": 14593309, "secret_hash": "aQL+3fwIPTpy/G2vW31cL2nAoP8QUXwn3RsexMv3kL2xtBnKL4Qc71cZRqNcojMG",
+        "hmsl_hash": "c1150af7814de655b6069ae54839018ab8350dec4151a441fa5d40bd0b489fd5",
+        "occurrences_count": 9, "status": "RESOLVED", "triggered_at": "2025-01-07T18:06:11.066572Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        "2026-01-26T14:38:12.774362Z", "resolver_id": 492181, "resolver_api_token_id":
+        null, "secret_revoked": true, "validity": "invalid", "severity": "critical",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 97, "severity_rule_id": 7263, "is_vaulted": false, "declarative_secret_status":
+        "revoked", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/518", "tags":
+        ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "AWS IAM Keys"}, {"id": 385, "detector": {"name": "aws_iam", "display_name":
+        "AWS IAM Keys", "nature": "specific", "family": "credentials", "category":
+        "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
         "AWS IAM Keys"}, "date": "2023-07-06T12:36:07Z", "secret_id": 9181441, "secret_hash":
         "mKn4Nj0bR4rIic8L5Vdx8VllYYtf+CISEyDv7GToL66gKwIWL4Qc71cZRqNcojMG", "hmsl_hash":
         "838d881ae00bfb022f27c3b2e57e4927d7a2ef12c4a2f75b8b6730c80dba47b3", "occurrences_count":
@@ -164,13 +166,13 @@ interactions:
         "destination_tickets": [], "incident_name": "AWS IAM Keys"}]'
     headers:
       CF-RAY:
-      - 9efb6e1e7aaf46a0-CDG
+      - a10397d09a73d152-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:57 GMT
+      - Tue, 23 Jun 2026 12:46:00 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -182,7 +184,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '11567'
+      - '11634'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -197,17 +199,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '198'
+      - '97'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_public_incidents_with_multi_value_enum_filters.yaml
+++ b/tests/cassettes/tools/vcr/test_list_public_incidents_with_multi_value_enum_filters.yaml
@@ -20,166 +20,163 @@ interactions:
     uri: https://api.gitguardian.com/v1/public-incidents/secrets?per_page=10&status=TRIGGERED%2CASSIGNED%2CRESOLVED%2CIGNORED&severity=critical%2Chigh%2Cmedium%2Clow%2Cinfo%2Cunknown&validity=valid%2Cinvalid%2Cfailed_to_check%2Cno_checker%2Cunknown&ordering=-date
   response:
     body:
-      string: '[{"id": 1656322, "detector": {"name": "generic_password", "display_name":
-        "Generic Password", "nature": "generic", "family": "other", "category": "other",
-        "detector_group_name": "generic_password", "detector_group_display_name":
-        "Generic Password"}, "date": "2026-04-08T13:57:02Z", "secret_id": 30877010,
-        "secret_hash": "xHPjwUsmqt6eA7ncYDxRlt7kV7BnCq1drlnSRHGknhfkmcDLfma8ieOEhD7igl+v",
-        "hmsl_hash": "7c3d0e84bbd9229c2997872cb4d17c04c6ff7220fd5f2812bbd1d1dbe6f5947a",
-        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2026-04-08T14:03:21.364805Z",
+      string: '[{"id": 2954877, "detector": {"name": "json_web_token", "display_name":
+        "JSON Web Token", "nature": "generic", "family": "other", "category": "other",
+        "detector_group_name": "json_web_token", "detector_group_display_name": "JSON
+        Web Token"}, "date": "2026-06-23T11:45:26Z", "secret_id": 34904128, "secret_hash":
+        "/uKNK09tzkxmPoFf3vj8jPyGxmvpayFjCCdnow7p0/fzFIUob/zCaMfAAG3RGpZN", "hmsl_hash":
+        "86b53de471f9bd2633d5bf47c107c028f8a42913d47262d64938e9a9a8495fb9", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2026-06-23T11:50:44.799930Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "no_checker", "severity": "high", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 53, "severity_rule_id":
+        11902, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/2954877",
+        "tags": ["JWT_PROPERTIES", "SENSITIVE_FILE"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "JSON Web Token"}, {"id": 2954259, "detector": {"name":
+        "json_web_token", "display_name": "JSON Web Token", "nature": "generic", "family":
+        "other", "category": "other", "detector_group_name": "json_web_token", "detector_group_display_name":
+        "JSON Web Token"}, "date": "2026-06-23T09:41:00Z", "secret_id": 34901242,
+        "secret_hash": "u+QTBcREJHTV9cQ9/lVIB9JNmoOEzac1Rnf97fSMIuFU/IrSb/zCaMfAAG3RGpZN",
+        "hmsl_hash": "25bc965e6d4fc75bf9d067ab4879f2d4d6b9782e3eb282e24428b239b225e60d",
+        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2026-06-23T09:46:08.920156Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        false, "validity": "no_checker", "severity": "high", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        52, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        53, "severity_rule_id": 11902, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1656322",
-        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "Generic Password"}, {"id": 1622340, "detector": {"name": "generic_password",
-        "display_name": "Generic Password", "nature": "generic", "family": "other",
-        "category": "other", "detector_group_name": "generic_password", "detector_group_display_name":
-        "Generic Password"}, "date": "2026-04-07T20:07:53Z", "secret_id": 30795205,
-        "secret_hash": "kB4u8+jrFoS2fxB1eoQxTY0F3Lh+PlC371M42NbxwiiCVuU9fma8ieOEhD7igl+v",
-        "hmsl_hash": "e6b9fe4ea6d7ad7257e228bc4c6040fe7d23c5a0c5872b80ec42bf08648876a1",
-        "occurrences_count": 8, "status": "TRIGGERED", "triggered_at": "2026-04-07T20:12:57.950362Z",
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2954259",
+        "tags": ["JWT_PROPERTIES", "SENSITIVE_FILE"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "JSON Web Token"}, {"id": 2949307, "detector": {"name":
+        "openai_apikey", "display_name": "OpenAI API Key", "nature": "specific", "family":
+        "token", "category": "ai", "detector_group_name": "openai_apikey", "detector_group_display_name":
+        "OpenAI API Key"}, "date": "2026-06-23T05:04:48Z", "secret_id": 34891713,
+        "secret_hash": "+V9R4W4h7xf8KvRB9RQ2AodNfidCwS1ycVkWB6rrrdK45ZnH95GRLqiXIWrK60u6",
+        "hmsl_hash": "c391a648c624e1acd6546268b1e376f91a99e40353834b3339c077f1c79b8af3",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2026-06-23T05:09:52.427805Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        38, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        6, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1622340",
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2949307",
         "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "Generic Password"}, {"id": 1565465, "detector": {"name": "generic_high_entropy_secret",
+        "OpenAI API Key"}, {"id": 2944806, "detector": {"name": "aws_iam", "display_name":
+        "AWS IAM Keys", "nature": "specific", "family": "credentials", "category":
+        "cloud_provider", "detector_group_name": "aws_iam", "detector_group_display_name":
+        "AWS IAM Keys"}, "date": "2026-06-22T05:03:49Z", "secret_id": 34862311, "secret_hash":
+        "v7ek1CGclYHnQemR/t8Pdr5CWuNYcBi4dJ9OgMye/a2P1zFuL4Qc71cZRqNcojMG", "hmsl_hash":
+        "12d9ae9e4002624a9444428efc0c98cc5d2a47bb77d9922be27e15070f798dd0", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2026-06-22T05:09:25.512641Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
+        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
+        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/2944806",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "AWS IAM Keys"}, {"id": 2939331, "detector": {"name": "slackbototken", "display_name":
+        "Slack Bot Token", "nature": "specific", "family": "token", "category": "messaging_system",
+        "detector_group_name": "slackbot_token", "detector_group_display_name": "Slack
+        Bot Token"}, "date": "2026-06-21T05:04:43Z", "secret_id": 34837770, "secret_hash":
+        "W6DrKdeBG5AAks4Oy0RD+6KCgSgAyXYRmVLoAlgzsIJ8mB78OMgPzYhV28m6OGG4", "hmsl_hash":
+        "5eb6c32e69404e85f4a18d4eb7228b47173c1820266b52c860cffca4fdd539d4", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2026-06-21T05:10:05.366593Z", "ignored_at":
+        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
+        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
+        "validity": "failed_to_check", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        22, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2939331",
+        "tags": ["IS_COMPANY_CONTEXT", "TEST_FILE"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Slack Bot Token"}, {"id": 2928718, "detector": {"name":
+        "redis_cli", "display_name": "Redis Credentials", "nature": "specific", "family":
+        "identifiers", "category": "data_storage", "detector_group_name": "redis_credentials",
+        "detector_group_display_name": "Redis Credentials"}, "date": "2026-06-20T05:04:41Z",
+        "secret_id": 34808900, "secret_hash": "WLDPW81cBEzU2MUWlylSbACzTRELqTaLnkl2+FoBdAJbNuRmlRcYim528R/HqvdL",
+        "hmsl_hash": "c46dbed818a424f3920162af2a280711d6df4d711b6edfc7e0e8d9091266ccc4",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2026-06-20T05:10:17.021056Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
+        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 48, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2928718",
+        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
+        "Redis Credentials"}, {"id": 2925409, "detector": {"name": "generic_high_entropy_secret",
         "display_name": "Generic High Entropy Secret", "nature": "generic", "family":
         "other", "category": "other", "detector_group_name": "generic_high_entropy_secret",
-        "detector_group_display_name": "Generic High Entropy Secret"}, "date": "2026-03-29T19:45:49Z",
-        "secret_id": 30242300, "secret_hash": "4U/oBUMl1qh7Srz5W44PGp28+z79LJdZ6yTv1DCbpNbOcxetp+KkPCNpyNbtXqJM",
-        "hmsl_hash": "945925d9c2d7d630159586c5cbf7edb6074e906dd69a7eabaa804e365857cab0",
-        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2026-03-29T19:50:52.892358Z",
+        "detector_group_display_name": "Generic High Entropy Secret"}, "date": "2026-06-19T13:43:42Z",
+        "secret_id": 34793738, "secret_hash": "i1NqGDt0lpXqisqgjfAE0pcA5xJw3ziWjHCedkJ13DATl/HLp+KkPCNpyNbtXqJM",
+        "hmsl_hash": "9de52e53da048babb53c132354d255bcfcfb1a824bd5340d9642cc3dab3d91fd",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2026-06-19T13:49:31.552742Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
         53, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1565465",
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2925409",
         "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "Generic High Entropy Secret"}, {"id": 1559615, "detector": {"name": "smtp_assignment",
-        "display_name": "SMTP credentials", "nature": "specific", "family": "identifiers",
-        "category": "messaging_system", "detector_group_name": "smtp_credentials",
-        "detector_group_display_name": "SMTP credentials"}, "date": "2026-03-28T23:24:10Z",
-        "secret_id": 30206041, "secret_hash": "8Kighb5RJJlUPfc3hkc6LGHKUPKBoGmqxqHjr7CUQ07ZiAyAnUgJKbY5bDWilWBS",
-        "hmsl_hash": "1b52928ad2792d1bad89e2a5e837ad513a4b50ced14971df92e46f8bf2764d10",
-        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2026-03-28T23:29:58.247999Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        63, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
-        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1559615",
-        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "SMTP credentials"}, {"id": 1554831, "detector": {"name": "generic_high_entropy_secret",
-        "display_name": "Generic High Entropy Secret", "nature": "generic", "family":
-        "other", "category": "other", "detector_group_name": "generic_high_entropy_secret",
-        "detector_group_display_name": "Generic High Entropy Secret"}, "date": "2026-03-27T18:11:26Z",
-        "secret_id": 30166298, "secret_hash": "8qyd9TAXAWR5J4Sxwjiisc+V7HVwl6+ZlRRt7H9d17ys7sMYp+KkPCNpyNbtXqJM",
-        "hmsl_hash": "b0a8f04800887cef654dd948c731a967b6b644c4b3bfdea1ea6400682251c89c",
-        "occurrences_count": 2, "status": "IGNORED", "triggered_at": "2026-03-27T18:16:57.754167Z",
-        "ignored_at": "2026-03-27T18:17:37.519114Z", "ignorer_id": 492181, "ignorer_api_token_id":
-        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
-        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
-        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
-        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1554831",
-        "tags": ["FALSE_POSITIVE"], "custom_tags": [], "destination_tickets": [],
-        "incident_name": "Generic High Entropy Secret"}, {"id": 1554830, "detector":
-        {"name": "generic_high_entropy_secret", "display_name": "Generic High Entropy
-        Secret", "nature": "generic", "family": "other", "category": "other", "detector_group_name":
-        "generic_high_entropy_secret", "detector_group_display_name": "Generic High
-        Entropy Secret"}, "date": "2026-03-27T18:11:26Z", "secret_id": 30166297, "secret_hash":
-        "PGGOlbTiQZGqXXA3Vj88RduN0f+72Aha3hUU4MwsiKW7Qj8dp+KkPCNpyNbtXqJM", "hmsl_hash":
-        "e2d81242e3b11cd65b823f92e2dde252dadd99821d401c06f00a8b08994d6e54", "occurrences_count":
-        15, "status": "IGNORED", "triggered_at": "2026-03-27T18:16:57.754167Z", "ignored_at":
-        "2026-03-27T18:17:37.519114Z", "ignorer_id": 492181, "ignorer_api_token_id":
-        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
-        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
-        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
-        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1554830",
-        "tags": ["FALSE_POSITIVE"], "custom_tags": [], "destination_tickets": [],
-        "incident_name": "Generic High Entropy Secret"}, {"id": 1532769, "detector":
-        {"name": "generic_high_entropy_secret", "display_name": "Generic High Entropy
-        Secret", "nature": "generic", "family": "other", "category": "other", "detector_group_name":
-        "generic_high_entropy_secret", "detector_group_display_name": "Generic High
-        Entropy Secret"}, "date": "2026-03-24T13:33:43Z", "secret_id": 29987838, "secret_hash":
-        "Z2VbNCIjdFtG93Q3kYNdR2hbcpLCInG8jb+7nhslcZcd+R7Qp+KkPCNpyNbtXqJM", "hmsl_hash":
-        "201d0f1de1596ef0339e3e77585afea740431bf00690761908402d5883491fd7", "occurrences_count":
-        3, "status": "TRIGGERED", "triggered_at": "2026-03-24T13:40:06.889200Z", "ignored_at":
-        null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
-        "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
-        "validity": "no_checker", "severity": "unknown", "assignee_id": null, "assignee_email":
-        null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 26, "severity_rule_id":
-        null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1532769",
-        "tags": ["TEST_FILE"], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "Generic High Entropy Secret"}, {"id": 1531153, "detector": {"name": "github_personal_access_token_v2",
-        "display_name": "GitHub Personal Access Token", "nature": "specific", "family":
-        "token", "category": "version_control_platform", "detector_group_name": "github_access_token",
-        "detector_group_display_name": "GitHub Personal Access Token"}, "date": "2026-03-24T11:11:40Z",
-        "secret_id": 29982248, "secret_hash": "BPc/RppCYpsDGMfSWRdhBTfbkxDhAYRQIzVwpAv/QcTMaF5aQ7Ami0oNRiGwGL9Y",
-        "hmsl_hash": "34a830ee06e4f30cb0468bea56b78d74c23c2534f8adb2964f690b92828089fe",
-        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2026-03-24T11:17:46.888920Z",
-        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
-        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
-        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
-        7, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
-        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1531153",
-        "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "GitHub Personal Access Token"}, {"id": 1511349, "detector": {"name": "stripe",
+        "Generic High Entropy Secret"}, {"id": 2916755, "detector": {"name": "stripe",
         "display_name": "Stripe Keys", "nature": "specific", "family": "token", "category":
         "payment_system", "detector_group_name": "stripe_keys", "detector_group_display_name":
-        "Stripe Keys"}, "date": "2026-03-20T13:33:50Z", "secret_id": 29858518, "secret_hash":
-        "pOmE5G+sseSAN7Hndl73KbCSugKMTtYHxfu5pa9tmPFM6+SOiIVhmFkAG+mbE/6F", "hmsl_hash":
-        "395dc4774bf51928c7b50864ec4638b7025eafe1df1831974789912256854544", "occurrences_count":
-        1, "status": "TRIGGERED", "triggered_at": "2026-03-20T13:39:23.289964Z", "ignored_at":
+        "Stripe Keys"}, "date": "2026-06-19T05:04:42Z", "secret_id": 34773372, "secret_hash":
+        "RjdMiWBbuUr8wrx6pYOzkNvldZS4OtGa0jDMIby5vz6/UL+SiIVhmFkAG+mbE/6F", "hmsl_hash":
+        "48046d10e397e4ba9b21f1cc537f0d562aba0613355f808fd51e71a2cb88c2c8", "occurrences_count":
+        1, "status": "TRIGGERED", "triggered_at": "2026-06-19T05:09:45.908419Z", "ignored_at":
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "invalid", "severity": "unknown", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
         null, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1511349",
+        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/2916755",
         "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "Stripe Keys"}, {"id": 1506118, "detector": {"name": "postgres_assignment_no_port",
-        "display_name": "PostgreSQL Credentials", "nature": "specific", "family":
-        "identifiers", "category": "data_storage", "detector_group_name": "postgresql_credentials",
-        "detector_group_display_name": "PostgreSQL Credentials"}, "date": "2026-03-19T12:29:33Z",
-        "secret_id": 29811650, "secret_hash": "YJkmAUIdJ63b+l5M/RUlnvvo0licUhpvkRFWitAPSfN7mYwdP+BRsGMAB9aU5i+6",
-        "hmsl_hash": "4b88e1f10010d73c70ddd61edcd5f7f91cf80dc04c4b92583e4422ee37fa184c",
-        "occurrences_count": 2, "status": "TRIGGERED", "triggered_at": "2026-03-19T12:34:45.565200Z",
+        "Stripe Keys"}, {"id": 2902002, "detector": {"name": "generic_password", "display_name":
+        "Generic Password", "nature": "generic", "family": "other", "category": "other",
+        "detector_group_name": "generic_password", "detector_group_display_name":
+        "Generic Password"}, "date": "2026-06-18T13:21:32Z", "secret_id": 34743025,
+        "secret_hash": "7JcW1U/z5XUsZzguyePttbrKhQ6tQqhCmodnfGyObhmvcWXWfma8ieOEhD7igl+v",
+        "hmsl_hash": "4503d0cfa228302882920893a0d66040551c6b1042008966a6a8d0d83d7895a2",
+        "occurrences_count": 1, "status": "IGNORED", "triggered_at": "2026-06-18T13:26:39.890360Z",
+        "ignored_at": "2026-06-18T16:16:05.383503Z", "ignorer_id": 525628, "ignorer_api_token_id":
+        null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
+        "secret_revoked": false, "validity": "no_checker", "severity": "unknown",
+        "assignee_id": null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
+        [], "risk_score": 26, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "test_cred", "resolve_reason": null, "ignore_reason": "test_credential", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2902002",
+        "tags": ["IS_COMPANY_CONTEXT", "TEST_FILE"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Generic Password"}, {"id": 2889389, "detector": {"name":
+        "aws_iam", "display_name": "AWS IAM Keys", "nature": "specific", "family":
+        "credentials", "category": "cloud_provider", "detector_group_name": "aws_iam",
+        "detector_group_display_name": "AWS IAM Keys"}, "date": "2026-06-18T05:04:53Z",
+        "secret_id": 34714205, "secret_hash": "/pM8KgM23ky6WjXF4c1QmHj+l6WvtsH2ORv+mN+mdFtx/k8HL4Qc71cZRqNcojMG",
+        "hmsl_hash": "147d2f3b8b0d27f8f8f36b545c8b73d0a715c021d4fc8693a6f159c1b84ed442",
+        "occurrences_count": 1, "status": "TRIGGERED", "triggered_at": "2026-06-18T05:10:12.891387Z",
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
-        false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
-        null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 49, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1506118",
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/2889389",
         "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
-        "PostgreSQL Credentials"}]'
+        "AWS IAM Keys"}]'
     headers:
       CF-RAY:
-      - 9efb6e1b19187011-CDG
+      - a10397ce5cd1a289-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:56 GMT
+      - Tue, 23 Jun 2026 12:45:59 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -191,13 +188,13 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '11696'
+      - '11400'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
       - same-origin
       link:
-      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0yMDI2LTAzLTE5KzEyJTNBMjklM0EzMyUyQjAwJTNBMDA%3D&ordering=-date&per_page=10&severity=critical%2Chigh%2Cmedium%2Clow%2Cinfo%2Cunknown&status=TRIGGERED%2CASSIGNED%2CRESOLVED%2CIGNORED&validity=valid%2Cinvalid%2Cfailed_to_check%2Cno_checker%2Cunknown>;
+      - <https://api.gitguardian.com/v1/public-incidents/secrets?cursor=cD0yMDI2LTA2LTE4KzA1JTNBMDQlM0E1MyUyQjAwJTNBMDA%3D&ordering=-date&per_page=10&severity=critical%2Chigh%2Cmedium%2Clow%2Cinfo%2Cunknown&status=TRIGGERED%2CASSIGNED%2CRESOLVED%2CIGNORED&validity=valid%2Cinvalid%2Cfailed_to_check%2Cno_checker%2Cunknown>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
@@ -206,17 +203,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '222'
+      - '124'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_public_occurrences_basic.yaml
+++ b/tests/cassettes/tools/vcr/test_list_public_occurrences_basic.yaml
@@ -25,25 +25,25 @@ interactions:
         "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
         "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
         "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
-        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
-        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
-        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
-        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
-        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
-        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
-        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
-        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
-        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
-        "destination_tickets": [], "incident_name": "Stripe Keys"}]'
+        "occurrences_count": 5, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1", "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}]'
     headers:
       CF-RAY:
-      - 9ef49a650cf33d13-CDG
+      - a10397d2dd5a6f33-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:47:50 GMT
+      - Tue, 23 Jun 2026 12:46:00 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -55,7 +55,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '1195'
+      - '1132'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -70,17 +70,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '175'
+      - '63'
       x-frame-options:
       - DENY
       x-per-page:
       - '1'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -158,13 +158,13 @@ interactions:
         "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
-      - 9ef49a67bd922c31-CDG
+      - a10397d4be8c0d9a-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Apr 2026 13:47:50 GMT
+      - Tue, 23 Jun 2026 12:46:00 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -190,17 +190,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '74'
+      - '38'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_public_occurrences_with_date_range.yaml
+++ b/tests/cassettes/tools/vcr/test_list_public_occurrences_with_date_range.yaml
@@ -25,25 +25,25 @@ interactions:
         "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
         "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
         "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
-        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
-        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
-        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
-        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
-        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
-        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
-        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
-        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
-        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
-        "destination_tickets": [], "incident_name": "Stripe Keys"}]'
+        "occurrences_count": 5, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1", "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}]'
     headers:
       CF-RAY:
-      - 9efb6e25db9a9a29-CDG
+      - a10397da7a1c8ce7-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:58 GMT
+      - Tue, 23 Jun 2026 12:46:01 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -55,7 +55,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '1195'
+      - '1132'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -70,17 +70,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '106'
+      - '55'
       x-frame-options:
       - DENY
       x-per-page:
       - '1'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -158,13 +158,13 @@ interactions:
         "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
-      - 9efb6e283a3c986b-CDG
+      - a10397dc4d59d11b-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:58 GMT
+      - Tue, 23 Jun 2026 12:46:01 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -190,17 +190,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '61'
+      - '59'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_public_occurrences_with_multi_value_filters.yaml
+++ b/tests/cassettes/tools/vcr/test_list_public_occurrences_with_multi_value_filters.yaml
@@ -25,25 +25,25 @@ interactions:
         "stripe_keys", "detector_group_display_name": "Stripe Keys"}, "date": "2022-09-21T12:48:20Z",
         "secret_id": 14030708, "secret_hash": "oRwIqXVsin9BmHcHQx6WhicHNz4oNA/2C46qrJwl9Mn9/1HViIVhmFkAG+mbE/6F",
         "hmsl_hash": "413ceb0ac344f91b4de665e1c6d73af3a46a26b6562b4a934fe143a900acbeb6",
-        "occurrences_count": 5, "status": "IGNORED", "triggered_at": "2025-01-07T18:06:02.721195Z",
-        "ignored_at": "2025-07-30T12:45:49.970856Z", "ignorer_id": null, "ignorer_api_token_id":
-        "e9a6365c-e79a-4ad9-b851-29489298e615", "resolved_at": null, "resolver_id":
-        null, "resolver_api_token_id": null, "secret_revoked": false, "validity":
-        "invalid", "severity": "unknown", "assignee_id": null, "assignee_email": null,
-        "share_url": "[REDACTED]", "feedback_list": [], "risk_score": 9, "severity_rule_id":
-        null, "is_vaulted": false, "declarative_secret_status": "invalid", "resolve_reason":
-        null, "ignore_reason": "invalid", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1",
-        "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [],
-        "destination_tickets": [], "incident_name": "Stripe Keys"}]'
+        "occurrences_count": 5, "status": "TRIGGERED", "triggered_at": "2025-01-07T18:06:02.721195Z",
+        "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
+        null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
+        false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
+        "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [], "risk_score":
+        9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1", "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets":
+        [], "incident_name": "Stripe Keys"}]'
     headers:
       CF-RAY:
-      - 9efb6e217a3e2a13-CDG
+      - a10397d699959b08-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:57 GMT
+      - Tue, 23 Jun 2026 12:46:00 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -55,7 +55,7 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '1195'
+      - '1132'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -70,17 +70,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '90'
+      - '58'
       x-frame-options:
       - DENY
       x-per-page:
       - '1'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -158,13 +158,13 @@ interactions:
         "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
-      - 9efb6e23af656989-CDG
+      - a10397d8aebe463a-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 09:40:57 GMT
+      - Tue, 23 Jun 2026 12:46:01 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -190,17 +190,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.437.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '48'
+      - '54'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.161.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_repo_occurrences_with_mine_true.yaml
+++ b/tests/cassettes/tools/vcr/test_list_repo_occurrences_with_mine_true.yaml
@@ -20,47 +20,58 @@ interactions:
     uri: https://api.gitguardian.com/v1/api_tokens/self
   response:
     body:
-      string: '{"id": "8a262c6a-832d-49e5-8744-23c743ff25ac", "name": "ggmcp CI",
-        "type": "personal_access_token", "scopes": ["scan", "incidents:read", "members:read",
-        "audit_logs:read", "teams:read", "honeytokens:read", "honeytokens:write",
-        "api_tokens:read", "sources:read", "nhi:send-inventory", "nhi:write-vault",
-        "custom_tags:read", "custom_tags:write", "secrets:read", "secrets:write",
-        "scan:create-incidents", "public-perimeter:read"], "member_id": 480870, "workspace_id":
-        8, "created_at": "2025-12-07T14:13:08.044416Z", "last_used_at": "2026-04-03T08:43:00Z",
-        "expire_at": null, "revoked_at": null, "status": "active", "creator_id": 480870}'
+      string: '{"id": "d0ca9877-641f-4c37-8857-c08e0ae148c4", "name": "ggmcp CI (April)",
+        "type": "personal_access_token", "scopes": ["scan", "incidents:read", "incidents:write",
+        "incidents:share", "members:read", "members:write", "audit_logs:read", "teams:read",
+        "teams:write", "honeytokens:read", "honeytokens:write", "api_tokens:read",
+        "api_tokens:write", "ip_allowlist:read", "ip_allowlist:write", "sources:read",
+        "sources:write", "nhi:send-inventory", "nhi:write-vault", "custom_tags:read",
+        "custom_tags:write", "secrets:read", "secrets:write", "scan:create-incidents",
+        "public-perimeter:read", "nhi:ownership:read", "nhi:ownership:write", "sources:scan"],
+        "member_id": 480870, "workspace_id": 8, "created_at": "2026-04-20T13:31:42.422943Z",
+        "last_used_at": "2026-06-23T12:46:00Z", "expire_at": null, "revoked_at": null,
+        "status": "active", "creator_id": 480870}'
     headers:
+      CF-RAY:
+      - a10397de1c8e9e8b-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:46:02 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, DELETE, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '594'
+      - '802'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:53 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '19'
+      - '24'
       x-frame-options:
       - DENY
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -91,111 +102,119 @@ interactions:
         "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
         [{"name": "apikey", "indice_start": 48, "indice_end": 726, "pre_line_start":
         3, "pre_line_end": 14, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "333db3e12b3f863ebb02cac6f232fc44e4f46533", "change_type": "deletion",
         "source_id": 12320}, {"id": 78200, "incident_id": 21461, "date": "2020-10-29T09:19:54.249454Z",
         "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
         [{"name": "apikey", "indice_start": 91, "indice_end": 769, "pre_line_start":
         null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 14}], "tags":
-        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "76dd4f31a31c78a151723031bfebff4d076751b2", "change_type": "addition",
         "source_id": 12320}, {"id": 78203, "incident_id": 21463, "date": "2020-10-29T06:20:19.846592Z",
         "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
         [{"name": "apikey", "indice_start": 48, "indice_end": 1842, "pre_line_start":
         3, "pre_line_end": 32, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-10/commit/65563d9586ec109e098c952559204dbb54e88d6f#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-10/commit/65563d9586ec109e098c952559204dbb54e88d6f#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "65563d9586ec109e098c952559204dbb54e88d6f", "change_type": "deletion",
         "source_id": 12308}, {"id": 78204, "incident_id": 21463, "date": "2020-10-29T06:20:15.521071Z",
         "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
         [{"name": "apikey", "indice_start": 91, "indice_end": 1885, "pre_line_start":
         null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 32}], "tags":
-        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-10/commit/35a6a3b548c4bf220b347f2bcb0be46f3692d35d#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-10/commit/35a6a3b548c4bf220b347f2bcb0be46f3692d35d#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "35a6a3b548c4bf220b347f2bcb0be46f3692d35d", "change_type": "addition",
         "source_id": 12308}, {"id": 78210, "incident_id": 21467, "date": "2020-10-26T16:19:44.303499Z",
         "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
         [{"name": "apikey", "indice_start": 46, "indice_end": 86, "pre_line_start":
         3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-10/commit/a18096b36e00c74db6878ad3acb9221e27539b14#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-10/commit/a18096b36e00c74db6878ad3acb9221e27539b14#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "a18096b36e00c74db6878ad3acb9221e27539b14", "change_type": "deletion",
         "source_id": 12350}, {"id": 78212, "incident_id": 21467, "date": "2020-10-26T14:19:40.469654Z",
         "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
         [{"name": "apikey", "indice_start": 89, "indice_end": 129, "pre_line_start":
         null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 3}], "tags":
-        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-10/commit/a37529b48365f196ed92632301558cbb675a5e1c#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-10/commit/a37529b48365f196ed92632301558cbb675a5e1c#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "a37529b48365f196ed92632301558cbb675a5e1c", "change_type": "addition",
         "source_id": 12350}, {"id": 78215, "incident_id": 21469, "date": "2020-10-26T00:19:46.194077Z",
         "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
         [{"name": "apikey", "indice_start": 48, "indice_end": 498, "pre_line_start":
         3, "pre_line_end": 10, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-09/commit/2c9fe6c6aff44b05bc748ec9f86447c99f5286fb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-09/commit/2c9fe6c6aff44b05bc748ec9f86447c99f5286fb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "2c9fe6c6aff44b05bc748ec9f86447c99f5286fb", "change_type": "deletion",
         "source_id": 12314}, {"id": 78216, "incident_id": 21469, "date": "2020-10-25T23:19:57.381648Z",
         "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
         [{"name": "apikey", "indice_start": 91, "indice_end": 541, "pre_line_start":
         null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 10}], "tags":
-        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-09/commit/5f4022de142ac57f9e2d4667c950268a3073afe3#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-09/commit/5f4022de142ac57f9e2d4667c950268a3073afe3#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "5f4022de142ac57f9e2d4667c950268a3073afe3", "change_type": "addition",
         "source_id": 12314}, {"id": 78217, "incident_id": 21470, "date": "2020-10-25T07:19:36.511158Z",
         "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
         [{"name": "apikey", "indice_start": 46, "indice_end": 83, "pre_line_start":
         3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2020-09/commit/4103f583616340e3ba72614410e5e001bbe8455f#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2020-09/commit/4103f583616340e3ba72614410e5e001bbe8455f#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "4103f583616340e3ba72614410e5e001bbe8455f", "change_type": "deletion",
         "source_id": 12367}, {"id": 78218, "incident_id": 21470, "date": "2020-10-25T05:20:21.486451Z",
         "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
         [{"name": "apikey", "indice_start": 89, "indice_end": 126, "pre_line_start":
         null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 3}], "tags":
-        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2020-09/commit/addd9179363127bce3e861fead4b74134600da0e#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2020-09/commit/addd9179363127bce3e861fead4b74134600da0e#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
         "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
         "sha": "addd9179363127bce3e861fead4b74134600da0e", "change_type": "addition",
         "source_id": 12367}]'
     headers:
+      CF-RAY:
+      - a10397dffc66c8ed-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:46:02 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '6649'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:54 GMT
       link:
       - <https://api.gitguardian.com/v1/occurrences/secrets?cursor=cD03ODIxOA%3D%3D&exclude_tags=TEST_FILE%2CFALSE_POSITIVE%2CCHECK_RUN_SKIP_FALSE_POSITIVE%2CCHECK_RUN_SKIP_LOW_RISK%2CCHECK_RUN_SKIP_TEST_CRED&member_assignee_id=480870&per_page=10&severity=critical%2Chigh%2Cmedium%2Cunknown&status=TRIGGERED%2CASSIGNED%2CRESOLVED&validity=valid%2Cfailed_to_check%2Cno_checker%2Cunknown&with_sources=false>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '66'
+      - '86'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_sources_basic.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_basic.yaml
@@ -20,102 +20,101 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?per_page=5
   response:
     body:
-      string: '[{"id": 12338, "type": "github", "full_name": "wayne-enterprises-gg/shared-app",
-        "health": "safe", "source_criticality": "low", "default_branch": "master",
-        "default_branch_head": "a219c18ff8e913427c38fc7d90756d6bb1bb5b43", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2026-02-02T10:49:30.905195Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 544, "duration":
-        "0.0", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "218964926", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/shared-app",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12356,
-        "type": "github", "full_name": "wayne-enterprises-gg/with-readme-repo-gg",
-        "health": "safe", "source_criticality": "medium", "default_branch": "master",
-        "default_branch_head": "21ca725ac5028cf45975b49f7b48928f34f73117", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:45:43.352734Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 1, "duration":
-        "3.265244", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "234115319", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/with-readme-repo-gg",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12364,
-        "type": "github", "full_name": "wayne-enterprises-gg/business-app", "health":
-        "safe", "source_criticality": "medium", "default_branch": "master", "default_branch_head":
-        "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count": 0, "closed_incidents_count":
-        76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1242, "duration": "9.779904", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "217533545", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 76, "severity_breakdown":
-        {"critical": 3, "high": 73, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/business-app", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 12369, "type": "github", "full_name":
-        "aymericGG/hello-world", "health": "safe", "source_criticality": "high", "default_branch":
-        "master", "default_branch_head": "665b4e495aef1d7b6737a503209407a297d37772",
-        "open_incidents_count": 0, "closed_incidents_count": 3, "last_scan": {"date":
-        "2025-10-09T16:45:43.352983Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 10, "duration": "0.84662", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "175174005",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
-        0, "high": 3, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/hello-world",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12370,
-        "type": "github", "full_name": "aymericGG/Project-back", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "", "default_branch_head":
+      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:45:43.353058Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.01237", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "253745397",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/Project-back",
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
+        "type": "github", "full_name": "lonely/hunter", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "22", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/hunter",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12261,
+        "type": "github", "full_name": "lonely/time", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "25", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/time",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12262,
+        "type": "github", "full_name": "lonely/tower", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "24", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/tower",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12263,
+        "type": "github", "full_name": "my-testing-org/christian_dior", "health":
+        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:39.211442Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1, "duration": "1.218169", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "12", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a10397e2aae70356-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:46:03 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '4374'
+      - '3712'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:54 GMT
       link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjM3MA%3D%3D&per_page=5>;
+      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjI2Mw%3D%3D&per_page=5>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '222'
+      - '458'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_sources_get_all.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_get_all.yaml
@@ -20,272 +20,281 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?per_page=20
   response:
     body:
-      string: '[{"id": 12338, "type": "github", "full_name": "wayne-enterprises-gg/shared-app",
-        "health": "safe", "source_criticality": "low", "default_branch": "master",
-        "default_branch_head": "a219c18ff8e913427c38fc7d90756d6bb1bb5b43", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2026-02-02T10:49:30.905195Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 544, "duration":
-        "0.0", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "218964926", "secret_incidents_breakdown": {"open_secret_incidents":
+      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/shared-app",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12356,
-        "type": "github", "full_name": "wayne-enterprises-gg/with-readme-repo-gg",
-        "health": "safe", "source_criticality": "medium", "default_branch": "master",
-        "default_branch_head": "21ca725ac5028cf45975b49f7b48928f34f73117", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:45:43.352734Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 1, "duration":
-        "3.265244", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "234115319", "secret_incidents_breakdown": {"open_secret_incidents":
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
+        "type": "github", "full_name": "lonely/hunter", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "22", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/hunter",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12261,
+        "type": "github", "full_name": "lonely/time", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "25", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/time",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12262,
+        "type": "github", "full_name": "lonely/tower", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "24", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/tower",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12263,
+        "type": "github", "full_name": "my-testing-org/christian_dior", "health":
+        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:39.211442Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1, "duration": "1.218169", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "12", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/with-readme-repo-gg",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12364,
-        "type": "github", "full_name": "wayne-enterprises-gg/business-app", "health":
-        "safe", "source_criticality": "medium", "default_branch": "master", "default_branch_head":
-        "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count": 0, "closed_incidents_count":
-        76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1242, "duration": "9.779904", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "217533545", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 76, "severity_breakdown":
-        {"critical": 3, "high": 73, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/business-app", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 12369, "type": "github", "full_name":
-        "aymericGG/hello-world", "health": "safe", "source_criticality": "high", "default_branch":
-        "master", "default_branch_head": "665b4e495aef1d7b6737a503209407a297d37772",
-        "open_incidents_count": 0, "closed_incidents_count": 3, "last_scan": {"date":
-        "2025-10-09T16:45:43.352983Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 10, "duration": "0.84662", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "175174005",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
-        0, "high": 3, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/hello-world",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12370,
-        "type": "github", "full_name": "aymericGG/Project-back", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "", "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:45:43.353058Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.01237", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "253745397",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/Project-back",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12371,
-        "type": "github", "full_name": "aymericGG/Project-Front", "health": "safe",
-        "source_criticality": "high", "default_branch": "", "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:45:43.353136Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.012344", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "253745330",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/Project-Front",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 9123340,
-        "type": "github", "full_name": "orga-083643/solid-octo", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "1218ef7297f84f36297c0111ea88b54b9befd365", "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": {"date": "2025-10-09T16:45:43.351408Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 7, "duration": "1.120819", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "630519649", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/orga-083643/solid-octo", "provider_metadata": {"archived":
-        false}, "deleted": false}, {"id": 9123465, "type": "github", "full_name":
-        "orga-083643/expert-train", "health": "safe", "source_criticality": "unknown",
-        "default_branch": "main", "default_branch_head": "1e3f25567a57f788700cbe9b21a05fb2a3dd23f9",
-        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
-        "2025-10-09T16:45:43.353647Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 4, "duration": "4.092814", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "630525080",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/expert-train",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 9123810,
-        "type": "github", "full_name": "orga-083643/ideal-journey", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "ab24e2860796dff2a67c4915b1a6d745b13bdd76", "open_incidents_count": 0, "closed_incidents_count":
-        1, "last_scan": {"date": "2025-10-09T16:45:43.354999Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 3, "duration": "0.866616", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "630531940", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/orga-083643/ideal-journey", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 9123882, "type": "github",
-        "full_name": "orga-083643/analytics-test", "health": "safe", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": "f19d79466ce40e0bb69c9ee0ea08787ead9b5845",
-        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
-        "2025-10-09T16:45:43.352186Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 7, "duration": "0.942938", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "630536182",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/analytics-test",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 9124147,
-        "type": "github", "full_name": "orga-083643/improved-carnival", "health":
-        "safe", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "cdaa5dd8497a52a75702879823adc18141ad88b4", "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": {"date": "2025-10-09T16:45:43.354520Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 4, "duration": "3.881061", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "630548292", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/orga-083643/improved-carnival", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 10294451, "type": "github",
-        "full_name": "babassov/PrivateVB", "health": "safe", "source_criticality":
-        "critical", "default_branch": "main", "default_branch_head": "346eeb121643aa8ab28828719d94d33664a55839",
-        "open_incidents_count": 0, "closed_incidents_count": 12, "last_scan": {"date":
-        "2025-10-09T16:45:43.353950Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 14, "duration": "1.396871", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "614802635",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 12, "severity_breakdown": {"critical":
-        0, "high": 12, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/babassov/PrivateVB",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 10836673,
-        "type": "github", "full_name": "leakymcgee/secretproject", "health": "at_risk",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "6fa238be5c8773d3560627df4597c1b0cddc708d", "open_incidents_count": 6, "closed_incidents_count":
-        2, "last_scan": {"date": "2025-10-09T16:45:43.354139Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 9, "duration": "0.0", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "684998195", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        6, "severity_breakdown": {"critical": 5, "high": 1, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 2, "severity_breakdown":
-        {"critical": 0, "high": 2, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/leakymcgee/secretproject", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 11018378, "type": "github",
-        "full_name": "leakymcgee/ggshield", "health": "at_risk", "source_criticality":
-        "high", "default_branch": "main", "default_branch_head": "261ad38336f401683315c9dd30d792d3043f1751",
-        "open_incidents_count": 13, "closed_incidents_count": 5, "last_scan": {"date":
-        "2025-10-09T16:45:43.353684Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 1515, "duration": "12.404975", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "691584428",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 13, "severity_breakdown":
-        {"critical": 12, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 5, "severity_breakdown": {"critical":
-        4, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/leakymcgee/ggshield",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11260258,
-        "type": "github", "full_name": "gitjez/git_playground", "health": "at_risk",
-        "source_criticality": "high", "default_branch": "main", "default_branch_head":
-        "21de97f3a7ab7346d33f92479c6266ed29086642", "open_incidents_count": 11, "closed_incidents_count":
-        13, "last_scan": {"date": "2025-10-09T16:45:43.354669Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 104, "duration": "5.271635", "branches_scanned":
-        15, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "602034939", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        11, "severity_breakdown": {"critical": 2, "high": 9, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 13, "severity_breakdown":
-        {"critical": 1, "high": 12, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/gitjez/git_playground", "provider_metadata": {"archived":
-        false}, "deleted": false}, {"id": 11260259, "type": "github", "full_name":
-        "gitjez/private_repo", "health": "safe", "source_criticality": "high", "default_branch":
-        "main", "default_branch_head": "a8102e99d82504517c016fd20aa499209c65e41d",
-        "open_incidents_count": 0, "closed_incidents_count": 19, "last_scan": {"date":
-        "2025-10-09T16:45:43.354706Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 10, "duration": "3.11961", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "699836994",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 19, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 1, "unknown": 18}}}, "url": "https://github.com/gitjez/private_repo",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11270152,
-        "type": "slack", "full_name": "Demo Slack Integration / #general", "health":
-        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 4, "closed_incidents_count": 6, "last_scan":
-        {"date": "2025-10-09T16:44:19.448855Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "2.282765", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "C05V11N7B1T",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 4, "severity_breakdown":
-        {"critical": 2, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 1}},
-        "closed_secret_incidents": {"total": 6, "severity_breakdown": {"critical":
-        3, "high": 1, "medium": 0, "low": 0, "info": 2, "unknown": 0}}}, "url": "https://demoslackinte-0vf1761.slack.com/archives/C05V11N7B1T",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11270153,
-        "type": "slack", "full_name": "Demo Slack Integration / #random", "health":
-        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:44:19.448890Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.215615", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "C0602J433A5",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://demoslackinte-0vf1761.slack.com/archives/C0602J433A5",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11328061,
-        "type": "slack", "full_name": "Demo Slack Integration / #demo-231009", "health":
-        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 2, "closed_incidents_count": 4, "last_scan":
-        {"date": "2025-10-09T16:44:19.448925Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.206472", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "C05VBD2TDST",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 2, "severity_breakdown":
-        {"critical": 0, "high": 2, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
-        1, "high": 1, "medium": 0, "low": 0, "info": 1, "unknown": 1}}}, "url": "https://demoslackinte-0vf1761.slack.com/archives/C05VBD2TDST",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11348776,
-        "type": "slack", "full_name": "Demo Slack Integration / #demo-231011", "health":
-        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12264,
+        "type": "github", "full_name": "my-testing-org/armani_code", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 1, "last_scan":
-        {"date": "2025-10-09T16:44:19.448960Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.22554", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "C061AL994KS",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
-        0, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://demoslackinte-0vf1761.slack.com/archives/C061AL994KS",
+        {"date": "2020-06-04T09:06:33.833273Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 2, "duration": "2.830578", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "30", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 1}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/armani_code",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12265,
+        "type": "github", "full_name": "my-testing-org/louis_vuitton", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:32.770273Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 0, "duration": "1.141495", "branches_scanned": 0, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "13", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/louis_vuitton",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12266,
+        "type": "github", "full_name": "my-testing-org/lagarfeld", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:33.598712Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1, "duration": "1.253906", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "29", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/lagarfeld",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12267,
+        "type": "github", "full_name": "my-testing-org/saint_laurent", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-10-09T12:55:14.542227Z", "status": "canceled", "failing_reason":
+        "", "commits_scanned": 0, "duration": "1.684644", "branches_scanned": 0, "progress":
+        0}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "28", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/saint_laurent",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12268,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2021-04",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
+        3, "last_scan": {"date": "2021-05-12T13:40:00.812612Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 686, "duration": "2.80448", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "353525015", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        1, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 3, "severity_breakdown": {"critical": 0, "high": 3, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2021-04",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12269,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2021-02",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
+        9, "last_scan": {"date": "2021-05-12T13:40:00.842952Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1474, "duration": "4.569221", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "339243552", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
+        2, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2021-02",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12270,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2021-04",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
+        4, "last_scan": {"date": "2021-05-12T13:40:00.804955Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 419, "duration": "2.634533", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "358427683", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 1}}, "closed_secret_incidents":
+        {"total": 4, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0,
+        "low": 0, "info": 1, "unknown": 2}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2021-04",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12271,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2021-03",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
+        7, "last_scan": {"date": "2021-05-12T13:40:00.809898Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1216, "duration": "8.598146", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "343245836", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 2}}, "closed_secret_incidents":
+        {"total": 7, "severity_breakdown": {"critical": 0, "high": 2, "medium": 0,
+        "low": 0, "info": 4, "unknown": 1}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2021-03",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12272,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2021-03",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
+        1, "last_scan": {"date": "2021-05-12T13:40:00.801498Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 940, "duration": "6.936519", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "348161051", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 1}}, "closed_secret_incidents":
+        {"total": 1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2021-03",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12273,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2021-03",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
+        6, "last_scan": {"date": "2021-05-12T13:40:00.818740Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 990, "duration": "6.295876", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "348161060", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
+        3, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 6, "severity_breakdown": {"critical": 0, "high": 6, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2021-03",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12274,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-07",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
+        6, "last_scan": {"date": "2020-09-24T09:06:39.253667Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1408, "duration": "4.083977", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "276237250", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
+        3, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 6, "severity_breakdown": {"critical": 0, "high": 6, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-07",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12275,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-08",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
+        9, "last_scan": {"date": "2020-09-24T09:06:39.215897Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 656, "duration": "5.5968", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "287845935", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
+        1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-08",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12276,
+        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-2020-12",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
+        6, "last_scan": {"date": "2021-02-01T15:38:48.535700Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1040, "duration": "2.651208", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "317380020", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
+        1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 6, "severity_breakdown": {"critical": 0, "high": 6, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-12",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12277,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2020-08",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
+        4, "last_scan": {"date": "2020-09-24T09:06:39.225976Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 913, "duration": "2.608482", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "284154416", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
+        1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 4, "severity_breakdown": {"critical": 0, "high": 4, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2020-08",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12278,
+        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-11",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
+        7, "last_scan": {"date": "2021-02-01T15:38:48.535276Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1282, "duration": "3.557603", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "313150729", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
+        3, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 7, "severity_breakdown": {"critical": 0, "high": 7, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-11",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a103989fcd413d10-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:46:33 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '17403'
+      - '17318'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:44:42 GMT
       link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMTM0ODc3Ng%3D%3D&per_page=20>;
+      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjI3OA%3D%3D&per_page=20>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '7839'
+      - '501'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -309,274 +318,278 @@ interactions:
       X-Privacy-Mode:
       - 'true'
     method: GET
-    uri: https://api.gitguardian.com/v1/sources?per_page=20&cursor=cD0xMTM0ODc3Ng%3D%3D
+    uri: https://api.gitguardian.com/v1/sources?per_page=20&cursor=cD0xMjI3OA%3D%3D
   response:
     body:
-      string: '[{"id": 11363204, "type": "github", "full_name": "amascia-gg/ftn-test-circleci",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": "main",
+      string: '[{"id": 12279, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-01",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
+        3, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "234319360", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
+        1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 3, "severity_breakdown": {"critical": 0, "high": 3, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-01",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12280,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2020-12",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
+        7, "last_scan": {"date": "2021-03-05T16:32:08.931273Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1343, "duration": "3.700622", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "321822525", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
+        1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 7, "severity_breakdown": {"critical": 0, "high": 7, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2020-12",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12281,
+        "type": "github", "full_name": "wayne-enterprises-gg/empty-repo", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-01-27T09:14:01.990109Z", "status": "failed", "failing_reason":
+        "Unknown error", "commits_scanned": 0, "duration": "0.0", "branches_scanned":
+        0, "progress": 0}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "236453863", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/empty-repo",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12282,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-07",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
-        1, "last_scan": {"date": "2025-10-09T16:45:43.354963Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 3121, "duration": "95.292729", "branches_scanned":
-        2, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "704004504", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        2, "severity_breakdown": {"critical": 1, "high": 1, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/amascia-gg/ftn-test-circleci", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 11379320, "type": "slack",
-        "full_name": "Demo Slack Integration / #public-channel", "health": "safe",
-        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 3, "last_scan":
-        {"date": "2025-10-09T16:44:19.448995Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.221121", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "C0610066CUD",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
-        0, "high": 1, "medium": 0, "low": 0, "info": 2, "unknown": 0}}}, "url": "https://demoslackinte-0vf1761.slack.com/archives/C0610066CUD",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11411960,
-        "type": "github", "full_name": "leakymcgee/nodejs-goof", "health": "at_risk",
-        "source_criticality": "critical", "default_branch": "main", "default_branch_head":
-        "8cacb884e328f0f883b934d427122e8fe8ad8b1c", "open_incidents_count": 3, "closed_incidents_count":
-        0, "last_scan": {"date": "2025-10-09T16:45:43.354368Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 113, "duration": "3.560034", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "705767874", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        3, "severity_breakdown": {"critical": 3, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/leakymcgee/nodejs-goof", "provider_metadata": {"archived":
-        false}, "deleted": false}, {"id": 11454870, "type": "slack", "full_name":
-        "Demo Slack Integration / #demo-231020", "health": "at_risk", "source_criticality":
-        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
-        1, "closed_incidents_count": 3, "last_scan": {"date": "2025-10-09T16:44:19.449030Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 0, "duration":
-        "0.218781", "branches_scanned": 0, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "C062255B9R8", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 1}}, "closed_secret_incidents": {"total":
-        3, "severity_breakdown": {"critical": 0, "high": 2, "medium": 0, "low": 0,
-        "info": 0, "unknown": 1}}}, "url": "https://demoslackinte-0vf1761.slack.com/archives/C062255B9R8",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11600587,
-        "type": "github", "full_name": "peterringball/terragoatGGDemoProd", "health":
-        "at_risk", "source_criticality": "medium", "default_branch": "master", "default_branch_head":
-        "d1138f0813f335cd09babbc2863e84ea8d462468", "open_incidents_count": 1, "closed_incidents_count":
-        0, "last_scan": {"date": "2025-10-09T16:45:43.354179Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 18, "duration": "3.934015", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "713321698", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        1, "severity_breakdown": {"critical": 1, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/peterringball/terragoatGGDemoProd", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 11677085, "type": "github",
-        "full_name": "peterringball/test", "health": "unknown", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": false, "visibility":
-        "private", "external_id": "673461264", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/peterringball/test",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11678252,
-        "type": "github", "full_name": "tuches/Test", "health": "safe", "source_criticality":
-        "low", "default_branch": "master", "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 1, "last_scan": {"date": "2025-10-09T16:45:43.352050Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 5, "duration":
-        "0.68205", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "291043633", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        1, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/tuches/Test", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 11678253, "type": "github",
-        "full_name": "tuches/x", "health": "safe", "source_criticality": "unknown",
-        "default_branch": "master", "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:45:43.352117Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 1, "duration":
-        "0.440233", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "299562498", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/tuches/x", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 11679819, "type": "github",
-        "full_name": "peterringball/cfngoat", "health": "at_risk", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": null, "open_incidents_count":
-        1, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:45:43.352774Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 1, "duration":
-        "1.096922", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "private", "external_id": "713839011", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 1, "severity_breakdown": {"critical": 1, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/peterringball/cfngoat",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11756704,
-        "type": "github", "full_name": "peterringball/test4", "health": "safe", "source_criticality":
-        "low", "default_branch": "main", "default_branch_head": "d7d00895483d9e6fd62acf72594199ee5cabf7c7",
-        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
-        "2025-10-09T16:45:43.353873Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 32, "duration": "3.878778", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "684649378",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/peterringball/test4",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12322614,
-        "type": "slack", "full_name": "Demo Slack Integration / #test-timothe-delion",
+        9, "last_scan": {"date": "2020-09-24T09:06:39.281285Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1146, "duration": "5.695658", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "280012005", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-07",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12283,
+        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-2020-09",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
+        5, "last_scan": {"date": "2020-09-24T09:06:39.249695Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 405, "duration": "4.641103", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "291853911", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 5, "severity_breakdown": {"critical": 0, "high": 5, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-09",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12284,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2020-06",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
+        10, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "272571163", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
+        1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 10, "severity_breakdown": {"critical": 0, "high": 10, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2020-06",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12285,
+        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-04",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
+        5, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "256067455", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 5, "severity_breakdown": {"critical": 0, "high": 5, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-04",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12286,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2020-11",
         "health": "safe", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": {"date": "2025-10-09T16:44:19.449065Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 0, "duration": "0.233054", "branches_scanned":
-        0, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "C06D386SZC0", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://demoslackinte-0vf1761.slack.com/archives/C06D386SZC0", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 12455380, "type": "slack",
-        "full_name": "Demo Slack Integration / #honeytoken", "health": "safe", "source_criticality":
-        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:44:19.449100Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 0, "duration":
-        "0.210458", "branches_scanned": 0, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "C06DJ0ZCSAK", "secret_incidents_breakdown": {"open_secret_incidents":
+        11, "last_scan": {"date": "2021-01-26T16:46:38.539876Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1486, "duration": "2.780691", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "308995512", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 11, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2020-11",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12287,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2020-04",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 6, "closed_incidents_count":
+        11, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "252029776", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 6, "severity_breakdown": {"critical":
+        6, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 11, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2020-04",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12288,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-12",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
+        6, "last_scan": {"date": "2021-03-11T11:00:13.725202Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1429, "duration": "2.608724", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "321822539", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
+        3, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 6, "severity_breakdown": {"critical": 0, "high": 6, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-12",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12289,
+        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-2020-02",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "237538596", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
+        1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://demoslackinte-0vf1761.slack.com/archives/C06DJ0ZCSAK",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12470998,
-        "type": "slack", "full_name": "Demo Slack Integration / #test-channel-creation",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-02",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12290,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2020-05",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
+        8, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "264326539", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 8, "severity_breakdown": {"critical": 0, "high": 8, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2020-05",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12291,
+        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-2020-07",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 6, "closed_incidents_count":
+        7, "last_scan": {"date": "2020-09-24T09:06:39.268982Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1442, "duration": "4.222266", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "276237232", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 6, "severity_breakdown": {"critical":
+        5, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 7, "severity_breakdown": {"critical": 0, "high": 7, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-07",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12292,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2020-08",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
+        13, "last_scan": {"date": "2020-11-04T14:06:32.755685Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1450, "duration": "2.440167", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "287845929", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
+        4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 13, "severity_breakdown": {"critical": 0, "high": 13, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2020-08",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12293,
+        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-2020-03",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        8, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "244061781", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 8, "severity_breakdown": {"critical": 0, "high": 8, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-03",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12294,
+        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-2021-03",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 5, "closed_incidents_count":
+        7, "last_scan": {"date": "2021-05-12T13:40:00.845299Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1247, "duration": "5.565196", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "343245830", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 5, "severity_breakdown": {"critical":
+        4, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 7, "severity_breakdown": {"critical": 0, "high": 7, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2021-03",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12295,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-02",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
+        1, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "240807321", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
+        3, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 1, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-02",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12296,
+        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-08",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
+        6, "last_scan": {"date": "2020-11-02T19:32:24.488911Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1414, "duration": "4.213635", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "287845921", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
+        3, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 6, "severity_breakdown": {"critical": 0, "high": 6, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-08",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12297,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-08",
         "health": "safe", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": {"date": "2025-10-09T16:44:19.444580Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 0, "duration": "0.23533", "branches_scanned":
-        0, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "C06EGV15G8Z", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://demoslackinte-0vf1761.slack.com/archives/C06EGV15G8Z", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 12482445, "type": "slack",
-        "full_name": "Demo Slack Integration / #test", "health": "safe", "source_criticality":
-        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:44:19.440496Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 0, "duration":
-        "0.26622", "branches_scanned": 0, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "C06EYF11U0G", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://demoslackinte-0vf1761.slack.com/archives/C06EYF11U0G",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12662970,
-        "type": "github", "full_name": "aymericGG/sample_secrets_Codacytest", "health":
-        "at_risk", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 1, "closed_incidents_count": 2, "last_scan":
-        {"date": "2025-10-09T16:45:43.354102Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 7, "duration": "2.949598", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "750268193",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 1, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
-        0, "high": 1, "medium": 1, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/sample_secrets_Codacytest",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12663154,
-        "type": "github", "full_name": "aymericGG/juice-shop-Codacytest", "health":
-        "at_risk", "source_criticality": "unknown", "default_branch": "master", "default_branch_head":
-        null, "open_incidents_count": 52, "closed_incidents_count": 33, "last_scan":
-        {"date": "2026-01-15T16:49:11.671959Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 19830, "duration": "82.392816", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "750273107", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        52, "severity_breakdown": {"critical": 27, "high": 25, "medium": 0, "low":
-        0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 33, "severity_breakdown":
-        {"critical": 2, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 30}}},
-        "url": "https://github.com/aymericGG/juice-shop-Codacytest", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 12842035, "type": "github",
-        "full_name": "ZGuardian/GitGoat", "health": "at_risk", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": "a7cbebb5a8449be04121bfe23d381fb61c4214ef",
-        "open_incidents_count": 11, "closed_incidents_count": 0, "last_scan": {"date":
-        "2025-10-09T16:45:43.352323Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 91, "duration": "1.635283", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "644504052",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 11, "severity_breakdown":
-        {"critical": 6, "high": 5, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ZGuardian/GitGoat",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12842036,
-        "type": "github", "full_name": "ZGuardian/wrongsecrets", "health": "at_risk",
-        "source_criticality": "critical", "default_branch": "master", "default_branch_head":
-        null, "open_incidents_count": 40, "closed_incidents_count": 24, "last_scan":
-        {"date": "2025-10-09T16:45:43.352396Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 2903, "duration": "28.527595", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "644518416", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        40, "severity_breakdown": {"critical": 35, "high": 5, "medium": 0, "low":
-        0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 24, "severity_breakdown":
-        {"critical": 7, "high": 17, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/ZGuardian/wrongsecrets", "provider_metadata": {"archived":
-        false}, "deleted": false}, {"id": 12842037, "type": "github", "full_name":
-        "ZGuardian/terragoat", "health": "at_risk", "source_criticality": "unknown",
-        "default_branch": "master", "default_branch_head": null, "open_incidents_count":
-        2, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:45:43.352470Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 259, "duration":
-        "8.001244", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "644519103", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 2, "severity_breakdown": {"critical": 1, "high": 1, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/ZGuardian/terragoat",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12842038,
-        "type": "github", "full_name": "ZGuardian/sample_secrets", "health": "at_risk",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 2, "closed_incidents_count": 9, "last_scan":
-        {"date": "2025-10-09T16:45:43.352543Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 14, "duration": "5.126184", "branches_scanned": 3,
-        "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "644877809", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        2, "severity_breakdown": {"critical": 0, "high": 1, "medium": 1, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 9, "severity_breakdown":
-        {"critical": 0, "high": 8, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/ZGuardian/sample_secrets", "provider_metadata":
-        {"archived": false}, "deleted": false}]'
+        11, "last_scan": {"date": "2020-09-24T09:06:39.261262Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 928, "duration": "3.06658", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "284154426", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 11, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12298,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-05",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
+        8, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "264326547", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
+        3, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 8, "severity_breakdown": {"critical": 0, "high": 8, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-05",
+        "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a10398a59c80c2cf-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:46:34 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '16951'
+      - '16935'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:44:44 GMT
       link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjg0MjAzOA%3D%3D&per_page=20>;
-        rel="next", <https://api.gitguardian.com/v1/sources?cursor=cj0xJnA9MTEzNjMyMDQ%3D&per_page=20>;
+      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjI5OA%3D%3D&per_page=20>;
+        rel="next", <https://api.gitguardian.com/v1/sources?cursor=cj0xJnA9MTIyNzk%3D&per_page=20>;
         rel="prev"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '1394'
+      - '451'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_sources_pagination.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_pagination.yaml
@@ -20,80 +20,80 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?per_page=3
   response:
     body:
-      string: '[{"id": 12338, "type": "github", "full_name": "wayne-enterprises-gg/shared-app",
-        "health": "safe", "source_criticality": "low", "default_branch": "master",
-        "default_branch_head": "a219c18ff8e913427c38fc7d90756d6bb1bb5b43", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2026-02-02T10:49:30.905195Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 544, "duration":
-        "0.0", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "218964926", "secret_incidents_breakdown": {"open_secret_incidents":
+      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/shared-app",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12356,
-        "type": "github", "full_name": "wayne-enterprises-gg/with-readme-repo-gg",
-        "health": "safe", "source_criticality": "medium", "default_branch": "master",
-        "default_branch_head": "21ca725ac5028cf45975b49f7b48928f34f73117", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:45:43.352734Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 1, "duration":
-        "3.265244", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "234115319", "secret_incidents_breakdown": {"open_secret_incidents":
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
+        "type": "github", "full_name": "lonely/hunter", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "22", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/with-readme-repo-gg",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12364,
-        "type": "github", "full_name": "wayne-enterprises-gg/business-app", "health":
-        "safe", "source_criticality": "medium", "default_branch": "master", "default_branch_head":
-        "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count": 0, "closed_incidents_count":
-        76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1242, "duration": "9.779904", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "217533545", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 76, "severity_breakdown":
-        {"critical": 3, "high": 73, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/business-app", "provider_metadata":
-        {"archived": false}, "deleted": false}]'
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/hunter",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12261,
+        "type": "github", "full_name": "lonely/time", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "25", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/time",
+        "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a103989a9ed2a9b8-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:46:32 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '2684'
+      - '2119'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:44:34 GMT
       link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjM2NA%3D%3D&per_page=3>;
+      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjI2MQ%3D%3D&per_page=3>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '216'
+      - '564'
       x-frame-options:
       - DENY
       x-per-page:
       - '3'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_sources_with_health_filter.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_with_health_filter.yaml
@@ -20,159 +20,172 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?health=safe&per_page=10
   response:
     body:
-      string: '[{"id": 12338, "type": "github", "full_name": "wayne-enterprises-gg/shared-app",
-        "health": "safe", "source_criticality": "low", "default_branch": "master",
-        "default_branch_head": "a219c18ff8e913427c38fc7d90756d6bb1bb5b43", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2026-02-02T10:49:30.905195Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 544, "duration":
-        "0.0", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
+      string: '[{"id": 12263, "type": "github", "full_name": "my-testing-org/christian_dior",
+        "health": "safe", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": {"date": "2020-09-24T09:06:39.211442Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1, "duration": "1.218169", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "12", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12264,
+        "type": "github", "full_name": "my-testing-org/armani_code", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 1, "last_scan":
+        {"date": "2020-06-04T09:06:33.833273Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 2, "duration": "2.830578", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "30", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 1}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/armani_code",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12265,
+        "type": "github", "full_name": "my-testing-org/louis_vuitton", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:32.770273Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 0, "duration": "1.141495", "branches_scanned": 0, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "13", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/louis_vuitton",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12266,
+        "type": "github", "full_name": "my-testing-org/lagarfeld", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:33.598712Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1, "duration": "1.253906", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "29", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/lagarfeld",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12267,
+        "type": "github", "full_name": "my-testing-org/saint_laurent", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-10-09T12:55:14.542227Z", "status": "canceled", "failing_reason":
+        "", "commits_scanned": 0, "duration": "1.684644", "branches_scanned": 0, "progress":
+        0}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "28", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/saint_laurent",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12286,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2020-11",
+        "health": "safe", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        11, "last_scan": {"date": "2021-01-26T16:46:38.539876Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1486, "duration": "2.780691", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "308995512", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 11, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2020-11",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12297,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-08",
+        "health": "safe", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        11, "last_scan": {"date": "2020-09-24T09:06:39.261262Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 928, "duration": "3.06658", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "284154426", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 11, "severity_breakdown": {"critical": 0, "high": 11, "medium":
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12308,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-10",
+        "health": "safe", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        9, "last_scan": {"date": "2020-12-10T10:45:12.767631Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1251, "duration": "4.299251", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "300095842", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-10",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12312,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2021-04",
+        "health": "safe", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        2, "last_scan": {"date": "2021-05-12T13:40:00.816026Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 701, "duration": "3.011352", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "353525012", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 2, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0,
+        "low": 0, "info": 1, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2021-04",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12338,
+        "type": "github", "full_name": "wayne-enterprises-gg/shared-app", "health":
+        "safe", "source_criticality": "low", "default_branch": "master", "default_branch_head":
+        "a219c18ff8e913427c38fc7d90756d6bb1bb5b43", "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": {"date": "2026-02-02T10:49:30.905195Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 544, "duration": "0.0", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "active", "visibility":
         "public", "external_id": "218964926", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
         "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/shared-app",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12356,
-        "type": "github", "full_name": "wayne-enterprises-gg/with-readme-repo-gg",
-        "health": "safe", "source_criticality": "medium", "default_branch": "master",
-        "default_branch_head": "21ca725ac5028cf45975b49f7b48928f34f73117", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:45:43.352734Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 1, "duration":
-        "3.265244", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "234115319", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/with-readme-repo-gg",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12364,
-        "type": "github", "full_name": "wayne-enterprises-gg/business-app", "health":
-        "safe", "source_criticality": "medium", "default_branch": "master", "default_branch_head":
-        "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count": 0, "closed_incidents_count":
-        76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1242, "duration": "9.779904", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "217533545", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 76, "severity_breakdown":
-        {"critical": 3, "high": 73, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/business-app", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 12369, "type": "github", "full_name":
-        "aymericGG/hello-world", "health": "safe", "source_criticality": "high", "default_branch":
-        "master", "default_branch_head": "665b4e495aef1d7b6737a503209407a297d37772",
-        "open_incidents_count": 0, "closed_incidents_count": 3, "last_scan": {"date":
-        "2025-10-09T16:45:43.352983Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 10, "duration": "0.84662", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "175174005",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
-        0, "high": 3, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/hello-world",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12370,
-        "type": "github", "full_name": "aymericGG/Project-back", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "", "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:45:43.353058Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.01237", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "253745397",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/Project-back",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12371,
-        "type": "github", "full_name": "aymericGG/Project-Front", "health": "safe",
-        "source_criticality": "high", "default_branch": "", "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:45:43.353136Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.012344", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "253745330",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/Project-Front",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 9123340,
-        "type": "github", "full_name": "orga-083643/solid-octo", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "1218ef7297f84f36297c0111ea88b54b9befd365", "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": {"date": "2025-10-09T16:45:43.351408Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 7, "duration": "1.120819", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "630519649", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/orga-083643/solid-octo", "provider_metadata": {"archived":
-        false}, "deleted": false}, {"id": 9123465, "type": "github", "full_name":
-        "orga-083643/expert-train", "health": "safe", "source_criticality": "unknown",
-        "default_branch": "main", "default_branch_head": "1e3f25567a57f788700cbe9b21a05fb2a3dd23f9",
-        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
-        "2025-10-09T16:45:43.353647Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 4, "duration": "4.092814", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "630525080",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/expert-train",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 9123810,
-        "type": "github", "full_name": "orga-083643/ideal-journey", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "ab24e2860796dff2a67c4915b1a6d745b13bdd76", "open_incidents_count": 0, "closed_incidents_count":
-        1, "last_scan": {"date": "2025-10-09T16:45:43.354999Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 3, "duration": "0.866616", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "630531940", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/orga-083643/ideal-journey", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 9123882, "type": "github",
-        "full_name": "orga-083643/analytics-test", "health": "safe", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": "f19d79466ce40e0bb69c9ee0ea08787ead9b5845",
-        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
-        "2025-10-09T16:45:43.352186Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 7, "duration": "0.942938", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "630536182",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/analytics-test",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a103980ccc0ac44b-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:46:24 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '8700'
+      - '8971'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:44:19 GMT
       link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD05MTIzODgy&health=safe&per_page=10>;
+      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjMzOA%3D%3D&health=safe&per_page=10>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '10891'
+      - '14720'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_sources_with_monitored_filter.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_with_monitored_filter.yaml
@@ -20,159 +20,161 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?monitored=true&per_page=10
   response:
     body:
-      string: '[{"id": 12338, "type": "github", "full_name": "wayne-enterprises-gg/shared-app",
-        "health": "safe", "source_criticality": "low", "default_branch": "master",
-        "default_branch_head": "a219c18ff8e913427c38fc7d90756d6bb1bb5b43", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2026-02-02T10:49:30.905195Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 544, "duration":
-        "0.0", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "218964926", "secret_incidents_breakdown": {"open_secret_incidents":
+      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/shared-app",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12356,
-        "type": "github", "full_name": "wayne-enterprises-gg/with-readme-repo-gg",
-        "health": "safe", "source_criticality": "medium", "default_branch": "master",
-        "default_branch_head": "21ca725ac5028cf45975b49f7b48928f34f73117", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:45:43.352734Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 1, "duration":
-        "3.265244", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "234115319", "secret_incidents_breakdown": {"open_secret_incidents":
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
+        "type": "github", "full_name": "lonely/hunter", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "22", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/hunter",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12261,
+        "type": "github", "full_name": "lonely/time", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "25", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/time",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12262,
+        "type": "github", "full_name": "lonely/tower", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "24", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/tower",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12263,
+        "type": "github", "full_name": "my-testing-org/christian_dior", "health":
+        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:39.211442Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1, "duration": "1.218169", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "12", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/with-readme-repo-gg",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12364,
-        "type": "github", "full_name": "wayne-enterprises-gg/business-app", "health":
-        "safe", "source_criticality": "medium", "default_branch": "master", "default_branch_head":
-        "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count": 0, "closed_incidents_count":
-        76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1242, "duration": "9.779904", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "217533545", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 76, "severity_breakdown":
-        {"critical": 3, "high": 73, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/business-app", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 12369, "type": "github", "full_name":
-        "aymericGG/hello-world", "health": "safe", "source_criticality": "high", "default_branch":
-        "master", "default_branch_head": "665b4e495aef1d7b6737a503209407a297d37772",
-        "open_incidents_count": 0, "closed_incidents_count": 3, "last_scan": {"date":
-        "2025-10-09T16:45:43.352983Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 10, "duration": "0.84662", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "175174005",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
-        0, "high": 3, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/hello-world",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12370,
-        "type": "github", "full_name": "aymericGG/Project-back", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "", "default_branch_head":
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12264,
+        "type": "github", "full_name": "my-testing-org/armani_code", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 1, "last_scan":
+        {"date": "2020-06-04T09:06:33.833273Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 2, "duration": "2.830578", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "30", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 1}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/armani_code",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12265,
+        "type": "github", "full_name": "my-testing-org/louis_vuitton", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:45:43.353058Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.01237", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "253745397",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/Project-back",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12371,
-        "type": "github", "full_name": "aymericGG/Project-Front", "health": "safe",
-        "source_criticality": "high", "default_branch": "", "default_branch_head":
+        {"date": "2020-09-24T09:06:32.770273Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 0, "duration": "1.141495", "branches_scanned": 0, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "13", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/louis_vuitton",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12266,
+        "type": "github", "full_name": "my-testing-org/lagarfeld", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:45:43.353136Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.012344", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "253745330",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/Project-Front",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 9123340,
-        "type": "github", "full_name": "orga-083643/solid-octo", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "1218ef7297f84f36297c0111ea88b54b9befd365", "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": {"date": "2025-10-09T16:45:43.351408Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 7, "duration": "1.120819", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "630519649", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
+        {"date": "2020-09-24T09:06:33.598712Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1, "duration": "1.253906", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "29", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/orga-083643/solid-octo", "provider_metadata": {"archived":
-        false}, "deleted": false}, {"id": 9123465, "type": "github", "full_name":
-        "orga-083643/expert-train", "health": "safe", "source_criticality": "unknown",
-        "default_branch": "main", "default_branch_head": "1e3f25567a57f788700cbe9b21a05fb2a3dd23f9",
-        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
-        "2025-10-09T16:45:43.353647Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 4, "duration": "4.092814", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "630525080",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/expert-train",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 9123810,
-        "type": "github", "full_name": "orga-083643/ideal-journey", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "ab24e2860796dff2a67c4915b1a6d745b13bdd76", "open_incidents_count": 0, "closed_incidents_count":
-        1, "last_scan": {"date": "2025-10-09T16:45:43.354999Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 3, "duration": "0.866616", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "630531940", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/lagarfeld",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12267,
+        "type": "github", "full_name": "my-testing-org/saint_laurent", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-10-09T12:55:14.542227Z", "status": "canceled", "failing_reason":
+        "", "commits_scanned": 0, "duration": "1.684644", "branches_scanned": 0, "progress":
+        0}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "28", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/orga-083643/ideal-journey", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 9123882, "type": "github",
-        "full_name": "orga-083643/analytics-test", "health": "safe", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": "f19d79466ce40e0bb69c9ee0ea08787ead9b5845",
-        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
-        "2025-10-09T16:45:43.352186Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 7, "duration": "0.942938", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "630536182",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/analytics-test",
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/saint_laurent",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12268,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2021-04",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
+        3, "last_scan": {"date": "2021-05-12T13:40:00.812612Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 686, "duration": "2.80448", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "353525015", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        1, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 3, "severity_breakdown": {"critical": 0, "high": 3, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2021-04",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a10398c45c940cd3-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:46:39 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '8700'
+      - '8150'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:44:52 GMT
       link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD05MTIzODgy&monitored=true&per_page=10>;
+      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjI2OA%3D%3D&monitored=true&per_page=10>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '7130'
+      - '474'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_sources_with_ordering.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_with_ordering.yaml
@@ -20,92 +20,108 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?ordering=-last_scan_date&per_page=5
   response:
     body:
-      string: '[{"id": 22877000, "type": "custom_source", "full_name": "GitHub Gist",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
-        20, "last_scan": null, "monitored": true, "visibility": "private", "external_id":
-        "6345947b-7ae5-406e-8655-6ea41785dba1", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 4, "severity_breakdown": {"critical": 3, "high": 1, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        20, "severity_breakdown": {"critical": 0, "high": 10, "medium": 1, "low":
-        0, "info": 0, "unknown": 9}}}, "url": "", "provider_metadata": {"archived":
-        false}, "deleted": false}, {"id": 26301895, "type": "sharepoint_online_drive",
-        "full_name": "Olivier Local testing (document libraries) / Documents", "health":
+      string: '[{"id": 17543387, "type": "microsoft_teams", "full_name": "GitGuardian
+        Engineering / Team 10 / 648 - a5c6943a5f124a5c96fe5b6c390a6f73", "health":
         "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        null, "monitored": false, "visibility": "private", "external_id": "b!228zEW-fFkq1-2oX01HbwHGZCWcIaVdMoP3Smh_fYPO2jtDlq8vWRaNE2VXTEJXs",
+        null, "monitored": false, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "19:8a2bdaf018b145faa7bf0aa4c6d9850d@thread.tacv2",
         "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
         {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
         "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitguardianengineering.sharepoint.com/sites/OlivierLocaltesting/Shared%20Documents",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 26694166,
-        "type": "slack", "full_name": "Testing Slack / #nouveau-canal", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        null, "monitored": true, "visibility": "public", "external_id": "C0ADSEJ45RT",
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://teams.microsoft.com/l/channel/19:8a2bdaf018b145faa7bf0aa4c6d9850d@thread.tacv2/648
+        - a5c6943a5f124a5c96fe5b6c390a6f73?groupId=3246a4a0-4abf-453d-a53a-f4d4f8b3cbf5&tenantId=1eb62cd2-9303-4be2-8187-2404c20ba039",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 17535602,
+        "type": "microsoft_teams", "full_name": "GitGuardian Engineering / team 12
+        / 689 - 522d63b20b20462fa75d3914f8ca2b12", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": false, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "19:c54840820fda4342a07fa5339f10d9ec@thread.tacv2",
         "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
         {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
         "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://11deletetestingslack.slack.com/archives/C0ADSEJ45RT",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 26301896,
-        "type": "sharepoint_online_pages", "full_name": "Olivier Local testing / Olivier
-        Local testing (pages)", "health": "unknown", "source_criticality": "unknown",
-        "default_branch": null, "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": false, "visibility":
-        "private", "external_id": "gitguardianengineering.sharepoint.com,11336fdb-9f6f-4a16-b5fb-6a17d351dbc0,67099971-6908-4c57-a0fd-d29a1fdf60f3:pages",
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://teams.microsoft.com/l/channel/19:c54840820fda4342a07fa5339f10d9ec@thread.tacv2/689
+        - 522d63b20b20462fa75d3914f8ca2b12?groupId=5dd00fc6-e9f1-40f6-994f-f8dca95b85bd&tenantId=1eb62cd2-9303-4be2-8187-2404c20ba039",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 17535609,
+        "type": "microsoft_teams", "full_name": "GitGuardian Engineering / team 12
+        / 945 - 522d63b20b20462fa75d3914f8ca2b12", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": false, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "19:c6fc498b392c4f7dbc37cb9ca469451b@thread.tacv2",
         "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
         {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
         "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitguardianengineering.sharepoint.com/sites/OlivierLocaltesting",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 19962427,
-        "type": "sharepoint_online_drive", "full_name": "general (document libraries)
-        / Documents", "health": "at_risk", "source_criticality": "unknown", "default_branch":
-        null, "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
-        1, "last_scan": null, "monitored": false, "visibility": "private", "external_id":
-        "b!I-MdHUXO9kiy2OmlVlg6PnySr3C4I49Cl0Q2EMNTyLC1yg1Wdp7qTpcJu1zCcTNy", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 1}}, "closed_secret_incidents":
-        {"total": 1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://gitguardianengineering.sharepoint.com/sites/general/Shared%20Documents",
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://teams.microsoft.com/l/channel/19:c6fc498b392c4f7dbc37cb9ca469451b@thread.tacv2/945
+        - 522d63b20b20462fa75d3914f8ca2b12?groupId=5dd00fc6-e9f1-40f6-994f-f8dca95b85bd&tenantId=1eb62cd2-9303-4be2-8187-2404c20ba039",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 17541285,
+        "type": "microsoft_teams", "full_name": "GitGuardian Engineering / Team 1
+        / 721 - b2d26e09fae34fcb85276c0306347b83", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": false, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "19:6f33c72b26384ecaa95c698ddbb080ab@thread.tacv2",
+        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
+        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
+        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://teams.microsoft.com/l/channel/19:6f33c72b26384ecaa95c698ddbb080ab@thread.tacv2/721
+        - b2d26e09fae34fcb85276c0306347b83?groupId=3facb188-3dcf-4f87-b4c7-5d047d87c76f&tenantId=1eb62cd2-9303-4be2-8187-2404c20ba039",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 17535603,
+        "type": "microsoft_teams", "full_name": "GitGuardian Engineering / team 12
+        / 892 - 522d63b20b20462fa75d3914f8ca2b12", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": false, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "19:c55077d54e434d198bb3d80ac7eaae1d@thread.tacv2",
+        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
+        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
+        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://teams.microsoft.com/l/channel/19:c55077d54e434d198bb3d80ac7eaae1d@thread.tacv2/892
+        - 522d63b20b20462fa75d3914f8ca2b12?groupId=5dd00fc6-e9f1-40f6-994f-f8dca95b85bd&tenantId=1eb62cd2-9303-4be2-8187-2404c20ba039",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a103988ecae602c1-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:46:31 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '3900'
+      - '4990'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:44:32 GMT
       link:
       - <https://api.gitguardian.com/v1/sources?cursor=bz01&ordering=-last_scan_date&per_page=5>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '321'
+      - '939'
       x-frame-options:
       - DENY
       x-per-page:
       - '5'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_sources_with_per_page.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_with_per_page.yaml
@@ -20,80 +20,80 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?per_page=3
   response:
     body:
-      string: '[{"id": 12338, "type": "github", "full_name": "wayne-enterprises-gg/shared-app",
-        "health": "safe", "source_criticality": "low", "default_branch": "master",
-        "default_branch_head": "a219c18ff8e913427c38fc7d90756d6bb1bb5b43", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2026-02-02T10:49:30.905195Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 544, "duration":
-        "0.0", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "218964926", "secret_incidents_breakdown": {"open_secret_incidents":
+      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/shared-app",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12356,
-        "type": "github", "full_name": "wayne-enterprises-gg/with-readme-repo-gg",
-        "health": "safe", "source_criticality": "medium", "default_branch": "master",
-        "default_branch_head": "21ca725ac5028cf45975b49f7b48928f34f73117", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:45:43.352734Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 1, "duration":
-        "3.265244", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "234115319", "secret_incidents_breakdown": {"open_secret_incidents":
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
+        "type": "github", "full_name": "lonely/hunter", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "22", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/with-readme-repo-gg",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12364,
-        "type": "github", "full_name": "wayne-enterprises-gg/business-app", "health":
-        "safe", "source_criticality": "medium", "default_branch": "master", "default_branch_head":
-        "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count": 0, "closed_incidents_count":
-        76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1242, "duration": "9.779904", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "217533545", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 76, "severity_breakdown":
-        {"critical": 3, "high": 73, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/business-app", "provider_metadata":
-        {"archived": false}, "deleted": false}]'
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/hunter",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12261,
+        "type": "github", "full_name": "lonely/time", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "25", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/time",
+        "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a10398963e3e9ef3-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:46:32 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '2684'
+      - '2119'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:44:33 GMT
       link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjM2NA%3D%3D&per_page=3>;
+      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjI2MQ%3D%3D&per_page=3>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '201'
+      - '458'
       x-frame-options:
       - DENY
       x-per-page:
       - '3'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_sources_with_search.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_with_search.yaml
@@ -20,156 +20,162 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?search=test&per_page=10
   response:
     body:
-      string: '[{"id": 9123882, "type": "github", "full_name": "orga-083643/analytics-test",
-        "health": "safe", "source_criticality": "unknown", "default_branch": "main",
-        "default_branch_head": "f19d79466ce40e0bb69c9ee0ea08787ead9b5845", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:45:43.352186Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 7, "duration":
-        "0.942938", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "private", "external_id": "630536182", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/analytics-test",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11363204,
-        "type": "github", "full_name": "amascia-gg/ftn-test-circleci", "health": "at_risk",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 2, "closed_incidents_count": 1, "last_scan":
-        {"date": "2025-10-09T16:45:43.354963Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 3121, "duration": "95.292729", "branches_scanned":
-        2, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "704004504", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        2, "severity_breakdown": {"critical": 1, "high": 1, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/amascia-gg/ftn-test-circleci", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 11677085, "type": "github",
-        "full_name": "peterringball/test", "health": "unknown", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": false, "visibility":
-        "private", "external_id": "673461264", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/peterringball/test",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11678252,
-        "type": "github", "full_name": "tuches/Test", "health": "safe", "source_criticality":
-        "low", "default_branch": "master", "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 1, "last_scan": {"date": "2025-10-09T16:45:43.352050Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 5, "duration":
-        "0.68205", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "291043633", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        1, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/tuches/Test", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 11756704, "type": "github",
-        "full_name": "peterringball/test4", "health": "safe", "source_criticality":
-        "low", "default_branch": "main", "default_branch_head": "d7d00895483d9e6fd62acf72594199ee5cabf7c7",
-        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
-        "2025-10-09T16:45:43.353873Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 32, "duration": "3.878778", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "684649378",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/peterringball/test4",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12322614,
-        "type": "slack", "full_name": "Demo Slack Integration / #test-timothe-delion",
+      string: '[{"id": 12263, "type": "github", "full_name": "my-testing-org/christian_dior",
         "health": "safe", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": {"date": "2025-10-09T16:44:19.449065Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 0, "duration": "0.233054", "branches_scanned":
-        0, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "C06D386SZC0", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
+        0, "last_scan": {"date": "2020-09-24T09:06:39.211442Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1, "duration": "1.218169", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "12", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12264,
+        "type": "github", "full_name": "my-testing-org/armani_code", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 1, "last_scan":
+        {"date": "2020-06-04T09:06:33.833273Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 2, "duration": "2.830578", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "30", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 1}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/armani_code",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12265,
+        "type": "github", "full_name": "my-testing-org/louis_vuitton", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:32.770273Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 0, "duration": "1.141495", "branches_scanned": 0, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "13", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://demoslackinte-0vf1761.slack.com/archives/C06D386SZC0", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 12470998, "type": "slack",
-        "full_name": "Demo Slack Integration / #test-channel-creation", "health":
-        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/louis_vuitton",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12266,
+        "type": "github", "full_name": "my-testing-org/lagarfeld", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:44:19.444580Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.23533", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "C06EGV15G8Z",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://demoslackinte-0vf1761.slack.com/archives/C06EGV15G8Z",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12482445,
-        "type": "slack", "full_name": "Demo Slack Integration / #test", "health":
-        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        {"date": "2020-09-24T09:06:33.598712Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1, "duration": "1.253906", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "29", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/lagarfeld",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12267,
+        "type": "github", "full_name": "my-testing-org/saint_laurent", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:44:19.440496Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.26622", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "C06EYF11U0G",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://demoslackinte-0vf1761.slack.com/archives/C06EYF11U0G",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12662970,
-        "type": "github", "full_name": "aymericGG/sample_secrets_Codacytest", "health":
+        {"date": "2020-10-09T12:55:14.542227Z", "status": "canceled", "failing_reason":
+        "", "commits_scanned": 0, "duration": "1.684644", "branches_scanned": 0, "progress":
+        0}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "28", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/saint_laurent",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 3342391,
+        "type": "github", "full_name": "github-app-test-eugene/test", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": "master", "default_branch_head":
+        "739d8fc531ae1130672b694ef20d445be095266c", "open_incidents_count": 0, "closed_incidents_count":
+        6, "last_scan": null, "monitored": false, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "157555465", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 6, "severity_breakdown": {"critical": 0, "high": 6, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/github-app-test-eugene/test",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 3342392,
+        "type": "github", "full_name": "github-app-test-eugene/test_preprod", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
+        "59ad17cf384bb8abdb3fd21bdc557382b8f85fbf", "open_incidents_count": 0, "closed_incidents_count":
+        4, "last_scan": null, "monitored": false, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "327924619", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 4, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 4}}}, "url": "https://github.com/github-app-test-eugene/test_preprod",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6088722,
+        "type": "github", "full_name": "github-app-test-eugene/test_local_1", "health":
         "at_risk", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 1, "closed_incidents_count": 2, "last_scan":
-        {"date": "2025-10-09T16:45:43.354102Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 7, "duration": "2.949598", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "750268193",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 1, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
-        0, "high": 1, "medium": 1, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/sample_secrets_Codacytest",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12663154,
-        "type": "github", "full_name": "aymericGG/juice-shop-Codacytest", "health":
-        "at_risk", "source_criticality": "unknown", "default_branch": "master", "default_branch_head":
-        null, "open_incidents_count": 52, "closed_incidents_count": 33, "last_scan":
-        {"date": "2026-01-15T16:49:11.671959Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 19830, "duration": "82.392816", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "750273107", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        52, "severity_breakdown": {"critical": 27, "high": 25, "medium": 0, "low":
-        0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 33, "severity_breakdown":
-        {"critical": 2, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 30}}},
-        "url": "https://github.com/aymericGG/juice-shop-Codacytest", "provider_metadata":
-        {"archived": false}, "deleted": false}]'
+        "529672f724fe0cb58ec7db5753f1ba8c26e62b1f", "open_incidents_count": 13, "closed_incidents_count":
+        8, "last_scan": null, "monitored": false, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "515202288", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 13, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 13}}, "closed_secret_incidents":
+        {"total": 8, "severity_breakdown": {"critical": 0, "high": 4, "medium": 0,
+        "low": 0, "info": 0, "unknown": 4}}}, "url": "https://github.com/github-app-test-eugene/test_local_1",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6088740,
+        "type": "github", "full_name": "github-app-test-eugene/test_local_2", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
+        "5f014343520d1baefd1dc34a9fca19ae210b052a", "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": false, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "515203110", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/github-app-test-eugene/test_local_2",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6088766,
+        "type": "github", "full_name": "github-app-test-eugene/test_local_3", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
+        "587f67ce9635b955452eb56a69ddae46e8bcbae6", "open_incidents_count": 0, "closed_incidents_count":
+        1, "last_scan": null, "monitored": false, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "515204240", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://github.com/github-app-test-eugene/test_local_3",
+        "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a10397e71dfaf174-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:46:04 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '8418'
+      - '8354'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:43:55 GMT
       link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjY2MzE1NA%3D%3D&per_page=10&search=test>;
+      - <https://api.gitguardian.com/v1/sources?cursor=cD02MDg4NzY2&per_page=10&search=test>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '222'
+      - '831'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_sources_with_source_criticality_filter.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_with_source_criticality_filter.yaml
@@ -20,157 +20,161 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?source_criticality=unknown&per_page=10
   response:
     body:
-      string: '[{"id": 12370, "type": "github", "full_name": "aymericGG/Project-back",
-        "health": "safe", "source_criticality": "unknown", "default_branch": "", "default_branch_head":
+      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:45:43.353058Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.01237", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "253745397",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/Project-back",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 9123340,
-        "type": "github", "full_name": "orga-083643/solid-octo", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "1218ef7297f84f36297c0111ea88b54b9befd365", "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": {"date": "2025-10-09T16:45:43.351408Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 7, "duration": "1.120819", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "630519649", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/orga-083643/solid-octo", "provider_metadata": {"archived":
-        false}, "deleted": false}, {"id": 9123465, "type": "github", "full_name":
-        "orga-083643/expert-train", "health": "safe", "source_criticality": "unknown",
-        "default_branch": "main", "default_branch_head": "1e3f25567a57f788700cbe9b21a05fb2a3dd23f9",
-        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
-        "2025-10-09T16:45:43.353647Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 4, "duration": "4.092814", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "630525080",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/expert-train",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 9123810,
-        "type": "github", "full_name": "orga-083643/ideal-journey", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "ab24e2860796dff2a67c4915b1a6d745b13bdd76", "open_incidents_count": 0, "closed_incidents_count":
-        1, "last_scan": {"date": "2025-10-09T16:45:43.354999Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 3, "duration": "0.866616", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "630531940", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/orga-083643/ideal-journey", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 9123882, "type": "github",
-        "full_name": "orga-083643/analytics-test", "health": "safe", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": "f19d79466ce40e0bb69c9ee0ea08787ead9b5845",
-        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
-        "2025-10-09T16:45:43.352186Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 7, "duration": "0.942938", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "630536182",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/analytics-test",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 9124147,
-        "type": "github", "full_name": "orga-083643/improved-carnival", "health":
-        "safe", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "cdaa5dd8497a52a75702879823adc18141ad88b4", "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": {"date": "2025-10-09T16:45:43.354520Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 4, "duration": "3.881061", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "630548292", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/orga-083643/improved-carnival", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 10836673, "type": "github",
-        "full_name": "leakymcgee/secretproject", "health": "at_risk", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": "6fa238be5c8773d3560627df4597c1b0cddc708d",
-        "open_incidents_count": 6, "closed_incidents_count": 2, "last_scan": {"date":
-        "2025-10-09T16:45:43.354139Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 9, "duration": "0.0", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "684998195",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 6, "severity_breakdown":
-        {"critical": 5, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
-        0, "high": 2, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/leakymcgee/secretproject",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11270152,
-        "type": "slack", "full_name": "Demo Slack Integration / #general", "health":
-        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 4, "closed_incidents_count": 6, "last_scan":
-        {"date": "2025-10-09T16:44:19.448855Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "2.282765", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "C05V11N7B1T",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 4, "severity_breakdown":
-        {"critical": 2, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 1}},
-        "closed_secret_incidents": {"total": 6, "severity_breakdown": {"critical":
-        3, "high": 1, "medium": 0, "low": 0, "info": 2, "unknown": 0}}}, "url": "https://demoslackinte-0vf1761.slack.com/archives/C05V11N7B1T",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11270153,
-        "type": "slack", "full_name": "Demo Slack Integration / #random", "health":
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
+        "type": "github", "full_name": "lonely/hunter", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "22", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/hunter",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12261,
+        "type": "github", "full_name": "lonely/time", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "25", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/time",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12262,
+        "type": "github", "full_name": "lonely/tower", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "24", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/tower",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12263,
+        "type": "github", "full_name": "my-testing-org/christian_dior", "health":
         "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:44:19.448890Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.215615", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "C0602J433A5",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://demoslackinte-0vf1761.slack.com/archives/C0602J433A5",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11328061,
-        "type": "slack", "full_name": "Demo Slack Integration / #demo-231009", "health":
-        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 2, "closed_incidents_count": 4, "last_scan":
-        {"date": "2025-10-09T16:44:19.448925Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.206472", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "C05VBD2TDST",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 2, "severity_breakdown":
-        {"critical": 0, "high": 2, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
-        1, "high": 1, "medium": 0, "low": 0, "info": 1, "unknown": 1}}}, "url": "https://demoslackinte-0vf1761.slack.com/archives/C05VBD2TDST",
+        {"date": "2020-09-24T09:06:39.211442Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1, "duration": "1.218169", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "12", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12264,
+        "type": "github", "full_name": "my-testing-org/armani_code", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 1, "last_scan":
+        {"date": "2020-06-04T09:06:33.833273Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 2, "duration": "2.830578", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "30", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 1}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/armani_code",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12265,
+        "type": "github", "full_name": "my-testing-org/louis_vuitton", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:32.770273Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 0, "duration": "1.141495", "branches_scanned": 0, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "13", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/louis_vuitton",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12266,
+        "type": "github", "full_name": "my-testing-org/lagarfeld", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:33.598712Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1, "duration": "1.253906", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "29", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/lagarfeld",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12267,
+        "type": "github", "full_name": "my-testing-org/saint_laurent", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-10-09T12:55:14.542227Z", "status": "canceled", "failing_reason":
+        "", "commits_scanned": 0, "duration": "1.684644", "branches_scanned": 0, "progress":
+        0}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "28", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/saint_laurent",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12268,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2021-04",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
+        3, "last_scan": {"date": "2021-05-12T13:40:00.812612Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 686, "duration": "2.80448", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "353525015", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        1, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 3, "severity_breakdown": {"critical": 0, "high": 3, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2021-04",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a103987068f823e6-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:46:30 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '8681'
+      - '8150'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:44:32 GMT
       link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMTMyODA2MQ%3D%3D&per_page=10&source_criticality=unknown>;
+      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjI2OA%3D%3D&per_page=10&source_criticality=unknown>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '11353'
+      - '4514'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_sources_with_team_id_filter.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_with_team_id_filter.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate, zstd
+      - gzip, deflate
       Connection:
       - keep-alive
       Content-Type:
@@ -20,149 +20,32 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?team_id=1&per_page=10
   response:
     body:
-      string: '[{"id": 12338, "type": "github", "full_name": "wayne-enterprises-gg/shared-app",
-        "health": "safe", "source_criticality": "low", "default_branch": "master",
-        "default_branch_head": "a219c18ff8e913427c38fc7d90756d6bb1bb5b43", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2026-02-02T10:49:30.905195Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 544, "duration":
-        "0.0", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "218964926", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/shared-app",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12356,
-        "type": "github", "full_name": "wayne-enterprises-gg/with-readme-repo-gg",
-        "health": "safe", "source_criticality": "medium", "default_branch": "master",
-        "default_branch_head": "21ca725ac5028cf45975b49f7b48928f34f73117", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:45:43.352734Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 1, "duration":
-        "3.265244", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "234115319", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/with-readme-repo-gg",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12364,
-        "type": "github", "full_name": "wayne-enterprises-gg/business-app", "health":
-        "safe", "source_criticality": "medium", "default_branch": "master", "default_branch_head":
-        "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count": 0, "closed_incidents_count":
-        76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1242, "duration": "9.779904", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "217533545", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 76, "severity_breakdown":
-        {"critical": 3, "high": 73, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/business-app", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 12369, "type": "github", "full_name":
-        "aymericGG/hello-world", "health": "safe", "source_criticality": "high", "default_branch":
-        "master", "default_branch_head": "665b4e495aef1d7b6737a503209407a297d37772",
-        "open_incidents_count": 0, "closed_incidents_count": 3, "last_scan": {"date":
-        "2025-10-09T16:45:43.352983Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 10, "duration": "0.84662", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "175174005",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
-        0, "high": 3, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/hello-world",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12370,
-        "type": "github", "full_name": "aymericGG/Project-back", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "", "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:45:43.353058Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.01237", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "253745397",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/Project-back",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12371,
-        "type": "github", "full_name": "aymericGG/Project-Front", "health": "safe",
-        "source_criticality": "high", "default_branch": "", "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:45:43.353136Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.012344", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "253745330",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/Project-Front",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 9123340,
-        "type": "github", "full_name": "orga-083643/solid-octo", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "1218ef7297f84f36297c0111ea88b54b9befd365", "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": {"date": "2025-10-09T16:45:43.351408Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 7, "duration": "1.120819", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "630519649", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/orga-083643/solid-octo", "provider_metadata": {"archived":
-        false}, "deleted": false}, {"id": 9123465, "type": "github", "full_name":
-        "orga-083643/expert-train", "health": "safe", "source_criticality": "unknown",
-        "default_branch": "main", "default_branch_head": "1e3f25567a57f788700cbe9b21a05fb2a3dd23f9",
-        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
-        "2025-10-09T16:45:43.353647Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 4, "duration": "4.092814", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "630525080",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/expert-train",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 9123810,
-        "type": "github", "full_name": "orga-083643/ideal-journey", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "ab24e2860796dff2a67c4915b1a6d745b13bdd76", "open_incidents_count": 0, "closed_incidents_count":
-        1, "last_scan": {"date": "2025-10-09T16:45:43.354999Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 3, "duration": "0.866616", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "630531940", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/orga-083643/ideal-journey", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 9123882, "type": "github",
-        "full_name": "orga-083643/analytics-test", "health": "safe", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": "f19d79466ce40e0bb69c9ee0ea08787ead9b5845",
-        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
-        "2025-10-09T16:45:43.352186Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 7, "duration": "0.942938", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "630536182",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/analytics-test",
-        "provider_metadata": {"archived": false}, "deleted": false}]'
+      string: '[]'
     headers:
       CF-RAY:
-      - 9fe2e86a08d7ebb1-CDG
+      - a10398ab093288fd-CDG
       Connection:
       - keep-alive
+      Content-Length:
+      - '2'
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 May 2026 11:54:56 GMT
+      - Tue, 23 Jun 2026 12:46:38 GMT
       Server:
       - cloudflare
-      Transfer-Encoding:
-      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
       cf-cache-status:
       - DYNAMIC
-      content-length:
-      - '8700'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
       - same-origin
       link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD05MTIzODgy&per_page=10&team_id=1>;
-        rel="next"
+      - ''
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -170,17 +53,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.468.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '19558'
+      - '3705'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.162.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_sources_with_type_filter.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_with_type_filter.yaml
@@ -20,159 +20,161 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?type=github&per_page=10
   response:
     body:
-      string: '[{"id": 12338, "type": "github", "full_name": "wayne-enterprises-gg/shared-app",
-        "health": "safe", "source_criticality": "low", "default_branch": "master",
-        "default_branch_head": "a219c18ff8e913427c38fc7d90756d6bb1bb5b43", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2026-02-02T10:49:30.905195Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 544, "duration":
-        "0.0", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "218964926", "secret_incidents_breakdown": {"open_secret_incidents":
+      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/shared-app",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12356,
-        "type": "github", "full_name": "wayne-enterprises-gg/with-readme-repo-gg",
-        "health": "safe", "source_criticality": "medium", "default_branch": "master",
-        "default_branch_head": "21ca725ac5028cf45975b49f7b48928f34f73117", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:45:43.352734Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 1, "duration":
-        "3.265244", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "public", "external_id": "234115319", "secret_incidents_breakdown": {"open_secret_incidents":
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
+        "type": "github", "full_name": "lonely/hunter", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "22", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/hunter",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12261,
+        "type": "github", "full_name": "lonely/time", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "25", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/time",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12262,
+        "type": "github", "full_name": "lonely/tower", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
+        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
+        "deleted_on_remote", "visibility": "public", "external_id": "24", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/tower",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12263,
+        "type": "github", "full_name": "my-testing-org/christian_dior", "health":
+        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:39.211442Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1, "duration": "1.218169", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "12", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/with-readme-repo-gg",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12364,
-        "type": "github", "full_name": "wayne-enterprises-gg/business-app", "health":
-        "safe", "source_criticality": "medium", "default_branch": "master", "default_branch_head":
-        "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count": 0, "closed_incidents_count":
-        76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1242, "duration": "9.779904", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "public", "external_id":
-        "217533545", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 76, "severity_breakdown":
-        {"critical": 3, "high": 73, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/wayne-enterprises-gg/business-app", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 12369, "type": "github", "full_name":
-        "aymericGG/hello-world", "health": "safe", "source_criticality": "high", "default_branch":
-        "master", "default_branch_head": "665b4e495aef1d7b6737a503209407a297d37772",
-        "open_incidents_count": 0, "closed_incidents_count": 3, "last_scan": {"date":
-        "2025-10-09T16:45:43.352983Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 10, "duration": "0.84662", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "175174005",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
-        0, "high": 3, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/hello-world",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12370,
-        "type": "github", "full_name": "aymericGG/Project-back", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "", "default_branch_head":
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12264,
+        "type": "github", "full_name": "my-testing-org/armani_code", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 1, "last_scan":
+        {"date": "2020-06-04T09:06:33.833273Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 2, "duration": "2.830578", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "30", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 1}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/armani_code",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12265,
+        "type": "github", "full_name": "my-testing-org/louis_vuitton", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:45:43.353058Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.01237", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "253745397",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/Project-back",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12371,
-        "type": "github", "full_name": "aymericGG/Project-Front", "health": "safe",
-        "source_criticality": "high", "default_branch": "", "default_branch_head":
+        {"date": "2020-09-24T09:06:32.770273Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 0, "duration": "1.141495", "branches_scanned": 0, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "13", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/louis_vuitton",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12266,
+        "type": "github", "full_name": "my-testing-org/lagarfeld", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:45:43.353136Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 0, "duration": "0.012344", "branches_scanned": 0, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "253745330",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/aymericGG/Project-Front",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 9123340,
-        "type": "github", "full_name": "orga-083643/solid-octo", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "1218ef7297f84f36297c0111ea88b54b9befd365", "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": {"date": "2025-10-09T16:45:43.351408Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 7, "duration": "1.120819", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "630519649", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
+        {"date": "2020-09-24T09:06:33.598712Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1, "duration": "1.253906", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "29", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/orga-083643/solid-octo", "provider_metadata": {"archived":
-        false}, "deleted": false}, {"id": 9123465, "type": "github", "full_name":
-        "orga-083643/expert-train", "health": "safe", "source_criticality": "unknown",
-        "default_branch": "main", "default_branch_head": "1e3f25567a57f788700cbe9b21a05fb2a3dd23f9",
-        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
-        "2025-10-09T16:45:43.353647Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 4, "duration": "4.092814", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "public", "external_id": "630525080",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/expert-train",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 9123810,
-        "type": "github", "full_name": "orga-083643/ideal-journey", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "ab24e2860796dff2a67c4915b1a6d745b13bdd76", "open_incidents_count": 0, "closed_incidents_count":
-        1, "last_scan": {"date": "2025-10-09T16:45:43.354999Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 3, "duration": "0.866616", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "630531940", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/lagarfeld",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12267,
+        "type": "github", "full_name": "my-testing-org/saint_laurent", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-10-09T12:55:14.542227Z", "status": "canceled", "failing_reason":
+        "", "commits_scanned": 0, "duration": "1.684644", "branches_scanned": 0, "progress":
+        0}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "28", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/orga-083643/ideal-journey", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 9123882, "type": "github",
-        "full_name": "orga-083643/analytics-test", "health": "safe", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": "f19d79466ce40e0bb69c9ee0ea08787ead9b5845",
-        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
-        "2025-10-09T16:45:43.352186Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 7, "duration": "0.942938", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "630536182",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/analytics-test",
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/saint_laurent",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12268,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2021-04",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
+        3, "last_scan": {"date": "2021-05-12T13:40:00.812612Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 686, "duration": "2.80448", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "353525015", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        1, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 3, "severity_breakdown": {"critical": 0, "high": 3, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2021-04",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a10397edde0a565a-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:46:09 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '8700'
+      - '8150'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:44:07 GMT
       link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD05MTIzODgy&per_page=10&type=github>;
+      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjI2OA%3D%3D&per_page=10&type=github>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '11786'
+      - '4668'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_sources_with_visibility_filter.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_with_visibility_filter.yaml
@@ -20,157 +20,168 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?visibility=private&per_page=10
   response:
     body:
-      string: '[{"id": 9123340, "type": "github", "full_name": "orga-083643/solid-octo",
-        "health": "safe", "source_criticality": "unknown", "default_branch": "main",
-        "default_branch_head": "1218ef7297f84f36297c0111ea88b54b9befd365", "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": {"date": "2025-10-09T16:45:43.351408Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 7, "duration":
-        "1.120819", "branches_scanned": 1, "progress": 100}, "monitored": true, "visibility":
-        "private", "external_id": "630519649", "secret_incidents_breakdown": {"open_secret_incidents":
+      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/solid-octo",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 9123810,
-        "type": "github", "full_name": "orga-083643/ideal-journey", "health": "safe",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "ab24e2860796dff2a67c4915b1a6d745b13bdd76", "open_incidents_count": 0, "closed_incidents_count":
-        1, "last_scan": {"date": "2025-10-09T16:45:43.354999Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 3, "duration": "0.866616", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "630531940", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 1, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/orga-083643/ideal-journey", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 9123882, "type": "github",
-        "full_name": "orga-083643/analytics-test", "health": "safe", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": "f19d79466ce40e0bb69c9ee0ea08787ead9b5845",
-        "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan": {"date":
-        "2025-10-09T16:45:43.352186Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 7, "duration": "0.942938", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "630536182",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/orga-083643/analytics-test",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 9124147,
-        "type": "github", "full_name": "orga-083643/improved-carnival", "health":
-        "safe", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "cdaa5dd8497a52a75702879823adc18141ad88b4", "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": {"date": "2025-10-09T16:45:43.354520Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 4, "duration": "3.881061", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "630548292", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/orga-083643/improved-carnival", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 10294451, "type": "github",
-        "full_name": "babassov/PrivateVB", "health": "safe", "source_criticality":
-        "critical", "default_branch": "main", "default_branch_head": "346eeb121643aa8ab28828719d94d33664a55839",
-        "open_incidents_count": 0, "closed_incidents_count": 12, "last_scan": {"date":
-        "2025-10-09T16:45:43.353950Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 14, "duration": "1.396871", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "614802635",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 12, "severity_breakdown": {"critical":
-        0, "high": 12, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/babassov/PrivateVB",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 10836673,
-        "type": "github", "full_name": "leakymcgee/secretproject", "health": "at_risk",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        "6fa238be5c8773d3560627df4597c1b0cddc708d", "open_incidents_count": 6, "closed_incidents_count":
-        2, "last_scan": {"date": "2025-10-09T16:45:43.354139Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 9, "duration": "0.0", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "684998195", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        6, "severity_breakdown": {"critical": 5, "high": 1, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 2, "severity_breakdown":
-        {"critical": 0, "high": 2, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/leakymcgee/secretproject", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 11260259, "type": "github",
-        "full_name": "gitjez/private_repo", "health": "safe", "source_criticality":
-        "high", "default_branch": "main", "default_branch_head": "a8102e99d82504517c016fd20aa499209c65e41d",
-        "open_incidents_count": 0, "closed_incidents_count": 19, "last_scan": {"date":
-        "2025-10-09T16:45:43.354706Z", "status": "finished", "failing_reason": "",
-        "commits_scanned": 10, "duration": "3.11961", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "699836994",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 19, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 1, "unknown": 18}}}, "url": "https://github.com/gitjez/private_repo",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11600587,
-        "type": "github", "full_name": "peterringball/terragoatGGDemoProd", "health":
-        "at_risk", "source_criticality": "medium", "default_branch": "master", "default_branch_head":
-        "d1138f0813f335cd09babbc2863e84ea8d462468", "open_incidents_count": 1, "closed_incidents_count":
-        0, "last_scan": {"date": "2025-10-09T16:45:43.354179Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 18, "duration": "3.934015", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "visibility": "private", "external_id":
-        "713321698", "secret_incidents_breakdown": {"open_secret_incidents": {"total":
-        1, "severity_breakdown": {"critical": 1, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total": 0, "severity_breakdown":
-        {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}},
-        "url": "https://github.com/peterringball/terragoatGGDemoProd", "provider_metadata":
-        {"archived": false}, "deleted": false}, {"id": 11677085, "type": "github",
-        "full_name": "peterringball/test", "health": "unknown", "source_criticality":
-        "unknown", "default_branch": "main", "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": false, "visibility":
-        "private", "external_id": "673461264", "secret_incidents_breakdown": {"open_secret_incidents":
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12265,
+        "type": "github", "full_name": "my-testing-org/louis_vuitton", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:32.770273Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 0, "duration": "1.141495", "branches_scanned": 0, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "13", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/peterringball/test",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 11679819,
-        "type": "github", "full_name": "peterringball/cfngoat", "health": "at_risk",
-        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
-        null, "open_incidents_count": 1, "closed_incidents_count": 0, "last_scan":
-        {"date": "2025-10-09T16:45:43.352774Z", "status": "finished", "failing_reason":
-        "", "commits_scanned": 1, "duration": "1.096922", "branches_scanned": 1, "progress":
-        100}, "monitored": true, "visibility": "private", "external_id": "713839011",
-        "secret_incidents_breakdown": {"open_secret_incidents": {"total": 1, "severity_breakdown":
-        {"critical": 1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}},
-        "closed_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/peterringball/cfngoat",
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/louis_vuitton",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12266,
+        "type": "github", "full_name": "my-testing-org/lagarfeld", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        {"date": "2020-09-24T09:06:33.598712Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1, "duration": "1.253906", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "29", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/lagarfeld",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12270,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2021-04",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
+        4, "last_scan": {"date": "2021-05-12T13:40:00.804955Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 419, "duration": "2.634533", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "358427683", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 1}}, "closed_secret_incidents":
+        {"total": 4, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0,
+        "low": 0, "info": 1, "unknown": 2}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2021-04",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12271,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2021-03",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
+        7, "last_scan": {"date": "2021-05-12T13:40:00.809898Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1216, "duration": "8.598146", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "343245836", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 2}}, "closed_secret_incidents":
+        {"total": 7, "severity_breakdown": {"critical": 0, "high": 2, "medium": 0,
+        "low": 0, "info": 4, "unknown": 1}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2021-03",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12272,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2021-03",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
+        1, "last_scan": {"date": "2021-05-12T13:40:00.801498Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 940, "duration": "6.936519", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "348161051", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 1}}, "closed_secret_incidents":
+        {"total": 1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2021-03",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12304,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2021-02",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
+        6, "last_scan": {"date": "2021-05-12T13:40:00.833901Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1425, "duration": "7.69941", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "339243545", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 1}}, "closed_secret_incidents":
+        {"total": 6, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0,
+        "low": 0, "info": 1, "unknown": 4}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2021-02",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12307,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2021-02",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
+        2, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "334786496", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
+        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 2, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0,
+        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2021-02",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12312,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2021-04",
+        "health": "safe", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        2, "last_scan": {"date": "2021-05-12T13:40:00.816026Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 701, "duration": "3.011352", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "353525012", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        {"total": 2, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0,
+        "low": 0, "info": 1, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2021-04",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12316,
+        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2021-01",
+        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
+        5, "last_scan": {"date": "2021-03-22T09:56:45.983204Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1345, "duration": "2.752545", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "325893139", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
+        1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 2}}, "closed_secret_incidents":
+        {"total": 5, "severity_breakdown": {"critical": 0, "high": 3, "medium": 0,
+        "low": 0, "info": 1, "unknown": 1}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2021-01",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
+      CF-RAY:
+      - a103986afeaa3cff-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:46:25 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '8534'
+      - '8756'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:44:20 GMT
       link:
-      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMTY3OTgxOQ%3D%3D&per_page=10&visibility=private>;
+      - <https://api.gitguardian.com/v1/sources?cursor=cD0xMjMxNg%3D%3D&per_page=10&visibility=private>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '211'
+      - '458'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_users_with_access_level.yaml
+++ b/tests/cassettes/tools/vcr/test_list_users_with_access_level.yaml
@@ -25,69 +25,77 @@ interactions:
         "last_login": "2020-09-30T12:21:19.319487Z", "active": true}, {"id": 13, "role":
         "manager", "access_level": "manager", "email": "aymeric.sicard@gitguardian.com",
         "name": "Aymeric SICARD", "created_at": "2020-01-21T09:35:47.907207Z", "last_login":
-        "2026-04-02T08:21:40.877924Z", "active": true}, {"id": 2508, "role": "manager",
+        "2026-06-22T14:20:46.680540Z", "active": true}, {"id": 2508, "role": "manager",
         "access_level": "manager", "email": "guillaume.charpiat@gitguardian.com",
         "name": "Guillaume CHARPIAT", "created_at": "2020-03-23T17:53:57.158457Z",
-        "last_login": "2026-03-25T10:56:33.130265Z", "active": true}, {"id": 37699,
+        "last_login": "2026-06-10T11:29:54.420261Z", "active": true}, {"id": 37699,
         "role": "manager", "access_level": "manager", "email": "alexis.larnaud@gitguardian.com",
         "name": "Alexis LARNAUD", "created_at": "2020-09-03T11:16:05.980606Z", "last_login":
-        "2026-03-31T09:14:08.791897Z", "active": true}, {"id": 63809, "role": "manager",
+        "2026-06-22T09:33:43.124144Z", "active": true}, {"id": 63809, "role": "manager",
         "access_level": "manager", "email": "orian.roturier@gitguardian.com", "name":
         "Orian ROTURIER", "created_at": "2020-11-25T14:01:01.749542Z", "last_login":
         "2025-08-05T08:47:38.723615Z", "active": true}, {"id": 104544, "role": "manager",
         "access_level": "manager", "email": "pierre.lalanne@gitguardian.com", "name":
         "Pierre LALANNE", "created_at": "2021-04-07T13:54:43.138909Z", "last_login":
-        "2026-04-02T15:39:43.217674Z", "active": true}, {"id": 104916, "role": "manager",
+        "2026-06-22T08:37:50.823418Z", "active": true}, {"id": 104916, "role": "manager",
         "access_level": "manager", "email": "wassim.hana@gitguardian.com", "name":
         "Wassim HANA", "created_at": "2021-04-08T14:54:40.049555Z", "last_login":
-        "2026-03-30T13:36:52.170984Z", "active": true}, {"id": 136170, "role": "manager",
+        "2026-06-22T07:42:16.988277Z", "active": true}, {"id": 136170, "role": "manager",
         "access_level": "manager", "email": "eric.fourrier@gitguardian.com", "name":
         "Eric FOURRIER", "created_at": "2021-07-13T07:29:59.706367Z", "last_login":
-        "2026-04-01T21:38:49.870359Z", "active": true}, {"id": 160089, "role": "manager",
+        "2026-06-23T12:05:26.347426Z", "active": true}, {"id": 160089, "role": "manager",
         "access_level": "manager", "email": "aurelien.gateau@gitguardian.com", "name":
         "Aur\u00e9lien G\u00c2TEAU", "created_at": "2021-09-08T14:07:28.496410Z",
-        "last_login": "2026-03-31T13:14:57.104011Z", "active": true}, {"id": 166199,
+        "last_login": "2026-06-22T12:34:48.437530Z", "active": true}, {"id": 166199,
         "role": "manager", "access_level": "manager", "email": "stanislas.crepin@gitguardian.com",
         "name": "Stanislas CR\u00c9PIN", "created_at": "2021-09-24T14:02:28.853139Z",
-        "last_login": "2026-04-02T09:05:55.887447Z", "active": true}]'
+        "last_login": "2026-06-22T12:24:56.053377Z", "active": true}]'
     headers:
+      CF-RAY:
+      - a10398cc9c7b6ed2-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:46:40 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '2204'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:44:54 GMT
       link:
       - <https://api.gitguardian.com/v1/members?access_level=manager&cursor=cD0xNjYxOTk%3D&per_page=10>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '40'
+      - '35'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_users_with_active_filter.yaml
+++ b/tests/cassettes/tools/vcr/test_list_users_with_active_filter.yaml
@@ -25,13 +25,13 @@ interactions:
         "last_login": "2020-09-30T12:21:19.319487Z", "active": true}, {"id": 13, "role":
         "manager", "access_level": "manager", "email": "aymeric.sicard@gitguardian.com",
         "name": "Aymeric SICARD", "created_at": "2020-01-21T09:35:47.907207Z", "last_login":
-        "2026-04-02T08:21:40.877924Z", "active": true}, {"id": 2508, "role": "manager",
+        "2026-06-22T14:20:46.680540Z", "active": true}, {"id": 2508, "role": "manager",
         "access_level": "manager", "email": "guillaume.charpiat@gitguardian.com",
         "name": "Guillaume CHARPIAT", "created_at": "2020-03-23T17:53:57.158457Z",
-        "last_login": "2026-03-25T10:56:33.130265Z", "active": true}, {"id": 37699,
+        "last_login": "2026-06-10T11:29:54.420261Z", "active": true}, {"id": 37699,
         "role": "manager", "access_level": "manager", "email": "alexis.larnaud@gitguardian.com",
         "name": "Alexis LARNAUD", "created_at": "2020-09-03T11:16:05.980606Z", "last_login":
-        "2026-03-31T09:14:08.791897Z", "active": true}, {"id": 63809, "role": "manager",
+        "2026-06-22T09:33:43.124144Z", "active": true}, {"id": 63809, "role": "manager",
         "access_level": "manager", "email": "orian.roturier@gitguardian.com", "name":
         "Orian ROTURIER", "created_at": "2020-11-25T14:01:01.749542Z", "last_login":
         "2025-08-05T08:47:38.723615Z", "active": true}, {"id": 69474, "role": "member",
@@ -39,55 +39,63 @@ interactions:
         "created_at": "2020-12-15T08:53:29.392054Z", "last_login": "2022-03-28T09:34:32.148429Z",
         "active": true}, {"id": 104544, "role": "manager", "access_level": "manager",
         "email": "pierre.lalanne@gitguardian.com", "name": "Pierre LALANNE", "created_at":
-        "2021-04-07T13:54:43.138909Z", "last_login": "2026-04-02T15:39:43.217674Z",
+        "2021-04-07T13:54:43.138909Z", "last_login": "2026-06-22T08:37:50.823418Z",
         "active": true}, {"id": 104916, "role": "manager", "access_level": "manager",
         "email": "wassim.hana@gitguardian.com", "name": "Wassim HANA", "created_at":
-        "2021-04-08T14:54:40.049555Z", "last_login": "2026-03-30T13:36:52.170984Z",
+        "2021-04-08T14:54:40.049555Z", "last_login": "2026-06-22T07:42:16.988277Z",
         "active": true}, {"id": 113168, "role": "owner", "access_level": "owner",
         "email": "henri.hubert@gitguardian.com", "name": "Henri HUBERT", "created_at":
-        "2021-05-04T08:20:06.714793Z", "last_login": "2026-03-25T20:59:02.655910Z",
+        "2021-05-04T08:20:06.714793Z", "last_login": "2026-06-22T16:25:44.928986Z",
         "active": true}, {"id": 136170, "role": "manager", "access_level": "manager",
         "email": "eric.fourrier@gitguardian.com", "name": "Eric FOURRIER", "created_at":
-        "2021-07-13T07:29:59.706367Z", "last_login": "2026-04-01T21:38:49.870359Z",
+        "2021-07-13T07:29:59.706367Z", "last_login": "2026-06-23T12:05:26.347426Z",
         "active": true}]'
     headers:
+      CF-RAY:
+      - a10398d00a362a26-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:46:40 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '2164'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:44:55 GMT
       link:
       - <https://api.gitguardian.com/v1/members?active=true&cursor=cD0xMzYxNzA%3D&per_page=10>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '39'
+      - '29'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_users_with_ordering.yaml
+++ b/tests/cassettes/tools/vcr/test_list_users_with_ordering.yaml
@@ -20,72 +20,78 @@ interactions:
     uri: https://api.gitguardian.com/v1/members?per_page=10&ordering=-created_at
   response:
     body:
-      string: '[{"id": 1757897, "role": "member", "access_level": "member", "email":
-        "rachel.chan@gitguardian.com", "name": "Rachel CHAN", "created_at": "2026-04-02T09:06:30.522496Z",
-        "last_login": null, "active": true}, {"id": 1755666, "role": "member", "access_level":
-        "member", "email": "ylan.cuvier@gitguardian.com", "name": "Ylan CUVIER", "created_at":
-        "2026-03-31T10:09:24.169492Z", "last_login": null, "active": true}, {"id":
-        1754656, "role": "manager", "access_level": "manager", "email": "candidate.playground+eu@gitguardian.com",
-        "name": "CandidateEU DemoAccess", "created_at": "2026-03-30T14:33:58.378802Z",
-        "last_login": "2026-04-03T06:24:50.603221Z", "active": true}, {"id": 1754650,
-        "role": "manager", "access_level": "manager", "email": "candidate.playground+us@gitguardian.com",
-        "name": "CandidateUS DemoAccess", "created_at": "2026-03-30T14:30:34.889065Z",
-        "last_login": "2026-03-30T14:42:58.800498Z", "active": true}, {"id": 1748270,
-        "role": "member", "access_level": "member", "email": "mehdi.himmid@gitguardian.com",
-        "name": "Mehdi HIMMID", "created_at": "2026-03-25T16:06:35.423734Z", "last_login":
-        null, "active": true}, {"id": 1748071, "role": "member", "access_level": "member",
-        "email": "arthur.bernaille.chambille@gitguardian.com", "name": "Arthur Bernaille",
-        "created_at": "2026-03-25T13:13:55.261169Z", "last_login": null, "active":
-        false}, {"id": 1742128, "role": "member", "access_level": "member", "email":
-        "ben.martinmooney@gitguardian.com", "name": "Ben MARTINMOONEY", "created_at":
-        "2026-03-20T12:16:02.861151Z", "last_login": "2026-04-01T16:50:27.380456Z",
-        "active": true}, {"id": 1742004, "role": "member", "access_level": "member",
-        "email": "alix.mouchet@gitguardian.com", "name": "Alix MOUCHET", "created_at":
-        "2026-03-20T10:06:13.001876Z", "last_login": null, "active": true}, {"id":
-        1739935, "role": "member", "access_level": "member", "email": "paula.kleine@gitguardian.com",
-        "name": "Paula KLEINE", "created_at": "2026-03-18T13:41:15.931617Z", "last_login":
-        null, "active": false}, {"id": 1738757, "role": "member", "access_level":
-        "member", "email": "lea.benouchene@gitguardian.com", "name": "L\u00e9a BENOUCHENE",
-        "created_at": "2026-03-17T15:15:39.089903Z", "last_login": null, "active":
-        true}]'
+      string: '[{"id": 1831560, "role": "member", "access_level": "member", "email":
+        "chris.heine@gitguardian.com", "name": "Chris HEINE", "created_at": "2026-06-22T09:31:09.529363Z",
+        "last_login": null, "active": true}, {"id": 1827687, "role": "member", "access_level":
+        "member", "email": "badr.bennasri@gitguardian.com", "name": "Badr BENNASRI",
+        "created_at": "2026-06-16T12:40:54.847312Z", "last_login": null, "active":
+        true}, {"id": 1827686, "role": "member", "access_level": "member", "email":
+        "kevin.duchier-ext@gitguardian.com", "name": "Kevin DUCHIER", "created_at":
+        "2026-06-16T12:40:53.811676Z", "last_login": null, "active": true}, {"id":
+        1826598, "role": "member", "access_level": "member", "email": "matthew.perry@gitguardian.com",
+        "name": "Matthew PERRY", "created_at": "2026-06-15T09:40:43.609269Z", "last_login":
+        null, "active": true}, {"id": 1823951, "role": "member", "access_level": "member",
+        "email": "colin.evans@gitguardian.com", "name": "Colin EVANS", "created_at":
+        "2026-06-11T19:46:03.577270Z", "last_login": null, "active": true}, {"id":
+        1821084, "role": "member", "access_level": "member", "email": "elias.zegouagh-new@gitguardian.com",
+        "name": "Elias ZEGOUAGH", "created_at": "2026-06-08T19:05:42.720751Z", "last_login":
+        null, "active": true}, {"id": 1815173, "role": "member", "access_level": "member",
+        "email": "zoraver.singh@gitguardian.com", "name": "Zoraver SINGH", "created_at":
+        "2026-06-03T15:36:30.208960Z", "last_login": null, "active": true}, {"id":
+        1810671, "role": "member", "access_level": "member", "email": "melanie.almeida-ext@gitguardian.com",
+        "name": "M\u00e9lanie ALMEIDA", "created_at": "2026-05-29T07:55:45.623834Z",
+        "last_login": null, "active": true}, {"id": 1810140, "role": "member", "access_level":
+        "member", "email": "lia.vector@gitguardian.com", "name": "Lia VECTOR", "created_at":
+        "2026-05-28T15:45:53.126488Z", "last_login": null, "active": true}, {"id":
+        1809695, "role": "member", "access_level": "member", "email": "patrycja.kucharska@gitguardian.com",
+        "name": "Patrycja KUCHARSKA", "created_at": "2026-05-28T07:06:18.936256Z",
+        "last_login": "2026-06-16T14:08:45.946144Z", "active": true}]'
     headers:
+      CF-RAY:
+      - a10398ce4b4ed785-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:46:40 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
-      - '2061'
+      - '1971'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:44:54 GMT
       link:
-      - <https://api.gitguardian.com/v1/members?cursor=cD0yMDI2LTAzLTE3KzE1JTNBMTUlM0EzOS4wODk5MDMlMkIwMCUzQTAw&ordering=-created_at&per_page=10>;
+      - <https://api.gitguardian.com/v1/members?cursor=cD0yMDI2LTA1LTI4KzA3JTNBMDYlM0ExOC45MzYyNTYlMkIwMCUzQTAw&ordering=-created_at&per_page=10>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '33'
+      - '52'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/tools/vcr/test_list_users_with_search.yaml
+++ b/tests/cassettes/tools/vcr/test_list_users_with_search.yaml
@@ -22,73 +22,81 @@ interactions:
     body:
       string: '[{"id": 13, "role": "manager", "access_level": "manager", "email":
         "aymeric.sicard@gitguardian.com", "name": "Aymeric SICARD", "created_at":
-        "2020-01-21T09:35:47.907207Z", "last_login": "2026-04-02T08:21:40.877924Z",
+        "2020-01-21T09:35:47.907207Z", "last_login": "2026-06-22T14:20:46.680540Z",
         "active": true}, {"id": 2508, "role": "manager", "access_level": "manager",
         "email": "guillaume.charpiat@gitguardian.com", "name": "Guillaume CHARPIAT",
-        "created_at": "2020-03-23T17:53:57.158457Z", "last_login": "2026-03-25T10:56:33.130265Z",
+        "created_at": "2020-03-23T17:53:57.158457Z", "last_login": "2026-06-10T11:29:54.420261Z",
         "active": true}, {"id": 37699, "role": "manager", "access_level": "manager",
         "email": "alexis.larnaud@gitguardian.com", "name": "Alexis LARNAUD", "created_at":
-        "2020-09-03T11:16:05.980606Z", "last_login": "2026-03-31T09:14:08.791897Z",
+        "2020-09-03T11:16:05.980606Z", "last_login": "2026-06-22T09:33:43.124144Z",
         "active": true}, {"id": 63809, "role": "manager", "access_level": "manager",
         "email": "orian.roturier@gitguardian.com", "name": "Orian ROTURIER", "created_at":
         "2020-11-25T14:01:01.749542Z", "last_login": "2025-08-05T08:47:38.723615Z",
         "active": true}, {"id": 104544, "role": "manager", "access_level": "manager",
         "email": "pierre.lalanne@gitguardian.com", "name": "Pierre LALANNE", "created_at":
-        "2021-04-07T13:54:43.138909Z", "last_login": "2026-04-02T15:39:43.217674Z",
+        "2021-04-07T13:54:43.138909Z", "last_login": "2026-06-22T08:37:50.823418Z",
         "active": true}, {"id": 104916, "role": "manager", "access_level": "manager",
         "email": "wassim.hana@gitguardian.com", "name": "Wassim HANA", "created_at":
-        "2021-04-08T14:54:40.049555Z", "last_login": "2026-03-30T13:36:52.170984Z",
+        "2021-04-08T14:54:40.049555Z", "last_login": "2026-06-22T07:42:16.988277Z",
         "active": true}, {"id": 113168, "role": "owner", "access_level": "owner",
         "email": "henri.hubert@gitguardian.com", "name": "Henri HUBERT", "created_at":
-        "2021-05-04T08:20:06.714793Z", "last_login": "2026-03-25T20:59:02.655910Z",
+        "2021-05-04T08:20:06.714793Z", "last_login": "2026-06-22T16:25:44.928986Z",
         "active": true}, {"id": 136170, "role": "manager", "access_level": "manager",
         "email": "eric.fourrier@gitguardian.com", "name": "Eric FOURRIER", "created_at":
-        "2021-07-13T07:29:59.706367Z", "last_login": "2026-04-01T21:38:49.870359Z",
+        "2021-07-13T07:29:59.706367Z", "last_login": "2026-06-23T12:05:26.347426Z",
         "active": true}, {"id": 160089, "role": "manager", "access_level": "manager",
         "email": "aurelien.gateau@gitguardian.com", "name": "Aur\u00e9lien G\u00c2TEAU",
-        "created_at": "2021-09-08T14:07:28.496410Z", "last_login": "2026-03-31T13:14:57.104011Z",
+        "created_at": "2021-09-08T14:07:28.496410Z", "last_login": "2026-06-22T12:34:48.437530Z",
         "active": true}, {"id": 166199, "role": "manager", "access_level": "manager",
         "email": "stanislas.crepin@gitguardian.com", "name": "Stanislas CR\u00c9PIN",
-        "created_at": "2021-09-24T14:02:28.853139Z", "last_login": "2026-04-02T09:05:55.887447Z",
+        "created_at": "2021-09-24T14:02:28.853139Z", "last_login": "2026-06-22T12:24:56.053377Z",
         "active": true}]'
     headers:
+      CF-RAY:
+      - a10398ca891a0342-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 12:46:39 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
       access-control-expose-headers:
       - X-App-Version
       allow:
       - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
       content-length:
       - '2204'
       content-security-policy:
       - frame-ancestors 'none'
-      content-type:
-      - application/json
       cross-origin-opener-policy:
       - same-origin
-      date:
-      - Fri, 03 Apr 2026 08:44:53 GMT
       link:
       - <https://api.gitguardian.com/v1/members?cursor=cD0xNjYxOTk%3D&per_page=10&search=gitguardian>;
         rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
-      server:
-      - istio-envoy
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       vary:
       - Cookie
       x-app-version:
-      - v2.426.0
+      - v2.521.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '29'
+      - '48'
       x-frame-options:
       - DENY
       x-per-page:
       - '10'
       x-secrets-engine-version:
-      - 2.159.0
+      - 2.165.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/client/vcr/test_public_incidents.py
+++ b/tests/client/vcr/test_public_incidents.py
@@ -420,9 +420,9 @@ class TestAssignPublicIncident:
             token_info = await real_client.get_current_token_info()
             assignee_id = token_info["member_id"]
 
-            page = await real_client.list_public_incidents(per_page=1)
+            page = await real_client.list_public_incidents(status="TRIGGERED", per_page=1)
             if not page["data"]:
-                pytest.skip("No public incidents available")
+                pytest.skip("No open public incident available to assign")
             incident_id = page["data"][0]["id"]
 
             result = await real_client.assign_public_incident(
@@ -446,9 +446,9 @@ class TestAssignPublicIncident:
             current_member = await real_client.get_current_member()
             email = current_member["email"]
 
-            page = await real_client.list_public_incidents(per_page=1)
+            page = await real_client.list_public_incidents(status="TRIGGERED", per_page=1)
             if not page["data"]:
-                pytest.skip("No public incidents available")
+                pytest.skip("No open public incident available to assign")
             incident_id = page["data"][0]["id"]
 
             result = await real_client.assign_public_incident(
@@ -472,9 +472,9 @@ class TestAssignPublicIncident:
             token_info = await real_client.get_current_token_info()
             assignee_id = token_info["member_id"]
 
-            page = await real_client.list_public_incidents(per_page=1)
+            page = await real_client.list_public_incidents(status="TRIGGERED", per_page=1)
             if not page["data"]:
-                pytest.skip("No public incidents available")
+                pytest.skip("No open public incident available to assign")
             incident_id = page["data"][0]["id"]
 
             result = await real_client.assign_public_incident(


### PR DESCRIPTION
## What

Refreshes all VCR cassettes (`make update-cassettes`) re-recorded against the live GitGuardian API, and fixes a flaky test surfaced during the refresh.

## Why

The `TestAssignPublicIncident` tests selected the first public incident from an unfiltered list (`list_public_incidents(per_page=1)`). That incident is now **closed**, so the API rejected assignment:

```
400 - Cannot change assignee of a closed incident.
```

A naive fix to `status=["TRIGGERED", "ASSIGNED"]` then hit a secondary `409 — Incident already assigned to this user`, because all three tests picked and assigned the same incident to the same member.

## Fix

Filter the assign tests to `status="TRIGGERED"` only (matching the resolve/ignore tests). Each test gets a fresh, **unassigned** incident; once assigned it flips to `ASSIGNED` and drops out of the filter, so the next test picks a different one and assignment always succeeds.

Also adds `GITGUARDIAN_API_KEY` / `GITGUARDIAN_API_KEY_ID` placeholders to `.env.example` (needed to record cassettes).

## Testing

`tests/client/vcr/test_public_incidents.py` — 29 passed on offline replay.