### PR TITLE
build: raise requires-python floor to >=3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 ]
 license = "MIT"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "gg-mcp-server",
     "developer-mcp-server",
@@ -122,7 +122,7 @@ markers = [
 ]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 warn_redundant_casts = true


### PR DESCRIPTION
Root requires-python said >=3.10 and mypy targeted 3.10, but every workspace package requires >=3.11 and uv.lock requires >=3.11; the 3.10 floor is unattainable and untested. Set root requires-python and mypy python_version to 3.11.