### PR TITLE
fix(sentry): init Sentry before the FastMCP server import so MCPIntegration instruments tools

### DIFF
--- a/packages/gg_mcp_server/src/gg_mcp_server/http_app.py
+++ b/packages/gg_mcp_server/src/gg_mcp_server/http_app.py
@@ -9,14 +9,15 @@ For local development, use the run_http_with_uvicorn() function instead.
 
 import logging
 
-from fastmcp.server.http import create_streamable_http_app
 from gg_api_core.sentry_integration import init_sentry
 
-from gg_mcp_server.server import mcp
+init_sentry()
+
+from fastmcp.server.http import create_streamable_http_app  # noqa: E402
+
+from gg_mcp_server.server import mcp  # noqa: E402
 
 logger = logging.getLogger(__name__)
-
-init_sentry()
 
 # StreamableHTTP with json_response=True and stateless_http=True allows
 # horizontal scaling without sticky sessions since no session state is

--- a/packages/gg_mcp_server/src/gg_mcp_server/http_app.py
+++ b/packages/gg_mcp_server/src/gg_mcp_server/http_app.py
@@ -9,15 +9,13 @@ For local development, use the run_http_with_uvicorn() function instead.
 
 import logging
 
-from gg_api_core.sentry_integration import init_sentry
+from fastmcp.server.http import create_streamable_http_app
 
-init_sentry()
-
-from fastmcp.server.http import create_streamable_http_app  # noqa: E402
-
-from gg_mcp_server.server import mcp  # noqa: E402
+from gg_mcp_server.server import get_server
 
 logger = logging.getLogger(__name__)
+
+mcp = get_server()
 
 # StreamableHTTP with json_response=True and stateless_http=True allows
 # horizontal scaling without sticky sessions since no session state is

--- a/packages/gg_mcp_server/src/gg_mcp_server/run.py
+++ b/packages/gg_mcp_server/src/gg_mcp_server/run.py
@@ -7,8 +7,9 @@ This module provides different ways to run the MCP server:
 
 import logging
 
-from gg_api_core.sentry_integration import init_sentry
 from gg_api_core.settings import get_settings
+
+from gg_mcp_server.server import get_server
 
 logger = logging.getLogger(__name__)
 
@@ -19,9 +20,7 @@ def run_stdio():
     This is the default mode for MCP servers, used when the server
     is invoked as a subprocess by MCP clients like Claude Desktop.
     """
-    init_sentry()
-
-    from gg_mcp_server.server import mcp
+    mcp = get_server()
 
     logger.info("GitGuardian MCP server running on stdio")
     mcp.run(show_banner=False)
@@ -33,9 +32,7 @@ def run_http_with_uvicorn():
     This is meant for local development. For production setups, use gunicorn
     with uvicorn ASGI workers via ``gg_mcp_server.http_app:http_app``.
     """
-    init_sentry()
-
-    from gg_mcp_server.server import mcp
+    mcp = get_server()
 
     settings = get_settings()
     mcp_port = int(settings.mcp_port or "8000")

--- a/packages/gg_mcp_server/src/gg_mcp_server/run.py
+++ b/packages/gg_mcp_server/src/gg_mcp_server/run.py
@@ -10,8 +10,6 @@ import logging
 from gg_api_core.sentry_integration import init_sentry
 from gg_api_core.settings import get_settings
 
-from gg_mcp_server.server import mcp
-
 logger = logging.getLogger(__name__)
 
 
@@ -22,6 +20,9 @@ def run_stdio():
     is invoked as a subprocess by MCP clients like Claude Desktop.
     """
     init_sentry()
+
+    from gg_mcp_server.server import mcp
+
     logger.info("GitGuardian MCP server running on stdio")
     mcp.run(show_banner=False)
 
@@ -33,6 +34,8 @@ def run_http_with_uvicorn():
     with uvicorn ASGI workers via ``gg_mcp_server.http_app:http_app``.
     """
     init_sentry()
+
+    from gg_mcp_server.server import mcp
 
     settings = get_settings()
     mcp_port = int(settings.mcp_port or "8000")

