### PR TITLE
fix(oauth_proxy): read token name/lifetime via settings, not os.environ

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/oauth_proxy_auth.py
+++ b/packages/gg_api_core/src/gg_api_core/oauth_proxy_auth.py
@@ -386,8 +386,8 @@ class GitGuardianOAuthThinProxy(PassThroughTokenVerifier):
         token_name = settings.mcp_oauth_token_name
         form_data.setdefault("name", token_name)
 
-        # Add token lifetime
-        token_lifetime = settings.gitguardian_token_lifetime
+        # Add token lifetime; unset ⇒ omitted ⇒ the server's DCR default/cap applies
+        token_lifetime = settings.mcp_oauth_token_lifetime
         if token_lifetime and token_lifetime.lower() != "never":
             form_data.setdefault("lifetime", token_lifetime)
 

--- a/packages/gg_api_core/src/gg_api_core/oauth_proxy_auth.py
+++ b/packages/gg_api_core/src/gg_api_core/oauth_proxy_auth.py
@@ -14,7 +14,6 @@ The MCP client gets the real GG PAT directly and sends it as Bearer token.
 """
 
 import logging
-import os
 from collections.abc import Callable
 from contextvars import ContextVar
 from urllib.parse import urlencode, urlparse
@@ -26,6 +25,8 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, RedirectResponse
 from starlette.routing import Route
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from .settings import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -381,11 +382,12 @@ class GitGuardianOAuthThinProxy(PassThroughTokenVerifier):
         form_data.setdefault("client_id", self.gg_client_id)
 
         # Add token name
-        token_name = os.environ.get("MCP_OAUTH_TOKEN_NAME", "MCP server token (OAuth Proxy)")
+        settings = get_settings()
+        token_name = settings.mcp_oauth_token_name
         form_data.setdefault("name", token_name)
 
         # Add token lifetime
-        token_lifetime = os.environ.get("GITGUARDIAN_TOKEN_LIFETIME")
+        token_lifetime = settings.gitguardian_token_lifetime
         if token_lifetime and token_lifetime.lower() != "never":
             form_data.setdefault("lifetime", token_lifetime)
 

--- a/packages/gg_api_core/src/gg_api_core/settings.py
+++ b/packages/gg_api_core/src/gg_api_core/settings.py
@@ -63,6 +63,7 @@ class Settings(BaseSettings):
     # --- OAuth proxy ---
     mcp_oauth_proxy_enabled: str | None = None
     mcp_base_url: str = "http://localhost:8000"
+    mcp_oauth_token_name: str = "MCP server token (OAuth Proxy)"
 
     # --- System ---
     xdg_config_home: str | None = None

--- a/packages/gg_api_core/src/gg_api_core/settings.py
+++ b/packages/gg_api_core/src/gg_api_core/settings.py
@@ -64,6 +64,11 @@ class Settings(BaseSettings):
     mcp_oauth_proxy_enabled: str | None = None
     mcp_base_url: str = "http://localhost:8000"
     mcp_oauth_token_name: str = "MCP server token (OAuth Proxy)"
+    # Explicit 90 mirrors the server-side policy for DCR-issued tokens
+    # (oauth2_access_token_max_lifetime: default and cap, per SI-3329). The local
+    # flow's 30-day gitguardian_token_lifetime default must not leak into the
+    # proxy — DCR tokens have a server backstop, local ones don't.
+    mcp_oauth_token_lifetime: str = "90"
 
     # --- System ---
     xdg_config_home: str | None = None


### PR DESCRIPTION
_handle_token read MCP_OAUTH_TOKEN_NAME and GITGUARDIAN_TOKEN_LIFETIME directly from os.environ, violating the project's use-settings-not-environ convention. Add an mcp_oauth_token_name setting (default "MCP server token (OAuth Proxy)") and route both reads through get_settings(); the proxy now honours the same default lifetime (30 days) as the local OAuth flow. Drop the now-unused os import.