### PR TITLE
feat(logging): route uvicorn logs through the structlog pipeline

### DIFF
--- a/packages/gg_mcp_server/src/gg_mcp_server/run.py
+++ b/packages/gg_mcp_server/src/gg_mcp_server/run.py
@@ -45,6 +45,7 @@ def run_http_with_uvicorn():
         mcp.http_app(path="/mcp", json_response=True, stateless_http=True),
         host=mcp_host,
         port=mcp_port,
+        log_config=None,
     )
 
 


### PR DESCRIPTION
## What

Pass `log_config=None` to `uvicorn.run()` so uvicorn's startup and access logs propagate to our root handler instead of being rendered by uvicorn's own default formatter.

## Why

With structured logging live (SI-3881), the app's own logs render as JSON — but uvicorn's access logs (e.g. `GET /health`, `POST /mcp`) still bypass the pipeline and emit as plain text. Setting `log_config=None` lets them propagate to the root structlog handler so **every** line, including access logs, renders as structured JSON.

Confirmed against preprod on `:main`: app logs are JSON, but `… - "GET /health HTTP/1.1" 200` access lines are still plain text — this closes that gap.

By default uvicorn applies its built-in `LOGGING_CONFIG` ([docs](https://uvicorn.dev/concepts/logging/)). `Config.configure_logging()` only applies a config when `log_config is not None`, so passing `None` skips that step entirely — uvicorn's loggers stay unconfigured and propagate to our root structlog handler. This behavior lives in the source, not the prose docs: https://github.com/encode/uvicorn/blob/master/uvicorn/config.py

## Before / after

Before — access logs bypass the pipeline, plain text:
```
INFO:     127.0.0.1 - "GET /health HTTP/1.1" 200 OK
```
After — same line as JSON:
```
{"event": "127.0.0.1 - \"GET /health HTTP/1.1\" 200 OK", "level": "info", "logger": "uvicorn.access", ...}
```

## Changes

- `gg_mcp_server/run.py`: `log_config=None` on the `uvicorn.run()` call in `run_http_with_uvicorn()`.

## Notes

Scope item 2 of SI-3888 (split out of the SI-3881 foundation). Tool-call tracing (scope item 1) is #188.

Refs SI-3888.
