### PR TITLE
feat(logging): value-based secret scrubbing for logs

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/logging_config.py
+++ b/packages/gg_api_core/src/gg_api_core/logging_config.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import structlog
 from structlog.types import EventDict, Processor, WrappedLogger
 
-from gg_api_core.sanitization import scrub_by_name
+from gg_api_core.sanitization import scrub_by_name, scrub_by_value
 
 if TYPE_CHECKING:
     from gg_api_core.settings import Settings
@@ -30,10 +30,17 @@ _RESERVED_KEYS = frozenset(
 )
 
 
-def _sanitize_event_dict(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
+def _scrub_sensitive_keys(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
     for key in list(event_dict.keys()):
         if key not in _RESERVED_KEYS:
             event_dict[key] = scrub_by_name(str(key), event_dict[key])
+    return event_dict
+
+
+def _scrub_reserved_values(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
+    for key in list(event_dict.keys()):
+        if key in _RESERVED_KEYS:
+            event_dict[key] = scrub_by_value(event_dict[key])
     return event_dict
 
 
@@ -67,7 +74,8 @@ def configure_logging(
         structlog.processors.StackInfoRenderer(),
         _add_exception_cls,
         structlog.processors.format_exc_info,
-        _sanitize_event_dict,
+        _scrub_sensitive_keys,
+        _scrub_reserved_values,
     ]
 
     structlog.configure(

--- a/packages/gg_api_core/src/gg_api_core/sanitization.py
+++ b/packages/gg_api_core/src/gg_api_core/sanitization.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+from datetime import date, datetime
 from typing import Any, Final
 
 SENSITIVE_DATA_PLACEHOLDER: Final = "[REDACTED]"
@@ -35,7 +37,29 @@ NON_SENSITIVE_NAME_ALLOWLIST: Final = frozenset(
     }
 )
 
-_LEAF_TYPES: Final = (int, float, bool, type(None))
+_LEAF_TYPES: Final = (int, float, bool, date, datetime, type(None))
+
+_SENSITIVE_URL_PARAMS_RE = re.compile(rf"(({'|'.join(SENSITIVE_PARAMETER_NAMES)})=)([^&]+)(&|$)")
+_SENSITIVE_GIT_CLONE_RE = re.compile(r"(https?://)[^:@/\s]*:[^@/\s]*@")
+
+
+def scrub_url_params(string: str) -> str:
+    return _SENSITIVE_URL_PARAMS_RE.sub(rf"\1{SENSITIVE_DATA_PLACEHOLDER}\4", string)
+
+
+def scrub_git_credentials(string: str) -> str:
+    return _SENSITIVE_GIT_CLONE_RE.sub(
+        rf"\1{SENSITIVE_DATA_PLACEHOLDER}:{SENSITIVE_DATA_PLACEHOLDER}@",
+        string,
+    )
+
+
+def scrub_by_value(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    value = scrub_url_params(value)
+    value = scrub_git_credentials(value)
+    return value
 
 
 def _name_is_sensitive(name: str) -> bool:
@@ -49,9 +73,6 @@ def scrub_by_name(name: str, value: Any) -> Any:
     if _name_is_sensitive(name):
         return SENSITIVE_DATA_PLACEHOLDER
 
-    if isinstance(value, _LEAF_TYPES) or isinstance(value, str):
-        return value
-
     if isinstance(value, dict):
         return {k: scrub_by_name(str(k), v) for k, v in value.items()}
 
@@ -61,5 +82,11 @@ def scrub_by_name(name: str, value: Any) -> Any:
             return type(value)(scrubbed)
         except TypeError:
             return scrubbed
+
+    if isinstance(value, str):
+        return scrub_by_value(value)
+
+    if isinstance(value, _LEAF_TYPES):
+        return value
 
     return value

--- a/tests/test_sanitization.py
+++ b/tests/test_sanitization.py
@@ -1,57 +1,76 @@
 import pytest
-from gg_api_core.sanitization import SENSITIVE_DATA_PLACEHOLDER, scrub_by_name
+from gg_api_core.sanitization import (
+    SENSITIVE_DATA_PLACEHOLDER,
+    scrub_by_name,
+    scrub_by_value,
+    scrub_git_credentials,
+    scrub_url_params,
+)
+
+PLACEHOLDER = SENSITIVE_DATA_PLACEHOLDER
 
 
 class TestScrubByName:
     @pytest.mark.parametrize(
-        "name",
+        ("name", "value", "expected"),
         [
-            # obvious secret-bearing names
-            "token",
-            "api_token",
-            "password",
-            "client_secret",
-            "authorization",
-            # scan-payload fields (raw content / matched secret)
-            "document",
-            "documents",
-            "filename",
-            "content",
-            "patch",
-            # matching is case-insensitive
-            "Authorization",
-            "API_KEY",
+            # sensitive key -> whole value redacted (case-insensitive)
+            ("token", "raw secret material", PLACEHOLDER),
+            ("client_secret", "raw secret material", PLACEHOLDER),
+            ("Authorization", "raw secret material", PLACEHOLDER),
+            ("document", "raw secret material", PLACEHOLDER),
+            # benign key -> value kept
+            ("account_id", 475789, 475789),
+            ("endpoint", "/v1/incidents", "/v1/incidents"),
+            # benign key whose value carries a secret shape -> value-scrubbed
+            ("url", "https://gg.com/cb?token=abc&safe=1", f"https://gg.com/cb?token={PLACEHOLDER}&safe=1"),
+            # dict under a benign key -> recurse, redact sensitive child keys
+            ("payload", {"account_id": 1, "token": "x"}, {"account_id": 1, "token": PLACEHOLDER}),
+            # list under a sensitive key -> whole value redacted
+            ("documents", [{"document": "c"}], PLACEHOLDER),
+            # list under a benign key -> recurse into items
+            ("results", [{"token": "x"}], [{"token": PLACEHOLDER}]),
         ],
     )
-    def test_sensitive_names_are_redacted(self, name):
-        assert scrub_by_name(name, "raw secret material") == SENSITIVE_DATA_PLACEHOLDER
+    def test_scrub_by_name(self, name, value, expected):
+        assert scrub_by_name(name, value) == expected
 
+
+class TestScrubUrlParams:
     @pytest.mark.parametrize(
-        ("name", "value"),
+        ("url", "expected"),
         [
-            ("account_id", 475789),
-            ("endpoint", "/v1/incidents"),
-            ("status_code", 200),
+            ("https://e.com/p?token=123&safe=456", f"https://e.com/p?token={PLACEHOLDER}&safe=456"),
+            ("/p?token=123&token=234", f"/p?token={PLACEHOLDER}&token={PLACEHOLDER}"),
+            ("/p?token=&key=123", f"/p?token=&key={PLACEHOLDER}"),
+            ("/p?safe=123", "/p?safe=123"),
         ],
     )
-    def test_non_sensitive_names_pass_through(self, name, value):
-        assert scrub_by_name(name, value) == value
+    def test_redacts_sensitive_params(self, url, expected):
+        assert scrub_url_params(url) == expected
 
-    def test_nested_dict_scrubbed_by_own_keys(self):
-        out = scrub_by_name("payload", {"account_id": 1, "token": "gg_pat_x", "nested": {"secret": "s"}})
-        assert out == {
-            "account_id": 1,
-            "token": SENSITIVE_DATA_PLACEHOLDER,
-            "nested": {"secret": SENSITIVE_DATA_PLACEHOLDER},
-        }
 
-    def test_list_under_sensitive_name_is_fully_redacted(self):
-        docs = [{"document": "content1", "filename": "a.py"}, {"document": "content2"}]
-        assert scrub_by_name("documents", docs) == SENSITIVE_DATA_PLACEHOLDER
+class TestScrubGitCredentials:
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            ("git clone https://u:p@host/r.git", f"git clone https://{PLACEHOLDER}:{PLACEHOLDER}@host/r.git"),
+            ("https://a:b@gitlab.com/x", f"https://{PLACEHOLDER}:{PLACEHOLDER}@gitlab.com/x"),
+            ("https://host/no-creds.git", "https://host/no-creds.git"),
+        ],
+    )
+    def test_redacts_credentials(self, url, expected):
+        assert scrub_git_credentials(url) == expected
 
-    def test_list_under_safe_name_recurses_into_items(self):
-        items = [{"account_id": 1, "token": "x"}, {"account_id": 2, "token": "y"}]
-        assert scrub_by_name("results", items) == [
-            {"account_id": 1, "token": SENSITIVE_DATA_PLACEHOLDER},
-            {"account_id": 2, "token": SENSITIVE_DATA_PLACEHOLDER},
-        ]
+
+class TestScrubByValue:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("clone https://u:p@host/r and ?token=abc", f"clone https://{PLACEHOLDER}:{PLACEHOLDER}@host/r and ?token={PLACEHOLDER}"),
+            ("no secrets here", "no secrets here"),
+            (42, 42),
+        ],
+    )
+    def test_scrub_by_value(self, value, expected):
+        assert scrub_by_value(value) == expected

