### PR TITLE
ci(docker): publish a unique per-commit main image tag

### DIFF
--- a/.claude/skills/docker-image-tags/SKILL.md
+++ b/.claude/skills/docker-image-tags/SKILL.md
@@ -12,22 +12,13 @@ when a merge to `main` changes `[project] version` in `pyproject.toml`
 same workflow run builds the image and creates the GitHub release. CI never
 pushes commits to `main`.
 
-## Tag matrix
+## Tag matrix and semantics
 
-| Event | Image tags pushed | Git tag / GitHub release |
-|---|---|---|
-| Merge to `main` **with** version bump | `X.Y.Z`, `X.Y`, `latest`, `main` | `vX.Y.Z` + release |
-| Merge to `main` **without** version bump | `main` | — |
-| `workflow_dispatch` from a non-main branch | `<branch>`, `<branch>-<sha>` | — |
-| Human-pushed `v*.*.*` git tag | `X.Y.Z`, `X.Y`, `latest`, `main` | release |
-
-## Tag semantics
-
-- `latest` — most recent **release** (NOT tip of main). Helm chart defaults use it.
-- `main` — rolling dev image, tip of `main`, release or not. For preprod/smoke-testing.
-- `X.Y.Z` — immutable release tags. Production pins these; Renovate (in GitLab
-  `applications-configurations`, `gim/*/values-1-gim.yaml`) tracks them with
-  strict semver, which ignores `latest`, `main`, `X.Y` and branch tags.
+`PUBLISHING.md` ("Docker Image Tag Matrix") is canonical for what each event
+pushes, what each tag means, and the tag format contract that fixes the shape of
+`main-<sha>-<seq>`. Read it before changing how any tag is built. Short answer to
+"which tag do I deploy": `X.Y.Z` for prod, `main-<sha>-<seq>` for envs tracking
+tip-of-main, never `main` or `latest`.
 
 ## Gotchas
 
@@ -37,9 +28,6 @@ pushes commits to `main`.
 - Tags created in CI with `GITHUB_TOKEN` do not trigger workflows: the Docker
   build must stay in the same workflow run as `tag-version` (a `needs:`
   dependency), never behind an `on: push: tags` trigger.
-- The `create-github-release` job must stay gated on a release tag existing —
-  no-bump main pushes still build the `main` image and would otherwise try to
+- The `create-github-release` job must stay gated on a release tag existing:
+  no-bump main pushes still build the `main` images and would otherwise try to
   create a release with an empty tag name.
-- Never tag images with versions that outrank semver releases (e.g. a
-  CalVer-looking `2026.6.0`): Renovate's semver ordering would consider every
-  real `0.x.y` release "older" and stop proposing updates.

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -21,7 +21,7 @@ on:
         type: boolean
         required: false
         default: false
-        description: Whether to also push the rolling `main` tag.
+        description: Whether to also push the `main` and `main-<sha>-<seq>` tags.
       no-cache:
         type: boolean
         required: false
@@ -51,6 +51,24 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
+          fetch-depth: 0 # Required by git rev-list --count below
+
+      # PUBLISHING.md defines the tag format contract.
+      - name: Stamp the unique per-commit main tag
+        id: stamp
+        run: |
+          if [ "$(git rev-parse --is-shallow-repository)" != false ]; then
+            echo "::error::full Git history is required to calculate the image sequence"
+            exit 1
+          fi
+          sha=$(git rev-parse HEAD)
+          seq=$(git rev-list --count HEAD)
+          tag="main-${sha:0:8}-${seq}"
+          if [[ ! $tag =~ ^main-[0-9a-f]{8}-[0-9]+$ ]]; then
+            echo "::error::tag '$tag' breaks the tag format contract in PUBLISHING.md"
+            exit 1
+          fi
+          printf 'tag=%s\n' "$tag" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -72,8 +90,10 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ inputs.release-tag || 'v0.0.0' }},enable=${{ inputs.release-tag != '' }}
             type=raw,value=latest,enable=${{ inputs.release-tag != '' }}
             type=raw,value=main,enable=${{ inputs.is-main }}
