### PR TITLE
chore(env): rename on_prem variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ GITGUARDIAN_URL=https://dashboard.gitguardian.com
 # Optional: Set to true when targeting a self-hosted GitGuardian instance
 # (false for SaaS). When unset, the instance type is guessed from the
 # GITGUARDIAN_URL hostname.
-# ON_PREM=true
+# IS_ON_PREM=true
 
 # API Key for VCR tests against the public API
 GITGUARDIAN_API_KEY=--fill-me--

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Minimum configuration:
 ```bash
 docker run -p 8000:8000 \
   -e GITGUARDIAN_URL=https://dashboard.gitguardian.mycorp.local \
-  -e ON_PREM=true \
+  -e IS_ON_PREM=true \
   -e MCP_BASE_URL=https://mcp.mycorp.local \
   -e MCP_OAUTH_PROXY_ENABLED=true \
   -e ENABLE_LOCAL_OAUTH=false \
@@ -207,7 +207,7 @@ docker run -p 8000:8000 \
            -b 0.0.0.0:8000 gg_mcp_server.http_app:app
 ```
 
-`ON_PREM=true` tells the server it talks to a self-hosted GIM instance
+`IS_ON_PREM=true` tells the server it talks to a self-hosted GIM instance
 (API served under `/exposed/v1`, self-hosted scope set). When unset, the
 server guesses from the `GITGUARDIAN_URL` hostname, which fails for
 self-hosted instances deployed under a `gitguardian.com`/`gitguardian.tech`
@@ -223,7 +223,7 @@ your domain.
 | Variable                            | Description                                      | Default                             |
 |-------------------------------------|--------------------------------------------------|-------------------------------------|
 | `GITGUARDIAN_URL`                   | GitGuardian dashboard URL                        | `https://dashboard.gitguardian.com` |
-| `ON_PREM`                           | `true` => self-hosted; `false` => SaaS; unset ⇒ guess from hostname | Unset            |
+| `IS_ON_PREM`                        | `true` => self-hosted; `false` => SaaS; unset ⇒ guess from hostname | Unset            |
 | `GITGUARDIAN_PERSONAL_ACCESS_TOKEN` | PAT (overrides OAuth)                            | Unset                               |
 | `GITGUARDIAN_SCOPES`                | Comma-separated OAuth scopes to request          | Auto                                |
 | `GITGUARDIAN_CLIENT_ID`             | OAuth client ID                                  | `ggshield_oauth`                    |

--- a/packages/gg_api_core/src/gg_api_core/host.py
+++ b/packages/gg_api_core/src/gg_api_core/host.py
@@ -40,7 +40,7 @@ def is_self_hosted_instance(gitguardian_url: str | None = None) -> bool:
     """
     Determine if we're connecting to a self-hosted GitGuardian instance.
 
-    The ON_PREM environment variable, when set, is authoritative. When unset,
+    The IS_ON_PREM environment variable, when set, is authoritative. When unset,
     use a heuristic.
 
     Args:

--- a/packages/gg_api_core/src/gg_api_core/settings.py
+++ b/packages/gg_api_core/src/gg_api_core/settings.py
@@ -12,6 +12,7 @@ test fixtures using ``patch.dict(os.environ, ...)`` or
 ``monkeypatch.setenv`` continue to work without cache invalidation.
 """
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 TRUTHY_ENV_VALUES = frozenset(
@@ -42,7 +43,7 @@ class Settings(BaseSettings):
     gitguardian_api_url: str | None = None
     gitguardian_personal_access_token: str | None = None
 
-    on_prem: str | None = None
+    on_prem: str | None = Field(default=None, alias="IS_ON_PREM")
 
     # GITGUARDIAN_REQUESTED_SCOPES is the legacy name kept for backward compat.
     gitguardian_scopes: str | None = None
@@ -79,7 +80,7 @@ class Settings(BaseSettings):
 
     @property
     def is_on_prem(self) -> bool | None:
-        """Explicit self-hosted/SaaS declaration, or None when ON_PREM is unset."""
+        """Explicit self-hosted/SaaS declaration, or None when IS_ON_PREM is unset."""
         if self.on_prem is None:
             return None
         return string_env_to_bool(self.on_prem)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ggmcp"
-version = "0.6.9"
+version = "0.6.10"
 description = "MCP server for GitGuardian"
 authors = [
     { name = "GitGuardian", email = "support@gitguardian.com" },

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -130,7 +130,7 @@ class TestIsSelfHostedInstance:
 
 
 class TestOnPremOverride:
-    """Tests for the ON_PREM environment variable override."""
+    """Tests for the IS_ON_PREM environment variable override."""
 
     @pytest.mark.parametrize(
         ("on_prem", "url", "expected"),
@@ -147,21 +147,21 @@ class TestOnPremOverride:
     )
     def test_on_prem_override(self, on_prem, url, expected):
         """
-        GIVEN ON_PREM set to true, false, or unset
+        GIVEN IS_ON_PREM set to true, false, or unset
         WHEN is_self_hosted_instance is called with any URL
         THEN the override decides when set, and the hostname heuristic decides when unset
         """
-        env = {"ON_PREM": on_prem} if on_prem is not None else {}
+        env = {"IS_ON_PREM": on_prem} if on_prem is not None else {}
         with patch.dict(os.environ, env, clear=True):
             assert is_self_hosted_instance(url) is expected
 
     def test_on_prem_true_derives_exposed_api_url(self):
         """
-        GIVEN ON_PREM=true and a self-hosted instance under a SaaS-like domain
+        GIVEN IS_ON_PREM=true and a self-hosted instance under a SaaS-like domain
         WHEN the public API URL is derived from the base URL
         THEN the /exposed/v1 prefix is appended
         """
-        with patch.dict(os.environ, {"ON_PREM": "true"}):
+        with patch.dict(os.environ, {"IS_ON_PREM": "true"}):
             assert (
                 derive_public_api_url("https://on-prem.preprod.gitguardian.tech")
                 == "https://on-prem.preprod.gitguardian.tech/exposed/v1"

--- a/uv.lock
+++ b/uv.lock
@@ -576,7 +576,7 @@ provides-extras = ["sentry"]
 
 [[package]]
 name = "ggmcp"
-version = "0.6.8"
+version = "0.6.10"
 source = { editable = "." }
 dependencies = [
     { name = "developer-mcp-server" },


### PR DESCRIPTION
To match existing naming on other apps and benefit from existing auto-injection when deployed on premise.