### PR TITLE
build(types): replace mypy with pyrefly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
   type-check:
     runs-on: ubuntu-latest
-    name: Type Check with Mypy
+    name: Type Check with Pyrefly
 
     steps:
       - uses: actions/checkout@v6
@@ -56,8 +56,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --all-groups
 
-      - name: Run mypy
-        run: uv run mypy packages/
+      - name: Run pyrefly
+        run: uv run pyrefly check packages/
 
   test-unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         run: uv sync --frozen --all-groups
 
       - name: Run pyrefly
-        run: uv run pyrefly check packages/
+        run: uv run pyrefly check
 
   test-unit:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -46,4 +46,4 @@ format:
 
 # Type checking
 typecheck:
-	uv run mypy .
+	uv run pyrefly check packages/

--- a/Makefile
+++ b/Makefile
@@ -46,4 +46,4 @@ format:
 
 # Type checking
 typecheck:
-	uv run pyrefly check packages/
+	uv run pyrefly check

--- a/mise.toml
+++ b/mise.toml
@@ -31,8 +31,8 @@ run = ["uv run ruff check --fix"]
 
 [tasks."type:check"]
 alias = "typecheck"
-run = "uv run mypy packages/"
-description = "Check type hints with mypy"
+run = "uv run pyrefly check packages/"
+description = "Check type hints with pyrefly"
 
 [tasks.check]
 depends = ["format:check", "lint:check", "type:check"]

--- a/mise.toml
+++ b/mise.toml
@@ -31,7 +31,7 @@ run = ["uv run ruff check --fix"]
 
 [tasks."type:check"]
 alias = "typecheck"
-run = "uv run pyrefly check packages/"
+run = "uv run pyrefly check"
 description = "Check type hints with pyrefly"
 
 [tasks.check]

--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -418,7 +418,7 @@ class GitGuardianClient:
             return False
 
     async def _request(
-        self, method: str, endpoint: str, *, expected_client_errors: Sequence[int] = (), **kwargs
+        self, method: str, endpoint: str, *, expected_client_errors: Sequence[int] = (), **kwargs: Any
     ) -> Any:
         """Make a request to the GitGuardian API (generic method).
 
@@ -508,12 +508,12 @@ class GitGuardianClient:
 
                 if response.status_code == 204:  # No content
                     logger.debug("Received 204 No Content response")
-                    return {}
+                    return cast(dict[str, Any], {})
 
                 try:
                     if not response.content or response.content.strip() == b"":
                         logger.debug("Received empty response content")
-                        return {}
+                        return cast(dict[str, Any], {})
 
                     data = response.json()
 
@@ -637,7 +637,7 @@ class GitGuardianClient:
         logger.debug(f"Extracted and decoded cursor: {cursor_encoded} -> {cursor_decoded}")
         return cursor_decoded
 
-    async def _request_get(self, endpoint: str, **kwargs) -> dict[str, Any]:
+    async def _request_get(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:
         """Make a GET request to the GitGuardian API.
 
         Args:
@@ -652,7 +652,7 @@ class GitGuardianClient:
         """
         return cast(dict[str, Any], await self._request("GET", endpoint, **kwargs))
 
-    async def _request_post(self, endpoint: str, **kwargs) -> dict[str, Any]:
+    async def _request_post(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:
         """Make a POST request to the GitGuardian API.
 
         Args:
@@ -667,7 +667,7 @@ class GitGuardianClient:
         """
         return cast(dict[str, Any], await self._request("POST", endpoint, **kwargs))
 
-    async def _request_patch(self, endpoint: str, **kwargs) -> dict[str, Any]:
+    async def _request_patch(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:
         """Make a PATCH request to the GitGuardian API.
 
         Args:
@@ -682,7 +682,7 @@ class GitGuardianClient:
         """
         return cast(dict[str, Any], await self._request("PATCH", endpoint, **kwargs))
 
-    async def _request_delete(self, endpoint: str, **kwargs) -> dict[str, Any]:
+    async def _request_delete(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:
         """Make a DELETE request to the GitGuardian API.
 
         Args:
@@ -697,7 +697,7 @@ class GitGuardianClient:
         """
         return cast(dict[str, Any], await self._request("DELETE", endpoint, **kwargs))
 
-    async def _request_list(self, endpoint: str, **kwargs) -> ListResponse:
+    async def _request_list(self, endpoint: str, **kwargs: Any) -> ListResponse:
         """Make a request to a list endpoint that returns standardized ListResponse.
 
         This method handles list endpoints that may return either a list directly or
@@ -726,7 +726,7 @@ class GitGuardianClient:
             response = await client.get(url, headers=headers, **kwargs)
             response.raise_for_status()
 
-            data = response.json() if response.content else {}
+            data: Any = response.json() if response.content else {}
             response_headers = dict(response.headers)
 
         # Handle both direct list and dict with "results" or "data" key
@@ -856,7 +856,7 @@ class GitGuardianClient:
         }
 
     async def create_honeytoken(
-        self, name: str, description: str = "", custom_tags: list | None = None
+        self, name: str, description: str = "", custom_tags: list[dict[str, str | None]] | None = None
     ) -> dict[str, Any]:
         """Create a new honeytoken in GitGuardian.
 
@@ -884,7 +884,7 @@ class GitGuardianClient:
         self,
         name: str,
         description: str = "",
-        custom_tags: list | None = None,
+        custom_tags: list[dict[str, str | None]] | None = None,
         language: str | None = None,
         filename: str | None = None,
         project_extensions: str | None = None,
@@ -1103,7 +1103,7 @@ class GitGuardianClient:
         self,
         incident_id: str,
         severity: str | None = None,
-        custom_tags: list | None = None,
+        custom_tags: list[dict[str, str | None]] | None = None,
     ) -> dict[str, Any]:
         """Update a secret incident.
 
@@ -2154,7 +2154,7 @@ class GitGuardianClient:
 
         return await self._request_list(endpoint, params=params)
 
