### PR TITLE
refactor: introduce ON_PREM env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,11 @@ GITGUARDIAN_SCOPES=honeytokens:read honeytokens:write incidents:read incidents:w
 # Optional: Override the GitGuardian instance URL
 GITGUARDIAN_URL=https://dashboard.gitguardian.com
 
+# Optional: Set to true when targeting a self-hosted GitGuardian instance
+# (false for SaaS). When unset, the instance type is guessed from the
+# GITGUARDIAN_URL hostname.
+# ON_PREM=true
+
 # API Key for VCR tests against the public API
 GITGUARDIAN_API_KEY=--fill-me--
 GITGUARDIAN_API_KEY_ID=--fill-me--

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Minimum configuration:
 ```bash
 docker run -p 8000:8000 \
   -e GITGUARDIAN_URL=https://dashboard.gitguardian.mycorp.local \
+  -e ON_PREM=true \
   -e MCP_BASE_URL=https://mcp.mycorp.local \
   -e MCP_OAUTH_PROXY_ENABLED=true \
   -e ENABLE_LOCAL_OAUTH=false \
@@ -205,6 +206,12 @@ docker run -p 8000:8000 \
   gunicorn --workers=4 --worker-class=uvicorn.workers.UvicornWorker \
            -b 0.0.0.0:8000 gg_mcp_server.http_app:app
 ```
+
+`ON_PREM=true` tells the server it talks to a self-hosted GIM instance
+(API served under `/exposed/v1`, self-hosted scope set). When unset, the
+server guesses from the `GITGUARDIAN_URL` hostname, which fails for
+self-hosted instances deployed under a `gitguardian.com`/`gitguardian.tech`
+domain — set it explicitly for any self-hosted deployment.
 
 `MCP_OAUTH_PROXY_ENABLED=true` makes the server advertise itself as an OAuth
 Protected Resource (RFC 9728) and proxy `/authorize`, `/token`, `/register`
@@ -216,6 +223,7 @@ your domain.
 | Variable                            | Description                                      | Default                             |
 |-------------------------------------|--------------------------------------------------|-------------------------------------|
 | `GITGUARDIAN_URL`                   | GitGuardian dashboard URL                        | `https://dashboard.gitguardian.com` |
+| `ON_PREM`                           | `true` => self-hosted; `false` => SaaS; unset ⇒ guess from hostname | Unset            |
 | `GITGUARDIAN_PERSONAL_ACCESS_TOKEN` | PAT (overrides OAuth)                            | Unset                               |
 | `GITGUARDIAN_SCOPES`                | Comma-separated OAuth scopes to request          | Auto                                |
 | `GITGUARDIAN_CLIENT_ID`             | OAuth client ID                                  | `ggshield_oauth`                    |

--- a/packages/gg_api_core/src/gg_api_core/host.py
+++ b/packages/gg_api_core/src/gg_api_core/host.py
@@ -40,14 +40,22 @@ def is_self_hosted_instance(gitguardian_url: str | None = None) -> bool:
     """
     Determine if we're connecting to a self-hosted GitGuardian instance.
 
+    The ON_PREM environment variable, when set, is authoritative. When unset,
+    use a heuristic.
+
     Args:
         gitguardian_url: GitGuardian URL to check, defaults to GITGUARDIAN_URL env var
 
     Returns:
         bool: True if self-hosted, False if SaaS
     """
+    settings = get_settings()
+
+    if settings.is_on_prem is not None:
+        return settings.is_on_prem
+
     if not gitguardian_url:
-        gitguardian_url = get_settings().gitguardian_url
+        gitguardian_url = settings.gitguardian_url
 
     try:
         parsed = urlparse(gitguardian_url)

--- a/packages/gg_api_core/src/gg_api_core/settings.py
+++ b/packages/gg_api_core/src/gg_api_core/settings.py
@@ -42,6 +42,8 @@ class Settings(BaseSettings):
     gitguardian_api_url: str | None = None
     gitguardian_personal_access_token: str | None = None
 
