### PR TITLE
chore(pre-commit): bump ruff rev to v0.14.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.10
+    rev: v0.14.3
     hooks:
       - id: ruff
         args: [--fix]


### PR DESCRIPTION
ruff-pre-commit was pinned at v0.11.10 while pyproject dev-deps and CI use ruff~=0.14 (resolves to 0.14.3). Align the pre-commit hook so local formatting matches CI.