### PR TITLE
ci(release): drop unused PYTHON_VERSION build-arg

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -89,8 +89,6 @@ jobs:
           cache-from: ${{ inputs.no-cache && '' || 'type=gha' }}
           cache-to: ${{ inputs.no-cache && '' || 'type=gha,mode=max' }}
           platforms: linux/amd64,linux/arm64
-          build-args: |
-            PYTHON_VERSION=3.13
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3


### PR DESCRIPTION
release.yml passed build-args: PYTHON_VERSION=3.13 but the Dockerfile defines no ARG PYTHON_VERSION, so it was silently ignored. Remove it.