### PR TITLE
ci: add nightly Docker rebuild to pick up base image security patches

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -95,13 +95,16 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
 
-      # Keyless signing (ggscout's pattern): signs by digest via Rekor/GitHub OIDC, --recursive for the multi-arch manifest.
+      # Uses meta's already-lowercased tags for the ref - github.repository_owner keeps the org's real case ("GitGuardian"), which cosign rejects as an invalid OCI reference.
       - name: Sign image with cosign
         env:
           COSIGN_YES: "true"
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
-          cosign sign --recursive --oidc-provider=github-actions \
-            "${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
+          first_tag="$(head -n1 <<< "$IMAGE_TAGS")"
+          image_ref="${first_tag%:*}"
+          cosign sign --recursive --oidc-provider=github-actions "${image_ref}@${DIGEST}"
 
       # Scans the already-pushed digest directly from the registry (no local
       # docker load needed) - only enabled on the nightly path, so regular

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,0 +1,125 @@
+name: Build Docker
+
+# Reusable build/push/sign logic, shared by release.yml (on a version tag or
+# main push) and nightly_docker_rebuild.yml (scheduled refresh of the latest
+# release with fresh base images). Keeping this in one place means a fix to
+# the build or signing steps only needs to be made once.
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: true
+        description: Git ref (tag/branch/sha) to checkout and build. Empty falls back to the triggering ref.
+      release-tag:
+        type: string
+        required: false
+        default: ''
+        description: Release tag (vX.Y.Z) to derive semver/latest image tags from. Empty means no semver/latest tags.
+      is-main:
+        type: boolean
+        required: false
+        default: false
+        description: Whether to also push the rolling `main` tag.
+      no-cache:
+        type: boolean
+        required: false
+        default: false
+        description: Skip the build cache and force a fresh base image pull (nightly rebuilds, to pick up upstream security patches).
+      scan:
+        type: boolean
+        required: false
+        default: false
+        description: Run an Anchore vulnerability scan on the pushed image and upload SARIF results.
+
+env:
+  IMAGE_NAME: mcp-server
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    name: Build and Push Docker Image
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # keyless cosign signing (Sigstore/Rekor via GitHub OIDC)
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ inputs.release-tag || 'v0.0.0' }},enable=${{ inputs.release-tag != '' }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.release-tag || 'v0.0.0' }},enable=${{ inputs.release-tag != '' }}
+            type=raw,value=latest,enable=${{ inputs.release-tag != '' }}
+            type=raw,value=main,enable=${{ inputs.is-main }}
+            type=ref,event=branch,enable=${{ inputs.release-tag == '' && !inputs.is-main }}
+            type=sha,prefix={{branch}}-,enable=${{ inputs.release-tag == '' && !inputs.is-main }}
+
+      - name: Build and push Docker image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          pull: ${{ inputs.no-cache }}
+          no-cache: ${{ inputs.no-cache }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: ${{ inputs.no-cache && '' || 'type=gha' }}
+          cache-to: ${{ inputs.no-cache && '' || 'type=gha,mode=max' }}
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            PYTHON_VERSION=3.13
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      # Keyless signing (ggscout's pattern): signs by digest via Rekor/GitHub OIDC, --recursive for the multi-arch manifest.
+      - name: Sign image with cosign
+        env:
+          COSIGN_YES: "true"
+        run: |
+          cosign sign --recursive --oidc-provider=github-actions \
+            "${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
+
+      # Scans the already-pushed digest directly from the registry (no local
+      # docker load needed) - only enabled on the nightly path, so regular
+      # releases aren't slowed down by it.
+      - name: Scan image for vulnerabilities
+        if: inputs.scan
+        id: scan
+        uses: anchore/scan-action@v7
+        with:
+          image: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          fail-build: false
+          output-format: sarif
+
+      - name: Upload scan results
+        if: inputs.scan && !cancelled()
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-scan-sarif
+          path: ${{ steps.scan.outputs.sarif }}
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/nightly_docker_rebuild.yml
+++ b/.github/workflows/nightly_docker_rebuild.yml
@@ -1,0 +1,49 @@
+name: Nightly Docker Rebuild
+
+# Rebuild and retag the latest released image with fresh base images to pick
+# up upstream Wolfi/Chainguard security patches, without cutting a new
+# release. Delegates to build_docker.yml so all build/push/sign logic lives
+# in one place, shared with the regular release path.
+
+on:
+  schedule:
+    - cron: '0 1 * * 1-5'    # Weekdays at 01:00 UTC, same cadence as ggscout
+  workflow_dispatch: {}
+
+concurrency:
+  group: nightly-docker-rebuild
+  cancel-in-progress: true
+
+jobs:
+  resolve-latest-release:
+    name: Resolve latest release tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+    steps:
+      - name: Get latest release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag=$(gh release view --repo "${{ github.repository }}" --json tagName -q .tagName)
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Latest release: $tag"
+
+  rebuild:
+    name: Rebuild latest release with fresh base images
+    needs: [ resolve-latest-release ]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    uses: ./.github/workflows/build_docker.yml
+    with:
+      ref: ${{ needs.resolve-latest-release.outputs.tag }}
+      release-tag: ${{ needs.resolve-latest-release.outputs.tag }}
+      is-main: false
+      no-cache: true
+      scan: true
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,6 @@ on:
       - 'v*.*.*'
   workflow_dispatch:
 
-env:
-  IMAGE_NAME: mcp-server
-  REGISTRY: ghcr.io
-
 # Serialize releases: two merges close together must tag sequentially.
 concurrency:
   group: release-${{ github.ref }}
@@ -56,7 +52,6 @@ jobs:
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
 
   build-and-push-docker:
-    runs-on: ubuntu-latest
     name: Build and Push Docker Image
     needs: [ tag-version ]
     # Two entry points: a version tag pushed by a human, or a tag freshly
@@ -77,68 +72,13 @@ jobs:
       contents: read
       packages: write
       id-token: write # keyless cosign signing (Sigstore/Rekor via GitHub OIDC)
-    env:
-      # Empty outside releases: switches image tags to main / <branch>-<sha>.
-      RELEASE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || needs.tag-version.outputs.tag }}
-      IS_MAIN: ${{ github.ref == 'refs/heads/main' }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.ref_type == 'tag' && github.ref_name || needs.tag-version.outputs.tag }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}},value=${{ env.RELEASE_TAG || 'v0.0.0' }},enable=${{ env.RELEASE_TAG != '' }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ env.RELEASE_TAG || 'v0.0.0' }},enable=${{ env.RELEASE_TAG != '' }}
-            type=raw,value=latest,enable=${{ env.RELEASE_TAG != '' }}
-            type=raw,value=main,enable=${{ env.IS_MAIN == 'true' }}
-            type=ref,event=branch,enable=${{ env.RELEASE_TAG == '' && env.IS_MAIN != 'true' }}
-            type=sha,prefix={{branch}}-,enable=${{ env.RELEASE_TAG == '' && env.IS_MAIN != 'true' }}
-
-      - name: Build and push Docker image
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
-          build-args: |
-            PYTHON_VERSION=3.13
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@v3
-
-      # Uses meta's already-lowercased tags for the ref - github.repository_owner keeps the org's real case ("GitGuardian"), which cosign rejects as an invalid OCI reference.
-      - name: Sign image with cosign
-        env:
-          COSIGN_YES: "true"
-          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
-          DIGEST: ${{ steps.build.outputs.digest }}
-        run: |
-          first_tag="$(head -n1 <<< "$IMAGE_TAGS")"
-          image_ref="${first_tag%:*}"
-          cosign sign --recursive --oidc-provider=github-actions "${image_ref}@${DIGEST}"
+    uses: ./.github/workflows/build_docker.yml
+    with:
+      # Empty outside releases: build_docker.yml then falls back to `main` / <branch>-<sha> tags.
+      ref: ${{ github.ref_type == 'tag' && github.ref_name || needs.tag-version.outputs.tag }}
+      release-tag: ${{ github.ref_type == 'tag' && github.ref_name || needs.tag-version.outputs.tag }}
+      is-main: ${{ github.ref == 'refs/heads/main' }}
+    secrets: inherit
 
   publish-to-pypi:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this do?

