### PR TITLE
feat(tools): add incident activity-log listing tools

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -1673,6 +1673,58 @@ class GitGuardianClient:
         logger.info(f"Deleting note {note_id} from public incident {incident_id}")
         return await self._request_delete(f"/public-incidents/secrets/{incident_id}/notes/{note_id}")
 
+    async def list_incident_activity_logs(
+        self,
+        incident_id: int | str,
+        params: dict[str, Any] | None = None,
+        get_all: bool = False,
+    ) -> ListResponse:
+        """List the full activity log (user notes AND system actions) of an internal secret incident.
+
+        Wraps GET /v1/incidents/secrets/{incident_id}/activity-logs.
+
+        Args:
+            incident_id: ID of the secret incident
+            params: Optional query parameters for filtering and pagination
+            get_all: If True, fetch all pages using paginate_all
+
+        Returns:
+            ListResponse with data, cursor, and has_more fields
+        """
+        logger.info(f"Listing activity logs for incident {incident_id}")
+        endpoint = f"/incidents/secrets/{incident_id}/activity-logs"
+
+        if get_all:
+            return await self.paginate_all(endpoint, params)
+
+        return await self._request_list(endpoint, params=params)
+
+    async def list_public_incident_activity_logs(
+        self,
+        incident_id: int | str,
+        params: dict[str, Any] | None = None,
+        get_all: bool = False,
+    ) -> ListResponse:
+        """List the full activity log (user notes AND system actions) of a public secret incident.
+
+        Wraps GET /v1/public-incidents/secrets/{incident_id}/activity-logs.
+
+        Args:
+            incident_id: ID of the public secret incident
+            params: Optional query parameters for filtering and pagination
+            get_all: If True, fetch all pages using paginate_all
+
+        Returns:
+            ListResponse with data, cursor, and has_more fields
+        """
+        logger.info(f"Listing activity logs for public incident {incident_id}")
+        endpoint = f"/public-incidents/secrets/{incident_id}/activity-logs"
+
+        if get_all:
+            return await self.paginate_all(endpoint, params)
+
+        return await self._request_list(endpoint, params=params)
+
     # Secret Occurrences management
     async def list_secret_occurrences(self, incident_id: str) -> dict[str, Any]:
         """List secret occurrences for an incident.

--- a/packages/gg_api_core/src/gg_api_core/tools/activity_logs.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/activity_logs.py
@@ -1,0 +1,149 @@
+"""Tools for listing the activity log of a secret incident.
+
+An incident's activity log is the full, chronological record of everything that
+happened to it: user notes (free-form comments) AND system actions (status
+changes, assignments, severity edits, new locations detected, etc.). The public
+API exposes it under ``.../activity-logs`` and each entry carries a ``content``
+discriminated union — ``{"type": "note", "comment": ...}`` for a comment or
+``{"type": "action", "content_key": ..., "data": ...}`` for a system action.
+
+This is broader than the notes-only listing (``list_incident_comments``): use
+the activity log to reconstruct an incident's full timeline. Internal incidents
+and Public Monitoring incidents have separate, non-interchangeable activity
+logs, so each perimeter gets its own dedicated tool — mirroring the split used
+elsewhere (e.g. ``assign_incident`` vs ``assign_public_incident``).
+"""
+
+import logging
+from typing import Any
+
+from fastmcp.exceptions import ToolError
+from pydantic import BaseModel, Field
+
+from gg_api_core.client import DEFAULT_PAGINATION_MAX_BYTES, ListResponse
+from gg_api_core.utils import get_client
+
+logger = logging.getLogger(__name__)
+
+
+class ListActivityLogsParams(BaseModel):
+    """Parameters for listing the activity log of a secret incident."""
+
+    incident_id: int = Field(description="ID of the secret incident whose activity log to list")
+    content_key: str | None = Field(
+        default=None,
+        description="Filter to a single system-action type (e.g. 'TRIGGER', 'RESOLVE', 'ASSIGN', 'SET_SEVERITY'). "
+        "Omit to return notes and every action type.",
+    )
+    member_id: int | None = Field(
+        default=None,
+        description="Filter to entries authored by a specific member (by member ID)",
+    )
+    cursor: str | None = Field(default=None, description="Pagination cursor for fetching the next page of results")
+    per_page: int = Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)")
+    get_all: bool = Field(
+        default=False,
+        description=f"If True, fetch all pages (capped at ~{DEFAULT_PAGINATION_MAX_BYTES / 1000}KB; check 'has_more' and use cursor to continue)",
+    )
+
+
+class ListActivityLogsResult(BaseModel):
+    """Result from listing the activity log of a secret incident."""
+
+    activity_logs: list[dict[str, Any]] = Field(
+        description="List of activity log entries (notes and system actions) attached to the incident"
+    )
+    total_count: int = Field(description="Total number of entries returned")
+    next_cursor: str | None = Field(default=None, description="Pagination cursor for next page (if applicable)")
+    has_more: bool = Field(default=False, description="True if more results exist (use next_cursor to fetch)")
+
+
+def _build_query_params(params: ListActivityLogsParams) -> dict[str, Any]:
+    """Build the query parameters dict from the tool params, dropping unset filters."""
+    query_params: dict[str, Any] = {"per_page": params.per_page}
+    if params.cursor:
+        query_params["cursor"] = params.cursor
+    if params.content_key:
+        query_params["content_key"] = params.content_key
+    if params.member_id is not None:
+        query_params["member_id"] = params.member_id
+    return query_params
+
+
+def _build_list_result(result: ListResponse) -> ListActivityLogsResult:
+    """Adapt a client ListResponse into a ListActivityLogsResult."""
+    return ListActivityLogsResult(
+        activity_logs=result["data"],
+        total_count=len(result["data"]),
+        next_cursor=result["cursor"],
+        has_more=result["has_more"],
+    )
+
+
+async def list_incident_activity_logs(params: ListActivityLogsParams) -> ListActivityLogsResult:
+    """
+    List the full activity log of an internal secret incident.
+
+    Returns both user notes (comments) and system actions (status changes,
+    assignments, severity edits, new locations detected, etc.) in one timeline.
+    Use this to reconstruct what happened to an incident and when. To read only
+    the comments use `list_incident_comments`; for Public Monitoring incidents
+    use `list_public_incident_activity_logs` instead.
+
+    Args:
+        params: ListActivityLogsParams with the incident ID, optional filters and pagination options
+
+    Returns:
+        ListActivityLogsResult with the entries, total_count, next_cursor, and has_more
+
+    Raises:
+        ToolError: If the listing operation fails
+    """
+    client = await get_client()
+    logger.debug(f"Listing activity logs for incident {params.incident_id}")
+
+    try:
+        result = await client.list_incident_activity_logs(
+            incident_id=params.incident_id,
+            params=_build_query_params(params),
+            get_all=params.get_all,
+        )
+        return _build_list_result(result)
+    except Exception as e:
+        logger.exception(f"Error listing activity logs for incident {params.incident_id}: {str(e)}")
+        raise ToolError(f"Error: {str(e)}")
+
+
+async def list_public_incident_activity_logs(params: ListActivityLogsParams) -> ListActivityLogsResult:
+    """
+    List the full activity log of a public secret incident.
+
+    Public incidents are surfaced by GitGuardian Public Monitoring (public GitHub
+    repos/gists, Docker Hub, etc.). Returns both user notes (comments) and system
+    actions (status changes, assignments, severity edits, etc.) in one timeline.
+    To read only the comments use `list_public_incident_comments`; for internal
+    incidents use `list_incident_activity_logs` instead. Public incident IDs are
+    NOT interchangeable with internal incident IDs.
+
+    Args:
+        params: ListActivityLogsParams with the public incident ID, optional filters and pagination options
+
+    Returns:
+        ListActivityLogsResult with the entries, total_count, next_cursor, and has_more
+
+    Raises:
+        ToolError: If the listing operation fails
+    """
+    client = await get_client()
+    logger.debug(f"Listing activity logs for public incident {params.incident_id}")
+
+    try:
+        result = await client.list_public_incident_activity_logs(
+            incident_id=params.incident_id,
+            params=_build_query_params(params),
+            get_all=params.get_all,
+        )
+        return _build_list_result(result)
+    except Exception as e:
+        logger.exception(f"Error listing activity logs for public incident {params.incident_id}: {str(e)}")
+        raise ToolError(f"Error: {str(e)}")

--- a/packages/gg_mcp_server/src/gg_mcp_server/register_tools.py
+++ b/packages/gg_mcp_server/src/gg_mcp_server/register_tools.py
@@ -10,6 +10,10 @@ from typing import Any
 
 from fastmcp.exceptions import ToolError
 from gg_api_core.mcp_server import AbstractGitGuardianFastMCP
+from gg_api_core.tools.activity_logs import (
+    list_incident_activity_logs,
+    list_public_incident_activity_logs,
+)
 from gg_api_core.tools.assign_incident import assign_incident
 from gg_api_core.tools.assign_public_incident import assign_public_incident
 from gg_api_core.tools.count_incidents import count_incidents
@@ -68,13 +72,14 @@ GitGuardian surfaces two distinct, non-overlapping categories of secret incident
   private/org Git repos, Slack, Jira, Confluence, container registries, SharePoint, etc.
   Identified by a `source_id`. Default category for most customer workflows.
   Read tools: `list_incidents`, `count_incidents`, `get_incident`, `list_repo_occurrences`,
-  `remediate_secret_incidents`, `list_sources`, `find_current_source_id`, `list_incident_comments`.
+  `remediate_secret_incidents`, `list_sources`, `find_current_source_id`, `list_incident_comments`,
+  `list_incident_activity_logs`.
   Write tools: `manage_private_incident`, `update_incident_status`, `assign_incident`,
   `update_or_create_incident_custom_tags`, `create_code_fix_request`, `manage_incident_comment`.
 - **Public incidents** — detected by GitGuardian Public Monitoring on the worldwide public
   perimeter: public GitHub repos/gists, Docker Hub, etc. Not linked to a workspace source.
   Read tools: `list_public_incidents`, `get_public_incident`, `list_public_occurrences`,
-  `list_public_incident_comments`.
+  `list_public_incident_comments`, `list_public_incident_activity_logs`.
   Write tools: `assign_public_incident`, `update_public_incident_status`, `manage_public_incident_comment`.
 
 Incident IDs are **not** interchangeable between the two categories. If the user's intent is
@@ -287,6 +292,24 @@ def register_tools(mcp: AbstractGitGuardianFastMCP) -> None:
         "List the comments (notes) left on a public secret incident detected by GitGuardian Public Monitoring. "
         "Use this to read the discussion and to find the comment_id to edit with manage_public_incident_comment. "
         "Public incident IDs are NOT interchangeable with internal incident IDs.",
+        required_scopes=["incidents:read"],
+    )
+
+    mcp.tool(
+        list_incident_activity_logs,
+        description="(Internal sources only — for public GitHub/gists/Docker Hub use list_public_incident_activity_logs) "
+        "List the full activity log of an internal secret incident: both user notes (comments) and system actions "
+        "(status changes, assignments, severity edits, new locations detected, etc.) in one timeline. Broader than "
+        "list_incident_comments, which returns notes only. Filter by content_key (action type) or member_id.",
+        required_scopes=["incidents:read"],
+    )
+
+    mcp.tool(
+        list_public_incident_activity_logs,
+        description="(Public Monitoring only — for internal sources use list_incident_activity_logs) "
+        "List the full activity log of a public secret incident detected by GitGuardian Public Monitoring: both user "
+        "notes (comments) and system actions in one timeline. Broader than list_public_incident_comments, which "
+        "returns notes only. Public incident IDs are NOT interchangeable with internal incident IDs.",
         required_scopes=["incidents:read"],
     )
 

--- a/tests/cassettes/client/vcr/test_list_incident_activity_logs.yaml
+++ b/tests/cassettes/client/vcr/test_list_incident_activity_logs.yaml
@@ -1,0 +1,79 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/incidents/secrets/21460/activity-logs
+  response:
+    body:
+      string: '[{"id": 9001, "incident_id": 21460, "member": {"id": 480870, "name":
+        "Jane Doe", "email": "jane.doe@example.com", "access_level": "owner"}, "api_token_id":
+        null, "created_at": "2026-06-23T10:00:00.123456Z", "updated_at": null, "content":
+        {"type": "note", "comment": "Investigating this incident via MCP"}}, {"id":
+        9002, "incident_id": 21460, "member": {"id": 480870, "name": "Jane Doe", "email":
+        "jane.doe@example.com", "access_level": "owner"}, "api_token_id": null, "created_at":
+        "2026-06-23T10:05:00.654321Z", "updated_at": null, "content": {"type": "action",
+        "content_key": "RESOLVE", "data": {"resolution": "revoked"}}}]'
+    headers:
+      CF-RAY:
+      - a10417019cc9229d-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 10:05:01 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '28'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '20'
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/client/vcr/test_list_public_incident_activity_logs.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incident_activity_logs.yaml
@@ -1,0 +1,78 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Host:
+      - api.gitguardian.com
+      User-Agent:
+      - GitGuardian-MCP-Server/0.5.0
+      X-Privacy-Mode:
+      - 'true'
+    method: GET
+    uri: https://api.gitguardian.com/v1/public-incidents/secrets/3759/activity-logs
+  response:
+    body:
+      string: '[{"id": 7101, "incident_id": 3759, "member": {"id": 480870, "name":
+        "Jane Doe", "email": "jane.doe@example.com", "access_level": "owner"}, "api_token_id":
+        "d0ca9877-641f-4c37-8857-c08e0ae148c4", "created_at": "2026-06-23T14:00:00.111111Z",
+        "updated_at": null, "content": {"type": "note", "comment": "Reported the leak
+        to the actor"}}, {"id": 7102, "incident_id": 3759, "member": null, "api_token_id":
+        null, "created_at": "2026-06-23T14:10:00.222222Z", "updated_at": null, "content":
+        {"type": "action", "content_key": "TRIGGER", "data": null}}]'
+    headers:
+      CF-RAY:
+      - a10417019cc9229d-CDG
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2026 14:10:01 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-expose-headers:
+      - X-App-Version
+      allow:
+      - GET, HEAD, OPTIONS
+      cf-cache-status:
+      - DYNAMIC
+      content-security-policy:
+      - frame-ancestors 'none'
+      cross-origin-opener-policy:
+      - same-origin
+      link:
+      - ''
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Cookie
+      x-app-version:
+      - v2.521.0
+      x-content-type-options:
+      - nosniff
+      x-envoy-upstream-service-time:
+      - '31'
+      x-frame-options:
+      - DENY
+      x-per-page:
+      - '20'
+      x-secrets-engine-version:
+      - 2.165.0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/client/vcr/test_activity_logs.py
+++ b/tests/client/vcr/test_activity_logs.py
@@ -1,0 +1,74 @@
+"""
+VCR tests for GitGuardianClient incident activity-log methods.
+
+These cover the read-only activity-log listings, which return both user notes
+and system actions for an incident:
+- list_incident_activity_logs (internal incidents)
+- list_public_incident_activity_logs (public incidents)
+
+NOTE: the /activity-logs endpoints are not deployed in production yet, so these
+cassettes are hand-authored to match the public API response shape and cannot be
+re-recorded against prod until the endpoints ship.
+"""
+
+import pytest
+
+
+class TestIncidentActivityLogs:
+    """Tests for listing the activity log of an internal secret incident."""
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_incident_activity_logs(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key and an internal incident with notes and actions
+        WHEN we list its activity log
+        THEN we receive a standardized ListResponse mixing note and action entries
+        """
+        with use_cassette("test_list_incident_activity_logs"):
+            result = await real_client.list_incident_activity_logs(21460)
+
+            assert "data" in result
+            assert "cursor" in result
+            assert "has_more" in result
+
+            entries = result["data"]
+            assert {entry["id"] for entry in entries} == {9001, 9002}
+            assert all(entry["incident_id"] == 21460 for entry in entries)
+
+            contents_by_id = {entry["id"]: entry["content"] for entry in entries}
+            assert contents_by_id[9001] == {
+                "type": "note",
+                "comment": "Investigating this incident via MCP",
+            }
+            assert contents_by_id[9002]["type"] == "action"
+            assert contents_by_id[9002]["content_key"] == "RESOLVE"
+
+
+class TestPublicIncidentActivityLogs:
+    """Tests for listing the activity log of a public secret incident."""
+
+    @pytest.mark.vcr_test
+    @pytest.mark.asyncio
+    async def test_list_public_incident_activity_logs(self, real_client, use_cassette):
+        """
+        GIVEN a valid GitGuardian API key and a public incident with notes and actions
+        WHEN we list its activity log
+        THEN we receive a standardized ListResponse mixing note and action entries
+        """
+        with use_cassette("test_list_public_incident_activity_logs"):
+            result = await real_client.list_public_incident_activity_logs(3759)
+
+            assert "data" in result
+            assert "cursor" in result
+            assert "has_more" in result
+
+            entries = result["data"]
+            assert {entry["id"] for entry in entries} == {7101, 7102}
+            assert all(entry["incident_id"] == 3759 for entry in entries)
+
+            note_entry = next(e for e in entries if e["content"]["type"] == "note")
+            assert note_entry["content"]["comment"] == "Reported the leak to the actor"
+
+            action_entry = next(e for e in entries if e["content"]["type"] == "action")
+            assert action_entry["content"]["content_key"] == "TRIGGER"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -368,6 +368,7 @@ def mock_gitguardian_client(request):
         "gg_api_core.tools.create_code_fix_request",
         "gg_api_core.tools.assign_incident",
         "gg_api_core.tools.assign_public_incident",
