### PR TITLE
feat(tools): add incident comment create/edit tools

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -1513,39 +1513,64 @@ class GitGuardianClient:
         logger.info(f"Getting impacted perimeter for incident {incident_id}")
         return await self._request_get(f"/incidents/secrets/{incident_id}/perimeter")
 
-    # Secret Incident Notes management
-    async def list_incident_notes(self, incident_id: str) -> dict[str, Any]:
-        """List notes on a secret incident.
+    # Secret Incident Notes (comments) management
+    #
+    # Notes are free-form comments left by members or API tokens on an incident.
+    # The public API exposes them under ``.../notes`` and the comment body is
+    # carried in the ``comment`` field (1-10000 characters). Internal incidents
+    # live under ``/incidents/secrets/{id}/notes`` while Public Monitoring
+    # incidents live under ``/public-incidents/secrets/{id}/notes``; the note ids
+    # are not interchangeable between the two perimeters.
+    async def list_incident_notes(
+        self,
+        incident_id: int | str,
+        params: dict[str, Any] | None = None,
+        get_all: bool = False,
+    ) -> ListResponse:
+        """List notes (comments) on an internal secret incident.
+
+        Wraps GET /v1/incidents/secrets/{incident_id}/notes.
 
         Args:
             incident_id: ID of the secret incident
+            params: Optional query parameters for filtering and pagination
+            get_all: If True, fetch all pages using paginate_all
 
         Returns:
-            List of notes attached to the incident
+            ListResponse with data, cursor, and has_more fields
         """
         logger.info(f"Listing notes for incident {incident_id}")
-        return await self._request_get(f"/incidents/secrets/{incident_id}/notes")
+        endpoint = f"/incidents/secrets/{incident_id}/notes"
 
-    async def create_incident_note(self, incident_id: str, content: str) -> dict[str, Any]:
-        """Create a note on a secret incident.
+        if get_all:
+            return await self.paginate_all(endpoint, params)
+
+        return await self._request_list(endpoint, params=params)
+
+    async def create_incident_note(self, incident_id: int | str, comment: str) -> dict[str, Any]:
+        """Create a note (comment) on an internal secret incident.
+
+        Wraps POST /v1/incidents/secrets/{incident_id}/notes.
 
         Args:
             incident_id: ID of the secret incident
-            content: Content of the note
+            comment: Content of the comment (1-10000 characters)
 
         Returns:
             Created note details
         """
         logger.info(f"Creating note for incident {incident_id}")
-        return await self._request_post(f"/incidents/secrets/{incident_id}/notes", json={"content": content})
+        return await self._request_post(f"/incidents/secrets/{incident_id}/notes", json={"comment": comment})
 
-    async def update_incident_note(self, incident_id: str, note_id: str, content: str) -> dict[str, Any]:
-        """Update a note on a secret incident.
+    async def update_incident_note(self, incident_id: int | str, note_id: int | str, comment: str) -> dict[str, Any]:
+        """Update a note (comment) on an internal secret incident.
+
+        Wraps PATCH /v1/incidents/secrets/{incident_id}/notes/{note_id}.
 
         Args:
             incident_id: ID of the secret incident
             note_id: ID of the note to update
-            content: New content for the note
+            comment: New content for the comment (1-10000 characters)
 
         Returns:
             Updated note details
@@ -1553,11 +1578,13 @@ class GitGuardianClient:
         logger.info(f"Updating note {note_id} for incident {incident_id}")
         return await self._request_patch(
             f"/incidents/secrets/{incident_id}/notes/{note_id}",
-            json={"content": content},
+            json={"comment": comment},
         )
 
-    async def delete_incident_note(self, incident_id: str, note_id: str) -> dict[str, Any]:
-        """Delete a note from a secret incident.
+    async def delete_incident_note(self, incident_id: int | str, note_id: int | str) -> dict[str, Any]:
+        """Delete a note (comment) from an internal secret incident.
+
+        Wraps DELETE /v1/incidents/secrets/{incident_id}/notes/{note_id}.
 
         Args:
             incident_id: ID of the secret incident
