### PR TITLE
feat(logging): consolidate MCP logging on the structlog foundation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -174,6 +174,75 @@ runs a localhost callback on a port in 29170-29998, storing the PAT under
 stdio deployments should use a PAT. The code path will be removed in a
 future release.
 
+## Logging
+
+Structured logging goes to stderr via structlog. `LOG_LEVEL` sets the level and
+`LOG_FORMAT` picks `json` or `console` (unset auto-detects: console on a TTY).
+`gg_api_core/logging_config.py` owns the processor chain.
+
+### Fields on every line
+
+Bound once per MCP message by `RequestLoggingContextMiddleware`, so they ride on
+every line emitted while handling it, including free-text lines from libraries.
+
+| Field | Meaning |
+| --- | --- |
+| `gg_service`, `gg_version` | Which service and which release produced the line |
+| `request_id` | Inbound `X-Request-ID`, or one generated per message |
+| `mcp_session_id` | FastMCP's session id. Groups a conversation **only if** the client sends a stable `Mcp-Session-Id`; under `stateless_http=True` it is otherwise per-request |
+| `user_agent` | The only client hint present on every request |
+| `authentication_mode` | How the request authenticates: OAuth proxy, authorization header, environment PAT, or local OAuth |
+| `account_id`, `workspace_id`, `member_id` | Which customer and which user. `account_id` aliases the GitGuardian API's `workspace_id` for cross-service observability |
+| `token_id`, `token_type`, `token_scopes_hash` | Which credential, and a digest of its scope set. Never the token itself |
+| `gg_host` | Separates SaaS from self-hosted; the same workspace id can exist on both |
+
+### Events
+
+| Event | When | Notable fields |
+| --- | --- | --- |
+| `tool_call` / `tool_call_failed` | Per tool invocation | `tool`, `arguments`, `elapsed_ms`, `result_bytes`, `result_items`, `truncated`, `downstream_calls`, `downstream_ms`, `downstream_retries`, `downstream_wait_ms`, and on failure `error_class`, `upstream_status`, `gg_error_code`, `fault` |
+| `mcp_request` / `mcp_request_failed` | Per protocol message except `tools/call` | `mcp_method`, `status`, `elapsed_ms` |
+| `mcp_initialize` | Handshake | `client_name`, `client_version`, `protocol_version` |
+| `list_tools` | Scope filtering | `tools_exposed`, `tools_hidden`, `hidden_tools` |
+| `api_request` | Per outbound GitGuardian API call | `method`, `path` (templated), `status`, `duration_ms`, `gg_request_id` |
+| `pagination_complete` | End of a paginated fetch | `items`, `response_bytes`, `truncated`, `pages` |
+| `oauth_step` | Each step of the OAuth proxy funnel | `oauth_step`, `outcome`, `status` |
+
+`fault` grades who has to act: `client` for bad input or a missing permission,
+`server` for anything worth paging about. Filter on it before reading a failure
+list. 408 and 429 count as server fault.
+
+`downstream_ms` includes retry backoff, so `elapsed_ms - downstream_ms` is time
+that was genuinely ours. `downstream_wait_ms` breaks out the backoff portion.
+Counters and `truncated` are emitted even at zero and false, so a rate has a
+denominator.
+
+`gg_error_code` carries only machine-readable `code`/`error` values, never
+DRF's `detail` prose, which on scan endpoints can echo the submitted payload.
+
+`ping` is answered by the low-level MCP SDK before FastMCP dispatches, so no
+middleware hook sees it and it produces no event.
+
+### Redaction
+
+`gg_api_core/sanitization.py` scrubs by field name and by value. When adding a
+field whose name contains a token like `token` or `content` but which carries no
+secret, add it to `NON_SENSITIVE_NAME_ALLOWLIST`, otherwise it renders as
+`[REDACTED]`.
+
+Sentry's `MCPIntegration` is the sole capture owner for tool exceptions.
+`LoggingIntegration` records INFO-and-higher lines as breadcrumbs but has event
+capture disabled, so client, tool, FastMCP, and middleware error logs cannot
+create duplicate issues.
+
+Sentry payloads are scrubbed at the SDK boundary. `before_breadcrumb` applies
+field-name redaction inside logging `data` and value redaction to the complete
+breadcrumb. `before_send` value-scrubs the finished event, including exception
+values and request data added by Sentry itself. Name-based redaction is not
+applied to the whole event because Sentry schema keys such as `filename` and
+`module` would destroy the stack trace. `include_local_variables=False` keeps
+frame locals out of the payload entirely.
+
 ## Optional Dependencies
 
 The project supports optional dependencies (extras) for additional features:
@@ -206,11 +275,11 @@ uvx --from git+https://github.com/GitGuardian/ggmcp.git@main gg-mcp-server
 
 ### Current Optional Dependencies
 
-- **sentry**: Adds Sentry SDK for error tracking and performance monitoring
+- **sentry**: Adds the Sentry SDK for error tracking
   - Core package: `gg-api-core[sentry]`
   - Available in: `gg-mcp-server[sentry]`
   - Implementation: `gg_api_core/src/gg_api_core/sentry_integration.py`
-  - Used for: Production error monitoring and alerting
+  - Used for: MCP exception capture, sanitized breadcrumbs, monitoring, and alerting
 
 ## Testing
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -200,8 +200,8 @@ every line emitted while handling it, including free-text lines from libraries.
 
 | Event | When | Notable fields |
 | --- | --- | --- |
-| `tool_call` / `tool_call_failed` | Per tool invocation | `tool`, `arguments`, `elapsed_ms`, `result_bytes`, `result_items`, `truncated`, `downstream_calls`, `downstream_ms`, `downstream_retries`, `downstream_wait_ms`, and on failure `error_class`, `upstream_status`, `gg_error_code`, `fault` |
-| `mcp_request` / `mcp_request_failed` | Per protocol message except `tools/call` | `mcp_method`, `status`, `elapsed_ms` |
+| `tool_call` / `tool_call_failed` | Per tool invocation | `tool`, `arguments`, `duration_ms`, `result_bytes`, `result_items`, `truncated`, `downstream_calls`, `downstream_ms`, `downstream_retries`, `downstream_wait_ms`, and on failure `error_class`, `upstream_status`, `gg_error_code`, `fault` |
+| `mcp_request` / `mcp_request_failed` | Per protocol message except `tools/call` | `mcp_method`, `status`, `duration_ms` |
 | `mcp_initialize` | Handshake | `client_name`, `client_version`, `protocol_version` |
 | `list_tools` | Scope filtering | `tools_exposed`, `tools_hidden`, `hidden_tools` |
 | `api_request` | Per outbound GitGuardian API call | `method`, `path` (templated), `status`, `duration_ms`, `gg_request_id` |
@@ -212,7 +212,7 @@ every line emitted while handling it, including free-text lines from libraries.
 `server` for anything worth paging about. Filter on it before reading a failure
 list. 408 and 429 count as server fault.
 
-`downstream_ms` includes retry backoff, so `elapsed_ms - downstream_ms` is time
+`downstream_ms` includes retry backoff, so `duration_ms - downstream_ms` is time
 that was genuinely ours. `downstream_wait_ms` breaks out the backoff portion.
 Counters and `truncated` are emitted even at zero and false, so a rate has a
 denominator.

--- a/packages/gg_api_core/pyproject.toml
+++ b/packages/gg_api_core/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 
 [project.optional-dependencies]
 sentry = [
-    "sentry-sdk~=2.43",
+    "sentry-sdk~=2.45",
 ]
 
 [build-system]

--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -6,7 +6,6 @@ import time
 from collections.abc import Awaitable, Sequence
 from datetime import datetime
 from enum import Enum
-from importlib.metadata import PackageNotFoundError, version
 from typing import Any, Dict, Optional, TypedDict, cast
 from urllib.parse import quote_plus, unquote, urlparse
 
@@ -15,6 +14,7 @@ from pydantic import TypeAdapter, ValidationError
 
 from gg_api_core.log_context import record_downstream_call, record_downstream_wait, record_truncation
 from gg_api_core.settings import get_settings
+from gg_api_core.version import APP_VERSION
 
 # Setup logger
 logger = logging.getLogger(__name__)
