### PR TITLE
fix(ci): derive cosign image ref from meta tags, not repository_owner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,13 +129,16 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
 
-      # Keyless signing (ggscout's pattern): signs by digest via Rekor/GitHub OIDC, --recursive for the multi-arch manifest.
+      # Uses meta's already-lowercased tags for the ref - github.repository_owner keeps the org's real case ("GitGuardian"), which cosign rejects as an invalid OCI reference.
       - name: Sign image with cosign
         env:
           COSIGN_YES: "true"
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
-          cosign sign --recursive --oidc-provider=github-actions \
-            "${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
+          first_tag="$(head -n1 <<< "$IMAGE_TAGS")"
+          image_ref="${first_tag%:*}"
+          cosign sign --recursive --oidc-provider=github-actions "${image_ref}@${DIGEST}"
 
   publish-to-pypi:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What's broken

Cosign signing has failed on **every real build on `main`** since #184 merged - confirmed on the actual post-merge run: https://github.com/GitGuardian/ggmcp/actions/runs/29586316891

The image itself builds and pushes fine; only the sign step fails, so every image pushed since the merge is **unsigned**.

## Root cause

`github.repository_owner` preserves the org's real case (`GitGuardian`), and the sign step used it directly to reconstruct the image reference (`ghcr.io/GitGuardian/mcp-server@sha256:...`). That's an invalid OCI reference (must be lowercase) - cosign rejects it with `parsing reference: could not parse reference`.

`docker/metadata-action` already lowercases the image reference correctly for the actual build/push tags - the sign step just wasn't reusing that.

## Fix

Derive the image ref for signing from `steps.meta.outputs.tags` (already correctly lowercased) instead of re-deriving it from `github.repository_owner`.

## Test plan

- [x] Dispatched `release.yml` on this exact branch and confirmed build, push, and sign all succeed: https://github.com/GitGuardian/ggmcp/actions/runs/29587350994