### PR TITLE
feat(mcp_server): log selected auth mode at startup

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/mcp_server.py
+++ b/packages/gg_api_core/src/gg_api_core/mcp_server.py
@@ -397,12 +397,28 @@ def get_mcp_server(*args, **kwargs) -> AbstractGitGuardianFastMCP:
             gg_api_url=settings.gitguardian_api_url,
             advertised_scopes=settings.effective_scopes,
         )
+        logger.info(
+            "Starting GitGuardian MCP server in %s mode",
+            GitGuardianOAuthProxyMCP.authentication_mode.value,
+        )
         return GitGuardianOAuthProxyMCP(*args, auth=oauth_proxy, **kwargs)
 
     if settings.is_oauth_enabled:
+        logger.info(
+            "Starting GitGuardian MCP server in %s mode",
+            GitGuardianLocalOAuthMCP.authentication_mode.value,
+        )
         return GitGuardianLocalOAuthMCP(*args, **kwargs)
 
     if personal_access_token := settings.gitguardian_personal_access_token:
+        logger.info(
+            "Starting GitGuardian MCP server in %s mode",
+            GitGuardianPATEnvMCP.authentication_mode.value,
+        )
         return GitGuardianPATEnvMCP(*args, personal_access_token=personal_access_token, **kwargs)
 
+    logger.info(
+        "Starting GitGuardian MCP server in %s mode",
+        GitGuardianAuthorizationHeaderMCP.authentication_mode.value,
+    )
     return GitGuardianAuthorizationHeaderMCP(*args, auth=PassThroughTokenVerifier(), **kwargs)

--- a/packages/gg_api_core/src/gg_api_core/mcp_server.py
+++ b/packages/gg_api_core/src/gg_api_core/mcp_server.py
@@ -391,15 +391,15 @@ def get_mcp_server(*args, **kwargs) -> AbstractGitGuardianFastMCP:
     settings = get_settings()
 
     if settings.is_oauth_proxy_enabled:
+        logger.info(
+            "Starting GitGuardian MCP server in %s mode",
+            GitGuardianOAuthProxyMCP.authentication_mode.value,
+        )
         oauth_proxy = create_oauth_proxy(
             base_url=settings.mcp_base_url,
             gg_url=settings.gitguardian_url,
             gg_api_url=settings.gitguardian_api_url,
             advertised_scopes=settings.effective_scopes,
-        )
-        logger.info(
-            "Starting GitGuardian MCP server in %s mode",
-            GitGuardianOAuthProxyMCP.authentication_mode.value,
         )
         return GitGuardianOAuthProxyMCP(*args, auth=oauth_proxy, **kwargs)
 


### PR DESCRIPTION
get_mcp_server silently picked one of four auth modes. Log the chosen AuthenticationMode before each return so prod logs show whether the server started in OAUTH_PROXY / LOCAL_OAUTH_FLOW / PAT_ENV_VAR / AUTHORIZATION_HEADER mode.