+        "gg_api_core.tools.activity_logs",
         "gg_api_core.tools.incident_notes",
         "gg_api_core.tools.manage_incident",
         "gg_api_core.tools.update_public_incident_status",

--- a/tests/tools/test_activity_logs.py
+++ b/tests/tools/test_activity_logs.py
@@ -1,0 +1,131 @@
+"""
+Tests for the incident activity-log tools.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+from gg_api_core.tools.activity_logs import (
+    ListActivityLogsParams,
+    ListActivityLogsResult,
+    list_incident_activity_logs,
+    list_public_incident_activity_logs,
+)
+
+
+def _note_entry(entry_id: int = 9001, incident_id: int = 21460, comment: str = "A note") -> dict:
+    """Realistic note activity-log entry as returned by the activity-logs endpoints."""
+    return {
+        "id": entry_id,
+        "incident_id": incident_id,
+        "member": {"id": 480870, "name": "Jane Doe", "email": "jane.doe@example.com", "access_level": "owner"},
+        "api_token_id": None,
+        "created_at": "2026-06-23T10:00:00Z",
+        "updated_at": None,
+        "content": {"type": "note", "comment": comment},
+    }
+
+
+def _action_entry(entry_id: int = 9002, incident_id: int = 21460, content_key: str = "RESOLVE") -> dict:
+    """Realistic system-action activity-log entry."""
+    return {
+        "id": entry_id,
+        "incident_id": incident_id,
+        "member": None,
+        "api_token_id": None,
+        "created_at": "2026-06-23T10:05:00Z",
+        "updated_at": None,
+        "content": {"type": "action", "content_key": content_key, "data": None},
+    }
+
+
+class TestListIncidentActivityLogs:
+    """Tests for the internal incident activity-log tool."""
+
+    @pytest.mark.asyncio
+    async def test_list_returns_notes_and_actions(self, mock_gitguardian_client):
+        """
+        GIVEN an incident with both notes and system actions
+        WHEN listing its activity log
+        THEN list_incident_activity_logs is called and a ListActivityLogsResult is returned
+        """
+        mock_gitguardian_client.list_incident_activity_logs = AsyncMock(
+            return_value={"data": [_note_entry(), _action_entry()], "cursor": None, "has_more": False}
+        )
+
+        result = await list_incident_activity_logs(ListActivityLogsParams(incident_id=21460))
+
+        mock_gitguardian_client.list_incident_activity_logs.assert_called_once_with(
+            incident_id=21460, params={"per_page": 20}, get_all=False
+        )
+        assert isinstance(result, ListActivityLogsResult)
+        assert result.total_count == 2
+        assert result.has_more is False
+        assert {e["content"]["type"] for e in result.activity_logs} == {"note", "action"}
+
+    @pytest.mark.asyncio
+    async def test_filters_are_forwarded(self, mock_gitguardian_client):
+        """
+        GIVEN content_key, member_id, cursor and per_page filters
+        WHEN listing the activity log
+        THEN every filter is forwarded as a query parameter and pagination metadata is surfaced
+        """
+        mock_gitguardian_client.list_incident_activity_logs = AsyncMock(
+            return_value={"data": [_action_entry()], "cursor": "next-cursor", "has_more": True}
+        )
+
+        result = await list_incident_activity_logs(
+            ListActivityLogsParams(
+                incident_id=21460, content_key="RESOLVE", member_id=480870, cursor="abc", per_page=50
+            )
+        )
+
+        mock_gitguardian_client.list_incident_activity_logs.assert_called_once_with(
+            incident_id=21460,
+            params={"per_page": 50, "cursor": "abc", "content_key": "RESOLVE", "member_id": 480870},
+            get_all=False,
+        )
+        assert result.next_cursor == "next-cursor"
+        assert result.has_more is True
+
+    @pytest.mark.asyncio
+    async def test_error_is_wrapped(self, mock_gitguardian_client):
+        """
+        GIVEN the API raises an exception
+        WHEN listing the activity log
+        THEN a ToolError is raised with the underlying message
+        """
+        mock_gitguardian_client.list_incident_activity_logs = AsyncMock(side_effect=Exception("boom"))
+
+        with pytest.raises(ToolError) as exc_info:
+            await list_incident_activity_logs(ListActivityLogsParams(incident_id=21460))
+
+        assert "boom" in str(exc_info.value)
+
+
+class TestListPublicIncidentActivityLogs:
+    """Tests for the public incident activity-log tool."""
+
+    @pytest.mark.asyncio
+    async def test_list_calls_public_method(self, mock_gitguardian_client):
+        """
+        GIVEN a public incident with activity-log entries
+        WHEN listing its activity log
+        THEN list_public_incident_activity_logs is called and the entries are returned
+        """
+        mock_gitguardian_client.list_public_incident_activity_logs = AsyncMock(
+            return_value={
+                "data": [_note_entry(entry_id=7101, incident_id=3759), _action_entry(entry_id=7102, incident_id=3759)],
+                "cursor": None,
+                "has_more": False,
+            }
+        )
+
+        result = await list_public_incident_activity_logs(ListActivityLogsParams(incident_id=3759))
+
+        mock_gitguardian_client.list_public_incident_activity_logs.assert_called_once_with(
+            incident_id=3759, params={"per_page": 20}, get_all=False
+        )
+        assert result.total_count == 2
+        assert all(e["incident_id"] == 3759 for e in result.activity_logs)


### PR DESCRIPTION
## What

Adds two read-only MCP tools that list an incident's **full activity log** — both user notes (comments) and system actions (status changes, assignments, severity edits, new locations detected, etc.) in one chronological timeline:

- `list_incident_activity_logs` — internal incidents
- `list_public_incident_activity_logs` — Public Monitoring incidents

Both gated by `incidents:read`. They wrap the public API endpoints `GET /v1/incidents/secrets/{id}/activity-logs` and `GET /v1/public-incidents/secrets/{id}/activity-logs`. Each entry exposes a `content` discriminated union: `{type: "note", comment}` or `{type: "action", content_key, data}`. Supports `content_key` and `member_id` filters plus cursor pagination.

## Why

This is broader than the existing notes-only `list_*_incident_comments` tools: it lets the agent reconstruct an incident's complete history, not just the discussion. Internal and public incidents get separate tools since their activity logs and ids are not interchangeable (mirroring the `assign_incident` / `assign_public_incident` split).

## Testing

- `tests/tools/test_activity_logs.py` — mocked tool-layer tests (filter forwarding, note/action mixing, error wrapping). Run today.
- `tests/client/vcr/test_activity_logs.py` — VCR tests for the client methods.

⚠️ **The `/activity-logs` endpoints are not deployed in production yet.** The VCR cassettes are hand-authored to match the documented public API response shape and **cannot be re-recorded against prod** until the endpoints ship. Once they're live, re-record with `make update-cassettes`.

Full suite: 654 passed, 3 skipped.

Refs: SI-3520