@@ -96,10 +96,7 @@ async def _track_api_request(
     return response
 
 
-try:
-    DEFAULT_USER_AGENT = f"GitGuardian-MCP-Server/{version('ggmcp')}"
-except PackageNotFoundError:
-    DEFAULT_USER_AGENT = "GitGuardian-MCP-Server"
+DEFAULT_USER_AGENT = f"GitGuardian-MCP-Server/{APP_VERSION}" if APP_VERSION else "GitGuardian-MCP-Server"
 
 
 def _to_date_only(value: str) -> str:

--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -2,7 +2,8 @@ import asyncio
 import json
 import logging
 import re
-from collections.abc import Sequence
+import time
+from collections.abc import Awaitable, Sequence
 from datetime import datetime
 from enum import Enum
 from importlib.metadata import PackageNotFoundError, version
@@ -12,10 +13,87 @@ from urllib.parse import quote_plus, unquote, urlparse
 import httpx
 from pydantic import TypeAdapter, ValidationError
 
+from gg_api_core.log_context import record_downstream_call, record_downstream_wait, record_truncation
 from gg_api_core.settings import get_settings
 
 # Setup logger
 logger = logging.getLogger(__name__)
+
+
+_UUID_SEGMENT_RE = re.compile(r"^[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$")
+
+_GG_REQUEST_ID_HEADERS = ("x-request-id", "x-gitguardian-request-id", "request-id")
+
+
+def _path_template(endpoint: str) -> str:
+    """Drop query strings and collapse ID path segments."""
+    path = endpoint.split("?", 1)[0].split("#", 1)[0]
+    segments = [
+        "{id}" if segment.isdigit() or _UUID_SEGMENT_RE.match(segment) else segment for segment in path.split("/")
+    ]
+    return "/".join(segments)
+
+
+def _log_api_request(
+    method: str,
+    endpoint: str,
+    *,
+    status: int | None,
+    duration_ms: float,
+    response: httpx.Response | None = None,
+    retried: bool = False,
+    error_class: str | None = None,
+) -> None:
+    """Log and account for one API request."""
+    fields: dict[str, Any] = {
+        "method": method.upper(),
+        "path": _path_template(endpoint),
+        "status": status,
+        "duration_ms": round(duration_ms),
+    }
+    if response is not None:
+        for header in _GG_REQUEST_ID_HEADERS:
+            if value := response.headers.get(header):
+                fields["gg_request_id"] = value
+                break
+    if error_class:
+        fields["error_class"] = error_class
+
+    logger.info("api_request", extra=fields)
+    record_downstream_call(duration_ms=duration_ms, status=status, retried=retried)
+
+
+async def _track_api_request(
+    method: str,
+    endpoint: str,
+    request: Awaitable[httpx.Response],
+    *,
+    retried: bool = False,
+) -> httpx.Response:
+    """Execute and record one downstream API attempt."""
+    request_started = time.perf_counter()
+    try:
+        response = await request
+    except Exception as exc:
+        _log_api_request(
+            method,
+            endpoint,
+            status=None,
+            duration_ms=(time.perf_counter() - request_started) * 1000,
+            retried=retried,
+            error_class=type(exc).__name__,
+        )
+        raise
+
+    _log_api_request(
+        method,
+        endpoint,
+        status=response.status_code,
+        duration_ms=(time.perf_counter() - request_started) * 1000,
+        response=response,
+        retried=retried,
+    )
+    return response
 
 
 try:
@@ -476,7 +554,12 @@ class GitGuardianClient:
             try:
                 async with httpx.AsyncClient(follow_redirects=True, timeout=DEFAULT_HTTP_TIMEOUT) as client:
                     logger.debug(f"Sending {method} request to {url}")
-                    response = await client.request(method, url, headers=headers, **kwargs)
+                    response = await _track_api_request(
+                        method,
+                        endpoint,
+                        client.request(method, url, headers=headers, **kwargs),
+                        retried=retry_count > 0,
+                    )
 
                 # Log detailed response information
                 logger.debug(f"Response status code: {response.status_code}")
@@ -501,6 +584,7 @@ class GitGuardianClient:
                     logger.warning(
                         f"Received 500 error, retrying in {wait_time}s (attempt {retry_count}/{max_retries})"
                     )
+                    record_downstream_wait(duration_ms=wait_time * 1000)
                     await asyncio.sleep(wait_time)
                     continue
 
@@ -723,7 +807,11 @@ class GitGuardianClient:
         headers.update(kwargs.pop("headers", {}))
 
         async with httpx.AsyncClient(follow_redirects=True, timeout=DEFAULT_HTTP_TIMEOUT) as client:
-            response = await client.get(url, headers=headers, **kwargs)
+            response = await _track_api_request(
+                "GET",
+                endpoint,
+                client.get(url, headers=headers, **kwargs),
+            )
             response.raise_for_status()
 
             data: Any = response.json() if response.content else {}
@@ -845,9 +933,18 @@ class GitGuardianClient:
                 logger.debug("No next cursor found, pagination complete")
                 break
 
+        if truncated:
+            record_truncation()
+
         logger.info(
-            f"Pagination complete for {endpoint}: collected {len(all_items)} items "
-            f"({total_bytes} bytes, capped={truncated})"
+            "pagination_complete",
+            extra={
+                "path": _path_template(endpoint),
+                "items": len(all_items),
+                "response_bytes": total_bytes,
+                "truncated": truncated,
+                "pages": page_count,
+            },
         )
         return {
             "data": all_items,

--- a/packages/gg_api_core/src/gg_api_core/log_context.py
+++ b/packages/gg_api_core/src/gg_api_core/log_context.py
@@ -1,0 +1,286 @@
+"""Request identity, downstream timing, and failure fields for logs."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from collections import OrderedDict
+from collections.abc import Awaitable, Callable, Iterable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+__all__ = [
+    "DownstreamStats",
+    "classify_failure",
+    "clear_caller_identity_cache",
+    "current_downstream_stats",
+    "derive_caller_identity",
+    "derive_client_identity",
+    "record_downstream_call",
+    "record_downstream_wait",
+    "record_truncation",
+    "resolve_caller_identity",
+    "scopes_fingerprint",
+    "track_downstream_calls",
+]
+
+# Logging-only cache; authorization deliberately uses uncached scopes.
+_IDENTITY_TTL_SECONDS = 300.0
+_IDENTITY_FAILURE_TTL_SECONDS = 30.0
+_IDENTITY_CACHE_MAX_ENTRIES = 512
+
+# Stdio has one process identity even when the server does not hold its token.
+_NO_TOKEN_KEY = "__no_token__"
+
+# Insertion order supports one-at-a-time eviction.
+_identity_cache: OrderedDict[str, tuple[float, dict[str, Any]]] = OrderedDict()
+
+logger = logging.getLogger(__name__)
+
+
+def scopes_fingerprint(scopes: Iterable[str]) -> str:
+    """Return an order-independent digest of a scope set."""
+    canonical = ",".join(sorted(set(scopes)))
+    return hashlib.sha256(canonical.encode()).hexdigest()[:12]
+
+
+def derive_caller_identity(token_info: dict[str, Any], *, api_url: str | None = None) -> dict[str, Any]:
+    """Map a ``/api_tokens/self`` payload to loggable caller fields."""
+    identity: dict[str, Any] = {}
+
+    for source, target in (
+        # GitGuardian's API calls the customer identifier `workspace_id`;
+        # `account_id` is the shared observability field used by other services.
+        ("workspace_id", "account_id"),
+        ("workspace_id", "workspace_id"),
+        ("member_id", "member_id"),
+        ("id", "token_id"),
+        ("type", "token_type"),
+    ):
+        value = token_info.get(source)
+        if value is not None:
+            identity[target] = value
+
+    scopes = token_info.get("scopes")
+    if scopes:
+        identity["token_scopes_hash"] = scopes_fingerprint(scopes)
+
+    if api_url:
+        host = urlparse(api_url).hostname
+        if host:
+            identity["gg_host"] = host
+
+    return identity
+
+
+def _identity_cache_key(token: str | None) -> str:
+    """Cache key for a token. The token is hashed, never stored or logged."""
+    if token is None:
+        return _NO_TOKEN_KEY
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def clear_caller_identity_cache(token: str | None = None, *, all_tokens: bool = False) -> None:
+    """Drop one token's cached identity, or all entries for tests."""
+    if all_tokens:
+        _identity_cache.clear()
+    else:
+        _identity_cache.pop(_identity_cache_key(token), None)
+
+
+async def resolve_caller_identity(
+    fetch_token_info: Callable[[], Awaitable[dict[str, Any]]],
+    *,
+    token: str | None,
+    api_url: str | None = None,
+) -> dict[str, Any]:
+    """Resolve cached log identity without exposing or storing the raw token."""
+    key = _identity_cache_key(token)
+
+    cached = _identity_cache.get(key)
+    if cached is not None and cached[0] > time.monotonic():
+        return cached[1]
+
+    identity: dict[str, Any]
+    try:
+        identity = derive_caller_identity(await fetch_token_info(), api_url=api_url)
+        ttl = _IDENTITY_TTL_SECONDS
+    except Exception as exc:
+        logger.debug("caller_identity_unavailable", extra={"reason": str(exc)})
+        identity = {}
+        ttl = _IDENTITY_FAILURE_TTL_SECONDS
+
+    while len(_identity_cache) >= _IDENTITY_CACHE_MAX_ENTRIES:
+        _identity_cache.popitem(last=False)
+    _identity_cache[key] = (time.monotonic() + ttl, identity)
+
+    return identity
+
+
+@dataclass
+class DownstreamStats:
+    """GitGuardian API statistics for one MCP message."""
+
+    calls: int = 0
+    total_ms: float = 0.0
+    wait_ms: float = 0.0
+    retries: int = 0
+    truncated: bool = False
+    statuses: set[int] = field(default_factory=set)
+
+    def as_log_fields(self) -> dict[str, Any]:
+        """Render counters, including falsey values, as log fields."""
+        fields: dict[str, Any] = {
+            "downstream_calls": self.calls,
+            "downstream_ms": round(self.total_ms),
+            "downstream_retries": self.retries,
+            "truncated": self.truncated,
+        }
+        if self.wait_ms:
+            fields["downstream_wait_ms"] = round(self.wait_ms)
+        if self.statuses:
+            fields["downstream_statuses"] = sorted(self.statuses)
+        return fields
+
+
+_downstream_stats: ContextVar[DownstreamStats | None] = ContextVar("gg_downstream_stats", default=None)
+
+
+@contextmanager
+def track_downstream_calls() -> Iterator[DownstreamStats]:
+    """Collect downstream API accounting for the duration of the block."""
+    stats = DownstreamStats()
+    token = _downstream_stats.set(stats)
+    try:
+        yield stats
+    finally:
+        _downstream_stats.reset(token)
+
+
+def current_downstream_stats() -> DownstreamStats | None:
+    """The accumulator for the call in flight, if anything is tracking."""
+    return _downstream_stats.get()
+
+
+def record_downstream_call(*, duration_ms: float, status: int | None = None, retried: bool = False) -> None:
+    """Add an API call to the active accumulator, if any."""
+    stats = _downstream_stats.get()
+    if stats is None:
+        return
+    stats.calls += 1
+    stats.total_ms += duration_ms
+    if retried:
+        stats.retries += 1
+    if status is not None:
+        stats.statuses.add(status)
+
+
+def record_downstream_wait(*, duration_ms: float) -> None:
+    """Add retry backoff without counting another API call."""
+    stats = _downstream_stats.get()
+    if stats is not None:
+        stats.total_ms += duration_ms
+        stats.wait_ms += duration_ms
+
+
+def record_truncation() -> None:
+    """Flag that a response was clipped before reaching the caller."""
+    stats = _downstream_stats.get()
+    if stats is not None:
+        stats.truncated = True
+
+
+_SERVER_FAULT_CLIENT_CODES = frozenset({408, 429})
+
+
+def _qualified_name(exc: BaseException) -> str:
+    cls = type(exc)
+    module = getattr(cls, "__module__", "")
+    return cls.__name__ if module in ("builtins", "") else f"{module}.{cls.__name__}"
+
+
+def _find_status_error(exc: BaseException, _seen: set[int] | None = None) -> httpx.HTTPStatusError | None:
+    """Find an HTTP status error through causes and exception groups."""
+    seen = _seen if _seen is not None else set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        if isinstance(current, httpx.HTTPStatusError):
+            return current
+        seen.add(id(current))
+
+        if isinstance(current, BaseExceptionGroup):
+            for nested in current.exceptions:
+                found = _find_status_error(nested, seen)
+                if found is not None:
+                    return found
+
+        if current.__cause__ is not None:
+            current = current.__cause__
+        elif current.__suppress_context__:
+            current = None
+        else:
+            current = current.__context__
+    return None
+
+
+_GG_ERROR_CODE_MAX_LENGTH = 64
+
+
+def _gg_error_code(response: httpx.Response) -> str | None:
+    """Read a bounded machine error code without logging ``detail`` prose."""
+    try:
+        body = response.json()
+    except Exception:
+        return None
+    if not isinstance(body, dict):
+        return None
+    for key in ("code", "error"):
+        value = body.get(key)
+        if isinstance(value, str) and value and len(value) <= _GG_ERROR_CODE_MAX_LENGTH:
+            return value
+    return None
+
+
+def classify_failure(exc: BaseException) -> dict[str, Any]:
+    """Turn an exception into queryable status and ownership fields."""
+    failure: dict[str, Any] = {"error_class": _qualified_name(exc)}
+
+    status_error = _find_status_error(exc)
+    if status_error is None:
+        # No HTTP status anywhere in the chain: a bug in our code, a timeout, or
+        # a validation error raised before the request went out.
+        failure["fault"] = "server"
+        return failure
+
+    response = status_error.response
+    status = response.status_code
+    failure["upstream_status"] = status
+    failure["fault"] = "client" if 400 <= status < 500 and status not in _SERVER_FAULT_CLIENT_CODES else "server"
+
+    code = _gg_error_code(response)
+    if code:
+        failure["gg_error_code"] = code
+
+    return failure
+
+
+def derive_client_identity(client_info: Any, protocol_version: Any = None) -> dict[str, Any]:
+    """Map optional MCP initialization metadata to log fields."""
+    identity: dict[str, Any] = {}
+
+    name = getattr(client_info, "name", None)
+    if name:
+        identity["client_name"] = name
+    version = getattr(client_info, "version", None)
+    if version:
+        identity["client_version"] = version
+    if protocol_version:
+        identity["protocol_version"] = str(protocol_version)
+
+    return identity

--- a/packages/gg_api_core/src/gg_api_core/logging_config.py
+++ b/packages/gg_api_core/src/gg_api_core/logging_config.py
@@ -30,6 +30,10 @@ _RESERVED_KEYS = frozenset(
 )
 
 
+# Their per-request INFO lines are replaced by structured events.
+_DEMOTED_LOGGERS = ("httpx", "httpcore", "mcp.server.lowlevel.server")
+
+
 def _scrub_sensitive_keys(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
     for key in list(event_dict.keys()):
         if key not in _RESERVED_KEYS:
@@ -40,6 +44,14 @@ def _scrub_sensitive_keys(logger: WrappedLogger, method_name: str, event_dict: E
 def _scrub_reserved_values(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
     for key in list(event_dict.keys()):
         if key in _RESERVED_KEYS:
+            event_dict[key] = scrub_by_value(event_dict[key])
+    return event_dict
+
+
+def _scrub_rendered_exception(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
+    """Scrub rendered traceback text."""
+    for key in ("exception", "stack"):
+        if key in event_dict:
             event_dict[key] = scrub_by_value(event_dict[key])
     return event_dict
 
@@ -73,9 +85,10 @@ def configure_logging(
         _add_service,
         structlog.processors.StackInfoRenderer(),
         _add_exception_cls,
-        structlog.processors.format_exc_info,
         _scrub_sensitive_keys,
         _scrub_reserved_values,
+        structlog.processors.format_exc_info,
+        _scrub_rendered_exception,
     ]
 
     structlog.configure(
@@ -99,7 +112,13 @@ def configure_logging(
     root = logging.getLogger()
     root.handlers = [h for h in root.handlers if h.name != "ggmcp-log"]
     root.addHandler(handler)
-    root.setLevel(logging.getLevelNamesMapping().get(log_level.upper(), logging.INFO))
+    root_level = logging.getLevelNamesMapping().get(log_level.upper(), logging.INFO)
+    root.setLevel(root_level)
+
+    # Preserve raw third-party request logs only when DEBUG is requested.
+    demoted_level = logging.NOTSET if root_level <= logging.DEBUG else logging.WARNING
+    for name in _DEMOTED_LOGGERS:
+        logging.getLogger(name).setLevel(demoted_level)
 
 
 def configure_logging_from_settings(settings: Settings) -> None:

--- a/packages/gg_api_core/src/gg_api_core/logging_config.py
+++ b/packages/gg_api_core/src/gg_api_core/logging_config.py
@@ -8,6 +8,7 @@ import structlog
 from structlog.types import EventDict, Processor, WrappedLogger
 
 from gg_api_core.sanitization import scrub_by_name, scrub_by_value
+from gg_api_core.version import APP_VERSION
 
 if TYPE_CHECKING:
     from gg_api_core.settings import Settings
@@ -72,8 +73,9 @@ def _add_exception_cls(logger: WrappedLogger, method_name: str, event_dict: Even
 def configure_logging(
     *, log_level: str = "INFO", log_format: str | None = None, service: str = "gg-mcp-server"
 ) -> None:
-    def _add_service(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
+    def _add_gg_fields(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
         event_dict["gg_service"] = service
+        event_dict["gg_version"] = APP_VERSION or "unknown"
         return event_dict
 
     shared: list[Processor] = [
@@ -82,7 +84,7 @@ def configure_logging(
         structlog.stdlib.add_logger_name,
         structlog.stdlib.ExtraAdder(),
         structlog.processors.TimeStamper(fmt="iso"),
-        _add_service,
+        _add_gg_fields,
         structlog.processors.StackInfoRenderer(),
         _add_exception_cls,
         _scrub_sensitive_keys,

--- a/packages/gg_api_core/src/gg_api_core/mcp_server.py
+++ b/packages/gg_api_core/src/gg_api_core/mcp_server.py
@@ -14,8 +14,10 @@ from typing_extensions import override
 
 from gg_api_core.client import GitGuardianClient
 from gg_api_core.icons import get_gitguardian_icons
+from gg_api_core.log_context import clear_caller_identity_cache
 from gg_api_core.middleware import (
     DownstreamUnauthorizedMiddleware,
+    RequestLoggingContextMiddleware,
     ScopeFilteringMiddleware,
     ToolCallLoggingMiddleware,
 )
@@ -122,6 +124,8 @@ class AbstractGitGuardianFastMCP(FastMCP, ABC):
         # Map each tool to its required scopes (instance attribute)
         self._tool_scopes: dict[str, set[str]] = {}
 
+        # Bind request context before downstream middleware emits logs.
+        self.add_middleware(RequestLoggingContextMiddleware(self))
         self.add_middleware(ScopeFilteringMiddleware(self))
         self.add_middleware(DownstreamUnauthorizedMiddleware())
         self.add_middleware(ToolCallLoggingMiddleware())
@@ -150,9 +154,15 @@ class AbstractGitGuardianFastMCP(FastMCP, ABC):
         try:
             logger.debug("Revoking current API token")
             # Call the DELETE /api_tokens/self endpoint
+            token = self.get_personal_access_token()
             client = await self.get_client()
             result = await client.revoke_current_token()
             logger.debug("API token revoked")
+            # The revoked token's workspace/member ids are no longer worth
+            # stamping onto log lines, and the entry would otherwise survive for
+            # the rest of its TTL. Only this token's entry: the server is
+            # multi-tenant, and other callers' credentials are still valid.
+            clear_caller_identity_cache(token)
             return result
         except Exception as e:
             logger.exception(f"Error revoking current API token: {str(e)}")

--- a/packages/gg_api_core/src/gg_api_core/middleware.py
+++ b/packages/gg_api_core/src/gg_api_core/middleware.py
@@ -95,7 +95,7 @@ class RequestLoggingContextMiddleware(Middleware):
                 extra={
                     "mcp_method": method,
                     "status": "error",
-                    "elapsed_ms": round((time.perf_counter() - start) * 1000),
+                    "duration_ms": round((time.perf_counter() - start) * 1000),
                     **classify_failure(exc),
                 },
             )
@@ -106,7 +106,7 @@ class RequestLoggingContextMiddleware(Middleware):
             extra={
                 "mcp_method": method,
                 "status": "ok",
-                "elapsed_ms": round((time.perf_counter() - start) * 1000),
+                "duration_ms": round((time.perf_counter() - start) * 1000),
             },
         )
         return result
@@ -249,7 +249,7 @@ class ToolCallLoggingMiddleware(Middleware):
                         "tool": tool,
                         "arguments": arguments,
                         "status": "error",
-                        "elapsed_ms": round((time.perf_counter() - start) * 1000),
+                        "duration_ms": round((time.perf_counter() - start) * 1000),
                         **classify_failure(exc),
                         **downstream.as_log_fields(),
                     },
@@ -262,7 +262,7 @@ class ToolCallLoggingMiddleware(Middleware):
                     "tool": tool,
                     "arguments": arguments,
                     "status": "ok",
-                    "elapsed_ms": round((time.perf_counter() - start) * 1000),
+                    "duration_ms": round((time.perf_counter() - start) * 1000),
                     **_result_shape(result),
                     **downstream.as_log_fields(),
                 },

--- a/packages/gg_api_core/src/gg_api_core/middleware.py
+++ b/packages/gg_api_core/src/gg_api_core/middleware.py
@@ -22,6 +22,7 @@ from gg_api_core.log_context import (
     track_downstream_calls,
 )
 from gg_api_core.oauth_proxy_auth import mark_downstream_unauthorized
+from gg_api_core.sentry_integration import set_sentry_request_id
 from gg_api_core.settings import get_settings
 from gg_api_core.urls import derive_public_api_url
 
@@ -63,10 +64,12 @@ class RequestLoggingContextMiddleware(Middleware):
 
     @override
     async def on_message(self, context: MiddlewareContext[Any], call_next: CallNext[Any, Any]) -> Any:
+        request_id = _resolve_request_id()
         bindings: dict[str, Any] = {
             "authentication_mode": self._mcp_server.authentication_mode.value,
-            "request_id": _resolve_request_id(),
+            "request_id": request_id,
         }
+        set_sentry_request_id(request_id)
 
         session_id = _resolve_session_id(context)
         if session_id:

--- a/packages/gg_api_core/src/gg_api_core/middleware.py
+++ b/packages/gg_api_core/src/gg_api_core/middleware.py
@@ -1,22 +1,148 @@
 """FastMCP middleware for GitGuardian MCP servers."""
 
 import logging
+import re
 import time
+import uuid
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 import mcp.types as mt
+import structlog
+from fastmcp.server.dependencies import get_http_headers
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.tools import Tool, ToolResult
 from typing_extensions import override
 
 from gg_api_core.client import DownstreamUnauthorizedError
+from gg_api_core.log_context import (
+    classify_failure,
+    derive_client_identity,
+    resolve_caller_identity,
+    track_downstream_calls,
+)
 from gg_api_core.oauth_proxy_auth import mark_downstream_unauthorized
+from gg_api_core.settings import get_settings
+from gg_api_core.urls import derive_public_api_url
 
 if TYPE_CHECKING:
     from gg_api_core.mcp_server import AbstractGitGuardianFastMCP
 
 logger = logging.getLogger(__name__)
+
+# Shape of an X-Request-ID we are willing to adopt from the caller.
+_SAFE_REQUEST_ID = re.compile(r"[A-Za-z0-9._-]{1,64}")
+
+# Handled by ToolCallLoggingMiddleware, which emits a richer line for it.
+_TOOL_CALL_METHOD = "tools/call"
+
+
+def _resolve_request_id() -> str:
+    """Return the inbound X-Request-ID or create one for this MCP message."""
+    inbound = get_http_headers().get("x-request-id", "")
+    return inbound if _SAFE_REQUEST_ID.fullmatch(inbound) else str(uuid.uuid4())
+
+
+def _resolve_session_id(context: MiddlewareContext[Any]) -> str | None:
+    """Return FastMCP's session ID when available."""
+    fastmcp_context = context.fastmcp_context
+    if fastmcp_context is None:
+        return None
+    try:
+        return fastmcp_context.session_id
+    except RuntimeError:
+        # Raised when no session exists, e.g. a server-initiated message.
+        return None
+
+
+class RequestLoggingContextMiddleware(Middleware):
+    """Bind identity and correlation fields for one MCP message."""
+
+    def __init__(self, mcp_server: "AbstractGitGuardianFastMCP"):
+        self._mcp_server = mcp_server
+
+    @override
+    async def on_message(self, context: MiddlewareContext[Any], call_next: CallNext[Any, Any]) -> Any:
+        bindings: dict[str, Any] = {
+            "authentication_mode": self._mcp_server.authentication_mode.value,
+            "request_id": _resolve_request_id(),
+        }
+
+        session_id = _resolve_session_id(context)
+        if session_id:
+            bindings["mcp_session_id"] = session_id
+
+        user_agent = get_http_headers().get("user-agent")
+        if user_agent:
+            bindings["user_agent"] = user_agent
+
+        with structlog.contextvars.bound_contextvars(**bindings):
+            with structlog.contextvars.bound_contextvars(**await self._caller_identity()):
+                return await self._traced(context, call_next)
+
+    async def _traced(self, context: MiddlewareContext[Any], call_next: CallNext[Any, Any]) -> Any:
+        """Emit one protocol event per non-tool MCP message."""
+        method = context.method
+        if method == _TOOL_CALL_METHOD:
+            return await call_next(context)
+
+        start = time.perf_counter()
+        try:
+            result = await call_next(context)
+        except Exception as exc:
+            logger.warning(
+                "mcp_request_failed",
+                extra={
+                    "mcp_method": method,
+                    "status": "error",
+                    "elapsed_ms": round((time.perf_counter() - start) * 1000),
+                    **classify_failure(exc),
+                },
+            )
+            raise
+
+        logger.info(
+            "mcp_request",
+            extra={
+                "mcp_method": method,
+                "status": "ok",
+                "elapsed_ms": round((time.perf_counter() - start) * 1000),
+            },
+        )
+        return result
+
+    async def _caller_identity(self) -> dict[str, Any]:
+        """Return caller identifiers without failing the MCP message."""
+        return await resolve_caller_identity(
+            self._mcp_server.get_token_info,
+            token=self._current_token(),
+            api_url=derive_public_api_url(get_settings().gitguardian_url),
+        )
+
+    def _current_token(self) -> str | None:
+        """The bearer token for this request, used only as a cache key."""
+        try:
+            return self._mcp_server.get_personal_access_token()
+        except Exception:
+            # Modes that resolve the token lazily inside the client, and
+            # requests with no usable bearer token at all.
+            return None
+
+    @override
+    async def on_initialize(
+        self,
+        context: MiddlewareContext[mt.InitializeRequest],
+        call_next: CallNext[mt.InitializeRequest, mt.InitializeResult | None],
+    ) -> mt.InitializeResult | None:
+        """Record client and protocol metadata from initialization."""
+        params = getattr(context.message, "params", context.message)
+        client_identity = derive_client_identity(
+            getattr(params, "clientInfo", None),
+            getattr(params, "protocolVersion", None),
+        )
+        with structlog.contextvars.bound_contextvars(**client_identity):
+            logger.info("mcp_initialize", extra=client_identity)
+            return await call_next(context)
 
 
 class DownstreamUnauthorizedMiddleware(Middleware):
@@ -55,6 +181,7 @@ class ScopeFilteringMiddleware(Middleware):
         # Filter tools by scopes
         scopes = await self._mcp_server.get_scopes()
         filtered_tools: list[Tool] = []
+        hidden: list[str] = []
         for tool in all_tools:
             tool_name = tool.name
             required_scopes = self._mcp_server._tool_scopes.get(tool_name, set())
@@ -62,13 +189,46 @@ class ScopeFilteringMiddleware(Middleware):
             if not required_scopes or required_scopes.issubset(scopes):
                 filtered_tools.append(tool)
             else:
+                hidden.append(tool_name)
                 missing_scopes = required_scopes - scopes
-                logger.info(f"Removing tool '{tool_name}' due to missing scopes: {', '.join(missing_scopes)}")
+                logger.debug(f"Removing tool '{tool_name}' due to missing scopes: {', '.join(missing_scopes)}")
 
+        logger.info(
+            "list_tools",
+            extra={
+                "tools_exposed": len(filtered_tools),
+                "tools_hidden": len(hidden),
+                "hidden_tools": sorted(hidden),
+            },
+        )
         return filtered_tools
 
 
+def _result_shape(result: Any) -> dict[str, Any]:
+    """Return the result's text size, block count, and list length."""
+    content = getattr(result, "content", None) or []
+    result_bytes = 0
+    for block in content:
+        text = getattr(block, "text", None)
+        if isinstance(text, str):
+            result_bytes += len(text.encode("utf-8"))
+
+    shape: dict[str, Any] = {"result_blocks": len(content), "result_bytes": result_bytes}
+
+    structured = getattr(result, "structured_content", None)
+    if isinstance(structured, dict):
+        for key in ("data", "result"):
+            value = structured.get(key)
+            if isinstance(value, list):
+                shape["result_items"] = len(value)
+                break
+
+    return shape
+
+
 class ToolCallLoggingMiddleware(Middleware):
+    """Log one structured event per tool invocation."""
+
     @override
     async def on_call_tool(
         self,
@@ -76,23 +236,35 @@ class ToolCallLoggingMiddleware(Middleware):
         call_next: CallNext[mt.CallToolRequestParams, ToolResult],
     ) -> ToolResult:
         tool = context.message.name
-        arguments = context.message.arguments
+        arguments = context.message.arguments or {}
+
         start = time.perf_counter()
-        try:
-            result = await call_next(context)
-        except Exception:
-            logger.exception(
-                "tool_call_failed",
-                extra={"tool": tool, "arguments": arguments, "elapsed_ms": round((time.perf_counter() - start) * 1000)},
+        with track_downstream_calls() as downstream:
+            try:
+                result = await call_next(context)
+            except Exception as exc:
+                logger.exception(
+                    "tool_call_failed",
+                    extra={
+                        "tool": tool,
+                        "arguments": arguments,
+                        "status": "error",
+                        "elapsed_ms": round((time.perf_counter() - start) * 1000),
+                        **classify_failure(exc),
+                        **downstream.as_log_fields(),
+                    },
+                )
+                raise
+
+            logger.info(
+                "tool_call",
+                extra={
+                    "tool": tool,
+                    "arguments": arguments,
+                    "status": "ok",
+                    "elapsed_ms": round((time.perf_counter() - start) * 1000),
+                    **_result_shape(result),
+                    **downstream.as_log_fields(),
+                },
             )
-            raise
-        logger.info(
-            "tool_call",
-            extra={
-                "tool": tool,
-                "arguments": arguments,
-                "status": "ok",
-                "elapsed_ms": round((time.perf_counter() - start) * 1000),
-            },
-        )
         return result

--- a/packages/gg_api_core/src/gg_api_core/oauth_proxy_auth.py
+++ b/packages/gg_api_core/src/gg_api_core/oauth_proxy_auth.py
@@ -36,6 +36,14 @@ logger = logging.getLogger(__name__)
 _downstream_unauthorized: ContextVar[bool] = ContextVar("downstream_unauthorized", default=False)
 
 
+def _log_oauth_step(step: str, *, outcome: str, status: int | None = None, **fields: Any) -> None:
+    """Emit one structured ``oauth_step`` event."""
+    logger.info(
+        "oauth_step",
+        extra={"oauth_step": step, "outcome": outcome, "status": status, **fields},
+    )
+
+
 def mark_downstream_unauthorized() -> None:
     """Signal that the downstream GG API rejected the current request as unauthorized.
 
@@ -45,6 +53,7 @@ def mark_downstream_unauthorized() -> None:
     FastMCP would otherwise serialize, letting the MCP client re-run the
     OAuth flow.
     """
+    _log_oauth_step("downstream_unauthorized", outcome="reauth_required", status=401)
     _downstream_unauthorized.set(True)
 
 
@@ -338,6 +347,12 @@ class GitGuardianOAuthThinProxy(PassThroughTokenVerifier):
                 headers={"Content-Type": "application/json"},
             )
 
+        _log_oauth_step(
+            "register",
+            outcome="ok" if response.status_code < 400 else "error",
+            status=response.status_code,
+            user_agent=request.headers.get("user-agent"),
+        )
         return JSONResponse(
             response.json(),
             status_code=response.status_code,
@@ -362,6 +377,14 @@ class GitGuardianOAuthThinProxy(PassThroughTokenVerifier):
 
         separator = "&" if "?" in self.gg_authorize_url else "?"
         url = f"{self.gg_authorize_url}{separator}{urlencode(params)}"
+        _log_oauth_step(
+            "authorize",
+            outcome="redirected",
+            status=302,
+            oauth_client_id=params.get("client_id"),
+            pkce=params.get("code_challenge_method"),
+            user_agent=request.headers.get("user-agent"),
+        )
         return RedirectResponse(url=url, status_code=302)
 
     async def _handle_token(self, request: Request) -> JSONResponse:
@@ -404,7 +427,17 @@ class GitGuardianOAuthThinProxy(PassThroughTokenVerifier):
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
             )
 
+        grant_type = form_data.get("grant_type")
+        oauth_client_id = form_data.get("client_id")
+
         if response.status_code != 200:
+            _log_oauth_step(
+                "token",
+                outcome="error",
+                status=response.status_code,
+                grant_type=grant_type,
+                oauth_client_id=oauth_client_id,
+            )
             return JSONResponse(
                 response.json()
                 if response.headers.get("content-type", "").startswith("application/json")
@@ -417,11 +450,25 @@ class GitGuardianOAuthThinProxy(PassThroughTokenVerifier):
         # Transform GG's non-standard response to OAuth standard
         access_token = token_data.get("access_token") or token_data.get("key")
         if not access_token:
+            _log_oauth_step(
+                "token",
+                outcome="missing_access_token",
+                status=500,
+                grant_type=grant_type,
+                oauth_client_id=oauth_client_id,
+            )
             return JSONResponse(
                 {"error": "server_error", "error_description": "No access token in upstream response"},
                 status_code=500,
             )
 
+        _log_oauth_step(
+            "token",
+            outcome="ok",
+            status=200,
+            grant_type=grant_type,
+            oauth_client_id=oauth_client_id,
+        )
         return JSONResponse(
             {
                 "access_token": access_token,

--- a/packages/gg_api_core/src/gg_api_core/sanitization.py
+++ b/packages/gg_api_core/src/gg_api_core/sanitization.py
@@ -31,6 +31,10 @@ NON_SENSITIVE_NAME_ALLOWLIST: Final = frozenset(
         "secrets_count",
         "token_id",
         "token_name",
+        # Describes a token rather than carrying one: "personal_access_token"
+        # or "service_account", and a digest of the scope set.
+        "token_type",
+        "token_scopes_hash",
         "match_count",
         "document_count",
         "documents_count",

--- a/packages/gg_api_core/src/gg_api_core/sentry_integration.py
+++ b/packages/gg_api_core/src/gg_api_core/sentry_integration.py
@@ -17,6 +17,13 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+try:
+    import sentry_sdk
+    from sentry_sdk.integrations.logging import LoggingIntegration
+except ImportError:
+    sentry_sdk = None
+    LoggingIntegration = None
+
 from .sanitization import SENSITIVE_DATA_PLACEHOLDER, scrub_by_name, scrub_by_value
 from .settings import SentrySettings
 
@@ -56,22 +63,7 @@ def _scrub_sentry_event(event: Event, hint: Hint) -> Event:
 
 
 def init_sentry() -> bool:
-    """
-    Initialize Sentry SDK if configured via environment variables.
-
-    This function attempts to import and configure Sentry SDK only if
-    SENTRY_DSN is provided. It gracefully handles missing sentry-sdk
-    installation and logs appropriate messages.
-
-    Returns:
-        bool: True if Sentry was successfully initialized, False otherwise
-
-    Example:
-        >>> import os
-        >>> os.environ["SENTRY_DSN"] = "https://..."
-        >>> init_sentry()
-        True
-    """
+    """Initialize Sentry when configured and available."""
     sentry_settings = SentrySettings()
     dsn = sentry_settings.dsn
 
@@ -79,10 +71,7 @@ def init_sentry() -> bool:
         logger.debug("SENTRY_DSN not configured, skipping Sentry initialization")
         return False
 
-    try:
-        import sentry_sdk
-        from sentry_sdk.integrations.logging import LoggingIntegration
-    except ImportError:
+    if sentry_sdk is None or LoggingIntegration is None:
         logger.warning("Sentry SDK not installed")
         return False
 
@@ -134,15 +123,12 @@ def set_sentry_context(key: str, value: Any) -> None:
     Example:
         >>> set_sentry_context("workspace", {"id": "123", "name": "acme"})
     """
+    if sentry_sdk is None:
+        return
     try:
-        import sentry_sdk
-
         sentry_sdk.set_context(key, value)
-    except ImportError:
-        # Sentry not installed, silently skip
-        pass
-    except Exception as e:
-        logger.debug(f"Failed to set Sentry context: {str(e)}")
+    except Exception as exc:
+        logger.debug("Failed to set Sentry context: %s", exc)
 
 
 def set_sentry_user(user_info: dict[str, Any]) -> None:
@@ -158,15 +144,12 @@ def set_sentry_user(user_info: dict[str, Any]) -> None:
     Example:
         >>> set_sentry_user({"id": "123", "email": "user@example.com"})
     """
+    if sentry_sdk is None:
+        return
     try:
-        import sentry_sdk
-
         sentry_sdk.set_user(user_info)
-    except ImportError:
-        # Sentry not installed, silently skip
-        pass
-    except Exception as e:
-        logger.debug(f"Failed to set Sentry user: {str(e)}")
+    except Exception as exc:
+        logger.debug("Failed to set Sentry user: %s", exc)
 
 
 def capture_exception(exception: Exception, **kwargs: Any) -> None:
@@ -186,12 +169,9 @@ def capture_exception(exception: Exception, **kwargs: Any) -> None:
         ...     capture_exception(e, extra={"operation": "risky_operation"})
         ...     handle_error(e)
     """
+    if sentry_sdk is None:
+        return
     try:
-        import sentry_sdk
-
         sentry_sdk.capture_exception(exception, **kwargs)
-    except ImportError:
-        # Sentry not installed, silently skip
-        pass
-    except Exception as e:
-        logger.debug(f"Failed to capture exception in Sentry: {str(e)}")
+    except Exception as exc:
+        logger.debug("Failed to capture exception in Sentry: %s", exc)

--- a/packages/gg_api_core/src/gg_api_core/sentry_integration.py
+++ b/packages/gg_api_core/src/gg_api_core/sentry_integration.py
@@ -12,12 +12,47 @@ Environment Variables:
     SENTRY_PROFILES_SAMPLE_RATE: Sampling rate for profiling (0.0 to 1.0)
 """
 
-import logging
-from typing import Any
+from __future__ import annotations
 
+import logging
+from typing import TYPE_CHECKING, Any
+
+from .sanitization import SENSITIVE_DATA_PLACEHOLDER, scrub_by_name, scrub_by_value
 from .settings import SentrySettings
 
+if TYPE_CHECKING:
+    from sentry_sdk.types import Event, Hint
+
 logger = logging.getLogger(__name__)
+
+
+_MAX_SCRUB_DEPTH = 12
+
+
+def _scrub_sentry_payload(value: Any, depth: int = 0) -> Any:
+    """Value-scrub strings recursively at the Sentry SDK boundary."""
+    if depth >= _MAX_SCRUB_DEPTH:
+        return SENSITIVE_DATA_PLACEHOLDER
+    if isinstance(value, str):
+        return scrub_by_value(value)
+    if isinstance(value, dict):
+        return {key: _scrub_sentry_payload(item, depth + 1) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return type(value)(_scrub_sentry_payload(item, depth + 1) for item in value)
+    return value
+
+
+def _scrub_breadcrumb(breadcrumb: dict[str, Any], hint: Hint) -> dict[str, Any]:
+    """Scrub breadcrumb values and sensitive logging ``data`` fields."""
+    data = breadcrumb.get("data")
+    if isinstance(data, dict):
+        breadcrumb["data"] = {str(key): scrub_by_name(str(key), value) for key, value in data.items()}
+    return _scrub_sentry_payload(breadcrumb)
+
+
+def _scrub_sentry_event(event: Event, hint: Hint) -> Event:
+    """Scrub an event before sending it to Sentry."""
+    return _scrub_sentry_payload(event)
 
 
 def init_sentry() -> bool:
@@ -56,11 +91,8 @@ def init_sentry() -> bool:
     traces_sample_rate = sentry_settings.traces_sample_rate
     profiles_sample_rate = sentry_settings.profiles_sample_rate
 
-    # Configure logging integration
-    logging_integration = LoggingIntegration(
-        level=logging.INFO,  # Capture info and above as breadcrumbs
-        event_level=logging.ERROR,  # Send errors as events
-    )
+    # Logs provide breadcrumbs only. MCPIntegration owns tool-failure events.
+    logging_integration = LoggingIntegration(level=logging.INFO, event_level=None)
 
     try:
         sentry_sdk.init(
@@ -70,6 +102,9 @@ def init_sentry() -> bool:
             traces_sample_rate=traces_sample_rate,
             profiles_sample_rate=profiles_sample_rate,
             integrations=[logging_integration],
+            include_local_variables=False,
+            before_send=_scrub_sentry_event,
+            before_breadcrumb=_scrub_breadcrumb,
             # Automatically capture unhandled exceptions
             send_default_pii=False,  # Don't send personally identifiable information by default
         )

--- a/packages/gg_api_core/src/gg_api_core/sentry_integration.py
+++ b/packages/gg_api_core/src/gg_api_core/sentry_integration.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 _MAX_SCRUB_DEPTH = 12
+_REQUEST_ID_FIELD = "request_id"
 
 
 def _scrub_sentry_payload(value: Any, depth: int = 0) -> Any:
@@ -57,9 +58,26 @@ def _scrub_breadcrumb(breadcrumb: dict[str, Any], hint: Hint) -> dict[str, Any]:
     return _scrub_sentry_payload(breadcrumb)
 
 
-def _scrub_sentry_event(event: Event, hint: Hint) -> Event:
-    """Scrub an event before sending it to Sentry."""
-    return _scrub_sentry_payload(event)
+def _request_id_from_trace(event: Event) -> str | None:
+    contexts = event.get("contexts")
+    if not isinstance(contexts, dict):
+        return None
+    trace = contexts.get("trace")
+    if not isinstance(trace, dict):
+        return None
+    data = trace.get("data")
+    if not isinstance(data, dict):
+        return None
+    request_id = data.get(_REQUEST_ID_FIELD)
+    return request_id if isinstance(request_id, str) else None
+
+
+def _prepare_sentry_event(event: Event, hint: Hint) -> Event:
+    event = _scrub_sentry_payload(event)
+    request_id = _request_id_from_trace(event)
+    if request_id:
+        event.setdefault("tags", {})[_REQUEST_ID_FIELD] = request_id
+    return event
 
 
 def init_sentry() -> bool:
@@ -92,7 +110,7 @@ def init_sentry() -> bool:
             profiles_sample_rate=profiles_sample_rate,
             integrations=[logging_integration],
             include_local_variables=False,
-            before_send=_scrub_sentry_event,
+            before_send=_prepare_sentry_event,
             before_breadcrumb=_scrub_breadcrumb,
             # Automatically capture unhandled exceptions
             send_default_pii=False,  # Don't send personally identifiable information by default
@@ -107,6 +125,18 @@ def init_sentry() -> bool:
     except Exception as e:
         logger.exception(f"Failed to initialize Sentry: {str(e)}")
         return False
+
+
+def set_sentry_request_id(request_id: str) -> None:
+    """Preserve a request ID on the active Sentry span."""
+    if sentry_sdk is None:
+        return
+    try:
+        span = sentry_sdk.get_current_span()
+        if span is not None:
+            span.set_data(_REQUEST_ID_FIELD, request_id)
+    except Exception as exc:
+        logger.debug("Failed to preserve request ID for Sentry: %s", exc)
 
 
 def set_sentry_context(key: str, value: Any) -> None:

--- a/packages/gg_api_core/src/gg_api_core/version.py
+++ b/packages/gg_api_core/src/gg_api_core/version.py
@@ -1,0 +1,15 @@
+"""Application release metadata."""
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as package_version
+
+
+def resolve_app_version() -> str | None:
+    """Return the installed ``ggmcp`` release, if its metadata is available."""
+    try:
+        return package_version("ggmcp")
+    except PackageNotFoundError:
+        return None
+
+
+APP_VERSION = resolve_app_version()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dev = [
     "respx~=0.22",
     "pytest-socket~=0.7",
     "pytest-voluptuous~=1.2",
+    "gg-api-core[sentry]",
 ]
 
 [project.scripts]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import parse_qs, quote, unquote, urlparse
 
 import pytest
+import structlog
 import vcr
+
+DEMOTABLE_LOGGERS = ("httpx", "httpcore", "mcp.server.lowlevel.server")
 
 # Configure logging for VCR debugging
 vcr_logger = logging.getLogger("vcr.debug")
@@ -597,3 +600,21 @@ def setup_test_env():
     # Restore original environment
     os.environ.clear()
     os.environ.update(original_env)
+
+
+@pytest.fixture(autouse=True)
+def restore_logging_configuration():
+    """Restore global logging state after each test."""
+    root = logging.getLogger()
+    saved_structlog_config = structlog.get_config()
+    saved_handlers = list(root.handlers)
+    saved_root_level = root.level
+    saved_levels = {name: logging.getLogger(name).level for name in DEMOTABLE_LOGGERS}
+
+    yield
+
+    structlog.configure(**saved_structlog_config)
+    root.handlers = saved_handlers
+    root.setLevel(saved_root_level)
+    for name, level in saved_levels.items():
+        logging.getLogger(name).setLevel(level)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,7 @@ from urllib.parse import parse_qs, quote, unquote, urlparse
 import pytest
 import structlog
 import vcr
-
-DEMOTABLE_LOGGERS = ("httpx", "httpcore", "mcp.server.lowlevel.server")
+from gg_api_core.logging_config import _DEMOTED_LOGGERS
 
 # Configure logging for VCR debugging
 vcr_logger = logging.getLogger("vcr.debug")
@@ -609,7 +608,7 @@ def restore_logging_configuration():
     saved_structlog_config = structlog.get_config()
     saved_handlers = list(root.handlers)
     saved_root_level = root.level
-    saved_levels = {name: logging.getLogger(name).level for name in DEMOTABLE_LOGGERS}
+    saved_levels = {name: logging.getLogger(name).level for name in _DEMOTED_LOGGERS}
 
     yield
 

--- a/tests/e2e/test_auth_and_tool_visibility.py
+++ b/tests/e2e/test_auth_and_tool_visibility.py
@@ -152,7 +152,9 @@ class TestScopeBasedToolVisibility:
         assert first_full_catalog == EXPECTED_FULL_TOOL_CATALOG
         assert scan_catalog == EXPECTED_SCAN_ONLY_TOOL_CATALOG
         assert second_full_catalog == EXPECTED_FULL_TOOL_CATALOG
-        assert token_route.call_count == 3
+        # Each tools/list resolves scopes. Logging enrichment also resolves caller
+        # identity once per distinct token, then serves repeat calls from its cache.
+        assert token_route.call_count == 5
 
     async def test_concurrent_requests_keep_tenant_context_isolated(self, mcp_client, gg_api):
         """

--- a/tests/e2e/test_stdio_transport.py
+++ b/tests/e2e/test_stdio_transport.py
@@ -123,7 +123,8 @@ async def test_installed_stdio_entrypoint_serves_gitguardian_tools(
 
     api_requests = _FakeGitGuardianApi.requests
     assert [request["path"] for request in api_requests] == [
-        f"{API_PREFIX}/api_tokens/self",
+        f"{API_PREFIX}/api_tokens/self",  # startup scope discovery
+        f"{API_PREFIX}/api_tokens/self",  # caller identity for log enrichment
         f"{API_PREFIX}/incidents/secrets/77",
     ]
     assert {request["authorization"] for request in api_requests} == {f"Token {STDIO_PAT}"}

--- a/tests/test_api_request_logging.py
+++ b/tests/test_api_request_logging.py
@@ -1,0 +1,204 @@
+"""The structured ``api_request`` event replacing httpx's free-text INFO line."""
+
+import asyncio
+import logging
+
+import httpx
+import pytest
+from gg_api_core.client import GitGuardianClient, _path_template
+from gg_api_core.log_context import track_downstream_calls
+from gg_api_core.logging_config import configure_logging
+
+
+def _responding_with(handler):
+    """Replacement for ``AsyncClient.request`` that answers from ``handler``.
+
+    Builds the response directly rather than delegating to another client, which
+    would re-enter the patched method.
+    """
+
+    async def request(self, method, url, **kwargs):
+        response = handler(httpx.Request(method, url))
+        response.request = httpx.Request(method, url)
+        return response
+
+    return request
+
+
+class TestPathTemplate:
+    @pytest.mark.parametrize(
+        ("endpoint", "expected"),
+        [
+            ("/incidents/secrets/12345", "/incidents/secrets/{id}"),
+            (
+                "/honeytokens/d0ca9877-641f-4c37-8857-c08e0ae148c4/revoke",
+                "/honeytokens/{id}/revoke",
+            ),
+            ("/incidents-for-mcp/count", "/incidents-for-mcp/count"),
+        ],
+    )
+    def test_collapses_id_segments(self, endpoint, expected):
+        """
+        GIVEN an endpoint path containing a numeric or UUID id
+        WHEN it is templated
+        THEN the id is collapsed to a placeholder
+        """
+        assert _path_template(endpoint) == expected
+
+    def test_drops_the_query_string(self):
+        """
+        GIVEN an endpoint carrying filter values in its query string
+        WHEN it is templated
+        THEN the query string is dropped entirely
+        """
+        assert _path_template("/incidents/secrets?assignee_email=a@b.com&severity=high") == "/incidents/secrets"
+
+
+class TestApiRequestEvent:
+    async def test_logs_method_path_status_and_duration(self, caplog, monkeypatch):
+        """
+        GIVEN a successful GitGuardian API call
+        WHEN it completes
+        THEN one api_request event reports method, templated path, status and duration
+        """
+        client = GitGuardianClient(gitguardian_url="https://dashboard.gitguardian.com", personal_access_token="tok")
+
+        def handler(request):
+            return httpx.Response(200, json={"count": 3}, headers={"x-request-id": "gg-req-7"})
+
+        monkeypatch.setattr(httpx.AsyncClient, "request", _responding_with(handler))
+
+        with caplog.at_level(logging.INFO, logger="gg_api_core.client"):
+            await client._request_get("/incidents/secrets/12345")
+
+        rec = next(r for r in caplog.records if r.getMessage() == "api_request")
+        assert rec.method == "GET"
+        assert rec.path == "/incidents/secrets/{id}"
+        assert rec.status == 200
+        assert isinstance(rec.duration_ms, int)
+        assert rec.gg_request_id == "gg-req-7"
+
+    async def test_list_requests_use_the_same_tracking_path(self, caplog, monkeypatch):
+        """
+        GIVEN a successful list request
+        WHEN it completes
+        THEN the shared tracker emits the same api_request event
+        """
+        client = GitGuardianClient(gitguardian_url="https://dashboard.gitguardian.com", personal_access_token="tok")
+
+        async def get(self, url, **kwargs):
+            response = httpx.Response(200, json=[])
+            response.request = httpx.Request("GET", url)
+            return response
+
+        monkeypatch.setattr(httpx.AsyncClient, "get", get)
+
+        with caplog.at_level(logging.INFO, logger="gg_api_core.client"):
+            await client._request_list("/incidents/secrets")
+
+        rec = next(r for r in caplog.records if r.getMessage() == "api_request")
+        assert rec.method == "GET"
+        assert rec.path == "/incidents/secrets"
+        assert rec.status == 200
+
+    async def test_accounts_the_call_against_the_enclosing_tool_call(self, monkeypatch):
+        """
+        GIVEN a GitGuardian API call made inside a tracked block
+        WHEN it completes
+        THEN the block's accumulator counts it and its latency
+        """
+        client = GitGuardianClient(gitguardian_url="https://dashboard.gitguardian.com", personal_access_token="tok")
+
+        def handler(request):
+            return httpx.Response(200, json={})
+
+        monkeypatch.setattr(httpx.AsyncClient, "request", _responding_with(handler))
+
+        with track_downstream_calls() as stats:
+            await client._request_get("/incidents/secrets/1")
+
+        assert stats.calls == 1
+        assert stats.statuses == {200}
+
+    async def test_reports_a_transport_failure_without_a_status(self, caplog, monkeypatch):
+        """
+        GIVEN an API call that never gets a response
+        WHEN it fails
+        THEN api_request reports the error class and no status
+        """
+        client = GitGuardianClient(gitguardian_url="https://dashboard.gitguardian.com", personal_access_token="tok")
+
+        async def failing_request(self, method, url, **kwargs):
+            raise httpx.ConnectTimeout("timed out")
+
+        monkeypatch.setattr(httpx.AsyncClient, "request", failing_request)
+
+        with caplog.at_level(logging.INFO, logger="gg_api_core.client"):
+            with pytest.raises(httpx.ConnectTimeout):
+                await client._request_get("/incidents/secrets")
+
+        rec = next(r for r in caplog.records if r.getMessage() == "api_request")
+        assert rec.status is None
+        assert rec.error_class == "ConnectTimeout"
+
+
+class TestRetryAccounting:
+    async def test_retry_backoff_counts_as_downstream_time(self, monkeypatch):
+        """
+        GIVEN an endpoint returning 500 until the retries run out
+        WHEN the call finally fails
+        THEN the backoff between attempts is counted in downstream time
+        """
+        client = GitGuardianClient(gitguardian_url="https://dashboard.gitguardian.com", personal_access_token="tok")
+
+        def handler(request):
+            return httpx.Response(500, json={"detail": "boom"})
+
+        monkeypatch.setattr(httpx.AsyncClient, "request", _responding_with(handler))
+        slept: list[float] = []
+
+        async def fake_sleep(seconds):
+            slept.append(seconds)
+
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+        with track_downstream_calls() as stats:
+            with pytest.raises(httpx.HTTPStatusError):
+                await client._request_get("/incidents/secrets")
+
+        assert stats.retries == 3
+        assert slept == [1, 2, 4]
+        assert stats.wait_ms == sum(slept) * 1000
+        assert stats.total_ms >= stats.wait_ms
+
+
+class TestNoisyLoggerDemotion:
+    def test_httpx_is_demoted_above_debug(self):
+        """
+        GIVEN logging configured at INFO
+        WHEN httpx's own logger is consulted
+        THEN its per-request INFO line is suppressed
+        """
+        configure_logging(log_level="INFO", log_format="json")
+
+        assert not logging.getLogger("httpx").isEnabledFor(logging.INFO)
+
+    def test_the_sdk_per_request_line_is_demoted(self):
+        """
+        GIVEN logging configured at INFO
+        WHEN the MCP SDK's low-level server logger is consulted
+        THEN its per-message INFO line is suppressed
+        """
+        configure_logging(log_level="INFO", log_format="json")
+
+        assert not logging.getLogger("mcp.server.lowlevel.server").isEnabledFor(logging.INFO)
+
+    def test_httpx_is_left_alone_at_debug(self):
+        """
+        GIVEN logging configured at DEBUG
+        WHEN httpx's own logger is consulted
+        THEN it is not demoted
+        """
+        configure_logging(log_level="DEBUG", log_format="json")
+
+        assert logging.getLogger("httpx").isEnabledFor(logging.DEBUG)

--- a/tests/test_failure_taxonomy.py
+++ b/tests/test_failure_taxonomy.py
@@ -1,0 +1,155 @@
+"""Grading of tool failures into queryable fields."""
+
+import httpx
+from gg_api_core.client import DownstreamUnauthorizedError
+from gg_api_core.log_context import classify_failure
+
+
+def _status_error(status: int, body: dict | str | None = None) -> httpx.HTTPStatusError:
+    """An HTTPStatusError shaped like one httpx raises from raise_for_status."""
+    request = httpx.Request("GET", "https://api.gitguardian.com/v1/incidents/secrets")
+    if isinstance(body, dict):
+        response = httpx.Response(status, json=body, request=request)
+    else:
+        response = httpx.Response(status, text=body or "", request=request)
+    return httpx.HTTPStatusError("error", request=request, response=response)
+
+
+class TestClassifyFailure:
+    def test_reports_the_exception_class(self):
+        """
+        GIVEN a plain exception
+        WHEN it is classified
+        THEN the module-qualified class name is reported
+        """
+        assert classify_failure(ValueError("boom"))["error_class"] == "ValueError"
+
+    def test_grades_a_4xx_as_the_caller_s_fault(self):
+        """
+        GIVEN a 400 from the GitGuardian API
+        WHEN it is classified
+        THEN the status is surfaced and the fault is the client's
+        """
+        failure = classify_failure(_status_error(400))
+
+        assert failure["upstream_status"] == 400
+        assert failure["fault"] == "client"
+
+    def test_grades_a_5xx_as_our_fault(self):
+        """
+        GIVEN a 502 from the GitGuardian API
+        WHEN it is classified
+        THEN the fault is the server's
+        """
+        assert classify_failure(_status_error(502))["fault"] == "server"
+
+    def test_grades_a_429_as_our_fault_despite_being_a_4xx(self):
+        """
+        GIVEN a 429 from the GitGuardian API
+        WHEN it is classified
+        THEN the fault is the server's
+        """
+        assert classify_failure(_status_error(429))["fault"] == "server"
+
+    def test_grades_an_unexpected_exception_as_our_fault(self):
+        """
+        GIVEN an exception with no HTTP status anywhere in its chain
+        WHEN it is classified
+        THEN the fault is the server's and no status is invented
+        """
+        failure = classify_failure(KeyError("missing"))
+
+        assert failure["fault"] == "server"
+        assert "upstream_status" not in failure
+
+    def test_finds_the_status_through_a_wrapped_exception(self):
+        """
+        GIVEN an HTTP error re-raised as a domain exception
+        WHEN it is classified
+        THEN the underlying status is still found
+        """
+        try:
+            try:
+                raise _status_error(401)
+            except httpx.HTTPStatusError as exc:
+                raise DownstreamUnauthorizedError("401 for /incidents") from exc
+        except DownstreamUnauthorizedError as exc:
+            failure = classify_failure(exc)
+
+        assert failure["upstream_status"] == 401
+        assert failure["fault"] == "client"
+        assert failure["error_class"] == "gg_api_core.client.DownstreamUnauthorizedError"
+
+    def test_surfaces_the_gitguardian_error_code(self):
+        """
+        GIVEN an error body carrying a machine-readable code
+        WHEN it is classified
+        THEN the code is surfaced as its own field
+        """
+        failure = classify_failure(_status_error(400, {"code": "invalid_severity"}))
+
+        assert failure["gg_error_code"] == "invalid_severity"
+
+    def test_ignores_the_detail_prose(self):
+        """
+        GIVEN an error body whose `detail` echoes the submitted document
+        WHEN it is classified
+        THEN no error code is emitted
+        """
+        failure = classify_failure(
+            _status_error(400, {"detail": "Invalid document: 'aws_secret_access_key=wJalrXUtnFEMI'"})
+        )
+
+        assert "gg_error_code" not in failure
+        assert "wJalrXUtnFEMI" not in str(failure)
+
+    def test_rejects_an_over_long_code(self):
+        """
+        GIVEN a `code` field carrying a sentence rather than an identifier
+        WHEN it is classified
+        THEN it is not surfaced
+        """
+        failure = classify_failure(_status_error(400, {"code": "x" * 200}))
+
+        assert "gg_error_code" not in failure
+
+    def test_finds_the_status_inside_an_exception_group(self):
+        """
+        GIVEN an HTTP error raised inside a task group
+        WHEN it is classified
+        THEN the status is still found
+        """
+        group = ExceptionGroup("task group failed", [ValueError("unrelated"), _status_error(400)])
+
+        failure = classify_failure(group)
+
+        assert failure["upstream_status"] == 400
+        assert failure["fault"] == "client"
+
+    def test_respects_a_severed_context(self):
+        """
+        GIVEN an unrelated HTTP error severed with `raise ... from None`
+        WHEN the outer exception is classified
+        THEN the severed status is not attributed to it
+        """
+        try:
+            try:
+                raise _status_error(404)
+            except httpx.HTTPStatusError:
+                raise ValueError("bad argument") from None
+        except ValueError as exc:
+            failure = classify_failure(exc)
+
+        assert "upstream_status" not in failure
+        assert failure["fault"] == "server"
+
+    def test_tolerates_a_non_json_error_body(self):
+        """
+        GIVEN an error body that is not JSON (a proxy's HTML error page)
+        WHEN it is classified
+        THEN the status is still reported and no code is invented
+        """
+        failure = classify_failure(_status_error(502, "<html>bad gateway</html>"))
+
+        assert failure["upstream_status"] == 502
+        assert "gg_error_code" not in failure

--- a/tests/test_log_context.py
+++ b/tests/test_log_context.py
@@ -1,0 +1,291 @@
+"""Derivation and caching of the identity fields bound to every log line."""
+
+import time
+
+import pytest
+from gg_api_core.log_context import (
+    _IDENTITY_CACHE_MAX_ENTRIES,
+    _IDENTITY_TTL_SECONDS,
+    _identity_cache,
+    _identity_cache_key,
+    clear_caller_identity_cache,
+    derive_caller_identity,
+    derive_client_identity,
+    resolve_caller_identity,
+    scopes_fingerprint,
+)
+
+# Shape of a real GET /api_tokens/self response, trimmed to the fields we read.
+TOKEN_INFO = {
+    "id": "d0ca9877-641f-4c37-8857-c08e0ae148c4",
+    "name": "ggmcp CI",
+    "type": "personal_access_token",
+    "scopes": ["scan", "incidents:read"],
+    "member_id": 480870,
+    "workspace_id": 8,
+    "status": "active",
+}
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    clear_caller_identity_cache(all_tokens=True)
+    yield
+    clear_caller_identity_cache(all_tokens=True)
+
+
+class TestScopesFingerprint:
+    def test_is_order_independent(self):
+        """
+        GIVEN the same scope set listed in two orders
+        WHEN each is fingerprinted
+        THEN both produce the same digest
+        """
+        assert scopes_fingerprint(["a", "b"]) == scopes_fingerprint(["b", "a"])
+
+    def test_differs_for_a_different_scope_set(self):
+        """
+        GIVEN two different scope sets
+        WHEN each is fingerprinted
+        THEN the digests differ
+        """
+        assert scopes_fingerprint(["a", "b"]) != scopes_fingerprint(["a", "b", "c"])
+
+
+class TestDeriveCallerIdentity:
+    def test_maps_the_api_payload_to_log_fields(self):
+        """
+        GIVEN a token info payload and an API URL
+        WHEN caller identity is derived
+        THEN workspace, member, token and host identifiers are returned
+        """
+        identity = derive_caller_identity(TOKEN_INFO, api_url="https://api.eu1.gitguardian.com/v1")
+
+        assert identity["account_id"] == 8
+        assert identity["workspace_id"] == 8
+        assert identity["member_id"] == 480870
+        assert identity["token_id"] == TOKEN_INFO["id"]
+        assert identity["token_type"] == "personal_access_token"
+        assert identity["gg_host"] == "api.eu1.gitguardian.com"
+        assert identity["token_scopes_hash"] == scopes_fingerprint(TOKEN_INFO["scopes"])
+
+    def test_never_returns_the_scope_list_or_token_name(self):
+        """
+        GIVEN a token info payload
+        WHEN caller identity is derived
+        THEN the raw scope list is reduced to a fingerprint
+        """
+        identity = derive_caller_identity(TOKEN_INFO)
+
+        assert "scopes" not in identity
+        assert TOKEN_INFO["scopes"][0] not in str(identity)
+
+    def test_omits_fields_the_payload_does_not_carry(self):
+        """
+        GIVEN a payload missing most fields
+        WHEN caller identity is derived
+        THEN absent fields are omitted rather than bound as None
+        """
+        identity = derive_caller_identity({"workspace_id": 8})
+
+        assert identity == {"account_id": 8, "workspace_id": 8}
+
+
+class TestDeriveClientIdentity:
+    def test_maps_client_info_and_protocol_version(self):
+        """
+        GIVEN an initialize payload's clientInfo and protocol version
+        WHEN client identity is derived
+        THEN name, version and protocol revision are returned
+        """
+        from types import SimpleNamespace
+
+        identity = derive_client_identity(SimpleNamespace(name="cursor", version="1.4.0"), "2025-06-18")
+
+        assert identity == {
+            "client_name": "cursor",
+            "client_version": "1.4.0",
+            "protocol_version": "2025-06-18",
+        }
+
+    def test_tolerates_a_missing_client_info(self):
+        """
+        GIVEN an initialize payload with no clientInfo
+        WHEN client identity is derived
+        THEN an empty mapping is returned
+        """
+        assert derive_client_identity(None) == {}
+
+
+class TestResolveCallerIdentity:
+    async def test_fetches_once_per_token(self):
+        """
+        GIVEN two lookups for the same token
+        WHEN caller identity is resolved
+        THEN the API is queried only the first time
+        """
+        calls = 0
+
+        async def fetch():
+            nonlocal calls
+            calls += 1
+            return TOKEN_INFO
+
+        first = await resolve_caller_identity(fetch, token="tok-a")
+        second = await resolve_caller_identity(fetch, token="tok-a")
+
+        assert first == second
+        assert calls == 1
+
+    async def test_does_not_share_identity_between_tokens(self):
+        """
+        GIVEN two different tokens
+        WHEN caller identity is resolved for each
+        THEN each gets its own payload
+        """
+
+        async def fetch_a():
+            return TOKEN_INFO
+
+        async def fetch_b():
+            return {**TOKEN_INFO, "workspace_id": 99, "member_id": 1}
+
+        a = await resolve_caller_identity(fetch_a, token="tok-a")
+        b = await resolve_caller_identity(fetch_b, token="tok-b")
+
+        assert a["workspace_id"] == 8
+        assert b["workspace_id"] == 99
+
+    async def test_returns_nothing_when_the_token_is_rejected(self):
+        """
+        GIVEN a token the API rejects
+        WHEN caller identity is resolved
+        THEN an empty mapping is returned rather than raising
+        """
+
+        async def fetch():
+            raise RuntimeError("401 Unauthorized")
+
+        assert await resolve_caller_identity(fetch, token="tok-bad") == {}
+
+    async def test_does_not_retry_a_rejected_token_on_every_message(self):
+        """
+        GIVEN a token the API rejects
+        WHEN identity is resolved repeatedly
+        THEN the failed lookup is not repeated
+        """
+        calls = 0
+
+        async def fetch():
+            nonlocal calls
+            calls += 1
+            raise RuntimeError("401 Unauthorized")
+
+        for _ in range(3):
+            await resolve_caller_identity(fetch, token="tok-bad")
+
+        assert calls == 1
+
+    async def test_caches_when_the_server_holds_no_token(self):
+        """
+        GIVEN no bearer token (stdio modes resolve it inside the client)
+        WHEN caller identity is resolved twice
+        THEN the lookup is still cached under a fixed key
+        """
+        calls = 0
+
+        async def fetch():
+            nonlocal calls
+            calls += 1
+            return TOKEN_INFO
+
+        await resolve_caller_identity(fetch, token=None)
+        await resolve_caller_identity(fetch, token=None)
+
+        assert calls == 1
+
+    async def test_does_not_retry_a_failing_lookup_when_the_server_holds_no_token(self):
+        """
+        GIVEN no bearer token and a GitGuardian API that is failing
+        WHEN identity is resolved repeatedly
+        THEN the failed lookup is not repeated
+        """
+        calls = 0
+
+        async def fetch():
+            nonlocal calls
+            calls += 1
+            raise RuntimeError("connection refused")
+
+        for _ in range(5):
+            await resolve_caller_identity(fetch, token=None)
+
+        assert calls == 1
+
+    async def test_evicts_one_entry_at_a_time_when_full(self):
+        """
+        GIVEN a cache filled to its bound
+        WHEN one more token is resolved
+        THEN only the oldest entry is dropped
+        """
+
+        async def fetch():
+            return TOKEN_INFO
+
+        for i in range(_IDENTITY_CACHE_MAX_ENTRIES):
+            await resolve_caller_identity(fetch, token=f"tok-{i}")
+        assert len(_identity_cache) == _IDENTITY_CACHE_MAX_ENTRIES
+
+        await resolve_caller_identity(fetch, token="tok-new")
+
+        assert len(_identity_cache) == _IDENTITY_CACHE_MAX_ENTRIES
+        assert _identity_cache_key("tok-0") not in _identity_cache
+        assert _identity_cache_key("tok-new") in _identity_cache
+
+    async def test_expires_after_the_ttl(self, monkeypatch):
+        """
+        GIVEN a cached identity older than the TTL
+        WHEN it is resolved again
+        THEN the API is queried afresh
+        """
+        calls = 0
+
+        async def fetch():
+            nonlocal calls
+            calls += 1
+            return TOKEN_INFO
+
+        await resolve_caller_identity(fetch, token="tok-a")
+        clock = [time.monotonic() + _IDENTITY_TTL_SECONDS + 1]
+        monkeypatch.setattr(time, "monotonic", lambda: clock[0])
+
+        await resolve_caller_identity(fetch, token="tok-a")
+
+        assert calls == 2
+
+
+class TestClearCallerIdentityCache:
+    async def test_revoking_one_token_leaves_other_tenants_cached(self):
+        """
+        GIVEN two tenants with cached identities
+        WHEN one token's entry is cleared
+        THEN the other tenant's entry survives
+        """
+        calls: dict[str, int] = {"a": 0, "b": 0}
+
+        def fetcher(name):
+            async def fetch():
+                calls[name] += 1
+                return TOKEN_INFO
+
+            return fetch
+
+        await resolve_caller_identity(fetcher("a"), token="tok-a")
+        await resolve_caller_identity(fetcher("b"), token="tok-b")
+
+        clear_caller_identity_cache("tok-a")
+
+        await resolve_caller_identity(fetcher("a"), token="tok-a")
+        await resolve_caller_identity(fetcher("b"), token="tok-b")
+
+        assert calls == {"a": 2, "b": 1}

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -4,6 +4,7 @@ import logging
 import pytest
 import structlog
 from gg_api_core.logging_config import configure_logging
+from gg_api_core.version import APP_VERSION
 
 
 def _reconfigure_json():
@@ -44,6 +45,7 @@ class TestConfigureLogging:
         assert payload["account_id"] == 475789
         assert payload["gg_service"] == "gg-mcp-server"
         assert payload["level"] == "info"
+        assert payload["gg_version"] == (APP_VERSION or "unknown")
 
     def test_structlog_kwargs_are_sanitized(self, capsys):
         _reconfigure_json()

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+import pytest
 import structlog
 from gg_api_core.logging_config import configure_logging
 
@@ -9,7 +10,25 @@ def _reconfigure_json():
     configure_logging(log_level="DEBUG", log_format="json")
 
 
+@pytest.fixture(scope="module")
+def _assert_structlog_configuration_restored():
+    """Assert the function-scoped logging fixture restores Structlog state."""
+    saved_config = structlog.get_config()
+    yield saved_config
+    assert structlog.get_config() == saved_config
+
+
 class TestConfigureLogging:
+    def test_configuration_does_not_leak_between_tests(self, _assert_structlog_configuration_restored):
+        """
+        GIVEN the process-global Structlog configuration before a test
+        WHEN configure_logging replaces its processor chain
+        THEN the autouse logging fixture restores the original configuration afterward
+        """
+        _reconfigure_json()
+
+        assert structlog.get_config() != _assert_structlog_configuration_restored
+
     def test_logs_go_to_stderr_not_stdout(self, capsys):
         _reconfigure_json()
         structlog.get_logger("t").info("hello")
@@ -59,3 +78,35 @@ class TestConfigureLogging:
             logging.getLogger("t.stdlib").exception("failed")
         payload = json.loads(capsys.readouterr().err.strip().splitlines()[-1])
         assert payload["exception_cls"] == "KeyError"
+
+    def test_bound_contextvars_reach_rendered_output(self, capsys):
+        """
+        GIVEN a value bound via structlog.contextvars
+        WHEN a line is emitted through the structlog and the stdlib logger
+        THEN both rendered payloads carry it
+
+        Guards ``merge_contextvars`` staying in *both* the structlog processor
+        chain and the ProcessorFormatter ``foreign_pre_chain``. Dropping it
+        from either silently strips ``request_id`` from production logs while
+        every contextvars-level unit test still passes.
+        """
+        _reconfigure_json()
+        with structlog.contextvars.bound_contextvars(
+            account_id=475789,
+            request_id="req-abc",
+            token_id="d0ca9877-641f-4c37-8857-c08e0ae148c4",
+        ):
+            structlog.get_logger("t").info("native")
+            # How ToolCallLoggingMiddleware actually emits: stdlib logger + extra.
+            logging.getLogger("t.stdlib").info("foreign", extra={"tool": "scan_secrets"})
+
+        native, foreign = (json.loads(line) for line in capsys.readouterr().err.strip().splitlines()[-2:])
+        assert native["event"] == "native"
+        assert native["account_id"] == 475789
+        assert native["request_id"] == "req-abc"
+        assert native["token_id"] == "d0ca9877-641f-4c37-8857-c08e0ae148c4"
+        assert foreign["event"] == "foreign"
+        assert foreign["account_id"] == 475789
+        assert foreign["request_id"] == "req-abc"
+        assert foreign["token_id"] == "d0ca9877-641f-4c37-8857-c08e0ae148c4"
+        assert foreign["tool"] == "scan_secrets"

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,414 @@
+import json
+import logging
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+import structlog
+from fastmcp import Client
+from fastmcp.tools import ToolResult
+from gg_api_core.log_context import clear_caller_identity_cache, record_downstream_call, record_truncation
+from gg_api_core.logging_config import configure_logging
+from gg_api_core.mcp_server import get_mcp_server
+from gg_api_core.middleware import RequestLoggingContextMiddleware, ToolCallLoggingMiddleware
+from mcp.types import TextContent
+
+TOKEN_INFO = {
+    "id": "tok-uuid",
+    "type": "personal_access_token",
+    "scopes": ["scan", "incidents:read"],
+    "member_id": 480870,
+    "workspace_id": 8,
+}
+
+
+def _ctx(name, arguments=None):
+    return SimpleNamespace(message=SimpleNamespace(name=name, arguments=arguments))
+
+
+def _message_ctx(message=None, session_id=None, method="tools/list"):
+    """A middleware context shaped like the fields the middleware reads."""
+    fastmcp_context = SimpleNamespace(session_id=session_id) if session_id else None
+    return SimpleNamespace(message=message, fastmcp_context=fastmcp_context, method=method)
+
+
+class FakeServer:
+    """Stands in for AbstractGitGuardianFastMCP's identity-resolution surface."""
+
+    authentication_mode = SimpleNamespace(value="TEST")
+
+    def __init__(self, token="tok-a", token_info=None):
+        self._token = token
+        self._token_info = TOKEN_INFO if token_info is None else token_info
+        self.token_info_calls = 0
+
+    def get_personal_access_token(self):
+        return self._token
+
+    async def get_token_info(self):
+        self.token_info_calls += 1
+        if isinstance(self._token_info, Exception):
+            raise self._token_info
+        return self._token_info
+
+
+@pytest.fixture(autouse=True)
+def _clean_identity_cache():
+    clear_caller_identity_cache(all_tokens=True)
+    yield
+    clear_caller_identity_cache(all_tokens=True)
+
+
+class TestToolCallLoggingMiddleware:
+    async def test_logs_successful_call(self, caplog):
+        """
+        GIVEN a tool call that succeeds
+        WHEN the call is handled
+        THEN a tool_call record carries the tool, status and elapsed time
+        """
+
+        async def call_next(ctx):
+            return "result"
+
+        with caplog.at_level(logging.INFO, logger="gg_api_core.middleware"):
+            result = await ToolCallLoggingMiddleware().on_call_tool(
+                _ctx("get_incident", {"incident_id": "123"}), call_next
+            )
+
+        assert result == "result"
+        rec = next(r for r in caplog.records if r.getMessage() == "tool_call")
+        assert rec.tool == "get_incident"
+        assert rec.status == "ok"
+        assert isinstance(rec.elapsed_ms, int)
+
+    async def test_logs_and_reraises_on_failure(self, caplog):
+        """
+        GIVEN a tool call that raises
+        WHEN the call is handled
+        THEN a tool_call_failed record is emitted and the error propagates
+        """
+
+        async def call_next(ctx):
+            raise ValueError("boom")
+
+        with caplog.at_level(logging.ERROR, logger="gg_api_core.middleware"):
+            with pytest.raises(ValueError, match="boom"):
+                await ToolCallLoggingMiddleware().on_call_tool(_ctx("scan_secrets"), call_next)
+
+        rec = next(r for r in caplog.records if r.getMessage() == "tool_call_failed")
+        assert rec.tool == "scan_secrets"
+        assert rec.exc_info is not None
+
+    async def test_pins_the_arguments_shape_when_none_are_sent(self, caplog):
+        """
+        GIVEN a tool call with no arguments
+        WHEN it is logged
+        THEN `arguments` is an empty mapping, not None
+        """
+
+        async def call_next(ctx):
+            return ToolResult(content=[])
+
+        with caplog.at_level(logging.INFO, logger="gg_api_core.middleware"):
+            await ToolCallLoggingMiddleware().on_call_tool(_ctx("list_detectors", None), call_next)
+
+        rec = next(r for r in caplog.records if r.getMessage() == "tool_call")
+        assert rec.arguments == {}
+
+    async def test_records_the_size_of_what_the_model_receives(self, caplog):
+        """
+        GIVEN a tool returning text content and a list of rows
+        WHEN the call is logged
+        THEN response size and item count are reported
+        """
+
+        async def call_next(ctx):
+            return ToolResult(
+                content=[TextContent(type="text", text='{"data": [1, 2, 3]}')],
+                structured_content={"data": [1, 2, 3]},
+            )
+
+        with caplog.at_level(logging.INFO, logger="gg_api_core.middleware"):
+            await ToolCallLoggingMiddleware().on_call_tool(_ctx("list_incidents"), call_next)
+
+        rec = next(r for r in caplog.records if r.getMessage() == "tool_call")
+        assert rec.result_bytes == len('{"data": [1, 2, 3]}')
+        assert rec.result_items == 3
+        assert rec.result_blocks == 1
+
+    async def test_splits_downstream_time_out_of_elapsed(self, caplog):
+        """
+        GIVEN a tool that makes two GitGuardian API calls
+        WHEN the call is logged
+        THEN downstream call count and time are reported separately
+        """
+
+        async def call_next(ctx):
+            record_downstream_call(duration_ms=30.0, status=200)
+            record_downstream_call(duration_ms=12.0, status=200)
+            return ToolResult(content=[])
+
+        with caplog.at_level(logging.INFO, logger="gg_api_core.middleware"):
+            await ToolCallLoggingMiddleware().on_call_tool(_ctx("get_incident"), call_next)
+
+        rec = next(r for r in caplog.records if r.getMessage() == "tool_call")
+        assert rec.downstream_calls == 2
+        assert rec.downstream_ms == 42
+        assert rec.downstream_statuses == [200]
+
+    async def test_flags_a_clipped_response(self, caplog):
+        """
+        GIVEN a tool whose pagination hit the byte cap
+        WHEN the call is logged
+        THEN the line is flagged as truncated
+        """
+
+        async def call_next(ctx):
+            record_truncation()
+            return ToolResult(content=[])
+
+        with caplog.at_level(logging.INFO, logger="gg_api_core.middleware"):
+            await ToolCallLoggingMiddleware().on_call_tool(_ctx("list_incidents"), call_next)
+
+        rec = next(r for r in caplog.records if r.getMessage() == "tool_call")
+        assert rec.truncated is True
+
+    async def test_grades_the_failure_on_the_failed_line(self, caplog):
+        """
+        GIVEN a tool failing with a wrapped GitGuardian 400
+        WHEN the failure is logged
+        THEN status, fault and error class are fields on that same line
+        """
+        request = httpx.Request("GET", "https://api.gitguardian.com/v1/incidents/secrets")
+        response = httpx.Response(400, json={"code": "invalid_severity"}, request=request)
+
+        async def call_next(ctx):
+            raise httpx.HTTPStatusError("bad request", request=request, response=response)
+
+        with caplog.at_level(logging.ERROR, logger="gg_api_core.middleware"):
+            with pytest.raises(httpx.HTTPStatusError):
+                await ToolCallLoggingMiddleware().on_call_tool(_ctx("list_incidents"), call_next)
+
+        rec = next(r for r in caplog.records if r.getMessage() == "tool_call_failed")
+        assert rec.upstream_status == 400
+        assert rec.fault == "client"
+        assert rec.gg_error_code == "invalid_severity"
+        assert rec.error_class == "httpx.HTTPStatusError"
+
+    async def test_downstream_stats_do_not_leak_between_calls(self, caplog):
+        """
+        GIVEN one tool call that made a downstream request
+        WHEN a second call makes none
+        THEN the second line reports zero downstream calls
+        """
+
+        async def call_next_with_downstream(ctx):
+            record_downstream_call(duration_ms=10.0, status=200)
+            return ToolResult(content=[])
+
+        async def call_next_without(ctx):
+            return ToolResult(content=[])
+
+        middleware = ToolCallLoggingMiddleware()
+        with caplog.at_level(logging.INFO, logger="gg_api_core.middleware"):
+            await middleware.on_call_tool(_ctx("get_incident"), call_next_with_downstream)
+            await middleware.on_call_tool(_ctx("list_detectors"), call_next_without)
+
+        first, second = (r for r in caplog.records if r.getMessage() == "tool_call")
+        assert first.downstream_calls == 1
+        assert second.downstream_calls == 0
+
+
+class TestRequestLoggingContextMiddleware:
+    async def test_binds_request_id_and_clears_after(self):
+        """
+        GIVEN an MCP message without a request ID
+        WHEN the message is handled
+        THEN a request ID is bound only for that message
+        """
+        seen: dict = {}
+
+        async def call_next(ctx):
+            seen.update(structlog.contextvars.get_contextvars())
+            return "ok"
+
+        result = await RequestLoggingContextMiddleware(FakeServer()).on_message(_message_ctx(), call_next)
+
+        assert result == "ok"
+        assert seen["request_id"]
+        assert "request_id" not in structlog.contextvars.get_contextvars()
+
+    async def test_prefers_inbound_x_request_id_header(self, monkeypatch):
+        """
+        GIVEN an MCP message with an X-Request-ID header
+        WHEN the message is handled
+        THEN the inbound request ID is bound
+        """
+        seen: dict = {}
+
+        async def call_next(ctx):
+            seen.update(structlog.contextvars.get_contextvars())
+            return "ok"
+
+        monkeypatch.setattr("gg_api_core.middleware.get_http_headers", lambda: {"x-request-id": "trace-123"})
+        await RequestLoggingContextMiddleware(FakeServer()).on_message(_message_ctx(), call_next)
+
+        assert seen["request_id"] == "trace-123"
+
+    @pytest.mark.parametrize("inbound", ["trace 123", "trace\nforged", "x" * 65, ""])
+    async def test_rejects_unsafe_inbound_request_id(self, monkeypatch, inbound):
+        """
+        GIVEN an X-Request-ID that is unsafe to stamp on every log line
+        WHEN the message is handled
+        THEN a fresh id is minted instead of adopting it
+        """
+        seen: dict = {}
+
+        async def call_next(ctx):
+            seen.update(structlog.contextvars.get_contextvars())
+            return "ok"
+
+        monkeypatch.setattr("gg_api_core.middleware.get_http_headers", lambda: {"x-request-id": inbound})
+        await RequestLoggingContextMiddleware(FakeServer()).on_message(_message_ctx(), call_next)
+
+        assert seen["request_id"] != inbound
+        uuid.UUID(seen["request_id"])
+
+    async def test_binds_caller_identity_and_session_and_user_agent(self, monkeypatch):
+        """
+        GIVEN a message from an authenticated caller over HTTP
+        WHEN the message is handled
+        THEN account, workspace, member, token, session and user-agent fields are all bound
+        """
+        seen: dict = {}
+
+        async def call_next(ctx):
+            seen.update(structlog.contextvars.get_contextvars())
+            return "ok"
+
+        monkeypatch.setattr("gg_api_core.middleware.get_http_headers", lambda: {"user-agent": "cursor/1.4.0"})
+        await RequestLoggingContextMiddleware(FakeServer()).on_message(_message_ctx(session_id="sess-1"), call_next)
+
+        assert seen["authentication_mode"] == "TEST"
+        assert seen["account_id"] == 8
+        assert seen["workspace_id"] == 8
+        assert seen["member_id"] == 480870
+        assert seen["token_id"] == "tok-uuid"
+        assert seen["mcp_session_id"] == "sess-1"
+        assert seen["user_agent"] == "cursor/1.4.0"
+        assert seen["token_scopes_hash"]
+
+    async def test_all_bound_fields_are_released_after_the_message(self, monkeypatch):
+        """
+        GIVEN a message that binds caller identity
+        WHEN the message completes
+        THEN none of the bound fields remain in the context
+        """
+
+        async def call_next(ctx):
+            return "ok"
+
+        monkeypatch.setattr("gg_api_core.middleware.get_http_headers", lambda: {"user-agent": "cursor/1.4.0"})
+        await RequestLoggingContextMiddleware(FakeServer()).on_message(_message_ctx(session_id="sess-1"), call_next)
+
+        assert structlog.contextvars.get_contextvars() == {}
+
+    async def test_unresolvable_caller_identity_does_not_fail_the_message(self):
+        """
+        GIVEN a token the API rejects
+        WHEN the message is handled
+        THEN the message still runs, without the identity fields
+        """
+        seen: dict = {}
+
+        async def call_next(ctx):
+            seen.update(structlog.contextvars.get_contextvars())
+            return "ok"
+
+        server = FakeServer(token_info=RuntimeError("401 Unauthorized"))
+        result = await RequestLoggingContextMiddleware(server).on_message(_message_ctx(), call_next)
+
+        assert result == "ok"
+        assert seen["request_id"]
+        assert "account_id" not in seen
+        assert "workspace_id" not in seen
+
+    async def test_identity_is_fetched_once_across_messages(self):
+        """
+        GIVEN several messages from the same token
+        WHEN each is handled
+        THEN token info is fetched only once
+        """
+
+        async def call_next(ctx):
+            return "ok"
+
+        server = FakeServer()
+        middleware = RequestLoggingContextMiddleware(server)
+        for _ in range(3):
+            await middleware.on_message(_message_ctx(), call_next)
+
+        assert server.token_info_calls == 1
+
+    async def test_logs_client_identity_on_initialize(self, caplog):
+        """
+        GIVEN an initialize request carrying clientInfo and a protocol version
+        WHEN it is handled
+        THEN an mcp_initialize event records both
+        """
+        params = SimpleNamespace(
+            clientInfo=SimpleNamespace(name="claude-ai", version="0.1.0"),
+            protocolVersion="2025-06-18",
+        )
+
+        async def call_next(ctx):
+            return None
+
+        with caplog.at_level(logging.INFO, logger="gg_api_core.middleware"):
+            await RequestLoggingContextMiddleware(FakeServer()).on_initialize(
+                _message_ctx(message=SimpleNamespace(params=params)), call_next
+            )
+
+        rec = next(r for r in caplog.records if r.getMessage() == "mcp_initialize")
+        assert rec.client_name == "claude-ai"
+        assert rec.client_version == "0.1.0"
+        assert rec.protocol_version == "2025-06-18"
+
+    async def test_every_middleware_log_carries_request_identity_through_the_real_stack(self, capsys):
+        """
+        GIVEN a server built by get_mcp_server
+        WHEN a tool is listed and called through the full middleware stack
+        THEN rendered lines from downstream middleware carry the request identity
+        """
+        mcp = get_mcp_server("Test Server")
+        mcp._fetch_token_scopes_from_api = AsyncMock(return_value={"scan"})
+        mcp.get_token_info = AsyncMock(return_value=TOKEN_INFO)
+
+        @mcp.tool(name="ping_tool", description="Tool used to drive the middleware stack")
+        async def ping_tool():
+            return "pong"
+
+        @mcp.tool(name="filtered_tool", description="Tool the token cannot satisfy", required_scopes=["nope:write"])
+        async def filtered_tool():
+            return "unreachable"
+
+        configure_logging(log_level="INFO", log_format="json")
+        async with Client(mcp) as client:
+            await client.list_tools()
+            await client.call_tool("ping_tool", {})
+
+        rendered = [json.loads(line) for line in capsys.readouterr().err.strip().splitlines() if line.startswith("{")]
+
+        tool_call = next(payload for payload in rendered if payload["event"] == "tool_call")
+        assert tool_call["tool"] == "ping_tool"
+        assert tool_call["authentication_mode"] == mcp.authentication_mode.value
+        assert tool_call["request_id"]
+        assert tool_call["account_id"] == TOKEN_INFO["workspace_id"]
+        assert tool_call["token_id"] == TOKEN_INFO["id"]
+
+        list_tools = next(payload for payload in rendered if payload["event"] == "list_tools")
+        assert list_tools["request_id"]
+        assert list_tools["account_id"] == TOKEN_INFO["workspace_id"]
+        assert list_tools["token_id"] == TOKEN_INFO["id"]

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -81,7 +81,7 @@ class TestToolCallLoggingMiddleware:
         rec = next(r for r in caplog.records if r.getMessage() == "tool_call")
         assert rec.tool == "get_incident"
         assert rec.status == "ok"
-        assert isinstance(rec.elapsed_ms, int)
+        assert isinstance(rec.duration_ms, int)
 
     async def test_logs_and_reraises_on_failure(self, caplog):
         """

--- a/tests/test_oauth_funnel_logging.py
+++ b/tests/test_oauth_funnel_logging.py
@@ -1,0 +1,165 @@
+"""Structured events for the OAuth proxy funnel."""
+
+import logging
+
+import httpx
+import pytest
+from gg_api_core.oauth_proxy_auth import create_oauth_proxy, mark_downstream_unauthorized
+from starlette.requests import Request
+
+LOGGER = "gg_api_core.oauth_proxy_auth"
+
+
+def _request(method="POST", body=b"", query="", headers=None):
+    """A Starlette request with a pre-read body."""
+    raw_headers = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": "/token",
+        "query_string": query.encode(),
+        "headers": raw_headers,
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(scope, receive)
+
+
+@pytest.fixture
+def proxy():
+    return create_oauth_proxy(base_url="https://mcp.example.com")
+
+
+def _steps(caplog):
+    return {r.oauth_step: r for r in caplog.records if r.getMessage() == "oauth_step"}
+
+
+class TestOAuthFunnelEvents:
+    async def test_registration_is_recorded_with_its_status(self, proxy, caplog, monkeypatch):
+        """
+        GIVEN a client registering via DCR
+        WHEN the proxy forwards the registration
+        THEN an oauth_step event records the outcome and status
+        """
+        monkeypatch.setattr(
+            httpx.AsyncClient,
+            "post",
+            _responding(httpx.Response(201, json={"client_id": "c-1"})),
+        )
+
+        with caplog.at_level(logging.INFO, logger=LOGGER):
+            await proxy._handle_register(_request(body=b"{}", headers={"user-agent": "claude-ai/1.0"}))
+
+        step = _steps(caplog)["register"]
+        assert step.outcome == "ok"
+        assert step.status == 201
+        assert step.user_agent == "claude-ai/1.0"
+
+    async def test_a_rejected_registration_is_recorded_as_an_error(self, proxy, caplog, monkeypatch):
+        """
+        GIVEN a registration the GitGuardian backend rejects
+        WHEN the proxy forwards it
+        THEN the event records an error outcome with the upstream status
+        """
+        monkeypatch.setattr(
+            httpx.AsyncClient,
+            "post",
+            _responding(httpx.Response(400, json={"error": "invalid_redirect_uri"})),
+        )
+
+        with caplog.at_level(logging.INFO, logger=LOGGER):
+            await proxy._handle_register(_request(body=b"{}"))
+
+        step = _steps(caplog)["register"]
+        assert step.outcome == "error"
+        assert step.status == 400
+
+    async def test_authorize_records_the_client_and_pkce_method(self, proxy, caplog):
+        """
+        GIVEN an authorize request using PKCE
+        WHEN the proxy redirects to the dashboard
+        THEN the event records the client id and the challenge method
+        """
+        with caplog.at_level(logging.INFO, logger=LOGGER):
+            await proxy._handle_authorize(
+                _request(method="GET", query="client_id=c-1&code_challenge_method=S256&state=xyz")
+            )
+
+        step = _steps(caplog)["authorize"]
+        assert step.outcome == "redirected"
+        assert step.oauth_client_id == "c-1"
+        assert step.pkce == "S256"
+
+    async def test_token_exchange_records_the_grant_type(self, proxy, caplog, monkeypatch):
+        """
+        GIVEN a successful authorization-code exchange
+        WHEN the proxy transforms the response
+        THEN the event records grant type, client and a success outcome
+        """
+        monkeypatch.setattr(
+            httpx.AsyncClient,
+            "post",
+            _responding(httpx.Response(200, json={"key": "gg-pat", "scope": ["scan"]})),
+        )
+
+        with caplog.at_level(logging.INFO, logger=LOGGER):
+            await proxy._handle_token(_request(body=b"grant_type=authorization_code&client_id=c-1&code=abc"))
+
+        step = _steps(caplog)["token"]
+        assert step.outcome == "ok"
+        assert step.status == 200
+        assert step.grant_type == "authorization_code"
+        assert step.oauth_client_id == "c-1"
+
+    async def test_a_token_response_without_an_access_token_is_recorded(self, proxy, caplog, monkeypatch):
+        """
+        GIVEN an upstream 200 carrying no usable token
+        WHEN the proxy handles it
+        THEN the event distinguishes this from a plain upstream error
+        """
+        monkeypatch.setattr(httpx.AsyncClient, "post", _responding(httpx.Response(200, json={})))
+
+        with caplog.at_level(logging.INFO, logger=LOGGER):
+            await proxy._handle_token(_request(body=b"grant_type=authorization_code&client_id=c-1"))
+
+        assert _steps(caplog)["token"].outcome == "missing_access_token"
+
+    async def test_a_downstream_401_is_recorded(self, caplog):
+        """
+        GIVEN a tool call the GitGuardian API rejects as unauthorized
+        WHEN the request is flagged for re-authentication
+        THEN an oauth_step event records it
+        """
+        with caplog.at_level(logging.INFO, logger=LOGGER):
+            mark_downstream_unauthorized()
+
+        step = _steps(caplog)["downstream_unauthorized"]
+        assert step.outcome == "reauth_required"
+        assert step.status == 401
+
+    async def test_no_secret_material_appears_in_the_events(self, proxy, caplog, monkeypatch):
+        """
+        GIVEN a token exchange whose form body carries a code and whose response carries a PAT
+        WHEN the exchange is logged
+        THEN neither the code nor the token appears in the event
+        """
+        monkeypatch.setattr(httpx.AsyncClient, "post", _responding(httpx.Response(200, json={"key": "gg-pat-secret"})))
+
+        with caplog.at_level(logging.INFO, logger=LOGGER):
+            await proxy._handle_token(_request(body=b"grant_type=authorization_code&code=secret-code&client_id=c-1"))
+
+        rendered = str(_steps(caplog)["token"].__dict__)
+        assert "gg-pat-secret" not in rendered
+        assert "secret-code" not in rendered
+
+
+def _responding(response: httpx.Response):
+    """Replacement for ``AsyncClient.post`` returning a fixed response."""
+
+    async def post(self, url, **kwargs):
+        response.request = httpx.Request("POST", url)
+        return response
+
+    return post

--- a/tests/test_protocol_lifecycle_logging.py
+++ b/tests/test_protocol_lifecycle_logging.py
@@ -1,0 +1,155 @@
+"""Protocol events exercised through a real FastMCP client."""
+
+import logging
+
+import pytest
+from fastmcp import Client, FastMCP
+from gg_api_core.middleware import RequestLoggingContextMiddleware, ScopeFilteringMiddleware
+
+from tests.test_middleware import FakeServer
+
+
+class FakeScopedServer(FakeServer):
+    """A FakeServer that also answers the scope-filtering surface."""
+
+    def __init__(self, scopes, tool_scopes):
+        super().__init__()
+        self._scopes = scopes
+        self._tool_scopes = tool_scopes
+
+    async def get_scopes(self):
+        return self._scopes
+
+
+@pytest.fixture
+def server():
+    mcp = FastMCP("lifecycle")
+    mcp.add_middleware(RequestLoggingContextMiddleware(FakeServer()))
+
+    @mcp.tool
+    async def visible_tool() -> str:
+        return "ok"
+
+    @mcp.resource("data://sample")
+    async def sample_resource() -> str:
+        return "sample"
+
+    @mcp.prompt
+    async def sample_prompt() -> str:
+        return "prompt"
+
+    return mcp
+
+
+def _events(caplog, name):
+    return [r for r in caplog.records if r.getMessage() == name]
+
+
+class TestProtocolLifecycleEvents:
+    async def test_every_dispatched_protocol_method_is_recorded(self, server, caplog):
+        """
+        GIVEN a client that connects and exercises the list and read methods
+        WHEN the session runs
+        THEN each method produces an mcp_request line
+        """
+        with caplog.at_level(logging.INFO, logger="gg_api_core.middleware"):
+            async with Client(server) as client:
+                await client.list_tools()
+                await client.list_resources()
+                await client.list_prompts()
+
+        methods = [r.mcp_method for r in _events(caplog, "mcp_request")]
+        assert "initialize" in methods
+        assert "tools/list" in methods
+        assert "resources/list" in methods
+        assert "prompts/list" in methods
+
+    async def test_ping_is_not_dispatched_through_middleware(self, server, caplog):
+        """
+        GIVEN a client that pings
+        WHEN the ping is answered
+        THEN no mcp_request line is emitted
+        """
+        with caplog.at_level(logging.INFO, logger="gg_api_core.middleware"):
+            async with Client(server) as client:
+                caplog.clear()
+                await client.ping()
+
+        assert _events(caplog, "mcp_request") == []
+
+    async def test_tool_calls_are_not_double_logged(self, server, caplog):
+        """
+        GIVEN a tool call
+        WHEN it is handled
+        THEN no mcp_request line is emitted for it
+        """
+        with caplog.at_level(logging.INFO, logger="gg_api_core.middleware"):
+            async with Client(server) as client:
+                await client.call_tool("visible_tool", {})
+
+        methods = [r.mcp_method for r in _events(caplog, "mcp_request")]
+        assert "tools/call" not in methods
+
+    async def test_initialize_records_the_client_and_protocol_version(self, server, caplog):
+        """
+        GIVEN a client connecting
+        WHEN the handshake completes
+        THEN mcp_initialize names the client and the protocol revision
+        """
+        with caplog.at_level(logging.INFO, logger="gg_api_core.middleware"):
+            async with Client(server):
+                pass
+
+        (rec,) = _events(caplog, "mcp_initialize")
+        assert rec.client_name
+        assert rec.protocol_version
+
+
+class TestListToolsCounts:
+    async def test_reports_exposed_and_hidden_counts_in_one_event(self, caplog):
+        """
+        GIVEN a token whose scopes hide one of two tools
+        WHEN tools are listed
+        THEN a single list_tools event carries both counts and the hidden names
+        """
+        mcp = FastMCP("scoped")
+        fake = FakeScopedServer(scopes={"scan"}, tool_scopes={"needs_incidents": {"incidents:read"}})
+        mcp.add_middleware(ScopeFilteringMiddleware(fake))
+
+        @mcp.tool
+        async def scan_tool() -> str:
+            return "ok"
+
+        @mcp.tool(name="needs_incidents")
+        async def needs_incidents() -> str:
+            return "ok"
+
+        with caplog.at_level(logging.DEBUG, logger="gg_api_core.middleware"):
+            async with Client(mcp) as client:
+                tools = await client.list_tools()
+
+        assert [t.name for t in tools] == ["scan_tool"]
+        (rec,) = _events(caplog, "list_tools")
+        assert rec.tools_exposed == 1
+        assert rec.tools_hidden == 1
+        assert rec.hidden_tools == ["needs_incidents"]
+
+    async def test_per_tool_removal_lines_are_debug_only(self, caplog):
+        """
+        GIVEN a hidden tool
+        WHEN tools are listed at INFO
+        THEN no per-tool removal line is emitted
+        """
+        mcp = FastMCP("scoped")
+        fake = FakeScopedServer(scopes={"scan"}, tool_scopes={"needs_incidents": {"incidents:read"}})
+        mcp.add_middleware(ScopeFilteringMiddleware(fake))
+
+        @mcp.tool(name="needs_incidents")
+        async def needs_incidents() -> str:
+            return "ok"
+
+        with caplog.at_level(logging.INFO, logger="gg_api_core.middleware"):
+            async with Client(mcp) as client:
+                await client.list_tools()
+
+        assert not [r for r in caplog.records if "Removing tool" in r.getMessage()]

--- a/tests/test_sanitization.py
+++ b/tests/test_sanitization.py
@@ -21,6 +21,7 @@ class TestScrubByName:
             ("document", "raw secret material", PLACEHOLDER),
             # benign key -> value kept
             ("account_id", 475789, 475789),
+            ("token_id", "d0ca9877-641f-4c37-8857-c08e0ae148c4", "d0ca9877-641f-4c37-8857-c08e0ae148c4"),
             ("endpoint", "/v1/incidents", "/v1/incidents"),
             # benign key whose value carries a secret shape -> value-scrubbed
             ("url", "https://gg.com/cb?token=abc&safe=1", f"https://gg.com/cb?token={PLACEHOLDER}&safe=1"),

--- a/tests/test_sentry_integration.py
+++ b/tests/test_sentry_integration.py
@@ -1,0 +1,27 @@
+from gg_api_core.sentry_integration import _prepare_sentry_event
+
+
+class TestPrepareSentryEvent:
+    def test_tags_event_with_request_id_from_trace_data(self):
+        """
+        GIVEN an event containing the active MCP span data
+        WHEN the event is prepared for Sentry
+        THEN its request ID is promoted without replacing existing tags
+        """
+        event = _prepare_sentry_event(
+            {
+                "contexts": {"trace": {"data": {"request_id": "req-mcp"}}},
+                "tags": {"existing": "kept"},
+            },
+            {},
+        )
+
+        assert event["tags"] == {"existing": "kept", "request_id": "req-mcp"}
+
+    def test_leaves_event_untagged_without_request_trace_data(self):
+        """
+        GIVEN an event without MCP request trace data
+        WHEN the event is prepared for Sentry
+        THEN no request ID tag is added
+        """
+        assert _prepare_sentry_event({}, {}) == {}

--- a/tests/test_sentry_logging.py
+++ b/tests/test_sentry_logging.py
@@ -135,11 +135,11 @@ class TestSentryCaptureOwnership:
         assert "raw scan payload" not in rendered
         assert "scan_secrets" in rendered
 
-    async def test_mcp_integration_is_the_only_tool_failure_owner(self, sentry_events):
+    async def test_mcp_integration_is_the_only_tool_failure_owner(self, sentry_events, monkeypatch):
         """
         GIVEN a real MCP tool that raises an exception
         WHEN it is called through the middleware stack
-        THEN MCPIntegration produces exactly one Sentry event
+        THEN MCPIntegration produces one event correlated with its tool log
         """
         mcp = get_mcp_server("Sentry ownership test")
         mcp._fetch_token_scopes_from_api = AsyncMock(return_value=set())
@@ -149,6 +149,7 @@ class TestSentryCaptureOwnership:
         async def failing_tool():
             raise RuntimeError("tool exploded")
 
+        monkeypatch.setattr("gg_api_core.middleware.get_http_headers", lambda: {"x-request-id": "req-sentry"})
         configure_logging(log_level="DEBUG", log_format="json")
         async with Client(mcp) as client:
             with pytest.raises(ToolError):
@@ -158,6 +159,8 @@ class TestSentryCaptureOwnership:
         event = sentry_events[0]
         exception_types = [value["type"] for value in event["exception"]["values"]]
         assert exception_types == ["RuntimeError", "ToolError"]
+
+        assert event["tags"]["request_id"] == "req-sentry"
 
     def test_rendered_traceback_remains_scrubbed(self, sentry_events, capsys):
         """

--- a/tests/test_sentry_logging.py
+++ b/tests/test_sentry_logging.py
@@ -1,0 +1,178 @@
+"""Sentry capture ownership and payload safety."""
+
+import json
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+import sentry_sdk
+import structlog
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+from gg_api_core.logging_config import configure_logging
+from gg_api_core.mcp_server import get_mcp_server
+from gg_api_core.sentry_integration import _MAX_SCRUB_DEPTH, _scrub_sentry_payload, init_sentry
+from sentry_sdk.transport import Transport
+
+
+class _CollectingTransport(Transport):
+    """Keep captured Sentry events in memory."""
+
+    def __init__(self, events: list[dict]):
+        super().__init__()
+        self._events = events
+
+    def capture_envelope(self, envelope) -> None:
+        event = envelope.get_event()
+        if event is not None:
+            self._events.append(event)
+
+
+@pytest.fixture
+def sentry_events(monkeypatch):
+    """Initialize the production Sentry configuration with a local transport."""
+    events: list[dict] = []
+    real_init = sentry_sdk.init
+
+    def init_with_local_transport(**kwargs):
+        return real_init(**kwargs, transport=_CollectingTransport(events))
+
+    monkeypatch.setattr(sentry_sdk, "init", init_with_local_transport)
+    monkeypatch.setenv("SENTRY_DSN", "https://public@localhost/1")
+    assert init_sentry() is True
+    sentry_sdk.get_isolation_scope().clear_breadcrumbs()
+    try:
+        yield events
+    finally:
+        sentry_sdk.get_isolation_scope().clear_breadcrumbs()
+        sentry_sdk.get_global_scope().set_client(None)
+
+
+class TestSentryPayloadScrubbing:
+    def test_depth_limit_redacts_the_remaining_subtree(self):
+        """
+        GIVEN a secret beyond the payload scrubber's depth limit
+        WHEN the payload is scrubbed
+        THEN the recursion guard redacts the remaining subtree
+        """
+        secret = "deep-secret"
+        payload: object = f"https://example.com?apikey={secret}"
+        for _ in range(_MAX_SCRUB_DEPTH + 1):
+            payload = {"nested": payload}
+
+        assert secret not in json.dumps(_scrub_sentry_payload(payload))
+
+    def test_captured_exception_is_value_scrubbed(self, sentry_events):
+        """
+        GIVEN an exception message containing credentials
+        WHEN the capture owner sends it to Sentry
+        THEN the final payload contains no credential
+        """
+        password = "hunter" + "2"
+        try:
+            raise ValueError(f"failed for https://user:{password}@github.com/acme/repo")
+        except ValueError as exc:
+            sentry_sdk.capture_exception(exc)
+
+        (event,) = sentry_events
+        assert password not in json.dumps(event, default=str)
+        assert event["exception"]["values"][-1]["type"] == "ValueError"
+
+    def test_frame_locals_are_not_sent(self, sentry_events):
+        """
+        GIVEN an exception frame containing a local value
+        WHEN the capture owner sends it to Sentry
+        THEN the stack frames contain no local variables
+        """
+
+        def scan():
+            document = "some-scan-payload"  # noqa: F841
+            raise RuntimeError("scan failed")
+
+        try:
+            scan()
+        except RuntimeError as exc:
+            sentry_sdk.capture_exception(exc)
+
+        (event,) = sentry_events
+        frames = event["exception"]["values"][-1]["stacktrace"]["frames"]
+        assert frames
+        assert all("vars" not in frame for frame in frames)
+
+
+class TestSentryCaptureOwnership:
+    def test_error_log_is_a_breadcrumb_not_an_event(self, sentry_events):
+        """
+        GIVEN Sentry logging receives an ERROR record
+        WHEN the record is emitted
+        THEN it creates no Sentry event
+        """
+        configure_logging(log_level="DEBUG", log_format="json")
+        try:
+            raise KeyError("missing-field")
+        except KeyError:
+            logging.getLogger("t.stdlib").exception("tool_call_failed")
+
+        assert sentry_events == []
+
+    def test_logging_breadcrumb_is_scrubbed(self, sentry_events):
+        """
+        GIVEN a log record containing sensitive message and extra data
+        WHEN another owner captures an exception
+        THEN its attached breadcrumb contains only scrubbed data
+        """
+        configure_logging(log_level="DEBUG", log_format="json")
+        logging.getLogger("t.stdlib").error(
+            "tool_call_failed ?apikey=RAWKEY123",
+            extra={"document": "raw scan payload", "tool": "scan_secrets"},
+        )
+        sentry_sdk.capture_exception(RuntimeError("capture owner"))
+
+        (event,) = sentry_events
+        breadcrumbs = event.get("breadcrumbs", {})
+        rendered = json.dumps(breadcrumbs, default=str)
+        assert "RAWKEY123" not in rendered
+        assert "raw scan payload" not in rendered
+        assert "scan_secrets" in rendered
+
+    async def test_mcp_integration_is_the_only_tool_failure_owner(self, sentry_events):
+        """
+        GIVEN a real MCP tool that raises an exception
+        WHEN it is called through the middleware stack
+        THEN MCPIntegration produces exactly one Sentry event
+        """
+        mcp = get_mcp_server("Sentry ownership test")
+        mcp._fetch_token_scopes_from_api = AsyncMock(return_value=set())
+        mcp.get_token_info = AsyncMock(return_value={})
+
+        @mcp.tool(name="failing_tool")
+        async def failing_tool():
+            raise RuntimeError("tool exploded")
+
+        configure_logging(log_level="DEBUG", log_format="json")
+        async with Client(mcp) as client:
+            with pytest.raises(ToolError):
+                await client.call_tool("failing_tool", {})
+
+        assert len(sentry_events) == 1
+        event = sentry_events[0]
+        exception_types = [value["type"] for value in event["exception"]["values"]]
+        assert exception_types == ["RuntimeError", "ToolError"]
+
+    def test_rendered_traceback_remains_scrubbed(self, sentry_events, capsys):
+        """
+        GIVEN an exception log containing credentials
+        WHEN it is rendered to stderr
+        THEN the log keeps the traceback but removes the credentials
+        """
+        configure_logging(log_level="DEBUG", log_format="json")
+        try:
+            raise ValueError("failed for https://user:hunter2@github.com/acme/repo")
+        except ValueError:
+            structlog.get_logger("t").exception("tool_call_failed")
+
+        payload = json.loads(capsys.readouterr().err.strip().splitlines()[-1])
+        assert "ValueError" in payload["exception"]
+        assert "hunter2" not in payload["exception"]
+        assert payload["exception_cls"] == "ValueError"
+        assert sentry_events == []

--- a/tests/test_tool_logging_middleware.py
+++ b/tests/test_tool_logging_middleware.py
@@ -23,7 +23,7 @@ class TestToolCallLoggingMiddleware:
         rec = next(r for r in caplog.records if r.getMessage() == "tool_call")
         assert rec.tool == "get_incident"
         assert rec.status == "ok"
-        assert isinstance(rec.elapsed_ms, int)
+        assert isinstance(rec.duration_ms, int)
 
     async def test_logs_and_reraises_on_failure(self, caplog):
         async def call_next(ctx):

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,34 @@
+from importlib.metadata import PackageNotFoundError
+from unittest.mock import Mock
+
+from gg_api_core.version import resolve_app_version
+
+
+class TestResolveAppVersion:
+    """Tests for application release metadata lookup."""
+
+    def test_returns_the_umbrella_distribution_version(self, monkeypatch):
+        """
+        GIVEN the ggmcp distribution metadata is installed
+        WHEN the application version is resolved
+        THEN its release number is returned
+        """
+        package_version = Mock(return_value="1.2.3")
+        monkeypatch.setattr("gg_api_core.version.package_version", package_version)
+
+        assert resolve_app_version() == "1.2.3"
+        package_version.assert_called_once_with("ggmcp")
+
+    def test_returns_none_when_distribution_metadata_is_unavailable(self, monkeypatch):
+        """
+        GIVEN the ggmcp distribution metadata is unavailable
+        WHEN the application version is resolved
+        THEN the absence is represented explicitly
+        """
+
+        def missing_distribution(distribution: str) -> str:
+            raise PackageNotFoundError(distribution)
+
+        monkeypatch.setattr("gg_api_core.version.package_version", missing_distribution)
+
+        assert resolve_app_version() is None

--- a/uv.lock
+++ b/uv.lock
@@ -541,7 +541,7 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.12" },
     { name = "pydantic-settings", specifier = "~=2.9" },
     { name = "python-dotenv", specifier = "~=1.1" },
-    { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = "~=2.43" },
+    { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = "~=2.45" },
     { name = "structlog", specifier = "~=26.1" },
 ]
 provides-extras = ["sentry"]
@@ -589,6 +589,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "gg-api-core", extra = ["sentry"] },
     { name = "pyrefly" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -612,6 +613,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "gg-api-core", extras = ["sentry"], editable = "packages/gg_api_core" },
     { name = "pyrefly", specifier = ">=1.1.1" },
     { name = "pytest", specifier = "~=8.4" },
     { name = "pytest-asyncio", specifier = "~=1.2" },


### PR DESCRIPTION
## Summary

Closes [SI-3888](https://linear.app/gitguardian/issue/SI-3888/consolidate-mcp-logging-on-top-of-the-structlog-foundation) and [SI-3912](https://linear.app/gitguardian/issue/SI-3912/enrich-structured-logs-with-gg-version-and-request-id).

Builds on the structlog foundation with consistent release, request, and caller context plus structured events across the MCP, GitGuardian API, pagination, and OAuth boundaries. It also makes Sentry ownership explicit, correlates Sentry failures with request logs, and hardens payload redaction.

## Changes

- Stamp every structured event with the installed `ggmcp` release as `gg_version` and reuse it in the GitGuardian API User-Agent.
- Bind request and caller context to request-scoped logs: `request_id`, `mcp_session_id`, `user_agent`, authentication mode, workspace/member/token identity, scope hash, and GitGuardian host.
- Promote the active MCP `request_id` to Sentry event tags for direct log correlation.
- Add structured `api_request`, `mcp_request`, `mcp_initialize`, `list_tools`, `pagination_complete`, and `oauth_step` events, and enrich tool events with downstream timing, retry, result-size, and truncation metrics.
- Classify failures as `client` or `server` faults and expose safe upstream status/error-code fields.
- Keep Sentry's `MCPIntegration` as the sole owner of MCP exception events. Logging remains breadcrumb-only; SDK-boundary hooks scrub breadcrumbs and events, and frame locals are disabled.
- Require a Sentry SDK version with default MCP integration support and install the optional integration in development.
- Reduce default third-party request noise while preserving it at `LOG_LEVEL=DEBUG`.
- Document the field/event reference and observability constraints in `DEVELOPMENT.md`.

## MCP behavior

There is no intended change to MCP tool schemas, inputs, outputs, authentication, scope filtering, or protocol responses.

The observable runtime differences are limited to:

- The first message for a token resolves `/api_tokens/self` to enrich logs; the result is cached for five minutes and lookup failures never fail the MCP message.
- Requests pass through the new logging middleware, adding a small amount of processing overhead.
- Logging and Sentry capture behavior changes as described above.

## Logs: before and after

### Before

A tool call carried only the operation, arguments, outcome, and total elapsed time:

```json
{
  "event": "tool_call",
  "tool": "list_incidents",
  "arguments": {"params": {"severity": ["high"]}},
  "status": "ok",
  "elapsed_ms": 842,
  "gg_service": "gg-mcp-server",
  "level": "info",
  "logger": "gg_api_core.middleware"
}
```

### After

The same line can be correlated to its caller and downstream work, and uses the shared `duration_ms` timing field:

```json
{
  "event": "tool_call",
  "tool": "list_incidents",
  "arguments": {"params": {"severity": ["high"]}},
  "status": "ok",
  "duration_ms": 842,
  "result_blocks": 1,
  "result_bytes": 12400,
  "result_items": 25,
  "downstream_calls": 3,
  "downstream_ms": 720,
  "downstream_retries": 0,
  "downstream_statuses": [200],
  "truncated": false,
  "request_id": "req-7f21",
  "mcp_session_id": "session-a92",
  "user_agent": "Cursor/1.4.0",
  "authentication_mode": "OAUTH_PROXY",
  "account_id": 42,
  "workspace_id": 42,
  "member_id": 918,
  "token_id": "token-uuid",
  "token_type": "personal_access_token",
  "token_scopes_hash": "ad73b428c901",
  "gg_host": "api.gitguardian.com",
  "gg_service": "gg-mcp-server",
  "gg_version": "0.6.10",
  "level": "info",
  "logger": "gg_api_core.middleware"
}
```

Each downstream attempt also has its own line carrying the same `request_id`:

```json
{
  "event": "api_request",
  "method": "GET",
  "path": "/incidents/secrets/{id}",
  "status": 200,
  "duration_ms": 240,
  "gg_request_id": "gg-api-8af2",
  "request_id": "req-7f21",
  "gg_service": "gg-mcp-server",
  "gg_version": "0.6.10"
}
```

## Design notes

- Caller identity is cached for five minutes per token and is used only for logging; it never affects authorization or scope filtering.
- `account_id` intentionally aliases the GitGuardian API's `workspace_id` for cross-service correlation.
- Under the stateless transport, `clientInfo` is observable only during `initialize`, and `ping` is handled below FastMCP middleware.
- Events-to-metrics configuration belongs in Coralogix and remains out of scope.

## Test plan

- Unit suite: 1050 passed, 3 skipped, 9 xfailed
- VCR suite: 181 passed
- Ruff lint and format checks
- Pyrefly type check
