### PR TITLE
Fix/tools params

### DIFF
--- a/packages/gg_api_core/pyproject.toml
+++ b/packages/gg_api_core/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "httpx~=0.28",
     "fastmcp~=3.0",
     "python-dotenv~=1.1",
+    "pydantic~=2.12",
     "pydantic-settings~=2.9",
     "jinja2~=3.1",
 ]

--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -1102,7 +1102,7 @@ class GitGuardianClient:
     async def update_incident(
         self,
         incident_id: str,
-        status: str | None = None,
+        severity: str | None = None,
         custom_tags: list | None = None,
     ) -> dict[str, Any]:
         """Update a secret incident.
@@ -1116,16 +1116,16 @@ class GitGuardianClient:
         Returns:
             Updated incident data
         """
-        logger.info(f"Updating incident {incident_id} with status={status}, custom_tags={custom_tags}")
+        logger.info(f"Updating incident {incident_id} with severity={severity}, custom_tags={custom_tags}")
 
         payload: dict[str, Any] = {}
-        if status:
-            payload["status"] = status
+        if severity:
+            payload["severity"] = severity
         if custom_tags:
             payload["custom_tags"] = custom_tags
 
         if not payload:
-            raise ValueError("At least one of status or custom_tags must be provided")
+            raise ValueError("At least one of severity or custom_tags must be provided")
 
         return await self._request_patch(f"/incidents/secrets/{incident_id}", json=payload)
 

--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -3,12 +3,14 @@ import json
 import logging
 import re
 from collections.abc import Sequence
+from datetime import datetime
 from enum import Enum
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any, Dict, Optional, TypedDict, cast
 from urllib.parse import quote_plus, unquote, urlparse
 
 import httpx
+from pydantic import TypeAdapter, ValidationError
 
 from gg_api_core.settings import get_settings
 
@@ -20,6 +22,14 @@ try:
     DEFAULT_USER_AGENT = f"GitGuardian-MCP-Server/{version('ggmcp')}"
 except PackageNotFoundError:
     DEFAULT_USER_AGENT = "GitGuardian-MCP-Server"
+
+
+def _to_date_only(value: str) -> str:
+    """Normalize a date/datetime string to its ``YYYY-MM-DD`` portion."""
+    try:
+        return TypeAdapter(datetime).validate_python(value.strip()).date().isoformat()
+    except ValidationError as exc:
+        raise ValueError(f"Invalid date value: {value!r}") from exc
 
 
 class DownstreamUnauthorizedError(Exception):
@@ -2639,9 +2649,9 @@ class GitGuardianClient:
 
         # Date filters
         if date_before:
-            params["date__le"] = date_before
+            params["date__le"] = _to_date_only(date_before)
         if date_after:
-            params["date__ge"] = date_after
+            params["date__ge"] = _to_date_only(date_after)
 
         # Secret scope filter
         if secret_scope:
@@ -2812,10 +2822,11 @@ class GitGuardianClient:
             params["teams__in"] = format_param(teams)
         if similar_to is not None:
             params["similar_to"] = similar_to
+        # Date filters
         if date_before:
-            params["date__le"] = date_before
+            params["date__le"] = _to_date_only(date_before)
         if date_after:
-            params["date__ge"] = date_after
+            params["date__ge"] = _to_date_only(date_after)
         if secret_scope:
             params["secret_scope__in"] = format_param(secret_scope)
         if analyzer_status:

--- a/packages/gg_api_core/src/gg_api_core/tools/manage_incident.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/manage_incident.py
@@ -99,30 +99,32 @@ async def manage_private_incident(params: ManageIncidentParams) -> dict[str, Any
         raise ToolError(f"Error: {str(e)}")
 
 
-class UpdateIncidentStatusParams(BaseModel):
-    """Parameters for updating incident status."""
+class UpdateIncidentSeverityParams(BaseModel):
+    """Parameters for updating incident severity."""
 
     incident_id: str | int = Field(description="ID of the secret incident")
-    status: str = Field(description="New status (IGNORED, TRIGGERED, ASSIGNED, RESOLVED)")
+    severity: Literal["critical", "high", "medium", "low", "info", "unknown"] = Field(
+        description="New severity for the incident"
+    )
 
 
-async def update_incident_status(params: UpdateIncidentStatusParams) -> dict[str, Any]:
+async def update_incident_severity(params: UpdateIncidentSeverityParams) -> dict[str, Any]:
     """
-    Update a secret incident with status and/or custom tags.
+    Set the severity of a secret incident.
 
     Args:
-        params: UpdateIncidentStatusParams model containing status update configuration
+        params: UpdateIncidentSeverityParams model containing the severity update configuration
 
     Returns:
         Updated incident data
     """
     client = await get_client()
-    logger.debug(f"Updating incident {params.incident_id} status to {params.status}")
+    logger.debug(f"Updating incident {params.incident_id} severity to {params.severity}")
 
     try:
-        result = await client.update_incident(incident_id=str(params.incident_id), status=params.status)
-        logger.debug(f"Updated incident {params.incident_id} status to {params.status}")
+        result = await client.update_incident(incident_id=str(params.incident_id), severity=params.severity)
+        logger.debug(f"Updated incident {params.incident_id} severity to {params.severity}")
         return result
     except Exception as e:
-        logger.exception(f"Error updating incident status: {str(e)}")
+        logger.exception(f"Error updating incident severity: {str(e)}")
         raise ToolError(f"Error: {str(e)}")

--- a/packages/gg_api_core/src/gg_api_core/tools/update_public_incident_status.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/update_public_incident_status.py
@@ -52,7 +52,7 @@ async def update_public_incident_status(params: UpdatePublicIncidentStatusParams
 
     Public incidents are surfaced by GitGuardian Public Monitoring (public GitHub repos/gists,
     Docker Hub, etc.). Public incident IDs are NOT interchangeable with internal incident IDs;
-    use this tool — not `manage_private_incident` / `update_incident_status` — when acting on
+    use this tool — not `manage_private_incident` — when acting on
     results from `list_public_incidents` or `get_public_incident`.
 
     Supported actions:

--- a/packages/gg_mcp_server/src/gg_mcp_server/register_tools.py
+++ b/packages/gg_mcp_server/src/gg_mcp_server/register_tools.py
@@ -42,7 +42,7 @@ from gg_api_core.tools.list_sources import list_sources
 from gg_api_core.tools.list_users import list_users
 from gg_api_core.tools.manage_incident import (
     manage_private_incident,
-    update_incident_status,
+    update_incident_severity,
 )
 from gg_api_core.tools.read_custom_tags import read_custom_tags
 from gg_api_core.tools.remediate_secret_incidents import remediate_secret_incidents
@@ -74,7 +74,7 @@ GitGuardian surfaces two distinct, non-overlapping categories of secret incident
   Read tools: `list_incidents`, `count_incidents`, `get_incident`, `list_repo_occurrences`,
   `remediate_secret_incidents`, `list_sources`, `find_current_source_id`, `list_incident_comments`,
   `list_incident_activity_logs`.
-  Write tools: `manage_private_incident`, `update_incident_status`, `assign_incident`,
+  Write tools: `manage_private_incident`, `update_incident_severity`, `assign_incident`,
   `update_or_create_incident_custom_tags`, `create_code_fix_request`, `manage_incident_comment`.
 - **Public incidents** — detected by GitGuardian Public Monitoring on the worldwide public
   perimeter: public GitHub repos/gists, Docker Hub, etc. Not linked to a workspace source.
@@ -339,8 +339,8 @@ def register_tools(mcp: AbstractGitGuardianFastMCP) -> None:
     )
 
     mcp.tool(
-        update_incident_status,
-        description="(Internal sources only) Update an internal secret incident with status. "
+        update_incident_severity,
+        description="(Internal sources only) Set the severity of an internal secret incident. "
         "Does not work on public-monitoring incident IDs.",
         required_scopes=["incidents:write"],
     )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -759,3 +759,22 @@ class TestIncidentsForMCPAssigneeFilter:
         params = client._request_get.call_args.kwargs["params"]
         assert params["assignee_member_id"] == "0"
         assert "assignee__in" not in params
+
+    @pytest.mark.asyncio
+    async def test_list_incidents_for_mcp_truncates_datetime_bounds_to_date(self, client):
+        """
+        GIVEN ISO datetime date bounds
+        WHEN calling list_incidents_for_mcp
+        THEN date__ge / date__le are sent as date-only values (the endpoint
+             filters on a date-only field and 400s on datetimes)
+        """
+        client._request_get = AsyncMock(return_value={"results": []})
+
+        await client.list_incidents_for_mcp(
+            date_after="2026-07-01T00:00:00Z",
+            date_before="2026-08-01T00:00:00Z",
+        )
+
+        params = client._request_get.call_args.kwargs["params"]
+        assert params["date__ge"] == "2026-07-01"
+        assert params["date__le"] == "2026-08-01"

--- a/uv.lock
+++ b/uv.lock
@@ -573,6 +573,7 @@ dependencies = [
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "jinja2" },
+    { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
 ]
@@ -587,6 +588,7 @@ requires-dist = [
     { name = "fastmcp", specifier = "~=3.0" },
     { name = "httpx", specifier = "~=0.28" },
     { name = "jinja2", specifier = "~=3.1" },
+    { name = "pydantic", specifier = "~=2.12" },
     { name = "pydantic-settings", specifier = "~=2.9" },
     { name = "python-dotenv", specifier = "~=1.1" },
     { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = "~=2.43" },


### PR DESCRIPTION
Fixing two tools:
- fix the `date_before`/`date_after` parameters requiring a date format when listing internal incidents
- fix the `update_incident_status` tool not working and replace it with `update_incident_severity` (to update an incident's status, one has to use the `manage_private_incident` tool