-    async def list_source_incidents(self, source_id: str, **kwargs) -> dict[str, Any]:
+    async def list_source_incidents(self, source_id: str, **kwargs: Any) -> dict[str, Any]:
         """List secret incidents of a source.
 
         Args:
@@ -2174,7 +2174,7 @@ class GitGuardianClient:
 
         return await self._request_get(endpoint)
 
-    async def list_member_incidents(self, member_id: str, **kwargs) -> dict[str, Any]:
+    async def list_member_incidents(self, member_id: str, **kwargs: Any) -> dict[str, Any]:
         """List secret incidents a member has access to.
 
         Args:
@@ -2340,7 +2340,7 @@ class GitGuardianClient:
         logger.info(f"Creating code fix request for {len(locations)} issue(s)")
         return await self._request_post("/code-fix-requests", json={"locations": locations})
 
-    async def list_members(self, params) -> ListResponse:
+    async def list_members(self, params: dict[str, Any]) -> ListResponse:
         """List all users in the account."""
         return await self._request_list("/members", params=params)
 

--- a/packages/gg_api_core/src/gg_api_core/host.py
+++ b/packages/gg_api_core/src/gg_api_core/host.py
@@ -78,5 +78,5 @@ def is_local_instance(gitguardian_url: str | None = None) -> bool:
     return _is_local_hostname(parsed.hostname)
 
 
-def has_exposed_prefix_for_api(gitguardian_url):
+def has_exposed_prefix_for_api(gitguardian_url: str | None) -> bool:
     return is_self_hosted_instance(gitguardian_url) or is_local_instance(gitguardian_url)

--- a/packages/gg_api_core/src/gg_api_core/mcp_server.py
+++ b/packages/gg_api_core/src/gg_api_core/mcp_server.py
@@ -175,7 +175,7 @@ class AbstractGitGuardianFastMCP(FastMCP, ABC):
         if args and callable(args[0]):
             # Direct call: mcp.tool(fn, required_scopes=...)
             fn = args[0]
-            name = kwargs.get("name", fn.__name__)
+            name: str = kwargs.get("name") or fn.__name__
             result = super().tool(*args, **kwargs)
             if required_scopes:
                 self._tool_scopes[name] = set(required_scopes)
@@ -185,7 +185,7 @@ class AbstractGitGuardianFastMCP(FastMCP, ABC):
             parent_decorator = super().tool(*args, **kwargs)
 
             def wrapper(fn):
-                name = kwargs.get("name", fn.__name__)
+                name: str = kwargs.get("name") or fn.__name__
                 result = parent_decorator(fn)
                 if required_scopes:
                     self._tool_scopes[name] = set(required_scopes)

--- a/packages/gg_api_core/src/gg_api_core/mcp_server.py
+++ b/packages/gg_api_core/src/gg_api_core/mcp_server.py
@@ -10,6 +10,7 @@ from typing import Any
 from fastmcp import FastMCP
 from fastmcp.exceptions import ValidationError
 from fastmcp.server.dependencies import get_access_token
+from typing_extensions import override
 
 from gg_api_core.client import GitGuardianClient
 from gg_api_core.icons import get_gitguardian_icons
@@ -53,7 +54,7 @@ class CachedTokenInfoMixin:
     _token_scopes: set[str] = set()
     _token_info: dict[str, Any] | None = None
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         # Add a custom lifespan contextmanager that fetches and cache token scopes and infos
         original_lifespan = kwargs.get("lifespan")
         kwargs["lifespan"] = self._create_token_scope_lifespan(original_lifespan)
@@ -65,13 +66,13 @@ class CachedTokenInfoMixin:
         self._token_scopes = set()
         self._token_info = None
 
-    def _create_token_scope_lifespan(self, original_lifespan=None):
+    def _create_token_scope_lifespan(self, original_lifespan: Any = None) -> Any:
         """Create a lifespan context manager that fetches token scopes."""
 
         @asynccontextmanager
-        async def token_scope_lifespan(fastmcp) -> AsyncIterator[dict]:
+        async def token_scope_lifespan(fastmcp: FastMCP) -> AsyncIterator[dict[str, Any]]:
             """Lifespan context manager that fetches token scopes on startup."""
-            context_result = {}
+            context_result: dict[str, Any] = {}
 
             # Call the original lifespan if provided
             if original_lifespan:
@@ -111,7 +112,7 @@ class AbstractGitGuardianFastMCP(FastMCP, ABC):
 
     authentication_mode: AuthenticationMode
 
-    def __init__(self, *args, default_scopes: list[str] | None = None, **kwargs):
+    def __init__(self, *args: Any, default_scopes: list[str] | None = None, **kwargs: Any) -> None:
         """
         Initialize the GitGuardian MCP server.
         """
@@ -157,7 +158,8 @@ class AbstractGitGuardianFastMCP(FastMCP, ABC):
             logger.exception(f"Error revoking current API token: {str(e)}")
             raise
 
-    def tool(self, *args, required_scopes: list[str] | None = None, **kwargs):
+    @override
+    def tool(self, *args: Any, required_scopes: list[str] | None = None, **kwargs: Any) -> Any:
         """
         Extended tool decorator that tracks required scopes.
 
@@ -184,7 +186,7 @@ class AbstractGitGuardianFastMCP(FastMCP, ABC):
             # Decorator usage: @mcp.tool(required_scopes=...)
             parent_decorator = super().tool(*args, **kwargs)
 
-            def wrapper(fn):
+            def wrapper(fn: Any) -> Any:
                 name: str = kwargs.get("name") or fn.__name__
                 result = parent_decorator(fn)
                 if required_scopes:
@@ -193,7 +195,7 @@ class AbstractGitGuardianFastMCP(FastMCP, ABC):
 
             return wrapper
 
-    async def _fetch_token_scopes_from_api(self, client=None) -> set[str]:
+    async def _fetch_token_scopes_from_api(self, client: GitGuardianClient | None = None) -> set[str]:
         """Fetch token scopes from the GitGuardian API.
 
         Args:
@@ -288,6 +290,7 @@ class GitGuardianLocalOAuthMCP(CachedTokenInfoMixin, AbstractGitGuardianFastMCP)
 
     authentication_mode = AuthenticationMode.LOCAL_OAUTH_FLOW
 
+    @override
     def get_personal_access_token(self) -> str | None:
         # It will be actually provided within the client by the OAuth flow, or from the filesystem storage
         return None
