### PR TITLE
test(cassettes): re-record incident activity-log cassettes against prod

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ggmcp"
-version = "0.6.4"
+version = "0.6.5"
 description = "MCP server for GitGuardian"
 authors = [
     { name = "GitGuardian", email = "support@gitguardian.com" },

--- a/tests/cassettes/client/vcr/test_list_incident_activity_logs.yaml
+++ b/tests/cassettes/client/vcr/test_list_incident_activity_logs.yaml
@@ -20,23 +20,87 @@ interactions:
     uri: https://api.gitguardian.com/v1/incidents/secrets/21460/activity-logs
   response:
     body:
-      string: '[{"id": 9001, "incident_id": 21460, "member": {"id": 480870, "name":
-        "Jane Doe", "email": "jane.doe@example.com", "access_level": "owner"}, "api_token_id":
-        null, "created_at": "2026-06-23T10:00:00.123456Z", "updated_at": null, "content":
-        {"type": "note", "comment": "Investigating this incident via MCP"}}, {"id":
-        9002, "incident_id": 21460, "member": {"id": 480870, "name": "Jane Doe", "email":
-        "jane.doe@example.com", "access_level": "owner"}, "api_token_id": null, "created_at":
-        "2026-06-23T10:05:00.654321Z", "updated_at": null, "content": {"type": "action",
-        "content_key": "RESOLVE", "data": {"resolution": "revoked"}}}]'
+      string: '[{"id": 92680, "member": null, "api_token_id": null, "created_at":
+        "2021-02-11T14:23:22.947577Z", "updated_at": null, "content": {"type": "action",
+        "content_key": "TRIGGER", "data": {"triggered_at": "2020-10-29T13:19:59.005564+00:00"}},
+        "incident_id": 21460}, {"id": 383926, "member": null, "api_token_id": null,
+        "created_at": "2021-03-10T09:59:27.398782Z", "updated_at": null, "content":
+        {"type": "action", "content_key": "RESOLVE", "data": {"revoked": true}}, "incident_id":
+        21460}, {"id": 1394920, "member": null, "api_token_id": null, "created_at":
+        "2021-08-25T17:16:06.029941Z", "updated_at": null, "content": {"type": "action",
+        "content_key": "SHARE", "data": {"shared_at": "2021-08-25T17:16:06.026036+00:00"}},
+        "incident_id": 21460}, {"id": 1547962, "member": null, "api_token_id": null,
+        "created_at": "2021-08-30T17:29:48.326754Z", "updated_at": null, "content":
+        {"type": "action", "content_key": "AUTO_UNSHARE", "data": {"issue_token_id":
+        5706}}, "incident_id": 21460}, {"id": 2918023, "member": {"id": 104916, "name":
+        "Wassim HANA", "email": "wassim.hana@gitguardian.com", "access_level": "manager"},
+        "api_token_id": null, "created_at": "2022-02-10T17:23:01.713143Z", "updated_at":
+        null, "content": {"type": "action", "content_key": "SHARE", "data": {"shared_at":
+        "2022-02-10T17:23:01.710300+00:00"}}, "incident_id": 21460}, {"id": 2918040,
+        "member": {"id": 104916, "name": "Wassim HANA", "email": "wassim.hana@gitguardian.com",
+        "access_level": "manager"}, "api_token_id": null, "created_at": "2022-02-10T17:31:53.593799Z",
+        "updated_at": null, "content": {"type": "action", "content_key": "UNSHARE",
+        "data": {"unshared_at": "2022-02-10T17:31:53.590070+00:00"}}, "incident_id":
+        21460}, {"id": 2999444, "member": null, "api_token_id": null, "created_at":
+        "2022-02-22T15:28:01.520877Z", "updated_at": null, "content": {"type": "action",
+        "content_key": "SET_SEVERITY", "data": {"severity": "critical", "previous_severity":
+        "unknown"}}, "incident_id": 21460}, {"id": 2999445, "member": null, "api_token_id":
+        null, "created_at": "2022-02-22T15:28:03.424967Z", "updated_at": null, "content":
+        {"type": "action", "content_key": "SET_SEVERITY", "data": {"severity": "unknown",
+        "previous_severity": "critical"}}, "incident_id": 21460}, {"id": 2999446,
+        "member": null, "api_token_id": null, "created_at": "2022-02-22T15:28:16.658526Z",
+        "updated_at": null, "content": {"type": "action", "content_key": "UNRESOLVE",
+        "data": null}, "incident_id": 21460}, {"id": 2999447, "member": null, "api_token_id":
+        null, "created_at": "2022-02-22T15:28:21.081191Z", "updated_at": null, "content":
+        {"type": "action", "content_key": "ASSIGN", "data": {"assignees": [9322]}},
+        "incident_id": 21460}, {"id": 2999451, "member": null, "api_token_id": null,
+        "created_at": "2022-02-22T15:29:24.093383Z", "updated_at": null, "content":
+        {"type": "action", "content_key": "SHARE", "data": {"shared_at": "2022-02-22T15:29:24.089492+00:00"}},
+        "incident_id": 21460}, {"id": 3006072, "member": null, "api_token_id": null,
+        "created_at": "2022-02-23T08:46:36.367333Z", "updated_at": null, "content":
+        {"type": "action", "content_key": "SET_SEVERITY", "data": {"severity": "critical",
+        "previous_severity": "unknown"}}, "incident_id": 21460}, {"id": 3212289, "member":
+        {"id": 104916, "name": "Wassim HANA", "email": "wassim.hana@gitguardian.com",
+        "access_level": "manager"}, "api_token_id": null, "created_at": "2022-03-21T15:29:47.748245Z",
+        "updated_at": null, "content": {"type": "action", "content_key": "UNSHARE",
+        "data": {"unshared_at": "2022-03-21T15:29:47.742352+00:00"}}, "incident_id":
+        21460}, {"id": 3212290, "member": {"id": 104916, "name": "Wassim HANA", "email":
+        "wassim.hana@gitguardian.com", "access_level": "manager"}, "api_token_id":
+        null, "created_at": "2022-03-21T15:29:49.559041Z", "updated_at": null, "content":
+        {"type": "action", "content_key": "SHARE", "data": {"shared_at": "2022-03-21T15:29:49.555144+00:00"}},
+        "incident_id": 21460}, {"id": 3212296, "member": {"id": 104916, "name": "Wassim
+        HANA", "email": "wassim.hana@gitguardian.com", "access_level": "manager"},
+        "api_token_id": null, "created_at": "2022-03-21T15:31:55.109710Z", "updated_at":
+        null, "content": {"type": "action", "content_key": "UNSHARE", "data": {"unshared_at":
+        "2022-03-21T15:31:55.102196+00:00"}}, "incident_id": 21460}, {"id": 3212297,
+        "member": {"id": 104916, "name": "Wassim HANA", "email": "wassim.hana@gitguardian.com",
+        "access_level": "manager"}, "api_token_id": null, "created_at": "2022-03-21T15:31:56.619889Z",
+        "updated_at": null, "content": {"type": "action", "content_key": "SHARE",
+        "data": {"shared_at": "2022-03-21T15:31:56.616061+00:00"}}, "incident_id":
+        21460}, {"id": 3375781, "member": {"id": 104916, "name": "Wassim HANA", "email":
+        "wassim.hana@gitguardian.com", "access_level": "manager"}, "api_token_id":
+        null, "created_at": "2022-04-07T08:57:17.261089Z", "updated_at": null, "content":
+        {"type": "action", "content_key": "GRANT_ACCESS", "data": {"users": [235930]}},
+        "incident_id": 21460}, {"id": 3375810, "member": {"id": 104916, "name": "Wassim
+        HANA", "email": "wassim.hana@gitguardian.com", "access_level": "manager"},
+        "api_token_id": null, "created_at": "2022-04-07T08:58:41.738456Z", "updated_at":
+        null, "content": {"type": "action", "content_key": "REMOVE_ACCESS", "data":
+        {"users": [235930]}}, "incident_id": 21460}, {"id": 3927232, "member": null,
+        "api_token_id": null, "created_at": "2022-04-20T16:08:13.163800Z", "updated_at":
+        null, "content": {"type": "action", "content_key": "AUTO_UNSHARE", "data":
+        {"issue_token_id": 15403}}, "incident_id": 21460}, {"id": 4191956, "member":
+        null, "api_token_id": null, "created_at": "2022-05-10T13:29:35.406608Z", "updated_at":
+        null, "content": {"type": "action", "content_key": "SET_SEVERITY", "data":
+        {"severity": "medium", "previous_severity": "critical"}}, "incident_id": 21460}]'
     headers:
       CF-RAY:
-      - a10417019cc9229d-CDG
+      - a113f7bd3bf63c86-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Jun 2026 10:05:01 GMT
+      - Thu, 25 Jun 2026 12:27:41 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -47,12 +111,15 @@ interactions:
       - GET, HEAD, OPTIONS
       cf-cache-status:
       - DYNAMIC
+      content-length:
+      - '5349'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
       - same-origin
       link:
-      - ''
+      - <https://api.gitguardian.com/v1/incidents/secrets/21460/activity-logs?cursor=cD00MTkxOTU2>;
+        rel="next"
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -60,17 +127,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.521.0
+      - v2.524.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '28'
+      - '93'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.165.0
+      - 2.166.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/client/vcr/test_list_public_incident_activity_logs.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incident_activity_logs.yaml
@@ -20,22 +20,23 @@ interactions:
     uri: https://api.gitguardian.com/v1/public-incidents/secrets/3759/activity-logs
   response:
     body:
-      string: '[{"id": 7101, "incident_id": 3759, "member": {"id": 480870, "name":
-        "Jane Doe", "email": "jane.doe@example.com", "access_level": "owner"}, "api_token_id":
-        "d0ca9877-641f-4c37-8857-c08e0ae148c4", "created_at": "2026-06-23T14:00:00.111111Z",
-        "updated_at": null, "content": {"type": "note", "comment": "Reported the leak
-        to the actor"}}, {"id": 7102, "incident_id": 3759, "member": null, "api_token_id":
-        null, "created_at": "2026-06-23T14:10:00.222222Z", "updated_at": null, "content":
-        {"type": "action", "content_key": "TRIGGER", "data": null}}]'
+      string: '[{"id": 3632, "member": null, "api_token_id": null, "created_at": "2025-01-07T18:59:16.484428Z",
+        "updated_at": null, "content": {"type": "action", "content_key": "TRIGGER",
+        "data": {"triggered_at": "2023-03-03T15:22:18+00:00"}}, "incident_id": 3759},
+        {"id": 5132786, "member": {"id": 480870, "name": "Timoth\u00e9 DELION", "email":
+        "timothe.delion@gitguardian.com", "access_level": "manager"}, "api_token_id":
+        "d0ca9877-641f-4c37-8857-c08e0ae148c4", "created_at": "2026-06-23T14:12:49.055117Z",
+        "updated_at": "2026-06-23T14:12:49.360819Z", "content": {"type": "note", "comment":
+        "Actor confirmed rotation"}, "incident_id": 3759}]'
     headers:
       CF-RAY:
