### PR TITLE
chore(server.json): bump version 0.5.0 -> 0.6.8

### DIFF
--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/GitGuardian/ggmcp",
     "source": "github"
   },
-  "version": "0.5.0",
+  "version": "0.6.8",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "ggmcp",
-      "version": "0.5.0",
+      "version": "0.6.8",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/GitGuardian/ggmcp",
     "source": "github"
   },
-  "version": "0.6.8",
+  "version": "0.6.10",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "ggmcp",
-      "version": "0.6.8",
+      "version": "0.6.10",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
server.json declared 0.5.0 while pyproject.toml is 0.6.8. Sync the top-level and package version fields.