### PR TITLE
ci: sign released docker images with cosign (keyless)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # keyless cosign signing (Sigstore/Rekor via GitHub OIDC)
     env:
       # Empty outside releases: switches image tags to main / <branch>-<sha>.
       RELEASE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || needs.tag-version.outputs.tag }}
@@ -111,6 +112,7 @@ jobs:
             type=sha,prefix={{branch}}-,enable=${{ env.RELEASE_TAG == '' && env.IS_MAIN != 'true' }}
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -123,6 +125,17 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             PYTHON_VERSION=3.13
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      # Keyless signing (ggscout's pattern): signs by digest via Rekor/GitHub OIDC, --recursive for the multi-arch manifest.
+      - name: Sign image with cosign
+        env:
+          COSIGN_YES: "true"
+        run: |
+          cosign sign --recursive --oidc-provider=github-actions \
+            "${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
 
   publish-to-pypi:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this PR do?

The `mcp-server` image pushed to `ghcr.io` currently has no signature at all — no cosign, no notation, no build provenance attestation. Anyone pulling the image has no way to verify it actually came from this repo's CI.

This adds keyless cosign signing right after the build-and-push step, in `build-and-push-docker`:
- `sigstore/cosign-installer@v3` to install the CLI
- `cosign sign --recursive --oidc-provider=github-actions <image>@<digest>`

### Design choices

- **Keyless (Sigstore/Rekor via GitHub OIDC)** — same pattern already used in [GitGuardian/ggscout](https://github.com/GitGuardian/ggscout/blob/main/.github/workflows/build_docker.yml). No key material to generate, store, or rotate; verification goes through Rekor's public transparency log.
- **Sign by digest, not by tag** — a tag is mutable, a digest isn't. `docker/build-push-action@v6` exposes `outputs.digest` directly, so no need for ggscout's bake-metadata-JSON parsing step (this repo doesn't use `docker/bake-action`, so that part doesn't apply here).
- **`--recursive`** signs every per-arch image inside the `linux/amd64,linux/arm64` manifest list, not just the top-level index.
- Deliberately **not** replicating GitGuardian/wolfi's full pipeline (SBOM attestation + SLSA3 provenance generator) — that's built for wolfi's own apko/crane base-image pipeline and is heavier than what a single MCP server image needs. Cosign signing alone covers the immediate gap (no verifiable provenance at all).
- Runs on every push that reaches this job (tagged releases, rolling `main`, manual branch dispatch) — consistent with the job's existing `if:` condition, not just tagged releases.

### To verify a signature after this merges

```bash
cosign verify \
  --certificate-identity-regexp "^https://github.com/GitGuardian/ggmcp/" \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  ghcr.io/gitguardian/mcp-server:latest
```

## Checklist

- [ ] CI passes on a real push/tag before relying on this for a release