### PR TITLE
feat(logging): add gg_version and request_id to logs

### DIFF
--- a/packages/gg_api_core/pyproject.toml
+++ b/packages/gg_api_core/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 
 [project.optional-dependencies]
 sentry = [
-    "sentry-sdk~=2.43",
+    "sentry-sdk~=2.45",
 ]
 
 [build-system]

--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -6,7 +6,6 @@ import time
 from collections.abc import Awaitable, Sequence
 from datetime import datetime
 from enum import Enum
-from importlib.metadata import PackageNotFoundError, version
 from typing import Any, Dict, Optional, TypedDict, cast
 from urllib.parse import quote_plus, unquote, urlparse
 
@@ -15,6 +14,7 @@ from pydantic import TypeAdapter, ValidationError
 
 from gg_api_core.log_context import record_downstream_call, record_downstream_wait, record_truncation
 from gg_api_core.settings import get_settings
+from gg_api_core.version import APP_VERSION
 
 # Setup logger
 logger = logging.getLogger(__name__)
@@ -96,10 +96,7 @@ async def _track_api_request(
     return response
 
 
-try:
-    DEFAULT_USER_AGENT = f"GitGuardian-MCP-Server/{version('ggmcp')}"
-except PackageNotFoundError:
-    DEFAULT_USER_AGENT = "GitGuardian-MCP-Server"
+DEFAULT_USER_AGENT = f"GitGuardian-MCP-Server/{APP_VERSION}" if APP_VERSION else "GitGuardian-MCP-Server"
 
 
 def _to_date_only(value: str) -> str:

--- a/packages/gg_api_core/src/gg_api_core/logging_config.py
+++ b/packages/gg_api_core/src/gg_api_core/logging_config.py
@@ -8,6 +8,7 @@ import structlog
 from structlog.types import EventDict, Processor, WrappedLogger
 
 from gg_api_core.sanitization import scrub_by_name, scrub_by_value
+from gg_api_core.version import APP_VERSION
 
 if TYPE_CHECKING:
     from gg_api_core.settings import Settings
@@ -72,8 +73,9 @@ def _add_exception_cls(logger: WrappedLogger, method_name: str, event_dict: Even
 def configure_logging(
     *, log_level: str = "INFO", log_format: str | None = None, service: str = "gg-mcp-server"
 ) -> None:
-    def _add_service(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
+    def _add_gg_fields(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
         event_dict["gg_service"] = service
+        event_dict["gg_version"] = APP_VERSION or "unknown"
         return event_dict
 
     shared: list[Processor] = [
@@ -82,7 +84,7 @@ def configure_logging(
         structlog.stdlib.add_logger_name,
         structlog.stdlib.ExtraAdder(),
         structlog.processors.TimeStamper(fmt="iso"),
-        _add_service,
+        _add_gg_fields,
         structlog.processors.StackInfoRenderer(),
         _add_exception_cls,
         _scrub_sensitive_keys,

--- a/packages/gg_api_core/src/gg_api_core/middleware.py
+++ b/packages/gg_api_core/src/gg_api_core/middleware.py
@@ -22,6 +22,7 @@ from gg_api_core.log_context import (
     track_downstream_calls,
 )
 from gg_api_core.oauth_proxy_auth import mark_downstream_unauthorized
+from gg_api_core.sentry_integration import set_sentry_request_id
 from gg_api_core.settings import get_settings
 from gg_api_core.urls import derive_public_api_url
 
@@ -63,10 +64,12 @@ class RequestLoggingContextMiddleware(Middleware):
 
     @override
     async def on_message(self, context: MiddlewareContext[Any], call_next: CallNext[Any, Any]) -> Any:
+        request_id = _resolve_request_id()
         bindings: dict[str, Any] = {
             "authentication_mode": self._mcp_server.authentication_mode.value,
-            "request_id": _resolve_request_id(),
+            "request_id": request_id,
         }
+        set_sentry_request_id(request_id)
 
         session_id = _resolve_session_id(context)
         if session_id:

--- a/packages/gg_api_core/src/gg_api_core/sentry_integration.py
+++ b/packages/gg_api_core/src/gg_api_core/sentry_integration.py
@@ -17,6 +17,13 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+try:
+    import sentry_sdk
+    from sentry_sdk.integrations.logging import LoggingIntegration
+except ImportError:
+    sentry_sdk = None
+    LoggingIntegration = None
+
 from .sanitization import SENSITIVE_DATA_PLACEHOLDER, scrub_by_name, scrub_by_value
 from .settings import SentrySettings
 
@@ -56,22 +63,7 @@ def _scrub_sentry_event(event: Event, hint: Hint) -> Event:
 
 
 def init_sentry() -> bool:
-    """
-    Initialize Sentry SDK if configured via environment variables.
-
-    This function attempts to import and configure Sentry SDK only if
-    SENTRY_DSN is provided. It gracefully handles missing sentry-sdk
-    installation and logs appropriate messages.
-
-    Returns:
-        bool: True if Sentry was successfully initialized, False otherwise
-
-    Example:
-        >>> import os
-        >>> os.environ["SENTRY_DSN"] = "https://..."
-        >>> init_sentry()
-        True
-    """
+    """Initialize Sentry when configured and available."""
     sentry_settings = SentrySettings()
     dsn = sentry_settings.dsn
 
@@ -79,10 +71,7 @@ def init_sentry() -> bool:
         logger.debug("SENTRY_DSN not configured, skipping Sentry initialization")
         return False
 
-    try:
-        import sentry_sdk
-        from sentry_sdk.integrations.logging import LoggingIntegration
-    except ImportError:
+    if sentry_sdk is None or LoggingIntegration is None:
         logger.warning("Sentry SDK not installed")
         return False
 
@@ -134,15 +123,12 @@ def set_sentry_context(key: str, value: Any) -> None:
     Example:
         >>> set_sentry_context("workspace", {"id": "123", "name": "acme"})
     """
+    if sentry_sdk is None:
+        return
     try:
-        import sentry_sdk
-
         sentry_sdk.set_context(key, value)
-    except ImportError:
-        # Sentry not installed, silently skip
-        pass
-    except Exception as e:
-        logger.debug(f"Failed to set Sentry context: {str(e)}")
+    except Exception as exc:
+        logger.debug("Failed to set Sentry context: %s", exc)
 
 
 def set_sentry_user(user_info: dict[str, Any]) -> None:
@@ -158,15 +144,12 @@ def set_sentry_user(user_info: dict[str, Any]) -> None:
     Example:
         >>> set_sentry_user({"id": "123", "email": "user@example.com"})
     """
+    if sentry_sdk is None:
+        return
     try:
-        import sentry_sdk
-
         sentry_sdk.set_user(user_info)
-    except ImportError:
-        # Sentry not installed, silently skip
-        pass
-    except Exception as e:
-        logger.debug(f"Failed to set Sentry user: {str(e)}")
+    except Exception as exc:
+        logger.debug("Failed to set Sentry user: %s", exc)
 
 
 def capture_exception(exception: Exception, **kwargs: Any) -> None:
@@ -186,12 +169,9 @@ def capture_exception(exception: Exception, **kwargs: Any) -> None:
         ...     capture_exception(e, extra={"operation": "risky_operation"})
         ...     handle_error(e)
     """
+    if sentry_sdk is None:
+        return
     try:
-        import sentry_sdk
-
         sentry_sdk.capture_exception(exception, **kwargs)
-    except ImportError:
-        # Sentry not installed, silently skip
-        pass
-    except Exception as e:
-        logger.debug(f"Failed to capture exception in Sentry: {str(e)}")
+    except Exception as exc:
+        logger.debug("Failed to capture exception in Sentry: %s", exc)

--- a/packages/gg_api_core/src/gg_api_core/sentry_integration.py
+++ b/packages/gg_api_core/src/gg_api_core/sentry_integration.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 _MAX_SCRUB_DEPTH = 12
+_REQUEST_ID_FIELD = "request_id"
 
 
 def _scrub_sentry_payload(value: Any, depth: int = 0) -> Any:
@@ -57,9 +58,26 @@ def _scrub_breadcrumb(breadcrumb: dict[str, Any], hint: Hint) -> dict[str, Any]:
     return _scrub_sentry_payload(breadcrumb)
 
 
-def _scrub_sentry_event(event: Event, hint: Hint) -> Event:
-    """Scrub an event before sending it to Sentry."""
-    return _scrub_sentry_payload(event)
+def _request_id_from_trace(event: Event) -> str | None:
+    contexts = event.get("contexts")
+    if not isinstance(contexts, dict):
+        return None
+    trace = contexts.get("trace")
+    if not isinstance(trace, dict):
+        return None
+    data = trace.get("data")
+    if not isinstance(data, dict):
+        return None
+    request_id = data.get(_REQUEST_ID_FIELD)
+    return request_id if isinstance(request_id, str) else None
+
+
+def _prepare_sentry_event(event: Event, hint: Hint) -> Event:
+    event = _scrub_sentry_payload(event)
+    request_id = _request_id_from_trace(event)
+    if request_id:
+        event.setdefault("tags", {})[_REQUEST_ID_FIELD] = request_id
+    return event
 
 
 def init_sentry() -> bool:
@@ -92,7 +110,7 @@ def init_sentry() -> bool:
             profiles_sample_rate=profiles_sample_rate,
             integrations=[logging_integration],
             include_local_variables=False,
-            before_send=_scrub_sentry_event,
+            before_send=_prepare_sentry_event,
             before_breadcrumb=_scrub_breadcrumb,
             # Automatically capture unhandled exceptions
             send_default_pii=False,  # Don't send personally identifiable information by default
@@ -107,6 +125,18 @@ def init_sentry() -> bool:
     except Exception as e:
         logger.exception(f"Failed to initialize Sentry: {str(e)}")
         return False
+
+
+def set_sentry_request_id(request_id: str) -> None:
+    """Preserve a request ID on the active Sentry span."""
+    if sentry_sdk is None:
+        return
+    try:
+        span = sentry_sdk.get_current_span()
+        if span is not None:
+            span.set_data(_REQUEST_ID_FIELD, request_id)
+    except Exception as exc:
+        logger.debug("Failed to preserve request ID for Sentry: %s", exc)
 
 
 def set_sentry_context(key: str, value: Any) -> None:

--- a/packages/gg_api_core/src/gg_api_core/version.py
+++ b/packages/gg_api_core/src/gg_api_core/version.py
@@ -1,0 +1,15 @@
+"""Application release metadata."""
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as package_version
+
+
+def resolve_app_version() -> str | None:
+    """Return the installed ``ggmcp`` release, if its metadata is available."""
+    try:
+        return package_version("ggmcp")
+    except PackageNotFoundError:
+        return None
+
+
+APP_VERSION = resolve_app_version()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dev = [
     "respx~=0.22",
     "pytest-socket~=0.7",
     "pytest-voluptuous~=1.2",
+    "gg-api-core[sentry]",
 ]
 
 [project.scripts]

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -4,6 +4,7 @@ import logging
 import pytest
 import structlog
 from gg_api_core.logging_config import configure_logging
+from gg_api_core.version import APP_VERSION
 
 
 def _reconfigure_json():
@@ -44,6 +45,7 @@ class TestConfigureLogging:
         assert payload["account_id"] == 475789
         assert payload["gg_service"] == "gg-mcp-server"
         assert payload["level"] == "info"
+        assert payload["gg_version"] == (APP_VERSION or "unknown")
 
     def test_structlog_kwargs_are_sanitized(self, capsys):
         _reconfigure_json()

--- a/tests/test_sentry_integration.py
+++ b/tests/test_sentry_integration.py
@@ -1,0 +1,27 @@
+from gg_api_core.sentry_integration import _prepare_sentry_event
+
+
+class TestPrepareSentryEvent:
+    def test_tags_event_with_request_id_from_trace_data(self):
+        """
+        GIVEN an event containing the active MCP span data
+        WHEN the event is prepared for Sentry
+        THEN its request ID is promoted without replacing existing tags
+        """
+        event = _prepare_sentry_event(
+            {
+                "contexts": {"trace": {"data": {"request_id": "req-mcp"}}},
+                "tags": {"existing": "kept"},
+            },
+            {},
+        )
+
+        assert event["tags"] == {"existing": "kept", "request_id": "req-mcp"}
+
+    def test_leaves_event_untagged_without_request_trace_data(self):
+        """
+        GIVEN an event without MCP request trace data
+        WHEN the event is prepared for Sentry
+        THEN no request ID tag is added
+        """
+        assert _prepare_sentry_event({}, {}) == {}

--- a/tests/test_sentry_logging.py
+++ b/tests/test_sentry_logging.py
@@ -135,11 +135,11 @@ class TestSentryCaptureOwnership:
         assert "raw scan payload" not in rendered
         assert "scan_secrets" in rendered
 
-    async def test_mcp_integration_is_the_only_tool_failure_owner(self, sentry_events):
+    async def test_mcp_integration_is_the_only_tool_failure_owner(self, sentry_events, monkeypatch):
         """
         GIVEN a real MCP tool that raises an exception
         WHEN it is called through the middleware stack
-        THEN MCPIntegration produces exactly one Sentry event
+        THEN MCPIntegration produces one event correlated with its tool log
         """
         mcp = get_mcp_server("Sentry ownership test")
         mcp._fetch_token_scopes_from_api = AsyncMock(return_value=set())
@@ -149,6 +149,7 @@ class TestSentryCaptureOwnership:
         async def failing_tool():
             raise RuntimeError("tool exploded")
 
+        monkeypatch.setattr("gg_api_core.middleware.get_http_headers", lambda: {"x-request-id": "req-sentry"})
         configure_logging(log_level="DEBUG", log_format="json")
         async with Client(mcp) as client:
             with pytest.raises(ToolError):
@@ -158,6 +159,8 @@ class TestSentryCaptureOwnership:
         event = sentry_events[0]
         exception_types = [value["type"] for value in event["exception"]["values"]]
         assert exception_types == ["RuntimeError", "ToolError"]
+
+        assert event["tags"]["request_id"] == "req-sentry"
 
     def test_rendered_traceback_remains_scrubbed(self, sentry_events, capsys):
         """

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,34 @@
+from importlib.metadata import PackageNotFoundError
+from unittest.mock import Mock
+
+from gg_api_core.version import resolve_app_version
+
+
+class TestResolveAppVersion:
+    """Tests for application release metadata lookup."""
+
+    def test_returns_the_umbrella_distribution_version(self, monkeypatch):
+        """
+        GIVEN the ggmcp distribution metadata is installed
+        WHEN the application version is resolved
+        THEN its release number is returned
+        """
+        package_version = Mock(return_value="1.2.3")
+        monkeypatch.setattr("gg_api_core.version.package_version", package_version)
+
+        assert resolve_app_version() == "1.2.3"
+        package_version.assert_called_once_with("ggmcp")
+
+    def test_returns_none_when_distribution_metadata_is_unavailable(self, monkeypatch):
+        """
+        GIVEN the ggmcp distribution metadata is unavailable
+        WHEN the application version is resolved
+        THEN the absence is represented explicitly
+        """
+
+        def missing_distribution(distribution: str) -> str:
+            raise PackageNotFoundError(distribution)
+
+        monkeypatch.setattr("gg_api_core.version.package_version", missing_distribution)
+
+        assert resolve_app_version() is None

--- a/uv.lock
+++ b/uv.lock
@@ -541,7 +541,7 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.12" },
     { name = "pydantic-settings", specifier = "~=2.9" },
     { name = "python-dotenv", specifier = "~=1.1" },
-    { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = "~=2.43" },
+    { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = "~=2.45" },
     { name = "structlog", specifier = "~=26.1" },
 ]
 provides-extras = ["sentry"]
@@ -589,6 +589,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "gg-api-core", extra = ["sentry"] },
     { name = "pyrefly" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -612,6 +613,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "gg-api-core", extras = ["sentry"], editable = "packages/gg_api_core" },
     { name = "pyrefly", specifier = ">=1.1.1" },
     { name = "pytest", specifier = "~=8.4" },
     { name = "pytest-asyncio", specifier = "~=1.2" },


### PR DESCRIPTION
## Summary

- Add the installed `ggmcp` release as `gg_version` on every structured log event.
- Reuse the same release lookup for the GitGuardian API User-Agent while preserving its unversioned fallback.
- Correlate Sentry tool-failure events with request logs by promoting the existing `request_id` to a Sentry tag.
- Require `sentry-sdk` 2.45+, where `MCPIntegration` is enabled by default, and install the optional integration in development.

Closes [SI-3912](https://linear.app/gitguardian/issue/SI-3912).

## Implementation

### Release metadata

`gg_api_core.version` resolves the umbrella `ggmcp` distribution once at startup. Logs render missing metadata as `"unknown"`; the API User-Agent keeps the previous unversioned fallback.

### Sentry correlation

FastMCP clears the structured-logging context before Sentry captures a tool failure. The request middleware therefore stores the validated `request_id` on the active MCP span. At Sentry's `before_send` boundary, that value is promoted to `event.tags.request_id` after payload scrubbing.

The existing request ID behavior is unchanged: a safe inbound `X-Request-ID` is preferred, otherwise the server generates a UUID.

## Validation

- Unit suite: 1050 passed, 3 skipped, 9 xfailed
- VCR suite: 181 passed
- Sentry integration tests against the minimum supported `sentry-sdk==2.45.0`: 9 passed
- Ruff formatting and linting: passed
- Pyrefly: passed
- Lockfile check: passed