+    on_prem: str | None = None
+
     # GITGUARDIAN_REQUESTED_SCOPES is the legacy name kept for backward compat.
     gitguardian_scopes: str | None = None
     gitguardian_requested_scopes: str | None = None
@@ -74,6 +76,13 @@ class Settings(BaseSettings):
         if self.enable_local_oauth is None:
             return True
         return string_env_to_bool(self.enable_local_oauth)
+
+    @property
+    def is_on_prem(self) -> bool | None:
+        """Explicit self-hosted/SaaS declaration, or None when ON_PREM is unset."""
+        if self.on_prem is None:
+            return None
+        return string_env_to_bool(self.on_prem)
 
     @property
     def is_multi_tenant(self) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ggmcp"
-version = "0.6.8"
+version = "0.6.9"
 description = "MCP server for GitGuardian"
 authors = [
     { name = "GitGuardian", email = "support@gitguardian.com" },

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -3,7 +3,9 @@
 import os
 from unittest.mock import patch
 
+import pytest
 from gg_api_core.host import SAAS_HOSTNAMES, _is_saas_hostname, is_self_hosted_instance
+from gg_api_core.urls import derive_public_api_url
 
 
 class TestIsSelfHostedInstance:
@@ -125,6 +127,45 @@ class TestIsSelfHostedInstance:
             # Construct a full URL for each hostname
             url = f"https://{hostname}"
             assert is_self_hosted_instance(url) is False, f"Expected False for {url}"
+
+
+class TestOnPremOverride:
+    """Tests for the ON_PREM environment variable override."""
+
+    @pytest.mark.parametrize(
+        ("on_prem", "url", "expected"),
+        [
+            ("true", "https://on-prem.preprod.gitguardian.tech", True),
+            ("true", "https://dashboard.gitguardian.com", True),
+            ("true", "https://gitguardian.mycompany.com", True),
+            ("false", "https://on-prem.preprod.gitguardian.tech", False),
+            ("false", "https://dashboard.gitguardian.com", False),
+            ("false", "https://gitguardian.mycompany.com", False),
+            (None, "https://dashboard.gitguardian.com", False),
+            (None, "https://gitguardian.mycompany.com", True),
+        ],
+    )
+    def test_on_prem_override(self, on_prem, url, expected):
+        """
+        GIVEN ON_PREM set to true, false, or unset
+        WHEN is_self_hosted_instance is called with any URL
+        THEN the override decides when set, and the hostname heuristic decides when unset
+        """
+        env = {"ON_PREM": on_prem} if on_prem is not None else {}
+        with patch.dict(os.environ, env, clear=True):
+            assert is_self_hosted_instance(url) is expected
+
+    def test_on_prem_true_derives_exposed_api_url(self):
+        """
+        GIVEN ON_PREM=true and a self-hosted instance under a SaaS-like domain
+        WHEN the public API URL is derived from the base URL
+        THEN the /exposed/v1 prefix is appended
+        """
+        with patch.dict(os.environ, {"ON_PREM": "true"}):
+            assert (
+                derive_public_api_url("https://on-prem.preprod.gitguardian.tech")
+                == "https://on-prem.preprod.gitguardian.tech/exposed/v1"
+            )
 
 
 class TestIsSaasHostname:


### PR DESCRIPTION
Being in a self-hosted environment or not matters for the MCP as GIM's public API does not have the same shape whether it is deployed on-prem or on saas.
Until this commit, it was done using a heuristic which was looking at GIM's domain to guess if it was a SaaS or self-hosted instance. However, it failed for GitGuardian's on-prem deployments which look like the saas domain (since "on-prem.gitguardian.tech" has "gitguardian.tech" like saas urls).

Fix: use an environment variable. The deployment should know already if it is self hosted or saas, so it can just provide this information to the MCP.
The heuristic is kept for now as a fallback while waiting for all GIM deployments to provide this environment variable.

Refs: SI-3813