--- a/packages/gg_mcp_server/src/gg_mcp_server/server.py
+++ b/packages/gg_mcp_server/src/gg_mcp_server/server.py
@@ -5,25 +5,49 @@ current token cannot satisfy are filtered out at list-tools time.
 """
 
 import logging
+from functools import cache
 
 from gg_api_core.logging_config import configure_logging_from_settings
-from gg_api_core.mcp_server import get_mcp_server, register_common_tools
+from gg_api_core.mcp_server import (
+    AbstractGitGuardianFastMCP,
+    get_mcp_server,
+    register_common_tools,
+)
+from gg_api_core.sentry_integration import init_sentry
 from gg_api_core.settings import get_settings
 
 from gg_mcp_server.add_health_check import add_health_check
 from gg_mcp_server.register_tools import GITGUARDIAN_INSTRUCTIONS, register_tools
 
-configure_logging_from_settings(get_settings())
-
 logger = logging.getLogger(__name__)
 
-mcp = get_mcp_server(
-    "GitGuardian",
-    instructions=GITGUARDIAN_INSTRUCTIONS,
-)
 
-register_tools(mcp)
-register_common_tools(mcp)
-add_health_check(mcp)
+@cache
+def get_server() -> AbstractGitGuardianFastMCP:
+    """Build (once) and return the configured GitGuardian MCP server.
 
-logger.info("GitGuardian MCP server instance created and configured")
+    Sentry is initialized here, before the server is constructed, and that
+    order is load-bearing: Sentry's ``MCPIntegration`` instruments tool calls
+    by patching the lowlevel ``Server`` decorators when ``sentry_sdk.init()``
+    runs, and FastMCP consumes those decorators in its constructor. A server
+    built before Sentry init never emits ``mcp.server`` spans (SI-3929).
+    """
+    init_sentry()
+    configure_logging_from_settings(get_settings())
+    mcp = get_mcp_server(
+        "GitGuardian",
+        instructions=GITGUARDIAN_INSTRUCTIONS,
+    )
+    register_tools(mcp)
+    register_common_tools(mcp)
+    add_health_check(mcp)
+    logger.info("GitGuardian MCP server instance created and configured")
+    return mcp
+
+
+def __getattr__(name: str) -> AbstractGitGuardianFastMCP:
+    # Backward compatibility: ``from gg_mcp_server.server import mcp`` still
+    # works, but builds the server lazily on first access (PEP 562).
+    if name == "mcp":
+        return get_server()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/gg_mcp_server/src/gg_mcp_server/sse_app.py
+++ b/packages/gg_mcp_server/src/gg_mcp_server/sse_app.py
@@ -7,14 +7,15 @@ use ``http_app.py`` instead which uses StreamableHTTP with JSON responses.
 
 import logging
 
-from fastmcp.server.http import create_sse_app
 from gg_api_core.sentry_integration import init_sentry
 
-from gg_mcp_server.server import mcp
+init_sentry()
+
+from fastmcp.server.http import create_sse_app  # noqa: E402
+
+from gg_mcp_server.server import mcp  # noqa: E402
 
 logger = logging.getLogger(__name__)
-
-init_sentry()
 
 sse_app = create_sse_app(
     server=mcp,

--- a/packages/gg_mcp_server/src/gg_mcp_server/sse_app.py
+++ b/packages/gg_mcp_server/src/gg_mcp_server/sse_app.py
@@ -7,15 +7,13 @@ use ``http_app.py`` instead which uses StreamableHTTP with JSON responses.
 
 import logging
 
-from gg_api_core.sentry_integration import init_sentry
+from fastmcp.server.http import create_sse_app
 
-init_sentry()
-
-from fastmcp.server.http import create_sse_app  # noqa: E402
-
-from gg_mcp_server.server import mcp  # noqa: E402
+from gg_mcp_server.server import get_server
 
 logger = logging.getLogger(__name__)
+
+mcp = get_server()
 
 sse_app = create_sse_app(
     server=mcp,


### PR DESCRIPTION
Sentry's auto-enabled `MCPIntegration` patches FastMCP at `sentry_sdk.init()` time. All three entrypoints imported `gg_mcp_server.server` — creating the server and registering every tool — before `init_sentry()`, so no `mcp.server` spans were ever emitted and the [MCP Overview dashboard](https://gitguardian.sentry.io/dashboard/462734/) stayed empty. Errors still flowed via `LoggingIntegration`, masking the gap.

**Fix:** init Sentry before the server import (`http_app.py`, `sse_app.py`); defer the server import past `init_sentry()` in `run.py`.

**Verified** with locked versions: init-first emits a `tools/call <tool>` transaction with op `mcp.server`; server-first captures zero envelopes. 697 tests pass.

Fixes SI-3929