-            type=ref,event=branch,enable=${{ inputs.release-tag == '' && !inputs.is-main }}
-            type=sha,prefix={{branch}}-,enable=${{ inputs.release-tag == '' && !inputs.is-main }}
+            type=raw,value=${{ steps.stamp.outputs.tag }},enable=${{ inputs.is-main }}
+            # Keep manual builds outside the reserved main-<sha>-<seq> namespace.
+            type=ref,event=branch,prefix=branch-,enable=${{ inputs.release-tag == '' && !inputs.is-main }}
+            type=sha,prefix=branch-{{branch}}-,enable=${{ inputs.release-tag == '' && !inputs.is-main }}
 
       - name: Build and push Docker image
         id: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,12 +54,8 @@ jobs:
   build-and-push-docker:
     name: Build and Push Docker Image
     needs: [ tag-version ]
-    # Two entry points: a version tag pushed by a human, or a tag freshly
-    # created by tag-version (tags pushed with GITHUB_TOKEN do not trigger
-    # workflows, hence the same-run dependency instead of a tag trigger).
-    # Manual dispatch from a non-main branch builds a <branch>-<sha> image
-    # (no semver, no latest) for testing. Every push to main also refreshes
-    # the mutable `main` tag (rolling dev image), release or not.
+    # Release tags publish release images; branches publish namespaced test images.
+    # Every main push refreshes `main` and `main-<sha>-<seq>`.
     if: |
       always() &&
       (
@@ -74,7 +70,7 @@ jobs:
       id-token: write # keyless cosign signing (Sigstore/Rekor via GitHub OIDC)
     uses: ./.github/workflows/build_docker.yml
     with:
-      # Empty outside releases: build_docker.yml then falls back to `main` / <branch>-<sha> tags.
+      # Empty outside releases: build_docker.yml then falls back to `main` / branch-<branch>-<sha> tags.
       ref: ${{ github.ref_type == 'tag' && github.ref_name || needs.tag-version.outputs.tag }}
       release-tag: ${{ github.ref_type == 'tag' && github.ref_name || needs.tag-version.outputs.tag }}
       is-main: ${{ github.ref == 'refs/heads/main' }}
@@ -206,7 +202,7 @@ jobs:
     name: Create GitHub Release
     needs: [ tag-version, build-and-push-docker, publish-to-pypi ]
     # The release-tag guard matters: main pushes without a version bump still
-    # build the rolling `main` image but must not create a GitHub release.
+    # build the `main` images but must not create a GitHub release.
     if: |
       always() &&
       (github.ref_type == 'tag' || needs.tag-version.outputs.tagged == 'true') &&

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -292,8 +292,9 @@ secrets before allowing commits and pushes.
 This project uses semantic versioning. To release, bump `[project] version`
 in `pyproject.toml` (and update `CHANGELOG.md`) in your PR. When it merges to
 `main`, the `tag-version` job in `.github/workflows/release.yml` tags
-`vX.Y.Z` and publishes the Docker image (`X.Y.Z`, `X.Y`, `latest`). Merges
-that don't change the version only refresh the rolling `main` image tag.
+`vX.Y.Z` and publishes the Docker image (`X.Y.Z`, `X.Y`, `latest`, plus `main`
+and `main-<sha>-<seq>`). Merges that don't change the version refresh only
+`main` and `main-<sha>-<seq>`.
 See `PUBLISHING.md` for manual fallbacks.
 
 ## Python 3.13 Features

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -56,20 +56,32 @@ What `release.yml` pushes to `ghcr.io/gitguardian/mcp-server`, per event:
 
 | Event | Image tags pushed | Git tag / GitHub release |
 |---|---|---|
-| Merge to `main` **with** `pyproject.toml` version bump | `X.Y.Z`, `X.Y`, `latest`, `main` | `vX.Y.Z` + release |
-| Merge to `main` **without** version bump | `main` | — |
-| `workflow_dispatch` from a non-main branch | `<branch>`, `<branch>-<sha>` | — |
-| Human-pushed `v*.*.*` git tag | `X.Y.Z`, `X.Y`, `latest`, `main` | release |
+| Merge to `main` **with** `pyproject.toml` version bump | `X.Y.Z`, `X.Y`, `latest`, `main`, `main-<sha>-<seq>` | `vX.Y.Z` + release |
+| Merge to `main` **without** version bump | `main`, `main-<sha>-<seq>` | — |
+| `workflow_dispatch` from `main` | as the two merge rows above (it re-runs the version check) | as above |
+| `workflow_dispatch` from a non-main branch | `branch-<branch>`, `branch-<branch>-<sha>` | — |
+| Human-pushed `v*.*.*` git tag | `X.Y.Z`, `X.Y`, `latest` | release |
 
-Semantics:
+The nightly rebuild republishes the release tags.
 
-- **`latest`** — most recent release. Only moves when a version is released.
-  This is what the Helm chart defaults point at.
-- **`main`** — rolling dev image, tip of the `main` branch (release or not).
-  Use for preprod/smoke-testing ahead of releases.
-- **`X.Y.Z`** — immutable release tags. Production pins these (Renovate
-  tracks them with strict semver, which ignores `latest`, `main`, `X.Y`
-  and branch tags).
+### Image tags
+
+- **`latest`**: most recent release.
+- **`main`**: current `main` image.
+- **`main-<sha>-<seq>`**: unique per-commit tag for `main`.
+- **`branch-<branch>`**: current image for a manually built branch.
+- **`branch-<branch>-<sha>`**: image for a specific manually built commit.
+- **`X.Y.Z`**: image for a release.
+
+For `main-<sha>-<seq>`, `<sha>` is the first 8 characters of the commit SHA and
+`<seq>` is the full-history commit count from `git rev-list --count`. Rebuilding
+the same commit produces the same tag.
+
+### Tag format contract
+
+Downstream deployment automation tracks `main-<sha>-<seq>` tags with
+`^main-[0-9a-f]{8}-(?<patch>\d+)$` and deploys the highest `<seq>`. The tag
+shape is a contract: changing how it is built silently breaks that tracking.
 
 ## Publishing a New Version
 
@@ -81,9 +93,10 @@ and merging to `main`. The `tag-version` job in `release.yml` then:
 - reads the version from `pyproject.toml` and checks it is `X.Y.Z` semver
 - if the tag `vX.Y.Z` does not exist yet, creates and pushes it
 - the same workflow run builds and pushes the Docker image tagged
-  `X.Y.Z`, `X.Y`, and `latest`, and creates the GitHub release
-- merges that don't touch the version only refresh the mutable `main`
-  image tag (rolling dev image — never `latest`, no git tag, no release)
+  `X.Y.Z`, `X.Y`, `latest`, `main` and `main-<sha>-<seq>`, and creates the
+  GitHub release
+- merges that don't touch the version only refresh `main` and
+  `main-<sha>-<seq>` (never `latest`, no git tag, no release)
 
 So: bump the version (and ideally `CHANGELOG.md`) in your PR — you can use
 `cz bump --files-only` to do both — merge, and watch the Release workflow.
@@ -120,8 +133,8 @@ For testing or special cases:
 1. Go to: https://github.com/GitGuardian/ggmcp/actions/workflows/release.yml
 2. Click "Run workflow" and pick a ref:
    - **a branch other than `main`**: builds and pushes a test image tagged
-     `<branch>` and `<branch>-<short-sha>` (no semver tags, no `latest`,
-     no git tag, no GitHub release)
+     `branch-<branch>` and `branch-<branch>-<short-sha>` (no semver tags,
+     no `latest`, no git tag, no GitHub release)
    - **`main`**: re-runs the release check (tags and publishes only if the
      `pyproject.toml` version has no `vX.Y.Z` tag yet)
 


### PR DESCRIPTION
## Summary

Publish `main-<sha>-<seq>` beside the rolling `main` image on every build from
`main`.

- `<sha>` is the first 8 characters of the built commit.
- `<seq>` is `git rev-list --count` for that commit.
- Manual branch builds use `branch-...` tags, so they cannot enter the reserved
  `main-...` namespace.

The existing `main` and release tags are unchanged.

## Why

Environments that track tip-of-main pull images through a caching registry. The
mutable `main` tag can keep resolving to an older digest after a new image is
published, and an unchanged tag does not trigger a rollout.

A unique per-commit tag avoids both problems: downstream automation tracks the
`main-<sha>-<seq>` tags and deploys the highest `<seq>`.

## Safety checks

The build:

- checks out full history before calculating `<seq>`;
- validates `^main-[0-9a-f]{8}-[0-9]+$`;
- derives both fields from the checked-out commit, so reruns cannot outrank newer
  commits.

`PUBLISHING.md` documents the tag format contract.

PR #196 changes the same release files, so whichever lands second will need a
rebase.

Refs: SI-3910
