### PR TITLE
fix(honeytokens): surface generate_honeytoken API errors and quiet handled 400

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -407,12 +407,18 @@ class GitGuardianClient:
             logger.warning(f"Could not refresh token: {e}")
             return False
 
-    async def _request(self, method: str, endpoint: str, **kwargs) -> Any:
+    async def _request(
+        self, method: str, endpoint: str, *, expected_client_errors: Sequence[int] = (), **kwargs
+    ) -> Any:
         """Make a request to the GitGuardian API (generic method).
 
         Args:
             method: HTTP method (GET, POST, etc.)
             endpoint: API endpoint path
+            expected_client_errors: Status codes (e.g. [400]) that this caller handles
+                itself and surfaces to the user; they are logged at warning instead of
+                exception so they don't become Sentry noise. List only the codes the
+                caller truly expects — any other error stays visible via logger.exception.
             **kwargs: Additional arguments to pass to requests
 
         Returns:
@@ -557,6 +563,15 @@ class GitGuardianClient:
                         f"GitGuardian API returned {e.response.status_code} "
                         f"{e.response.reason_phrase} for {url} - token may be invalid, "
                         "expired, revoked, or lacking the required scope"
+                    )
+                elif e.response.status_code in expected_client_errors:
+                    # This caller declared this status as one it handles itself (e.g. a
+                    # duplicate-name 400 on honeytoken creation) and surfaces to the user,
+                    # so it is an expected client condition, not a server fault. Warn
+                    # instead of logger.exception so it doesn't become Sentry noise. Any
+                    # status not listed still hits logger.exception below.
+                    logger.warning(
+                        f"GitGuardian API returned {e.response.status_code} {e.response.reason_phrase} for {url}"
                     )
                 else:
                     logger.exception(f"HTTP error occurred: {e.response.status_code} - {e.response.reason_phrase}")
@@ -851,7 +866,9 @@ class GitGuardianClient:
             "custom_tags": custom_tags or [],
         }
 
-        return await self._request_post("/honeytokens", json=data)
+        # The generate_honeytoken tool handles a duplicate-name 400 and surfaces it to
+        # the caller, so it should not be logged as a server fault.
+        return await self._request_post("/honeytokens", json=data, expected_client_errors=[400])
 
     async def create_honeytoken_with_context(
         self,

--- a/packages/gg_api_core/src/gg_api_core/tools/generate_honey_token.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/generate_honey_token.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any
 
+import httpx
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
 
@@ -9,16 +10,39 @@ from gg_api_core.utils import get_client
 logger = logging.getLogger(__name__)
 
 
+def _extract_api_detail(response: httpx.Response) -> str:
+    """Pull a human-readable reason out of a GitGuardian API error response, so the
+    caller sees *why* the request was rejected rather than a bare status code."""
+    try:
+        body = response.json()
+    except Exception:
+        return response.text or f"HTTP {response.status_code}"
+    if isinstance(body, dict):
+        if body.get("detail"):
+            return str(body["detail"])
+        # DRF field errors, e.g. {"name": ["This field may not be blank."]}
+        field_errors = [
+            f"{field}: {'; '.join(errs) if isinstance(errs, list) else errs}" for field, errs in body.items()
+        ]
+        if field_errors:
+            return " | ".join(field_errors)
+    return str(body)
+
+
 class GenerateHoneytokenParams(BaseModel):
     """Parameters for generating a honeytoken."""
 
-    name: str = Field(description="Name for the honeytoken")
+    name: str = Field(
+        description="Name for the honeytoken. Must be UNIQUE among the workspace's active honeytokens — "
+        "reusing the name of an existing active token is rejected by the API. Pick a specific, descriptive "
+        "name (e.g. 'aws-prod-db-decoy-2026-07'), not a generic one."
+    )
     description: str = Field(default="", description="Description of what the honeytoken is used for")
     new_token: bool = Field(
         default=False,
-        description="If False, retrieves an existing active honeytoken created by you instead of generating a new one. "
-        "If no existing token is found, a new one will be created. "
-        "To generate a new token, set this to True.",
+        description="If False (default), reuse your most recent active honeytoken instead of generating a new one; "
+        "the name is only used when no reusable token exists and one must be created. "
+        "If True, always create a new honeytoken — this fails if the name is already taken, so pass a fresh unique name.",
     )
 
 
@@ -124,6 +148,17 @@ async def generate_honeytoken(params: GenerateHoneytokenParams) -> GenerateHoney
         }
 
         return GenerateHoneytokenResult(**creation_result)
+    except ToolError:
+        raise
+    except httpx.HTTPStatusError as e:
+        # The API rejected the request — most often because an active honeytoken with
+        # this name already exists (names are unique per workspace). This is an expected,
+        # caller-actionable condition, not a server fault: surface the API's reason so the
+        # client can retry with a different name (or adjust new_token). Log at warning so
+        # it does not surface as a Sentry error.
+        detail = _extract_api_detail(e.response)
+        logger.warning(f"Honeytoken creation rejected ({e.response.status_code}): {detail}")
+        raise ToolError(f"Could not create honeytoken: {detail}") from e
     except Exception as e:
         logger.exception(f"Error generating honeytoken: {str(e)}")
         raise ToolError(f"Failed to generate honeytoken: {str(e)}")

--- a/packages/gg_mcp_server/src/gg_mcp_server/register_tools.py
+++ b/packages/gg_mcp_server/src/gg_mcp_server/register_tools.py
@@ -210,7 +210,8 @@ def register_tools(mcp: AbstractGitGuardianFastMCP) -> None:
 
     mcp.tool(
         generate_honeytoken,
-        description="Generate an AWS GitGuardian honeytoken and get injection recommendations",
+        description="Generate an AWS GitGuardian honeytoken and get injection recommendations. "
+        "Honeytoken names must be unique among the workspace's active honeytokens.",
         required_scopes=["honeytokens:write"],
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ggmcp"
-version = "0.6.5"
+version = "0.6.6"
 description = "MCP server for GitGuardian"
 authors = [
     { name = "GitGuardian", email = "support@gitguardian.com" },

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -185,6 +185,52 @@ class TestGitGuardianClient:
             "expected a WARNING log mentioning the auth status code"
         )
 
+    def _mock_400(self, mock_httpx_client):
+        """Wire the mocked httpx client to raise a 400 on the next request."""
+        mock_request = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.reason_phrase = "Bad Request"
+        mock_response.text = "client error"
+        mock_response.json.return_value = {"detail": "rejected"}
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "400", request=mock_request, response=mock_response
+        )
+        async_client_instance = AsyncMock()
+        async_client_instance.__aenter__.return_value = mock_httpx_client
+        mock_httpx_client.request = AsyncMock(return_value=mock_response)
+        return async_client_instance
+
+    async def test_request_client_error_logged_as_error_by_default(self, client, mock_httpx_client, caplog):
+        """A 4xx is logged at ERROR by default, so unexpected client errors stay visible."""
+        import logging
+
+        async_client_instance = self._mock_400(mock_httpx_client)
+        with patch("httpx.AsyncClient", return_value=async_client_instance):
+            with caplog.at_level(logging.WARNING, logger="gg_api_core.client"):
+                with pytest.raises(httpx.HTTPStatusError):
+                    await client._request("GET", "/test")
+
+        assert [r for r in caplog.records if r.levelno >= logging.ERROR], "default 4xx should be logged at ERROR"
+
+    async def test_request_client_error_warning_when_expected(self, client, mock_httpx_client, caplog):
+        """With the status listed in expected_client_errors (e.g. honeytoken creation
+        passing [400]), that 4xx is logged at warning, not error, so a handled rejection
+        like a duplicate-name 400 is not Sentry noise (GIM-MCP-SERVER-3 / GIM-MCP-SERVER-Z)."""
+        import logging
+
+        async_client_instance = self._mock_400(mock_httpx_client)
+        with patch("httpx.AsyncClient", return_value=async_client_instance):
+            with caplog.at_level(logging.WARNING, logger="gg_api_core.client"):
+                with pytest.raises(httpx.HTTPStatusError):
+                    await client._request("POST", "/test", expected_client_errors=[400])
+
+        errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert not errors, f"an expected 4xx should not be logged at ERROR level: {errors}"
+        assert any(r.levelno == logging.WARNING and "400" in r.getMessage() for r in caplog.records), (
+            "expected a WARNING log mentioning the 400 status code"
+        )
+
     @pytest.mark.asyncio
     async def test_create_honeytoken(self, client):
         """Test create_honeytoken method."""
@@ -212,6 +258,7 @@ class TestGitGuardianClient:
                     "type": "AWS",
                     "custom_tags": [{"key": "test", "value": "value"}],
                 },
+                expected_client_errors=[400],
             )
 
             # Assert response

--- a/tests/tools/test_generate_honey_tokens.py
+++ b/tests/tools/test_generate_honey_tokens.py
@@ -75,6 +75,37 @@ class TestGenerateHoneytoken:
         assert f"Failed to generate honeytoken: {error_message}" in str(excinfo.value)
 
 
+@pytest.mark.asyncio
+async def test_generate_honeytoken_surfaces_api_detail_on_400(caplog):
+    """A 400 from the API (e.g. duplicate name) is surfaced to the caller as a ToolError
+    carrying the API's detail, and logged at warning — not error — so it does not become
+    Sentry noise (GIM-MCP-SERVER-Z)."""
+    import logging
+    from unittest.mock import MagicMock, patch
+
+    import httpx
+    from gg_api_core.tools.generate_honey_token import GenerateHoneytokenParams, generate_honeytoken
+
+    detail = "Another active honeytoken already exists with this name"
+    mock_response = MagicMock()
+    mock_response.status_code = 400
+    mock_response.json.return_value = {"detail": detail}
+    error = httpx.HTTPStatusError("400", request=MagicMock(), response=mock_response)
+
+    mock_client = AsyncMock()
+    mock_client.create_honeytoken = AsyncMock(side_effect=error)
+
+    with patch("gg_api_core.tools.generate_honey_token.get_client", AsyncMock(return_value=mock_client)):
+        with caplog.at_level(logging.WARNING, logger="gg_api_core.tools.generate_honey_token"):
+            with pytest.raises(ToolError) as excinfo:
+                # new_token=True skips the reuse lookup and goes straight to creation.
+                await generate_honeytoken(GenerateHoneytokenParams(name="dup", new_token=True))
+
+    assert detail in str(excinfo.value)
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert not errors, f"a handled 400 must not be logged at ERROR level: {errors}"
+
+
 # TestListIncidents class has been removed as the structure of the server has changed
 # and the test cannot be easily fixed without modifying the server.py code
 


### PR DESCRIPTION
## Context

Sentry [GIM-MCP-SERVER-Z](https://gitguardian.sentry.io/issues/7582104424/) / Linear [SI-3700](https://linear.app/gitguardian/issue/SI-3700/error-calling-tool-generate-honeytoken): `Error calling tool 'generate_honeytoken'`.

Investigation showed SI-3700 is the fastmcp wrapper log for the same failing request already tracked as **SI-3398 / GIM-MCP-SERVER-3** — a `400 Bad Request` on `POST /v1/honeytokens`. The only 400 the tool's payload can hit is the per-workspace active-name uniqueness check: `{"detail": "Another active honeytoken already exists with this name"}`.

Two problems:
1. The tool wrapped it as `Failed to generate honeytoken: Client error '400 Bad Request' for url …` — httpx's message has **no response body**, so the client never saw *why* it failed.
2. The 400 was logged via `logger.exception` → Sentry noise.

## Changes

- **Surface the real error (no self-healing).** `generate_honeytoken` now extracts the API `detail` and raises a clean `ToolError("Could not create honeytoken: <detail>")`, so the client can retry with a unique name / adjust `new_token` based on its own goals.
- **Quiet the handled 400, scoped to honeytoken.** Added an opt-in `expected_client_errors: Sequence[int]` on `GitGuardianClient._request`; `create_honeytoken` passes `[400]`. Every other endpoint keeps logging 4xx as errors, so unexpected client errors stay visible. `401/403` handling is unchanged.
- **Clearer tool contract.** `name` states it must be unique among active honeytokens (with an example); `new_token` describes the reuse-vs-create behavior accurately.

## Tests

- `test_request_client_error_logged_as_error_by_default` — a 400 with no opt-in still logs at ERROR.
- `test_request_client_error_warning_when_expected` — a 400 with `expected_client_errors=[400]` logs at WARNING, no ERROR.
- `test_generate_honeytoken_surfaces_api_detail_on_400` — the `ToolError` carries the API detail; nothing logs at ERROR.
- `test_create_honeytoken` updated for the new arg.

`ruff` ✅ · `mypy` ✅ · `pytest tests/test_client.py tests/tools/test_generate_honey_tokens.py` → 38 passed, 3 skipped.

## Known limitation

The fastmcp 3.1.0 layer logs **any** raised `ToolError` via `logger.exception` (`server.py:989`), so **GIM-MCP-SERVER-Z will still fire** — this is by design (surface the error to the client). Fully silencing it would require a Sentry-side filter on the `fastmcp.server.server` logger, which would also hide genuine tool failures; deliberately not done here.

Refs: SI-3700