-      - a10417019cc9229d-CDG
+      - a113f7bf6987ee96-CDG
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Jun 2026 14:10:01 GMT
+      - Thu, 25 Jun 2026 12:27:41 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -46,6 +47,8 @@ interactions:
       - GET, HEAD, OPTIONS
       cf-cache-status:
       - DYNAMIC
+      content-length:
+      - '582'
       content-security-policy:
       - frame-ancestors 'none'
       cross-origin-opener-policy:
@@ -59,17 +62,17 @@ interactions:
       vary:
       - Cookie
       x-app-version:
-      - v2.521.0
+      - v2.524.0
       x-content-type-options:
       - nosniff
       x-envoy-upstream-service-time:
-      - '31'
+      - '51'
       x-frame-options:
       - DENY
       x-per-page:
       - '20'
       x-secrets-engine-version:
-      - 2.165.0
+      - 2.166.0
       x-xss-protection:
       - 1; mode=block
     status:

--- a/tests/client/vcr/test_activity_logs.py
+++ b/tests/client/vcr/test_activity_logs.py
@@ -5,13 +5,23 @@ These cover the read-only activity-log listings, which return both user notes
 and system actions for an incident:
 - list_incident_activity_logs (internal incidents)
 - list_public_incident_activity_logs (public incidents)
