### PR TITLE
chore(gg_api_core): remove unexisting/unused endpoints

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -1528,18 +1528,6 @@ class GitGuardianClient:
 
         return await self._request_list(endpoint, params=params)
 
-    async def get_incident_impacted_perimeter(self, incident_id: str) -> dict[str, Any]:
-        """Retrieve the impacted perimeter of a secret incident.
-
-        Args:
-            incident_id: ID of the secret incident
-
-        Returns:
-            Information about the impacted perimeter
-        """
-        logger.info(f"Getting impacted perimeter for incident {incident_id}")
-        return await self._request_get(f"/incidents/secrets/{incident_id}/perimeter")
-
     # Secret Incident Notes (comments) management
     #
     # Notes are free-form comments left by members or API tokens on an incident.
@@ -1751,19 +1739,6 @@ class GitGuardianClient:
             return await self.paginate_all(endpoint, params)
 
         return await self._request_list(endpoint, params=params)
-
-    # Secret Occurrences management
-    async def list_secret_occurrences(self, incident_id: str) -> dict[str, Any]:
-        """List secret occurrences for an incident.
-
-        Args:
-            incident_id: ID of the secret incident
-
-        Returns:
-            List of secret occurrences
-        """
-        logger.info(f"Listing secret occurrences for incident ID: {incident_id}")
-        return await self._request_get(f"/incidents/{incident_id}/secret-occurrences")
 
     async def list_occurrences(
         self,

--- a/tests/client/vcr/test_incidents.py
+++ b/tests/client/vcr/test_incidents.py
@@ -7,7 +7,6 @@ These tests cover:
 - get_incident(incident_id)
 - get_incidents(incident_ids)
 - list_incident_members(incident_id)
-- get_incident_impacted_perimeter(incident_id)
 - list_incident_notes(incident_id)
 """
 

--- a/tests/client/vcr/test_occurrences.py
+++ b/tests/client/vcr/test_occurrences.py
@@ -3,7 +3,6 @@ VCR tests for GitGuardianClient occurrence methods.
 
 These tests cover:
 - list_occurrences(...)
-- list_secret_occurrences(incident_id)
 """
 
 import pytest


### PR DESCRIPTION
These endpoints seem to have been generated but never used or tested. They appear in vcr comments but not in actual tests. Both are non-existing on GitGuardian API