### PR TITLE
feat(client): log outbound GG API requests at INFO

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import re
+import time
 from collections.abc import Sequence
 from datetime import datetime
 from enum import Enum
@@ -476,10 +477,13 @@ class GitGuardianClient:
             try:
                 async with httpx.AsyncClient(follow_redirects=True, timeout=DEFAULT_HTTP_TIMEOUT) as client:
                     logger.debug(f"Sending {method} request to {url}")
+                    request_start = time.perf_counter()
                     response = await client.request(method, url, headers=headers, **kwargs)
+                    elapsed_ms = (time.perf_counter() - request_start) * 1000
+
+                logger.info(f"GG API {method} {endpoint} -> {response.status_code} ({elapsed_ms:.0f}ms)")
 
                 # Log detailed response information
-                logger.debug(f"Response status code: {response.status_code}")
                 logger.debug(f"Response headers: {dict(response.headers)}")
 
                 # Log response content if present
@@ -722,8 +726,11 @@ class GitGuardianClient:
         }
         headers.update(kwargs.pop("headers", {}))
 
+        request_start = time.perf_counter()
         async with httpx.AsyncClient(follow_redirects=True, timeout=DEFAULT_HTTP_TIMEOUT) as client:
             response = await client.get(url, headers=headers, **kwargs)
+            elapsed_ms = (time.perf_counter() - request_start) * 1000
+            logger.info(f"GG API GET {endpoint} -> {response.status_code} ({elapsed_ms:.0f}ms)")
             response.raise_for_status()
 
             data = response.json() if response.content else {}


### PR DESCRIPTION
_request and _request_list logged method/URL/status only at DEBUG, so in production (INFO) no GG API call was recorded. Add one INFO line per request with method, endpoint, status and elapsed_ms (timed with time.perf_counter). Only the endpoint path is logged, never query params, to avoid leaking sensitive values.

:information_source: We should discuss more around how we handle logging in ggmcp. AGENTS.md references Structlog but that is never used in the project. IMO we should rework it to add metadata on logs and support proper context propagation (traceId, spanId, GitGuardian request id).