-
-NOTE: the /activity-logs endpoints are not deployed in production yet, so these
-cassettes are hand-authored to match the public API response shape and cannot be
-re-recorded against prod until the endpoints ship.
 """
 
 import pytest
+
+
+def _assert_activity_log_entry(entry: dict, expected_incident_id: int) -> None:
+    """Assert an entry matches the public activity-log envelope + content union."""
+    assert entry["incident_id"] == expected_incident_id
+    assert isinstance(entry["id"], int)
+    assert {"id", "incident_id", "member", "api_token_id", "created_at", "updated_at", "content"} <= entry.keys()
+
+    content = entry["content"]
+    if content["type"] == "note":
+        assert isinstance(content["comment"], str)
+    else:
+        assert content["type"] == "action"
+        assert isinstance(content["content_key"], str)
 
 
 class TestIncidentActivityLogs:
@@ -21,9 +31,9 @@ class TestIncidentActivityLogs:
     @pytest.mark.asyncio
     async def test_list_incident_activity_logs(self, real_client, use_cassette):
         """
-        GIVEN a valid GitGuardian API key and an internal incident with notes and actions
+        GIVEN a valid GitGuardian API key and an internal incident with activity
         WHEN we list its activity log
-        THEN we receive a standardized ListResponse mixing note and action entries
+        THEN we receive a standardized ListResponse of note/action entries
         """
         with use_cassette("test_list_incident_activity_logs"):
             result = await real_client.list_incident_activity_logs(21460)
@@ -33,16 +43,14 @@ class TestIncidentActivityLogs:
             assert "has_more" in result
 
             entries = result["data"]
-            assert {entry["id"] for entry in entries} == {9001, 9002}
-            assert all(entry["incident_id"] == 21460 for entry in entries)
+            assert entries, "expected at least one activity-log entry"
+            for entry in entries:
+                _assert_activity_log_entry(entry, expected_incident_id=21460)
 
-            contents_by_id = {entry["id"]: entry["content"] for entry in entries}
-            assert contents_by_id[9001] == {
-                "type": "note",
-                "comment": "Investigating this incident via MCP",
-            }
-            assert contents_by_id[9002]["type"] == "action"
-            assert contents_by_id[9002]["content_key"] == "RESOLVE"
+            # This incident has more than one page of activity; the client
+            # surfaces the next cursor so callers can paginate.
+            assert result["has_more"] is True
+            assert result["cursor"] is not None
 
 
 class TestPublicIncidentActivityLogs:
@@ -52,7 +60,7 @@ class TestPublicIncidentActivityLogs:
     @pytest.mark.asyncio
     async def test_list_public_incident_activity_logs(self, real_client, use_cassette):
         """