--- a/tests/test_sanitization.py
+++ b/tests/test_sanitization.py
@@ -67,7 +67,10 @@ class TestScrubByValue:
     @pytest.mark.parametrize(
         ("value", "expected"),
         [
-            ("clone https://u:p@host/r and ?token=abc", f"clone https://{PLACEHOLDER}:{PLACEHOLDER}@host/r and ?token={PLACEHOLDER}"),
+            (
+                "clone https://u:p@host/r and ?token=abc",
+                f"clone https://{PLACEHOLDER}:{PLACEHOLDER}@host/r and ?token={PLACEHOLDER}",
+            ),
             ("no secrets here", "no secrets here"),
             (42, 42),
         ],


### PR DESCRIPTION
> Draft — SI-3890.

Log scrubbing was **name-based only**: a value was redacted only when its *key* looked sensitive. Secrets under a benign key (`repo_url`), in the log message, or in a traceback slipped through. This adds **value-based** scrubbing (`scrub_by_value`, ported from ward's `by_value.py`: URL params + URL credentials) that redacts a secret by its *shape*, wherever it appears — via two passes: `_scrub_sensitive_keys` (name-based, user fields) and `_scrub_reserved_values` (value-based, message + traceback).

**Before**
```json
{"event": "oauth callback https://app.gg.com/cb?token=SECRET&state=ok"}
{"event": "scanning repo", "arguments": {"repo_url": "https://u:p@github.com/acme/app.git"}}
{"event": "tool failed", "exception": "... ValueError: bad url https://app/cb?token=xyz789"}
```

**After**
```json
{"event": "oauth callback https://app.gg.com/cb?token=[REDACTED]&state=ok"}
{"event": "scanning repo", "arguments": {"repo_url": "https://[REDACTED]:[REDACTED]@github.com/acme/app.git"}}
{"event": "tool failed", "exception": "... ValueError: bad url https://app/cb?token=[REDACTED]"}
```

Pattern-based defense-in-depth, not a full-entropy guarantee.
