### PR TITLE
ci: add least-privilege permissions block to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The workflow had no permissions: block, so GITHUB_TOKEN inherited the repo/org default (potentially contents:write). All CI jobs are read-only, so pin to contents:read.

This enforces `contents: read` on workflows that are read-only (push is set to false during CI and only enabled during release).