### PR TITLE
feat(logging): structured logging foundation (structlog + secret scrubbing)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,9 @@ GITGUARDIAN_API_KEY_ID=--fill-me--
 # Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 LOG_LEVEL=INFO
 
+# Log format: "json" or "console". Unset = auto (console on a TTY, json otherwise).
+# LOG_FORMAT=json
+
 # Optional: Sentry Integration for Error Tracking
 # Sentry provides error tracking and performance monitoring
 # Install with: pip install 'gg-mcp-server[sentry]'

--- a/packages/gg_api_core/pyproject.toml
+++ b/packages/gg_api_core/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pydantic~=2.12",
     "pydantic-settings~=2.9",
     "jinja2~=3.1",
+    "structlog~=26.1",
 ]
 
 [project.optional-dependencies]

--- a/packages/gg_api_core/src/gg_api_core/logging_config.py
+++ b/packages/gg_api_core/src/gg_api_core/logging_config.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import logging
+import sys
+from typing import TYPE_CHECKING
+
+import structlog
+from structlog.types import EventDict, Processor, WrappedLogger
+
+from gg_api_core.sanitization import scrub_by_name
+
+if TYPE_CHECKING:
+    from gg_api_core.settings import Settings
+
+_RESERVED_KEYS = frozenset(
+    {
+        "event",
+        "level",
+        "logger",
+        "logger_name",
+        "timestamp",
+        "exc_info",
+        "exception",
+        "exception_cls",
+        "stack",
+        "stack_info",
+        "_record",
+        "_from_structlog",
+    }
+)
+
+
+def _sanitize_event_dict(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
+    for key in list(event_dict.keys()):
+        if key not in _RESERVED_KEYS:
+            event_dict[key] = scrub_by_name(str(key), event_dict[key])
+    return event_dict
+
+
+def _add_exception_cls(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
+    exc_info = event_dict.get("exc_info")
+    if not exc_info or "exception_cls" in event_dict:
+        return event_dict
+    exc = sys.exc_info() if exc_info is True else exc_info
+    exc_type = exc[0] if isinstance(exc, tuple) else type(exc)
+    if exc_type is not None:
+        module = getattr(exc_type, "__module__", "")
+        name = getattr(exc_type, "__name__", str(exc_type))
+        event_dict["exception_cls"] = name if module in ("builtins", "") else f"{module}.{name}"
+    return event_dict
+
+
+def configure_logging(
+    *, log_level: str = "INFO", log_format: str | None = None, service: str = "gg-mcp-server"
+) -> None:
+    def _add_service(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
+        event_dict["gg_service"] = service
+        return event_dict
+
+    shared: list[Processor] = [
+        structlog.contextvars.merge_contextvars,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.ExtraAdder(),
+        structlog.processors.TimeStamper(fmt="iso"),
+        _add_service,
+        structlog.processors.StackInfoRenderer(),
+        _add_exception_cls,
+        structlog.processors.format_exc_info,
+        _sanitize_event_dict,
+    ]
+
+    structlog.configure(
+        processors=[*shared, structlog.stdlib.ProcessorFormatter.wrap_for_formatter],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=False,
+    )
+
+    console = log_format == "console" or (log_format is None and sys.stderr.isatty())
+    renderer = structlog.dev.ConsoleRenderer() if console else structlog.processors.JSONRenderer()
+    formatter = structlog.stdlib.ProcessorFormatter(
+        foreign_pre_chain=shared,
+        processors=[structlog.stdlib.ProcessorFormatter.remove_processors_meta, renderer],
+    )
+
+    handler = logging.StreamHandler(sys.stderr)
+    handler.name = "ggmcp-log"
+    handler.setFormatter(formatter)
+
+    root = logging.getLogger()
+    root.handlers = [h for h in root.handlers if h.name != "ggmcp-log"]
+    root.addHandler(handler)
+    root.setLevel(logging.getLevelNamesMapping().get(log_level.upper(), logging.INFO))
+
+
+def configure_logging_from_settings(settings: Settings) -> None:
+    configure_logging(log_level=settings.log_level, log_format=settings.log_format)

--- a/packages/gg_api_core/src/gg_api_core/sanitization.py
+++ b/packages/gg_api_core/src/gg_api_core/sanitization.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any, Final
+
+SENSITIVE_DATA_PLACEHOLDER: Final = "[REDACTED]"
+
+SENSITIVE_PARAMETER_NAMES: Final = frozenset(
+    {
+        "key",
+        "token",
+        "password",
+        "secret",
+        "authorization",
+        "credential",
+        "apikey",
+        "document",
+        "filename",
+        "content",
+        "match",
+        "patch",
+        "sensitive",
+    }
+)
+
+NON_SENSITIVE_NAME_ALLOWLIST: Final = frozenset(
+    {
+        "secret_id",
+        "secret_count",
+        "secrets_count",
+        "token_id",
+        "token_name",
+        "match_count",
+        "document_count",
+        "documents_count",
+    }
+)
+
+_LEAF_TYPES: Final = (int, float, bool, type(None))
+
+
+def _name_is_sensitive(name: str) -> bool:
+    lowered = name.lower()
+    if lowered in NON_SENSITIVE_NAME_ALLOWLIST:
+        return False
+    return any(token in lowered for token in SENSITIVE_PARAMETER_NAMES)
+
+
+def scrub_by_name(name: str, value: Any) -> Any:
+    if _name_is_sensitive(name):
+        return SENSITIVE_DATA_PLACEHOLDER
+
+    if isinstance(value, _LEAF_TYPES) or isinstance(value, str):
+        return value
+
+    if isinstance(value, dict):
+        return {k: scrub_by_name(str(k), v) for k, v in value.items()}
+
+    if isinstance(value, (list, tuple, set)):
+        scrubbed = [scrub_by_name(name, item) for item in value]
+        try:
+            return type(value)(scrubbed)
+        except TypeError:
+            return scrubbed
+
+    return value

--- a/packages/gg_api_core/src/gg_api_core/settings.py
+++ b/packages/gg_api_core/src/gg_api_core/settings.py
@@ -12,6 +12,8 @@ test fixtures using ``patch.dict(os.environ, ...)`` or
 ``monkeypatch.setenv`` continue to work without cache invalidation.
 """
 
+from typing import Literal
+
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -75,6 +77,9 @@ class Settings(BaseSettings):
 
     # --- System ---
     xdg_config_home: str | None = None
+    log_level: str = "INFO"
+    # "json" or "console"; unset ⇒ auto (console on a TTY, else json)
+    log_format: Literal["json", "console"] | None = None
 
     # --- Derived helpers ---
     @property

--- a/packages/gg_mcp_server/src/gg_mcp_server/server.py
+++ b/packages/gg_mcp_server/src/gg_mcp_server/server.py
@@ -6,12 +6,14 @@ current token cannot satisfy are filtered out at list-tools time.
 
 import logging
 
+from gg_api_core.logging_config import configure_logging_from_settings
 from gg_api_core.mcp_server import get_mcp_server, register_common_tools
+from gg_api_core.settings import get_settings
 
 from gg_mcp_server.add_health_check import add_health_check
 from gg_mcp_server.register_tools import GITGUARDIAN_INSTRUCTIONS, register_tools
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+configure_logging_from_settings(get_settings())
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,61 @@
+import json
+import logging
+
+import structlog
+from gg_api_core.logging_config import configure_logging
+
+
+def _reconfigure_json():
+    configure_logging(log_level="DEBUG", log_format="json")
+
+
+class TestConfigureLogging:
+    def test_logs_go_to_stderr_not_stdout(self, capsys):
+        _reconfigure_json()
+        structlog.get_logger("t").info("hello")
+        captured = capsys.readouterr()
+        assert captured.out == ""  # stdout is the stdio JSON-RPC channel — must stay clean
+        assert "hello" in captured.err
+
+    def test_json_format_renders_with_service(self, capsys):
+        _reconfigure_json()
+        structlog.get_logger("t").info("event msg", account_id=475789)
+        payload = json.loads(capsys.readouterr().err.strip().splitlines()[-1])
+        assert payload["event"] == "event msg"
+        assert payload["account_id"] == 475789
+        assert payload["gg_service"] == "gg-mcp-server"
+        assert payload["level"] == "info"
+
+    def test_structlog_kwargs_are_sanitized(self, capsys):
+        _reconfigure_json()
+        structlog.get_logger("t").warning("scan", document="RAW", secret_id=42, token="gg_pat_x")
+        payload = json.loads(capsys.readouterr().err.strip().splitlines()[-1])
+        assert payload["document"] == "[REDACTED]"
+        assert payload["token"] == "[REDACTED]"
+        assert payload["secret_id"] == 42
+
+    def test_stdlib_extra_is_captured_and_sanitized(self, capsys):
+        _reconfigure_json()
+        logging.getLogger("t.stdlib").info("m", extra={"account_id": 1, "token": "gg_pat_x", "endpoint": "/v1/x"})
+        payload = json.loads(capsys.readouterr().err.strip().splitlines()[-1])
+        assert payload["account_id"] == 1
+        assert payload["endpoint"] == "/v1/x"
+        assert payload["token"] == "[REDACTED]"
+
+    def test_exception_cls_is_added(self, capsys):
+        _reconfigure_json()
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            structlog.get_logger("t").exception("failed")
+        payload = json.loads(capsys.readouterr().err.strip().splitlines()[-1])
+        assert payload["exception_cls"] == "ValueError"
+
+    def test_exception_cls_on_stdlib_logger(self, capsys):
+        _reconfigure_json()
+        try:
+            raise KeyError("k")
+        except KeyError:
+            logging.getLogger("t.stdlib").exception("failed")
+        payload = json.loads(capsys.readouterr().err.strip().splitlines()[-1])
+        assert payload["exception_cls"] == "KeyError"

--- a/tests/test_sanitization.py
+++ b/tests/test_sanitization.py
@@ -1,0 +1,57 @@
+import pytest
+from gg_api_core.sanitization import SENSITIVE_DATA_PLACEHOLDER, scrub_by_name
+
+
+class TestScrubByName:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            # obvious secret-bearing names
+            "token",
+            "api_token",
+            "password",
+            "client_secret",
+            "authorization",
+            # scan-payload fields (raw content / matched secret)
+            "document",
+            "documents",
+            "filename",
+            "content",
+            "patch",
+            # matching is case-insensitive
+            "Authorization",
+            "API_KEY",
+        ],
+    )
+    def test_sensitive_names_are_redacted(self, name):
+        assert scrub_by_name(name, "raw secret material") == SENSITIVE_DATA_PLACEHOLDER
+
+    @pytest.mark.parametrize(
+        ("name", "value"),
+        [
+            ("account_id", 475789),
+            ("endpoint", "/v1/incidents"),
+            ("status_code", 200),
+        ],
+    )
+    def test_non_sensitive_names_pass_through(self, name, value):
+        assert scrub_by_name(name, value) == value
+
+    def test_nested_dict_scrubbed_by_own_keys(self):
+        out = scrub_by_name("payload", {"account_id": 1, "token": "gg_pat_x", "nested": {"secret": "s"}})
+        assert out == {
+            "account_id": 1,
+            "token": SENSITIVE_DATA_PLACEHOLDER,
+            "nested": {"secret": SENSITIVE_DATA_PLACEHOLDER},
+        }
+
+    def test_list_under_sensitive_name_is_fully_redacted(self):
+        docs = [{"document": "content1", "filename": "a.py"}, {"document": "content2"}]
+        assert scrub_by_name("documents", docs) == SENSITIVE_DATA_PLACEHOLDER
+
+    def test_list_under_safe_name_recurses_into_items(self):
+        items = [{"account_id": 1, "token": "x"}, {"account_id": 2, "token": "y"}]
+        assert scrub_by_name("results", items) == [
+            {"account_id": 1, "token": SENSITIVE_DATA_PLACEHOLDER},
+            {"account_id": 2, "token": SENSITIVE_DATA_PLACEHOLDER},
+        ]

--- a/uv.lock
+++ b/uv.lock
@@ -525,6 +525,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "structlog" },
 ]
 
 [package.optional-dependencies]
@@ -541,6 +542,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = "~=2.9" },
     { name = "python-dotenv", specifier = "~=1.1" },
     { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = "~=2.43" },
+    { name = "structlog", specifier = "~=26.1" },
 ]
 provides-extras = ["sentry"]
 
@@ -698,7 +700,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.14'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
@@ -1669,8 +1671,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -1714,6 +1716,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "structlog"
+version = "26.1.0"
+source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/89/b4a0bcfdf4f71a3dea31379f095929613d7e4528a0996bca6aa964cd0dca/structlog-26.1.0.tar.gz", hash = "sha256:f63a716cbd1b1291cf7661de7794b455acfa4c43c5bcf1630e6ad5ddc1adb3b7", size = 1459881, upload-time = "2026-06-06T07:33:39.348Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/18/489c97b834dfff9cf2fc2507cede4bcd4b11e67f84bc462acd1992496f86/structlog-26.1.0-py3-none-any.whl", hash = "sha256:e081a26d6c373e6d201eca24eede26d8ffab07f88f477822e679183428d3d91e", size = 73764, upload-time = "2026-06-06T07:33:38.046Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Foundation for SI-3881: explicit structlog + stdlib pipeline replacing the one-line basicConfig — stderr-only (stdio-safe), LOG_LEVEL/LOG_FORMAT, exception_cls tag, recursive secret scrubber on the Coralogix egress. Sentry stays the ERROR channel. 682 tests pass; ruff + mypy clean; no change to existing log call sites.

Follow-ups: client.py DEBUG leak conversion (SI-3831), correlation id, tool-error wrapping, structlog-sentry swap.