@@ -298,10 +301,11 @@ class GitGuardianPATEnvMCP(CachedTokenInfoMixin, AbstractGitGuardianFastMCP):
 
     authentication_mode = AuthenticationMode.PERSONAL_ACCESS_TOKEN_ENV_VAR
 
-    def __init__(self, *args, personal_access_token: str, **kwargs):
+    def __init__(self, *args: Any, personal_access_token: str, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.personal_access_token = personal_access_token
 
+    @override
     def get_personal_access_token(self) -> str:
         return self.personal_access_token
 
@@ -315,12 +319,14 @@ class _BearerTokenMCP(AbstractGitGuardianFastMCP):
     below differ only in :attr:`authentication_mode`.
     """
 
+    @override
     def get_personal_access_token(self) -> str:
         access_token = get_access_token()
         if not access_token:
             raise ValidationError("No access token available - bearer authentication required")
         return access_token.token
 
+    @override
     async def get_token_info(self) -> dict[str, Any]:
         return await self._fetch_token_info_from_api()
 
@@ -341,7 +347,7 @@ class GitGuardianOAuthProxyMCP(_BearerTokenMCP):
     authentication_mode = AuthenticationMode.OAUTH_PROXY
 
 
-def get_mcp_server(*args, **kwargs) -> AbstractGitGuardianFastMCP:
+def get_mcp_server(*args: Any, **kwargs: Any) -> AbstractGitGuardianFastMCP:
     kwargs.setdefault("icons", get_gitguardian_icons())
 
     settings = get_settings()

--- a/packages/gg_api_core/src/gg_api_core/middleware.py
+++ b/packages/gg_api_core/src/gg_api_core/middleware.py
@@ -3,11 +3,12 @@
 import logging
 import time
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import mcp.types as mt
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.tools import Tool, ToolResult
+from typing_extensions import override
 
 from gg_api_core.client import DownstreamUnauthorizedError
 from gg_api_core.oauth_proxy_auth import mark_downstream_unauthorized
@@ -26,7 +27,8 @@ class DownstreamUnauthorizedMiddleware(Middleware):
     rewrites the status to 401 based on the flag set here.
     """
 
-    async def on_message(self, context, call_next):
+    @override
+    async def on_message(self, context: MiddlewareContext[Any], call_next: CallNext[Any, Any]) -> Any:
         try:
             return await call_next(context)
         except DownstreamUnauthorizedError:
@@ -40,10 +42,11 @@ class ScopeFilteringMiddleware(Middleware):
     def __init__(self, mcp_server: "AbstractGitGuardianFastMCP"):
         self._mcp_server = mcp_server
 
+    @override
     async def on_list_tools(
         self,
-        context,
-        call_next,
+        context: MiddlewareContext[mt.ListToolsRequest],
+        call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]],
     ) -> Sequence[Tool]:
         """Filter tools based on the user's API token scopes."""
         # Get all tools from the next middleware/handler
@@ -66,6 +69,7 @@ class ScopeFilteringMiddleware(Middleware):
 
 
 class ToolCallLoggingMiddleware(Middleware):