-        GIVEN a valid GitGuardian API key and a public incident with notes and actions
+        GIVEN a valid GitGuardian API key and a public incident with a note and an action
         WHEN we list its activity log
         THEN we receive a standardized ListResponse mixing note and action entries
         """
@@ -64,11 +72,10 @@ class TestPublicIncidentActivityLogs:
             assert "has_more" in result
 
             entries = result["data"]
-            assert {entry["id"] for entry in entries} == {7101, 7102}
-            assert all(entry["incident_id"] == 3759 for entry in entries)
+            assert entries, "expected at least one activity-log entry"
+            for entry in entries:
+                _assert_activity_log_entry(entry, expected_incident_id=3759)
 
-            note_entry = next(e for e in entries if e["content"]["type"] == "note")
-            assert note_entry["content"]["comment"] == "Reported the leak to the actor"
-
-            action_entry = next(e for e in entries if e["content"]["type"] == "action")
-            assert action_entry["content"]["content_key"] == "TRIGGER"
+            # The public incident's log mixes a user note and a system action.
+            content_types = {entry["content"]["type"] for entry in entries}
+            assert content_types == {"note", "action"}


### PR DESCRIPTION
## What

Re-records the two incident activity-log VCR cassettes against the live GitGuardian API, now that the `/activity-logs` endpoints are deployed in production:

- `tests/cassettes/client/vcr/test_list_incident_activity_logs.yaml`
- `tests/cassettes/client/vcr/test_list_public_incident_activity_logs.yaml`

The `tests/client/vcr/test_activity_logs.py` assertions are reworked to validate the response envelope and the note/action `content` discriminated union **structurally**, instead of matching the placeholder ids and bodies the hand-authored cassettes used.

## Why

The original cassettes (added in #162) were hand-authored because the endpoints weren't live yet. They're real now, so the tests should exercise the actual API response shape.

## Notes

- Real recordings confirm the shape: internal incident `21460` returns a full page of system actions (TRIGGER, RESOLVE, ASSIGN, SET_SEVERITY, SHARE…) with a next cursor (`has_more=True`); public incident `3759` returns a note + a TRIGGER action.
- No auth/secret material is present in the cassettes (the `Authorization` header is stripped by the VCR config). Member name/email in the recordings is the recording user's own data, consistent with the existing note cassettes.

## Testing

`tests/client/vcr/test_activity_logs.py` — 2 passed on offline replay. Full suite: 654 passed, 3 skipped.

Refs: SI-3520