Adds a scheduled nightly rebuild of the latest released `mcp-server` image, mirroring the pattern already used on `ggscout`.

- **`build_docker.yml`** (new): the build/push/sign logic extracted from `release.yml` into a reusable `workflow_call` workflow, so it's maintained in one place.
- **`nightly_docker_rebuild.yml`** (new): cron (`0 1 * * 1-5`, weekdays 01:00 UTC, same cadence as ggscout) + manual dispatch. Resolves the latest GitHub release tag, then rebuilds and retags it with `pull`/`no-cache` forced - so upstream Wolfi/Chainguard base image security patches land without waiting for the next version bump. No new release is cut; the existing `vX.Y.Z`, `X.Y`, and `latest` tags are refreshed in place.
- **`release.yml`**: behavior unchanged, now calls the shared `build_docker.yml` instead of duplicating the steps inline.
- The nightly image is also scanned with Anchore (non-blocking, SARIF uploaded as a 30-day artifact) for visibility into the rebuild's effect on known CVEs - not run on regular releases, to keep those fast.

## Note: the cosign signing bug found while building this PR is already fixed on `main`

While testing this PR I found the cosign signing step had been failing on **every real build on `main`** since #184 merged (`github.repository_owner` preserves the org's real case, `GitGuardian`, which cosign rejects as an invalid OCI reference). That fix landed separately and is already merged: #186.

This branch has been **rebased onto `main` after #186 merged**, so `build_docker.yml` carries the fix directly (not a duplicate) - confirmed `edb604c` (#186's merge commit) is an ancestor of this branch's history, and re-validated end-to-end post-rebase: [29590131411](https://github.com/GitGuardian/ggmcp/actions/runs/29590131411) - build, push, and sign all succeed.

The fix itself was also hardened slightly after #186 first merged: instead of `cut -d: -f1` (which breaks if the registry ever includes a port, e.g. `host:5000/repo`), it now strips only the trailing `:tag` via bash suffix removal (`${first_tag%:*}`), which is safe regardless of how many colons appear earlier in the reference.

## Why (nightly rebuild)

`mcp-server`'s image is built on Chainguard/Wolfi base images, which are rebuilt frequently upstream with security fixes. Without a nightly rebuild, those fixes only reach the image on the next version release, which could be weeks away.

## Test plan

- [x] Dispatched `release.yml` from this branch post-rebase (exercises the shared `build_docker.yml`) - build, push, and sign all succeed: [29590131411](https://github.com/GitGuardian/ggmcp/actions/runs/29590131411)
- [ ] `nightly_docker_rebuild.yml` itself can only be test-dispatched once merged to the default branch (GitHub limitation for brand-new `workflow_dispatch` workflows) - to validate post-merge: dispatch it manually and confirm it resolves the latest release, rebuilds, pushes, signs, and scans successfully
- [ ] Verify the rebuilt image's digest actually differs from the pre-rebuild image (proving base layers were refreshed, not just cache-hit no-ops)