### PR TITLE
fix(register_tools): correct revoke_secret required_scopes to secrets:write

### DIFF
--- a/packages/gg_mcp_server/src/gg_mcp_server/register_tools.py
+++ b/packages/gg_mcp_server/src/gg_mcp_server/register_tools.py
@@ -368,7 +368,7 @@ def register_tools(mcp: AbstractGitGuardianFastMCP) -> None:
         revoke_secret,
         description="Revoke a secret by its ID through the GitGuardian API. Operates on a secret_id regardless of whether "
         "the incident surfaced on an internal source or via Public Monitoring.",
-        required_scopes=["write:secret"],
+        required_scopes=["secrets:write"],
     )
 
     mcp.tool(


### PR DESCRIPTION
`revoke_secret` was registered with required_scopes=["write:secret"], a scope that does not exist in ALL_SCOPES (the real scope is "secrets:write"). ScopeFilteringMiddleware keeps a tool only when its required_scopes are a subset of the token's scopes, so revoke_secret was hidden from every client.