+    @override
     async def on_call_tool(
         self,
         context: MiddlewareContext[mt.CallToolRequestParams],

--- a/packages/gg_api_core/src/gg_api_core/oauth.py
+++ b/packages/gg_api_core/src/gg_api_core/oauth.py
@@ -8,12 +8,13 @@ import time
 import webbrowser
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 from urllib.parse import parse_qs, urlparse
 
 from mcp.client.auth import TokenStorage
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 from pydantic import BaseModel, Field
+from typing_extensions import override
 
 from .settings import get_settings
 
@@ -60,7 +61,7 @@ _oauth_client_counter = 0
 class FileTokenStorage:
     """File-based storage for OAuth tokens to enable token reuse."""
 
-    def __init__(self, token_file=None):
+    def __init__(self, token_file: str | Path | None = None) -> None:
         """Initialize the token storage.
 
         Args:
@@ -94,7 +95,7 @@ class FileTokenStorage:
             # Ensure parent directory exists
             self.token_file.parent.mkdir(exist_ok=True, parents=True)
 
-    def load_tokens(self):
+    def load_tokens(self) -> dict[str, Any]:
         """Load tokens from the token file."""
         try:
             if self.token_file.exists():
@@ -104,7 +105,7 @@ class FileTokenStorage:
             logger.warning(f"Failed to load tokens from {self.token_file}: {e}")
         return {}
 
-    def save_token(self, instance_url, token_data):
+    def save_token(self, instance_url: str, token_data: dict[str, Any]) -> None:
         """Save a token for a specific instance URL."""
         tokens = self.load_tokens()
 
@@ -153,15 +154,19 @@ class InMemoryTokenStorage(TokenStorage):
         self._tokens: Optional[OAuthToken] = None
         self._client_info: Optional[OAuthClientInformationFull] = None
 
+    @override
     async def get_tokens(self) -> Optional[OAuthToken]:
         return self._tokens
 
+    @override
     async def set_tokens(self, tokens: OAuthToken) -> None:
         self._tokens = tokens
 
+    @override
     async def get_client_info(self) -> Optional[OAuthClientInformationFull]:
         return self._client_info
 
+    @override
     async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
         self._client_info = client_info
 
@@ -169,7 +174,7 @@ class InMemoryTokenStorage(TokenStorage):
 class CallbackHandler(BaseHTTPRequestHandler):
     """Simple HTTP handler to capture OAuth callback."""
 
-    def __init__(self, request, client_address, server, callback_data):
+    def __init__(self, request: Any, client_address: Any, server: Any, callback_data: dict[str, Any]) -> None:
         """Initialize with callback data storage."""
         self.callback_data = callback_data
         super().__init__(request, client_address, server)
@@ -296,7 +301,8 @@ class CallbackHandler(BaseHTTPRequestHandler):
             self.send_response(404)
             self.end_headers()
 
-    def log_message(self, format, *args):
+    @override
+    def log_message(self, format: str, *args: Any) -> None:
         """Suppress default logging."""
         pass
 
@@ -304,7 +310,12 @@ class CallbackHandler(BaseHTTPRequestHandler):
 class CallbackServer:
     """Simple server to handle OAuth callbacks."""
 
-    def __init__(self, port_range=CALLBACK_PORT_RANGE, dashboard_url=None, use_dashboard_page=False):
+    def __init__(
+        self,
+        port_range: tuple[int, int] = CALLBACK_PORT_RANGE,
+        dashboard_url: str | None = None,
+        use_dashboard_page: bool = False,
+    ) -> None:
         """Initialize the callback server with a range of ports to try.
 
         Args:
@@ -313,9 +324,9 @@ class CallbackServer:
             use_dashboard_page: If True, redirect to dashboard authenticated page instead of showing local page
         """
         self.port_range = port_range
-        self.port = None
-        self.server = None
-        self.thread = None
+        self.port: int | None = None
+        self.server: HTTPServer | None = None
+        self.thread: threading.Thread | None = None
         self.callback_data = {
             "dashboard_url": dashboard_url,
             "authorization_code": None,
@@ -329,12 +340,12 @@ class CallbackServer:
         callback_data = self.callback_data
 
         class DataCallbackHandler(CallbackHandler):
-            def __init__(self, request, client_address, server):
+            def __init__(self, request: Any, client_address: Any, server: Any) -> None:
                 super().__init__(request, client_address, server, callback_data)
 
         return DataCallbackHandler
 
-    def is_port_available(self, port):
+    def is_port_available(self, port: int) -> bool:
         """Check if a port is available by attempting to bind to it.
 
         Args:
@@ -397,7 +408,7 @@ class CallbackServer:
         if self.thread:
             self.thread.join(timeout=1)
 
-    def wait_for_callback(self, timeout=300):
+    def wait_for_callback(self, timeout: float = 300):
         """Wait for OAuth callback with timeout."""
         start_time = time.time()
         while time.time() - start_time < timeout:
@@ -441,9 +452,9 @@ class GitGuardianOAuthClient:
         self.scopes = scopes or ["scan"]
         self.token_storage = InMemoryTokenStorage()
         self.file_token_storage = FileTokenStorage()
-        self.oauth_provider = None
-        self.access_token = None
-        self.token_info = None
+        self.oauth_provider: Any = None
+        self.access_token: str | None = None
+        self.token_info: APITokenInfo | None = None
 
         # Use provided token name or use the default "MCP server token"
         self.token_name = token_name

--- a/packages/gg_api_core/src/gg_api_core/oauth_proxy_auth.py
+++ b/packages/gg_api_core/src/gg_api_core/oauth_proxy_auth.py
@@ -16,6 +16,7 @@ The MCP client gets the real GG PAT directly and sends it as Bearer token.
 import logging
 from collections.abc import Callable
 from contextvars import ContextVar
+from typing import Any
 from urllib.parse import urlencode, urlparse
 
 import httpx
@@ -25,6 +26,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, RedirectResponse
 from starlette.routing import Route
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
+from typing_extensions import override
 
 from .settings import get_settings
 
@@ -54,6 +56,7 @@ class PassThroughTokenVerifier(TokenVerifier):
     fail with a real 401 if the token is invalid.
     """
 
+    @override
     async def verify_token(self, token: str) -> AccessToken | None:
         return AccessToken(token=token, client_id="unknown", scopes=[])
 
@@ -165,8 +168,8 @@ class GitGuardianOAuthThinProxy(PassThroughTokenVerifier):
         gg_api_url: str,
         gg_client_id: str = "ggshield_oauth",
         advertised_scopes: list[str] | None = None,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         super().__init__(**kwargs)
         self.gg_authorize_url = gg_authorize_url
         self.gg_token_url = gg_token_url
@@ -176,10 +179,12 @@ class GitGuardianOAuthThinProxy(PassThroughTokenVerifier):
         self._advertised_scopes = advertised_scopes
 
     @property
+    @override
     def scopes_supported(self) -> list[str]:
         return self._advertised_scopes or ["scan"]
 
-    def get_middleware(self) -> list:
+    @override
+    def get_middleware(self) -> list[Middleware]:
         """Add downstream-401 handling and WWW-Authenticate advertising.
 
         Order matters. ``TranslateDownstreamUnauthorizedMiddleware`` runs
@@ -214,6 +219,7 @@ class GitGuardianOAuthThinProxy(PassThroughTokenVerifier):
             return None
         return str(build_resource_metadata_url(self._resource_url))
 
+    @override
     def get_routes(self, mcp_path: str | None = None) -> list[Route]:
         """Return OAuth proxy routes alongside discovery metadata.
 

--- a/packages/gg_api_core/src/gg_api_core/sentry_integration.py
+++ b/packages/gg_api_core/src/gg_api_core/sentry_integration.py
@@ -134,7 +134,7 @@ def set_sentry_user(user_info: dict[str, Any]) -> None:
         logger.debug(f"Failed to set Sentry user: {str(e)}")
 
 
-def capture_exception(exception: Exception, **kwargs) -> None:
+def capture_exception(exception: Exception, **kwargs: Any) -> None:
     """
     Manually capture an exception to Sentry.
 

--- a/packages/gg_api_core/src/gg_api_core/tools/generate_honey_token.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/generate_honey_token.py
@@ -128,7 +128,7 @@ async def generate_honeytoken(params: GenerateHoneytokenParams) -> GenerateHoney
     # Create a new honeytoken if requested or if we couldn't find an existing one
     try:
         # Generate the honeytoken with default tags
-        custom_tags = [
+        custom_tags: list[dict[str, str | None]] = [
             {"key": "source", "value": "auto-generated"},
             {"key": "type", "value": "aws"},
         ]

--- a/packages/gg_api_core/src/gg_api_core/tools/remediate_secret_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/remediate_secret_incidents.py
@@ -22,7 +22,7 @@ REMEDIATION_PROMPT_PATH = Path(__file__).parent / "remediation_prompt.md"
 class ListRepoOccurrencesParamsForRemediate(ListRepoOccurrencesParams):
     # Overriding the tags one to add a default filter : for remediation, we're more interested in occurrences that
     # are in the branch the developer is currently on. And occurrences on DEFAULT_BRANCH are a heuristic for that
-    tags: list[str] = Field(
+    tags: list[str] | None = Field(
         default=[TagNames.DEFAULT_BRANCH.value],
         description="List of tags to filter incidents by. Default to DEFAULT_BRANCH to avoid requiring a git checkout for the fix",
     )

--- a/packages/gg_api_core/src/gg_api_core/tools/remediate_secret_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/remediate_secret_incidents.py
@@ -158,7 +158,7 @@ async def remediate_secret_incidents(
         return RemediateSecretIncidentsError(error=f"Failed to remediate incidents: {str(e)}")
 
 
-async def filter_mine(occurrences):
+async def filter_mine(occurrences: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Filter occurrences create by the current user"""
     client = await get_client()
     try:
@@ -173,6 +173,6 @@ async def filter_mine(occurrences):
     return occurrences
 
 
-async def trim_occurrences_for_remediation(occurrences):
+async def trim_occurrences_for_remediation(occurrences: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Limit the number of occurrences to be remediated by the agent"""
     return occurrences[:10]

--- a/packages/gg_mcp_server/src/gg_mcp_server/add_health_check.py
+++ b/packages/gg_mcp_server/src/gg_mcp_server/add_health_check.py
@@ -1,8 +1,9 @@
+from fastmcp import FastMCP
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 
 
-def add_health_check(mcp):
+def add_health_check(mcp: FastMCP) -> None:
     """Add a health check endpoint"""
 
     @mcp.custom_route("/health", methods=["GET"])

--- a/packages/secops_mcp_server/src/config/gunicorn.py
+++ b/packages/secops_mcp_server/src/config/gunicorn.py
@@ -5,6 +5,7 @@ with Python's logging system for consistent log formatting.
 """
 
 import logging
+from typing import Any
 
 
 class GunicornLogger:
@@ -14,59 +15,59 @@ class GunicornLogger:
     to ensure consistent log formatting across the application.
     """
 
-    def __init__(self, cfg):
+    def __init__(self, cfg: Any) -> None:
         """Initialize the GunicornLogger.
 
         Args:
             cfg: Gunicorn configuration object
         """
         self.cfg = cfg
-        self._error_log = None
-        self._access_log = None
+        self._error_log: logging.Logger | None = None
+        self._access_log: logging.Logger | None = None
 
     @property
-    def error_log(self):
+    def error_log(self) -> logging.Logger:
         """Get the error logger."""
         if not self._error_log:
             self._error_log = logging.getLogger("gunicorn.error")
         return self._error_log
 
     @property
-    def access_log(self):
+    def access_log(self) -> logging.Logger:
         """Get the access logger."""
         if not self._access_log:
             self._access_log = logging.getLogger("gunicorn.access")
         return self._access_log
 
-    def critical(self, msg, *args, **kwargs):
+    def critical(self, msg: str, *args: Any, **kwargs: Any) -> None:
         """Log critical message."""
         self.error_log.critical(msg, *args, **kwargs)
 
-    def error(self, msg, *args, **kwargs):
+    def error(self, msg: str, *args: Any, **kwargs: Any) -> None:
         """Log error message."""
         self.error_log.error(msg, *args, **kwargs)
 
-    def warning(self, msg, *args, **kwargs):
+    def warning(self, msg: str, *args: Any, **kwargs: Any) -> None:
         """Log warning message."""
         self.error_log.warning(msg, *args, **kwargs)
 
-    def info(self, msg, *args, **kwargs):
+    def info(self, msg: str, *args: Any, **kwargs: Any) -> None:
         """Log info message."""
         self.error_log.info(msg, *args, **kwargs)
 
-    def debug(self, msg, *args, **kwargs):
+    def debug(self, msg: str, *args: Any, **kwargs: Any) -> None:
         """Log debug message."""
         self.error_log.debug(msg, *args, **kwargs)
 
-    def exception(self, msg, *args, **kwargs):
+    def exception(self, msg: str, *args: Any, **kwargs: Any) -> None:
         """Log exception message."""
         self.error_log.exception(msg, *args, **kwargs)
 
-    def log(self, lvl, msg, *args, **kwargs):
+    def log(self, lvl: int, msg: str, *args: Any, **kwargs: Any) -> None:
         """Log message at specific level."""
         self.error_log.log(lvl, msg, *args, **kwargs)
 
-    def access(self, resp, req, environ, request_time):
+    def access(self, resp: Any, req: Any, environ: dict[str, Any], request_time: Any) -> None:
         """Log access information."""
         self.access_log.info(
             '%s - "%s %s %s" %d',
@@ -77,10 +78,10 @@ class GunicornLogger:
             resp.status_code,
         )
 
-    def reopen_files(self):
+    def reopen_files(self) -> None:
         """Reopen log files (for log rotation)."""
         pass
 
-    def close_on_exec(self):
+    def close_on_exec(self) -> None:
         """Close log files on exec."""
         pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ Homepage = "https://github.com/GitGuardian/ggmcp"
 
 [dependency-groups]
 dev = [
-    "mypy~=1.18",
     "pytest~=8.4",
     "pytest-asyncio~=1.2",
     "pytest-cov~=7.0",
@@ -53,6 +52,7 @@ dev = [
     "ruff~=0.14",
     "vcrpy~=8.0",
     "pyyaml~=6.0",
+    "pyrefly>=1.1.1",
 ]
 
 [project.scripts]
@@ -121,20 +121,6 @@ markers = [
     "vcr_test", # mark a test as using VCR cassettes (disables auto-mocking)
 ]
 
-[tool.mypy]
-python_version = "3.11"
-warn_return_any = true
-warn_unused_configs = true
-warn_redundant_casts = true
-warn_unused_ignores = true
-disallow_untyped_defs = false  # Start lenient, can be enabled later
-check_untyped_defs = true
-no_implicit_optional = true
-strict_optional = true
-ignore_missing_imports = true  # For packages without type stubs
-show_error_codes = true
-pretty = true
-
 [tool.commitizen]
 name = "cz_conventional_commits"
 tag_format = "v$version"
@@ -143,3 +129,7 @@ tag_format = "v$version"
 version_provider = "pep621"
 update_changelog_on_bump = true
 gpg_sign = true
+
+[tool.pyrefly]
+python-version = "3.11"
+ignore-missing-imports = ["*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,5 +131,10 @@ update_changelog_on_bump = true
 gpg_sign = true
 
 [tool.pyrefly]
+preset = "strict"
 python-version = "3.11"
+project-includes = ["packages/**"]
+# uv installs the workspace packages as editable installs, so pyrefly's
+# heuristics would treat packages/*/src as site-packages and skip them.
+disable-project-excludes-heuristics = true
 ignore-missing-imports = ["*"]

--- a/uv.lock
+++ b/uv.lock
@@ -589,7 +589,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "mypy" },
+    { name = "pyrefly" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -609,7 +609,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = "~=1.18" },
+    { name = "pyrefly", specifier = ">=1.1.1" },
     { name = "pytest", specifier = "~=8.4" },
     { name = "pytest-asyncio", specifier = "~=1.2" },
     { name = "pytest-cov", specifier = "~=7.0" },
@@ -984,53 +984,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy"
-version = "1.18.2"
-source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
-dependencies = [
-    { name = "mypy-extensions" },
-    { name = "pathspec" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/77/8f0d0001ffad290cef2f7f216f96c814866248a0b92a722365ed54648e7e/mypy-1.18.2.tar.gz", hash = "sha256:06a398102a5f203d7477b2923dda3634c36727fa5c237d8f859ef90c42a9924b", size = 3448846, upload-time = "2025-09-19T00:11:10.519Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/87/cafd3ae563f88f94eec33f35ff722d043e09832ea8530ef149ec1efbaf08/mypy-1.18.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:807d9315ab9d464125aa9fcf6d84fde6e1dc67da0b6f80e7405506b8ac72bc7f", size = 12731198, upload-time = "2025-09-19T00:09:44.857Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/e0/1e96c3d4266a06d4b0197ace5356d67d937d8358e2ee3ffac71faa843724/mypy-1.18.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:776bb00de1778caf4db739c6e83919c1d85a448f71979b6a0edd774ea8399341", size = 11817879, upload-time = "2025-09-19T00:09:47.131Z" },
-    { url = "https://files.pythonhosted.org/packages/72/ef/0c9ba89eb03453e76bdac5a78b08260a848c7bfc5d6603634774d9cd9525/mypy-1.18.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1379451880512ffce14505493bd9fe469e0697543717298242574882cf8cdb8d", size = 12427292, upload-time = "2025-09-19T00:10:22.472Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/52/ec4a061dd599eb8179d5411d99775bec2a20542505988f40fc2fee781068/mypy-1.18.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1331eb7fd110d60c24999893320967594ff84c38ac6d19e0a76c5fd809a84c86", size = 13163750, upload-time = "2025-09-19T00:09:51.472Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/5f/2cf2ceb3b36372d51568f2208c021870fe7834cf3186b653ac6446511839/mypy-1.18.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3ca30b50a51e7ba93b00422e486cbb124f1c56a535e20eff7b2d6ab72b3b2e37", size = 13351827, upload-time = "2025-09-19T00:09:58.311Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/7d/2697b930179e7277529eaaec1513f8de622818696857f689e4a5432e5e27/mypy-1.18.2-cp311-cp311-win_amd64.whl", hash = "sha256:664dc726e67fa54e14536f6e1224bcfce1d9e5ac02426d2326e2bb4e081d1ce8", size = 9757983, upload-time = "2025-09-19T00:10:09.071Z" },
-    { url = "https://files.pythonhosted.org/packages/07/06/dfdd2bc60c66611dd8335f463818514733bc763e4760dee289dcc33df709/mypy-1.18.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:33eca32dd124b29400c31d7cf784e795b050ace0e1f91b8dc035672725617e34", size = 12908273, upload-time = "2025-09-19T00:10:58.321Z" },
-    { url = "https://files.pythonhosted.org/packages/81/14/6a9de6d13a122d5608e1a04130724caf9170333ac5a924e10f670687d3eb/mypy-1.18.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a3c47adf30d65e89b2dcd2fa32f3aeb5e94ca970d2c15fcb25e297871c8e4764", size = 11920910, upload-time = "2025-09-19T00:10:20.043Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/a9/b29de53e42f18e8cc547e38daa9dfa132ffdc64f7250e353f5c8cdd44bee/mypy-1.18.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d6c838e831a062f5f29d11c9057c6009f60cb294fea33a98422688181fe2893", size = 12465585, upload-time = "2025-09-19T00:10:33.005Z" },
-    { url = "https://files.pythonhosted.org/packages/77/ae/6c3d2c7c61ff21f2bee938c917616c92ebf852f015fb55917fd6e2811db2/mypy-1.18.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01199871b6110a2ce984bde85acd481232d17413868c9807e95c1b0739a58914", size = 13348562, upload-time = "2025-09-19T00:10:11.51Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/31/aec68ab3b4aebdf8f36d191b0685d99faa899ab990753ca0fee60fb99511/mypy-1.18.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a2afc0fa0b0e91b4599ddfe0f91e2c26c2b5a5ab263737e998d6817874c5f7c8", size = 13533296, upload-time = "2025-09-19T00:10:06.568Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/83/abcb3ad9478fca3ebeb6a5358bb0b22c95ea42b43b7789c7fb1297ca44f4/mypy-1.18.2-cp312-cp312-win_amd64.whl", hash = "sha256:d8068d0afe682c7c4897c0f7ce84ea77f6de953262b12d07038f4d296d547074", size = 9828828, upload-time = "2025-09-19T00:10:28.203Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/04/7f462e6fbba87a72bc8097b93f6842499c428a6ff0c81dd46948d175afe8/mypy-1.18.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:07b8b0f580ca6d289e69209ec9d3911b4a26e5abfde32228a288eb79df129fcc", size = 12898728, upload-time = "2025-09-19T00:10:01.33Z" },
-    { url = "https://files.pythonhosted.org/packages/99/5b/61ed4efb64f1871b41fd0b82d29a64640f3516078f6c7905b68ab1ad8b13/mypy-1.18.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ed4482847168439651d3feee5833ccedbf6657e964572706a2adb1f7fa4dfe2e", size = 11910758, upload-time = "2025-09-19T00:10:42.607Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/46/d297d4b683cc89a6e4108c4250a6a6b717f5fa96e1a30a7944a6da44da35/mypy-1.18.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3ad2afadd1e9fea5cf99a45a822346971ede8685cc581ed9cd4d42eaf940986", size = 12475342, upload-time = "2025-09-19T00:11:00.371Z" },
-    { url = "https://files.pythonhosted.org/packages/83/45/4798f4d00df13eae3bfdf726c9244bcb495ab5bd588c0eed93a2f2dd67f3/mypy-1.18.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a431a6f1ef14cf8c144c6b14793a23ec4eae3db28277c358136e79d7d062f62d", size = 13338709, upload-time = "2025-09-19T00:11:03.358Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/09/479f7358d9625172521a87a9271ddd2441e1dab16a09708f056e97007207/mypy-1.18.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7ab28cc197f1dd77a67e1c6f35cd1f8e8b73ed2217e4fc005f9e6a504e46e7ba", size = 13529806, upload-time = "2025-09-19T00:10:26.073Z" },
-    { url = "https://files.pythonhosted.org/packages/71/cf/ac0f2c7e9d0ea3c75cd99dff7aec1c9df4a1376537cb90e4c882267ee7e9/mypy-1.18.2-cp313-cp313-win_amd64.whl", hash = "sha256:0e2785a84b34a72ba55fb5daf079a1003a34c05b22238da94fcae2bbe46f3544", size = 9833262, upload-time = "2025-09-19T00:10:40.035Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/0c/7d5300883da16f0063ae53996358758b2a2df2a09c72a5061fa79a1f5006/mypy-1.18.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:62f0e1e988ad41c2a110edde6c398383a889d95b36b3e60bcf155f5164c4fdce", size = 12893775, upload-time = "2025-09-19T00:10:03.814Z" },
-    { url = "https://files.pythonhosted.org/packages/50/df/2cffbf25737bdb236f60c973edf62e3e7b4ee1c25b6878629e88e2cde967/mypy-1.18.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8795a039bab805ff0c1dfdb8cd3344642c2b99b8e439d057aba30850b8d3423d", size = 11936852, upload-time = "2025-09-19T00:10:51.631Z" },
-    { url = "https://files.pythonhosted.org/packages/be/50/34059de13dd269227fb4a03be1faee6e2a4b04a2051c82ac0a0b5a773c9a/mypy-1.18.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6ca1e64b24a700ab5ce10133f7ccd956a04715463d30498e64ea8715236f9c9c", size = 12480242, upload-time = "2025-09-19T00:11:07.955Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/11/040983fad5132d85914c874a2836252bbc57832065548885b5bb5b0d4359/mypy-1.18.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d924eef3795cc89fecf6bedc6ed32b33ac13e8321344f6ddbf8ee89f706c05cb", size = 13326683, upload-time = "2025-09-19T00:09:55.572Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/ba/89b2901dd77414dd7a8c8729985832a5735053be15b744c18e4586e506ef/mypy-1.18.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20c02215a080e3a2be3aa50506c67242df1c151eaba0dcbc1e4e557922a26075", size = 13514749, upload-time = "2025-09-19T00:10:44.827Z" },
-    { url = "https://files.pythonhosted.org/packages/25/bc/cc98767cffd6b2928ba680f3e5bc969c4152bf7c2d83f92f5a504b92b0eb/mypy-1.18.2-cp314-cp314-win_amd64.whl", hash = "sha256:749b5f83198f1ca64345603118a6f01a4e99ad4bf9d103ddc5a3200cc4614adf", size = 9982959, upload-time = "2025-09-19T00:10:37.344Z" },
-    { url = "https://files.pythonhosted.org/packages/87/e3/be76d87158ebafa0309946c4a73831974d4d6ab4f4ef40c3b53a385a66fd/mypy-1.18.2-py3-none-any.whl", hash = "sha256:22a1748707dd62b58d2ae53562ffc4d7f8bcc727e8ac7cbc69c053ddc874d47e", size = 2352367, upload-time = "2025-09-19T00:10:15.489Z" },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
-]
-
-[[package]]
 name = "openapi-pydantic"
 version = "0.5.1"
 source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
@@ -1070,15 +1023,6 @@ source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packag
 sdist = { url = "https://files.pythonhosted.org/packages/66/f3/5a20387de9bcd0607871bfc2198ee0e15836da7baa4592ccd7f24c27c986/pathable-0.6.0.tar.gz", hash = "sha256:6404b8b82aef5ff0fd478934137128b99b12212ba35afdde5525ca4f8388ea58", size = 18970, upload-time = "2026-05-19T18:15:11.911Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/e8/6d75ffd9784bce2e93d1ae4415649427e39a53bb172d4672b2b59c6f0a7b/pathable-0.6.0-py3-none-any.whl", hash = "sha256:82c4ca6c98c502ad12e0d4e9779b6210afee93c38990988c8c5d1b49bdcdf566", size = 18983, upload-time = "2026-05-19T18:15:10.728Z" },
-]
-
-[[package]]
-name = "pathspec"
-version = "0.12.1"
-source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
 ]
 
 [[package]]
@@ -1299,6 +1243,25 @@ source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packag
 sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
+]
+
+[[package]]
+name = "pyrefly"
+version = "1.1.1"
+source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/20/976165fa4b1517a1a92f393b3f4d4badabfff1165eff09d4cd4908428183/pyrefly-1.1.1.tar.gz", hash = "sha256:6deda959f8603a7dbdf112c48983e2275b2903cf33c8c739ed65d7e71a4fd520", size = 5880491, upload-time = "2026-06-18T23:45:43.785Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/d6/02ba666018c6a1cb4ddfa2db98ada721adddd374db5c29ba47a0bf2637fa/pyrefly-1.1.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f4b8595f91885bc8b5e3c282ab68d1df21201668a84e6508b1e15f2feec0bb8d", size = 13631867, upload-time = "2026-06-18T23:45:13.923Z" },
+    { url = "https://files.pythonhosted.org/packages/71/47/7a3457dbbddb513a83cf4fe527d5d5ebda5201a1010ad2a6034030e3e358/pyrefly-1.1.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d6b238e1362622d47a6eb5af704fd8b613c94e8c303386efd6350e3da59fecc8", size = 13075304, upload-time = "2026-06-18T23:45:16.865Z" },
+    { url = "https://files.pythonhosted.org/packages/84/df/70f4b3f42d58ed686a80df31e04eca54d88036cea4f9b96195c64ad0b2b5/pyrefly-1.1.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b50d4510e4f8aaea79e2c4b343a4d7a060c9451c0b2aa9bfe10d7ca1ef33d68d", size = 13446966, upload-time = "2026-06-18T23:45:19.644Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/53/12a19bd6c7af985bcbc13c6910d0f9f6684069ead2282a5c08c2bfbb5d03/pyrefly-1.1.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f330cf039ef3da3b910c84f3a7e431f0cf8d0c1d2dad26491d6cadf3c7cd4759", size = 14449222, upload-time = "2026-06-18T23:45:22.252Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f0/e55c48a50076fc0f9ecf4bdedec50456db383e01162f5e2121f8468be071/pyrefly-1.1.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a6342d87c52b04f72156da04f554c4d57f3616f2b32d1763969efb22d05a1407", size = 14472947, upload-time = "2026-06-18T23:45:24.858Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e7/30e085b31fed978ecb675bdbb54df566673ab550469e5af2d350f6af0be6/pyrefly-1.1.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c08b814ad03175e9cf47111390537161828b472044c39ab3320252b3ac6b2edd", size = 13975252, upload-time = "2026-06-18T23:45:27.247Z" },
+    { url = "https://files.pythonhosted.org/packages/47/58/49c3e67641133d3fe5d8d9a660dc0826c6c37ca197d86cad05fa7dd8bfd6/pyrefly-1.1.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d50cad97f19fc893b04deff7239626cffff5dd27ffb29b7d303a1b770247b208", size = 13471780, upload-time = "2026-06-18T23:45:29.775Z" },
+    { url = "https://files.pythonhosted.org/packages/71/1e/65a7ba8355e2c39d8331832905fb74dcc85fc122a3f1dfd6dbf2a88907ad/pyrefly-1.1.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2150b450ee6a6bcbe69b2d45d9a4ebc934a609e1abcf65e490433f38eb873d84", size = 13989306, upload-time = "2026-06-18T23:45:32.576Z" },
+    { url = "https://files.pythonhosted.org/packages/37/de/b7ee1ab2392c36945738246fba7524439810befa3cfcc03cb6157567fc10/pyrefly-1.1.1-py3-none-win32.whl", hash = "sha256:5ffd8a8ed62fe4e6bf0afe1837d1bad149bb3b9f80e928ef248c96b836db3742", size = 12608469, upload-time = "2026-06-18T23:45:35.419Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9c/a0f5b52934bf80e9c7eff08222e7caf318287b9aef76acb8d9ac5740581b/pyrefly-1.1.1-py3-none-win_amd64.whl", hash = "sha256:4e0430f3ef69c8ac73505fd6584db70ed504665a9f0816fef7f723de510f26cb", size = 13502172, upload-time = "2026-06-18T23:45:38.375Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/4c6bcb3d456835f51445d3662a428f56c3ea5643ec798c577030ae34298c/pyrefly-1.1.1-py3-none-win_arm64.whl", hash = "sha256:83baf0db71e172665db1fca0ced50b8f7773f5192ca57e8ac6773a772b6d2fc5", size = 12895979, upload-time = "2026-06-18T23:45:41.026Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Replace **mypy** with **pyrefly** (Rust-based type checker) as the project's type
checker. Addresses the SI-3908 follow-up note on enabling typechecking. Standalone
PR based on `main`, independent of the middleware-extraction PR (#192).

## Changes

- Swap the `mypy` dev dependency for `pyrefly`; migrate `[tool.mypy]` → `[tool.pyrefly]`.
- Use pyrefly's **`default`** preset (not `legacy`), so type checking is enforced rather than lenient.
- Point the CI `type-check` job, the Makefile `typecheck` target, and the mise `type:check` task at `pyrefly check packages/` — the same explicit-path pattern the old `mypy packages/` used.
- Two small fixes for the errors the default preset surfaced:
  - `mcp_server.py` — `name` could be `None` as a dict key → `name: str = kwargs.get("name") or fn.__name__`.
  - `remediate_secret_incidents.py` — override widened `tags` back to `list[str] | None` to match the parent.

Minimal config:

```toml
[tool.pyrefly]
python-version = "3.11"
ignore-missing-imports = ["*"]   # sentry-sdk is an optional extra, absent from the type-check env
```

## Verification

- `pyrefly check packages/` → **0 errors**
- `ruff check` + `ruff format --check` → clean
- unit tests → **512 passed, 3 skipped**

## Strict preset assessment (follow-up)

For reference, running `preset = "strict"` surfaces **114 errors** — ~84% pure
annotation debt (the codebase was never fully annotated; the old mypy ran with
`disallow_untyped_defs = false`), not latent bugs:

| Error code | Count | Nature |
|---|---|---|
| `implicit-any-parameter` | 77 | missing parameter annotations |
| `missing-override-decorator` | 17 | missing `@override` |
| `implicit-any-attribute` | 8 | attributes inferred as `Any` |
| `implicit-any-type-argument` | 6 | bare generics (`list` vs `list[str]`) |
| `implicit-any-empty-container` | 5 | untyped `[]` / `{}` |
| `bad-override` | 1 | `AbstractGitGuardianFastMCP.tool` vs FastMCP's overloaded `tool` |
| **Total** | **114** | |

Most-affected files: `oauth.py` (29), `config/gunicorn.py` (29, a Gunicorn logging
shim), `mcp_server.py` (23), `client.py` (15), `middleware.py` (7).

Only the single `bad-override` points at anything structural, and it has no clean
fix (FastMCP's `tool` is an overloaded decorator, so even a fully-strict codebase
would suppress it). Suggested path: adopt `strict` in a follow-up via a **baseline**
so new code is held to strict while the 114 existing errors are burned down
file-by-file — rather than one large annotation PR.