@@ -1568,6 +1595,83 @@ class GitGuardianClient:
         """
         logger.info(f"Deleting note {note_id} from incident {incident_id}")
         return await self._request_delete(f"/incidents/secrets/{incident_id}/notes/{note_id}")
+
+    async def list_public_incident_notes(
+        self,
+        incident_id: int | str,
+        params: dict[str, Any] | None = None,
+        get_all: bool = False,
+    ) -> ListResponse:
+        """List notes (comments) on a public secret incident.
+
+        Wraps GET /v1/public-incidents/secrets/{incident_id}/notes.
+
+        Args:
+            incident_id: ID of the public secret incident
+            params: Optional query parameters for filtering and pagination
+            get_all: If True, fetch all pages using paginate_all
+
+        Returns:
+            ListResponse with data, cursor, and has_more fields
+        """
+        logger.info(f"Listing notes for public incident {incident_id}")
+        endpoint = f"/public-incidents/secrets/{incident_id}/notes"
+
+        if get_all:
+            return await self.paginate_all(endpoint, params)
+
+        return await self._request_list(endpoint, params=params)
+
+    async def create_public_incident_note(self, incident_id: int | str, comment: str) -> dict[str, Any]:
+        """Create a note (comment) on a public secret incident.
+
+        Wraps POST /v1/public-incidents/secrets/{incident_id}/notes.
+
+        Args:
+            incident_id: ID of the public secret incident
+            comment: Content of the comment (1-10000 characters)
+
+        Returns:
+            Created note details
+        """
+        logger.info(f"Creating note for public incident {incident_id}")
+        return await self._request_post(f"/public-incidents/secrets/{incident_id}/notes", json={"comment": comment})
+
+    async def update_public_incident_note(
+        self, incident_id: int | str, note_id: int | str, comment: str
+    ) -> dict[str, Any]:
+        """Update a note (comment) on a public secret incident.
+
+        Wraps PATCH /v1/public-incidents/secrets/{incident_id}/notes/{note_id}.
+
+        Args:
+            incident_id: ID of the public secret incident
+            note_id: ID of the note to update
+            comment: New content for the comment (1-10000 characters)
+
+        Returns:
+            Updated note details
+        """
+        logger.info(f"Updating note {note_id} for public incident {incident_id}")
+        return await self._request_patch(
+            f"/public-incidents/secrets/{incident_id}/notes/{note_id}",
+            json={"comment": comment},
+        )
+
+    async def delete_public_incident_note(self, incident_id: int | str, note_id: int | str) -> dict[str, Any]:
+        """Delete a note (comment) from a public secret incident.
+
+        Wraps DELETE /v1/public-incidents/secrets/{incident_id}/notes/{note_id}.
+
+        Args:
+            incident_id: ID of the public secret incident
+            note_id: ID of the note to delete
+
+        Returns:
+            Status of the operation
+        """
+        logger.info(f"Deleting note {note_id} from public incident {incident_id}")
+        return await self._request_delete(f"/public-incidents/secrets/{incident_id}/notes/{note_id}")
 
     # Secret Occurrences management
     async def list_secret_occurrences(self, incident_id: str) -> dict[str, Any]:

--- a/packages/gg_api_core/src/gg_api_core/tools/incident_notes.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/incident_notes.py
@@ -1,0 +1,238 @@
+"""Tools for managing notes (comments) on secret incidents.
+
+Notes are free-form comments members or API tokens leave on an incident. The
+public API exposes them under ``.../notes`` and the comment body is carried in
+the ``comment`` field. Internal incidents and Public Monitoring incidents have
+separate, non-interchangeable note collections, so each perimeter gets its own
+dedicated tools — mirroring the split used elsewhere (e.g. ``assign_incident``
+vs ``assign_public_incident``).
+"""
+
+import logging
+from typing import Annotated, Any, Literal
+
+from fastmcp.exceptions import ToolError
+from pydantic import BaseModel, Field, StringConstraints, model_validator
+
+from gg_api_core.client import DEFAULT_PAGINATION_MAX_BYTES, ListResponse
+from gg_api_core.utils import get_client
+
+logger = logging.getLogger(__name__)
+
+
+# The public API limits a comment body to 1-10000 characters (whitespace stripped).
+CommentStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=10_000)]
+
+
+class ListIncidentCommentsParams(BaseModel):
+    """Parameters for listing comments on a secret incident."""
+
+    incident_id: int = Field(description="ID of the secret incident whose comments to list")
+    cursor: str | None = Field(default=None, description="Pagination cursor for fetching the next page of results")
+    per_page: int = Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)")
+    get_all: bool = Field(
+        default=False,
+        description=f"If True, fetch all pages (capped at ~{DEFAULT_PAGINATION_MAX_BYTES / 1000}KB; check 'has_more' and use cursor to continue)",
+    )
+
+
+class ListCommentsResult(BaseModel):
+    """Result from listing comments on a secret incident."""
+
+    comments: list[dict[str, Any]] = Field(description="List of comment objects attached to the incident")
+    total_count: int = Field(description="Total number of comments returned")
+    next_cursor: str | None = Field(default=None, description="Pagination cursor for next page (if applicable)")
+    has_more: bool = Field(default=False, description="True if more results exist (use next_cursor to fetch)")
+
+
+class ManageIncidentCommentParams(BaseModel):
+    """Parameters for adding or editing a comment on a secret incident."""
+
+    incident_id: int = Field(description="ID of the secret incident to comment on")
+    action: Literal["add", "edit"] = Field(
+        description="Action to perform: 'add' creates a new comment, 'edit' replaces the body of an existing comment "
+        "(requires comment_id)"
+    )
+    comment: CommentStr = Field(
+        description="Body of the comment (1-10000 characters). For 'add' this is the new comment; for 'edit' this "
+        "is the replacement text."
+    )
+    comment_id: int | None = Field(
+        default=None,
+        description="ID of the comment to edit. Required when action is 'edit'. Use the listing tool to find it.",
+    )
+
+    @model_validator(mode="after")
+    def validate_comment_id_for_edit(self):
+        """Require comment_id for edits and reject it for new comments."""
+        if self.action == "edit" and self.comment_id is None:
+            raise ValueError("comment_id is required when action is 'edit'")
+        if self.action == "add" and self.comment_id is not None:
+            raise ValueError("comment_id must not be provided when action is 'add'")
+        return self
+
+
+def _build_list_result(result: ListResponse) -> ListCommentsResult:
+    """Adapt a client ListResponse into a ListCommentsResult."""
+    return ListCommentsResult(
+        comments=result["data"],
+        total_count=len(result["data"]),
+        next_cursor=result["cursor"],
+        has_more=result["has_more"],
+    )
+
+
+async def list_incident_comments(params: ListIncidentCommentsParams) -> ListCommentsResult:
+    """
+    List the comments (notes) left on an internal secret incident.
+
+    Use this to read the discussion on an internal incident, and to find the
+    `comment_id` of a comment you want to edit with `manage_incident_comment`.
+    For Public Monitoring incidents use `list_public_incident_comments` instead.
+
+    Args:
+        params: ListIncidentCommentsParams with the incident ID and pagination options
+
+    Returns:
+        ListCommentsResult with the comments, total_count, next_cursor, and has_more
+
+    Raises:
+        ToolError: If the listing operation fails
+    """
+    client = await get_client()
+    logger.debug(f"Listing comments for incident {params.incident_id}")
+
+    query_params: dict[str, Any] = {"per_page": params.per_page}
+    if params.cursor:
+        query_params["cursor"] = params.cursor
+
+    try:
+        result = await client.list_incident_notes(
+            incident_id=params.incident_id,
+            params=query_params,
+            get_all=params.get_all,
+        )
+        return _build_list_result(result)
+    except Exception as e:
+        logger.exception(f"Error listing comments for incident {params.incident_id}: {str(e)}")
+        raise ToolError(f"Error: {str(e)}")
+
+
+async def manage_incident_comment(params: ManageIncidentCommentParams) -> dict[str, Any]:
+    """
+    Add a new comment to an internal secret incident, or edit an existing one.
+
+    - action='add': create a new comment on the incident.
+    - action='edit': replace the body of the comment identified by `comment_id`
+      (find it with `list_incident_comments`).
+
+    For Public Monitoring incidents use `manage_public_incident_comment` instead;
+    note ids are not interchangeable between the two perimeters.
+
+    Args:
+        params: ManageIncidentCommentParams with the incident ID, action, comment
+            body, and comment_id (for edits)
+
+    Returns:
+        Dictionary containing the created or updated comment data from the API
+
+    Raises:
+        ToolError: If the operation fails
+    """
+    client = await get_client()
+    logger.debug(f"Managing comment on incident {params.incident_id} with action: {params.action}")
+
+    try:
+        if params.action == "add":
+            return await client.create_incident_note(incident_id=params.incident_id, comment=params.comment)
+
+        # action == "edit" (comment_id presence enforced by the validator)
+        assert params.comment_id is not None
+        return await client.update_incident_note(
+            incident_id=params.incident_id,
+            note_id=params.comment_id,
+            comment=params.comment,
+        )
+    except Exception as e:
+        logger.exception(f"Error managing comment on incident {params.incident_id}: {str(e)}")
+        raise ToolError(f"Error: {str(e)}")
+
+
+async def list_public_incident_comments(params: ListIncidentCommentsParams) -> ListCommentsResult:
+    """
+    List the comments (notes) left on a public secret incident.
+
+    Public incidents are surfaced by GitGuardian Public Monitoring (public GitHub
+    repos/gists, Docker Hub, etc.). Use this to read the discussion on a public
+    incident and to find the `comment_id` to edit with
+    `manage_public_incident_comment`. For internal incidents use
+    `list_incident_comments` instead.
+
+    Args:
+        params: ListIncidentCommentsParams with the public incident ID and pagination options
+
+    Returns:
+        ListCommentsResult with the comments, total_count, next_cursor, and has_more
+
+    Raises:
+        ToolError: If the listing operation fails
+    """
+    client = await get_client()
+    logger.debug(f"Listing comments for public incident {params.incident_id}")
+
+    query_params: dict[str, Any] = {"per_page": params.per_page}
+    if params.cursor:
+        query_params["cursor"] = params.cursor
+
+    try:
+        result = await client.list_public_incident_notes(
+            incident_id=params.incident_id,
+            params=query_params,
+            get_all=params.get_all,
+        )
+        return _build_list_result(result)
+    except Exception as e:
+        logger.exception(f"Error listing comments for public incident {params.incident_id}: {str(e)}")
+        raise ToolError(f"Error: {str(e)}")
+
+
+async def manage_public_incident_comment(params: ManageIncidentCommentParams) -> dict[str, Any]:
+    """
+    Add a new comment to a public secret incident, or edit an existing one.
+
+    Public incidents are surfaced by GitGuardian Public Monitoring. Public
+    incident IDs are NOT interchangeable with internal incident IDs.
+
+    - action='add': create a new comment on the public incident.
+    - action='edit': replace the body of the comment identified by `comment_id`
+      (find it with `list_public_incident_comments`).
+
+    For internal incidents use `manage_incident_comment` instead.
+
+    Args:
+        params: ManageIncidentCommentParams with the public incident ID, action,
+            comment body, and comment_id (for edits)
+
+    Returns:
+        Dictionary containing the created or updated comment data from the API
+
+    Raises:
+        ToolError: If the operation fails
+    """
+    client = await get_client()
+    logger.debug(f"Managing comment on public incident {params.incident_id} with action: {params.action}")
+
+    try:
+        if params.action == "add":
+            return await client.create_public_incident_note(incident_id=params.incident_id, comment=params.comment)
+
+        # action == "edit" (comment_id presence enforced by the validator)
+        assert params.comment_id is not None
+        return await client.update_public_incident_note(
+            incident_id=params.incident_id,
+            note_id=params.comment_id,
+            comment=params.comment,
+        )
+    except Exception as e:
+        logger.exception(f"Error managing comment on public incident {params.incident_id}: {str(e)}")
+        raise ToolError(f"Error: {str(e)}")

--- a/packages/gg_mcp_server/src/gg_mcp_server/register_tools.py
+++ b/packages/gg_mcp_server/src/gg_mcp_server/register_tools.py
@@ -20,6 +20,12 @@ from gg_api_core.tools.get_incident import get_incident
 from gg_api_core.tools.get_member import get_member
 from gg_api_core.tools.get_public_incident import get_public_incident
 from gg_api_core.tools.get_remediation_workflow import get_remediation_workflow
+from gg_api_core.tools.incident_notes import (
+    list_incident_comments,
+    list_public_incident_comments,
+    manage_incident_comment,
+    manage_public_incident_comment,
+)
 from gg_api_core.tools.list_detectors import list_detectors
 from gg_api_core.tools.list_honeytokens import list_honeytokens
 from gg_api_core.tools.list_incident_members import list_incident_members
@@ -62,13 +68,14 @@ GitGuardian surfaces two distinct, non-overlapping categories of secret incident
   private/org Git repos, Slack, Jira, Confluence, container registries, SharePoint, etc.
   Identified by a `source_id`. Default category for most customer workflows.
   Read tools: `list_incidents`, `count_incidents`, `get_incident`, `list_repo_occurrences`,
-  `remediate_secret_incidents`, `list_sources`, `find_current_source_id`.
+  `remediate_secret_incidents`, `list_sources`, `find_current_source_id`, `list_incident_comments`.
   Write tools: `manage_private_incident`, `update_incident_status`, `assign_incident`,
-  `update_or_create_incident_custom_tags`, `create_code_fix_request`.
+  `update_or_create_incident_custom_tags`, `create_code_fix_request`, `manage_incident_comment`.
 - **Public incidents** — detected by GitGuardian Public Monitoring on the worldwide public
   perimeter: public GitHub repos/gists, Docker Hub, etc. Not linked to a workspace source.
-  Read tools: `list_public_incidents`, `get_public_incident`, `list_public_occurrences`.
-  Write tools: `assign_public_incident`, `update_public_incident_status`.
+  Read tools: `list_public_incidents`, `get_public_incident`, `list_public_occurrences`,
+  `list_public_incident_comments`.
+  Write tools: `assign_public_incident`, `update_public_incident_status`, `manage_public_incident_comment`.
 
 Incident IDs are **not** interchangeable between the two categories. If the user's intent is
 about leaks "on public GitHub / outside the org / on Docker Hub / found by Public Monitoring",
@@ -266,6 +273,23 @@ def register_tools(mcp: AbstractGitGuardianFastMCP) -> None:
         required_scopes=["incidents:read"],
     )
 
+    mcp.tool(
+        list_incident_comments,
+        description="(Internal sources only — for public GitHub/gists/Docker Hub use list_public_incident_comments) "
+        "List the comments (notes) left on an internal secret incident. Use this to read the discussion on an "
+        "incident and to find the comment_id of a comment you want to edit with manage_incident_comment.",
+        required_scopes=["incidents:read"],
+    )
+
+    mcp.tool(
+        list_public_incident_comments,
+        description="(Public Monitoring only — for internal sources use list_incident_comments) "
+        "List the comments (notes) left on a public secret incident detected by GitGuardian Public Monitoring. "
+        "Use this to read the discussion and to find the comment_id to edit with manage_public_incident_comment. "
+        "Public incident IDs are NOT interchangeable with internal incident IDs.",
+        required_scopes=["incidents:read"],
+    )
+
     # Write tools — previously SecOps-only.
 
     @mcp.tool(
@@ -353,5 +377,24 @@ def register_tools(mcp: AbstractGitGuardianFastMCP) -> None:
         description="(Internal sources only) Create code fix requests for multiple internal secret incidents with their "
         "locations. This will generate pull requests to automatically remediate detected secrets in the repositories the "
         "workspace monitors. Does not apply to public-monitoring incidents.",
+        required_scopes=["incidents:write"],
+    )
+
+    mcp.tool(
+        manage_incident_comment,
+        description="(Internal sources only — for public GitHub/gists/Docker Hub use manage_public_incident_comment) "
+        "Add a comment (note) to an internal secret incident, or edit an existing one. Use action='add' to create a "
+        "new comment, or action='edit' with a comment_id (from list_incident_comments) to replace a comment's body. "
+        "Does not work on public-monitoring incident IDs.",
+        required_scopes=["incidents:write"],
+    )
+
+    mcp.tool(
+        manage_public_incident_comment,
+        description="(Public Monitoring only — for internal sources use manage_incident_comment) "
+        "Add a comment (note) to a public secret incident detected by GitGuardian Public Monitoring, or edit an "
+        "existing one. Use action='add' to create a new comment, or action='edit' with a comment_id (from "
+        "list_public_incident_comments) to replace a comment's body. Public incident IDs are NOT interchangeable "
+        "with internal incident IDs.",
         required_scopes=["incidents:write"],
     )

--- a/tests/cassettes/client/vcr/test_create_and_update_incident_note.yaml
+++ b/tests/cassettes/client/vcr/test_create_and_update_incident_note.yaml
@@ -1,0 +1,146 @@
+interactions:
+- request:
+    body: '{"comment": "Investigating this incident via MCP"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '49'
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: POST
+    uri: https://api.gitguardian.com/v1/incidents/secrets/21460/notes
+  response:
+    body:
+      string: '{"id": 74758007, "member_id": 480870, "api_token_id": "d0ca9877-641f-4c37-8857-c08e0ae148c4",
+        "created_at": "2026-06-23T14:12:48.339652Z", "updated_at": null, "comment":
+        "Investigating this incident via MCP", "issue_id": 21460, "incident_id": 21460,
+        "user_id": 480218, "api_token": "ggmcp CI (April)"}'
+    headers:
+      CF-RAY:
+      - a10416f95d7dfa77-CDG
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '282'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 14:12:48 GMT
+      Server:
+      - cloudflare
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, POST, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '81'
+      x-frame-options:
+      - DENY
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"comment":"Resolved: secret rotated"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: PATCH
+    uri: https://api.gitguardian.com/v1/incidents/secrets/21460/notes/74758007
+  response:
+    body:
+      string: '{"id": 74758007, "member_id": 480870, "api_token_id": "d0ca9877-641f-4c37-8857-c08e0ae148c4",
+        "created_at": "2026-06-23T14:12:48.339652Z", "updated_at": "2026-06-23T14:12:48.681495Z",
+        "comment": "Resolved: secret rotated", "issue_id": 21460, "incident_id": 21460,
+        "user_id": 480218, "api_token": "ggmcp CI (April)"}'
+    headers:
+      CF-RAY:
+      - a10416fb79162a08-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 14:12:48 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - PUT, PATCH, DELETE, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '296'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '106'
+      x-frame-options:
+      - DENY
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_create_and_update_public_incident_note.yaml
+++ b/tests/cassettes/client/vcr/test_create_and_update_public_incident_note.yaml
@@ -1,0 +1,144 @@
+interactions:
+- request:
+    body: '{"comment": "Reported the leak to the actor"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: POST
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/3759/notes
+  response:
+    body:
+      string: '{"id": 5132786, "member_id": 480870, "api_token_id": "d0ca9877-641f-4c37-8857-c08e0ae148c4",
+        "created_at": "2026-06-23T14:12:49.055117Z", "updated_at": null, "comment":
+        "Reported the leak to the actor", "incident_id": 3759}'
+    headers:
+      CF-RAY:
+      - a10416fdbdaa99bd-CDG
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '210'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 14:12:49 GMT
+      Server:
+      - cloudflare
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, POST, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '54'
+      x-frame-options:
+      - DENY
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"comment":"Actor confirmed rotation"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: PATCH
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/3759/notes/5132786
+  response:
+    body:
+      string: '{"id": 5132786, "member_id": 480870, "api_token_id": "d0ca9877-641f-4c37-8857-c08e0ae148c4",
+        "created_at": "2026-06-23T14:12:49.055117Z", "updated_at": "2026-06-23T14:12:49.360819Z",
+        "comment": "Actor confirmed rotation", "incident_id": 3759}'
+    headers:
+      CF-RAY:
+      - a10416ffbd85341e-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 14:12:49 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - PUT, PATCH, DELETE, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '229'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '65'
+      x-frame-options:
+      - DENY
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_incident_notes.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incident_notes.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/3759/notes
+  response:
+    body:
+      string: '[{"id": 5132786, "member_id": 480870, "api_token_id": "d0ca9877-641f-4c37-8857-c08e0ae148c4",
+        "created_at": "2026-06-23T14:12:49.055117Z", "updated_at": "2026-06-23T14:12:49.360819Z",
+        "comment": "Actor confirmed rotation", "incident_id": 3759}]'
+    headers:
+      CF-RAY:
+      - a10417019cc9229d-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 14:12:49 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, POST, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '231'
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '34'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '20'
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/client/vcr/test_incident_notes.py
+++ b/tests/client/vcr/test_incident_notes.py
@@ -1,0 +1,81 @@
+"""
+VCR tests for GitGuardianClient incident note (comment) methods.
+
+These tests cover:
+- create_incident_note / update_incident_note (internal incidents)
+- create_public_incident_note / update_public_incident_note (public incidents)
+- list_public_incident_notes (internal list is covered in test_incidents.py)
+"""
+
+import pytest
+
+
+class TestIncidentNotes:
+    """Tests for creating and editing comments on internal secret incidents."""
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_create_and_update_incident_note(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key and an internal incident
+        WHEN we create a comment and then edit it
+        THEN the API echoes back the comment body in the `comment` field
+        """
+        with use_cassette("test_create_and_update_incident_note"):
+            created = await real_client.create_incident_note(
+                incident_id=21460, comment="Investigating this incident via MCP"
+            )
+            assert created["comment"] == "Investigating this incident via MCP"
+            assert created["incident_id"] == 21460
+
+            updated = await real_client.update_incident_note(
+                incident_id=21460,
+                note_id=created["id"],
+                comment="Resolved: secret rotated",
+            )
+            assert updated["id"] == created["id"]
+            assert updated["comment"] == "Resolved: secret rotated"
+            assert updated["updated_at"] is not None
+
+
+class TestPublicIncidentNotes:
+    """Tests for creating, editing and listing comments on public secret incidents."""
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_create_and_update_public_incident_note(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key and a public incident
+        WHEN we create a comment and then edit it
+        THEN the API echoes back the comment body in the `comment` field
+        """
+        with use_cassette("test_create_and_update_public_incident_note"):
+            created = await real_client.create_public_incident_note(
+                incident_id=3759, comment="Reported the leak to the actor"
+            )
+            assert created["comment"] == "Reported the leak to the actor"
+            assert created["incident_id"] == 3759
+
+            updated = await real_client.update_public_incident_note(
+                incident_id=3759,
+                note_id=created["id"],
+                comment="Actor confirmed rotation",
+            )
+            assert updated["id"] == created["id"]
+            assert updated["comment"] == "Actor confirmed rotation"
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incident_notes(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key and a public incident
+        WHEN we list its comments
+        THEN we receive a standardized ListResponse
+        """
+        with use_cassette("test_list_public_incident_notes"):
+            result = await real_client.list_public_incident_notes(3759)
+
+            assert "data" in result
+            assert isinstance(result["data"], list)
+            assert "cursor" in result
+            assert "has_more" in result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -368,6 +368,7 @@ def mock_gitguardian_client(request):
         "gg_api_core.tools.create_code_fix_request",
         "gg_api_core.tools.assign_incident",
         "gg_api_core.tools.assign_public_incident",
+        "gg_api_core.tools.incident_notes",
         "gg_api_core.tools.manage_incident",
         "gg_api_core.tools.update_public_incident_status",
         "gg_api_core.tools.list_public_incidents",

--- a/tests/tools/test_incident_notes.py
+++ b/tests/tools/test_incident_notes.py
@@ -1,0 +1,257 @@
+"""
+Tests for the incident comment (note) tools.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+from gg_api_core.tools.incident_notes import (
+    ListCommentsResult,
+    ListIncidentCommentsParams,
+    ManageIncidentCommentParams,
+    list_incident_comments,
+    list_public_incident_comments,
+    manage_incident_comment,
+    manage_public_incident_comment,
+)
+from pydantic import ValidationError
+
+
+def _note_payload(note_id: int = 42, incident_id: int = 123, comment: str = "Looks like a test credential") -> dict:
+    """Realistic note payload as returned by the notes endpoints."""
+    return {
+        "id": note_id,
+        "incident_id": incident_id,
+        "member_id": 480870,
+        "api_token_id": "11111111-2222-3333-4444-555555555555",
+        "created_at": "2026-06-23T10:00:00Z",
+        "updated_at": None,
+        "comment": comment,
+    }
+
+
+class TestManageIncidentCommentParams:
+    """Tests for ManageIncidentCommentParams validation."""
+
+    def test_add_action_is_valid(self):
+        """
+        GIVEN action='add' with a comment and no comment_id
+        WHEN creating the params
+        THEN the params are valid
+        """
+        params = ManageIncidentCommentParams(incident_id=123, action="add", comment="A new comment")
+        assert params.action == "add"
+        assert params.comment_id is None
+
+    def test_edit_action_with_comment_id_is_valid(self):
+        """
+        GIVEN action='edit' with a comment_id
+        WHEN creating the params
+        THEN the params are valid
+        """
+        params = ManageIncidentCommentParams(incident_id=123, action="edit", comment="Edited", comment_id=42)
+        assert params.action == "edit"
+        assert params.comment_id == 42
+
+    def test_edit_without_comment_id_raises_error(self):
+        """
+        GIVEN action='edit' without a comment_id
+        WHEN creating the params
+        THEN a validation error is raised
+        """
+        with pytest.raises(ValidationError) as exc_info:
+            ManageIncidentCommentParams(incident_id=123, action="edit", comment="Edited")
+
+        assert "comment_id is required when action is 'edit'" in str(exc_info.value)
+
+    def test_add_with_comment_id_raises_error(self):
+        """
+        GIVEN action='add' with a comment_id
+        WHEN creating the params
+        THEN a validation error is raised
+        """
+        with pytest.raises(ValidationError) as exc_info:
+            ManageIncidentCommentParams(incident_id=123, action="add", comment="New", comment_id=42)
+
+        assert "comment_id must not be provided when action is 'add'" in str(exc_info.value)
+
+    def test_empty_comment_raises_error(self):
+        """
+        GIVEN a blank comment
+        WHEN creating the params
+        THEN a validation error is raised (min length 1 after stripping)
+        """
+        with pytest.raises(ValidationError):
+            ManageIncidentCommentParams(incident_id=123, action="add", comment="   ")
+
+    def test_comment_too_long_raises_error(self):
+        """
+        GIVEN a comment longer than 10000 characters
+        WHEN creating the params
+        THEN a validation error is raised
+        """
+        with pytest.raises(ValidationError):
+            ManageIncidentCommentParams(incident_id=123, action="add", comment="x" * 10_001)
+
+    def test_comment_is_stripped(self):
+        """
+        GIVEN a comment with surrounding whitespace
+        WHEN creating the params
+        THEN the comment is stripped
+        """
+        params = ManageIncidentCommentParams(incident_id=123, action="add", comment="  hello  ")
+        assert params.comment == "hello"
+
+
+class TestManageIncidentComment:
+    """Tests for the manage_incident_comment function (internal incidents)."""
+
+    @pytest.mark.asyncio
+    async def test_add_calls_create(self, mock_gitguardian_client):
+        """
+        GIVEN action='add'
+        WHEN managing the comment
+        THEN create_incident_note is called and the created note is returned
+        """
+        mock_gitguardian_client.create_incident_note = AsyncMock(return_value=_note_payload())
+
+        result = await manage_incident_comment(
+            ManageIncidentCommentParams(incident_id=123, action="add", comment="Looks like a test credential")
+        )
+
+        mock_gitguardian_client.create_incident_note.assert_called_once_with(
+            incident_id=123, comment="Looks like a test credential"
+        )
+        assert result["id"] == 42
+        assert result["comment"] == "Looks like a test credential"
+
+    @pytest.mark.asyncio
+    async def test_edit_calls_update(self, mock_gitguardian_client):
+        """
+        GIVEN action='edit' with a comment_id
+        WHEN managing the comment
+        THEN update_incident_note is called with the note id
+        """
+        mock_gitguardian_client.update_incident_note = AsyncMock(return_value=_note_payload(comment="Updated comment"))
+
+        result = await manage_incident_comment(
+            ManageIncidentCommentParams(incident_id=123, action="edit", comment="Updated comment", comment_id=42)
+        )
+
+        mock_gitguardian_client.update_incident_note.assert_called_once_with(
+            incident_id=123, note_id=42, comment="Updated comment"
+        )
+        assert result["comment"] == "Updated comment"
+
+    @pytest.mark.asyncio
+    async def test_api_error_is_wrapped(self, mock_gitguardian_client):
+        """
+        GIVEN the API raises an exception
+        WHEN managing the comment
+        THEN a ToolError is raised with the underlying message
+        """
+        mock_gitguardian_client.create_incident_note = AsyncMock(side_effect=Exception("API error: forbidden"))
+
+        with pytest.raises(ToolError) as exc_info:
+            await manage_incident_comment(ManageIncidentCommentParams(incident_id=123, action="add", comment="hi"))
+
+        assert "API error: forbidden" in str(exc_info.value)
+
+
+class TestManagePublicIncidentComment:
+    """Tests for the manage_public_incident_comment function (public incidents)."""
+
+    @pytest.mark.asyncio
+    async def test_add_calls_create_public(self, mock_gitguardian_client):
+        """
+        GIVEN action='add'
+        WHEN managing the public comment
+        THEN create_public_incident_note is called
+        """
+        mock_gitguardian_client.create_public_incident_note = AsyncMock(return_value=_note_payload())
+
+        result = await manage_public_incident_comment(
+            ManageIncidentCommentParams(incident_id=3759, action="add", comment="Reported to the actor")
+        )
+
+        mock_gitguardian_client.create_public_incident_note.assert_called_once_with(
+            incident_id=3759, comment="Reported to the actor"
+        )
+        assert result["id"] == 42
+
+    @pytest.mark.asyncio
+    async def test_edit_calls_update_public(self, mock_gitguardian_client):
+        """
+        GIVEN action='edit' with a comment_id
+        WHEN managing the public comment
+        THEN update_public_incident_note is called with the note id
+        """
+        mock_gitguardian_client.update_public_incident_note = AsyncMock(return_value=_note_payload())
+
+        await manage_public_incident_comment(
+            ManageIncidentCommentParams(incident_id=3759, action="edit", comment="Edited", comment_id=42)
+        )
+
+        mock_gitguardian_client.update_public_incident_note.assert_called_once_with(
+            incident_id=3759, note_id=42, comment="Edited"
+        )
+
+
+class TestListIncidentComments:
+    """Tests for the listing tools."""
+
+    @pytest.mark.asyncio
+    async def test_list_internal_comments(self, mock_gitguardian_client):
+        """
+        GIVEN an incident with comments
+        WHEN listing internal comments
+        THEN list_incident_notes is called and a ListCommentsResult is returned
+        """
+        mock_gitguardian_client.list_incident_notes = AsyncMock(
+            return_value={"data": [_note_payload(), _note_payload(note_id=43)], "cursor": None, "has_more": False}
+        )
+
+        result = await list_incident_comments(ListIncidentCommentsParams(incident_id=123))
+
+        mock_gitguardian_client.list_incident_notes.assert_called_once_with(
+            incident_id=123, params={"per_page": 20}, get_all=False
+        )
+        assert isinstance(result, ListCommentsResult)
+        assert result.total_count == 2
+        assert result.has_more is False
+
+    @pytest.mark.asyncio
+    async def test_list_public_comments_forwards_cursor(self, mock_gitguardian_client):
+        """
+        GIVEN a cursor is supplied
+        WHEN listing public comments
+        THEN the cursor is forwarded and pagination metadata is surfaced
+        """
+        mock_gitguardian_client.list_public_incident_notes = AsyncMock(
+            return_value={"data": [_note_payload()], "cursor": "next-cursor", "has_more": True}
+        )
+
+        result = await list_public_incident_comments(
+            ListIncidentCommentsParams(incident_id=3759, cursor="abc", per_page=50)
+        )
+
+        mock_gitguardian_client.list_public_incident_notes.assert_called_once_with(
+            incident_id=3759, params={"per_page": 50, "cursor": "abc"}, get_all=False
+        )
+        assert result.next_cursor == "next-cursor"
+        assert result.has_more is True
+
+    @pytest.mark.asyncio
+    async def test_list_error_is_wrapped(self, mock_gitguardian_client):
+        """
+        GIVEN the API raises an exception
+        WHEN listing comments
+        THEN a ToolError is raised
+        """
+        mock_gitguardian_client.list_incident_notes = AsyncMock(side_effect=Exception("boom"))
+
+        with pytest.raises(ToolError) as exc_info:
+            await list_incident_comments(ListIncidentCommentsParams(incident_id=123))
+
+        assert "boom" in str(exc_info.value)


### PR DESCRIPTION
Let the agent manage comments (notes) on a single incident, covering goal (1) "100% management of a single incident". Adds manage_incident_comment and manage_public_incident_comment (action add/edit, gated by incidents:write), plus list_incident_comments and list_public_incident_comments (incidents:read) so the comment_id needed to edit can be discovered. Internal and public incidents get separate tools since their note collections and ids are not interchangeable.

Also fixes the pre-existing private note client methods, which sent the body in a "content" field the API ignores; the public API expects "comment".

Refs: SI-3521