### PR TITLE
test(e2e): remote MCP regression suite over the production ASGI app (SI-3891)

### DIFF
--- a/packages/gg_mcp_server/src/gg_mcp_server/http_app.py
+++ b/packages/gg_mcp_server/src/gg_mcp_server/http_app.py
@@ -9,24 +9,13 @@ For local development, use the run_http_with_uvicorn() function instead.
 
 import logging
 
-from fastmcp.server.http import create_streamable_http_app
-
-from gg_mcp_server.server import get_server
+from gg_mcp_server.server import build_http_app, get_server
 
 logger = logging.getLogger(__name__)
 
 mcp = get_server()
 
-# StreamableHTTP with json_response=True and stateless_http=True allows
-# horizontal scaling without sticky sessions since no session state is
-# maintained between requests.
-http_app = create_streamable_http_app(
-    server=mcp,
-    streamable_http_path="/mcp",
-    auth=mcp.auth,
-    json_response=True,
-    stateless_http=True,
-)
+http_app = build_http_app(mcp)
 
 # Backward-compatible alias for callers (e.g. gunicorn configs) that imported
 # the SecOps server's ``app`` attribute.

--- a/packages/gg_mcp_server/src/gg_mcp_server/server.py
+++ b/packages/gg_mcp_server/src/gg_mcp_server/server.py
@@ -7,6 +7,7 @@ current token cannot satisfy are filtered out at list-tools time.
 import logging
 from functools import cache
 
+from fastmcp.server.http import create_streamable_http_app
 from gg_api_core.logging_config import configure_logging_from_settings
 from gg_api_core.mcp_server import (
     AbstractGitGuardianFastMCP,
@@ -15,11 +16,44 @@ from gg_api_core.mcp_server import (
 )
 from gg_api_core.sentry_integration import init_sentry
 from gg_api_core.settings import get_settings
+from starlette.applications import Starlette
 
 from gg_mcp_server.add_health_check import add_health_check
 from gg_mcp_server.register_tools import GITGUARDIAN_INSTRUCTIONS, register_tools
 
 logger = logging.getLogger(__name__)
+
+
+def build_server() -> AbstractGitGuardianFastMCP:
+    """Compose the GitGuardian MCP server: auth mode, tools, health check.
+
+    Pure composition, no process-level side effects (Sentry, logging), so
+    tests can build fresh instances of the exact production server.
+    """
+    mcp = get_mcp_server(
+        "GitGuardian",
+        instructions=GITGUARDIAN_INSTRUCTIONS,
+    )
+    register_tools(mcp)
+    register_common_tools(mcp)
+    add_health_check(mcp)
+    return mcp
+
+
+def build_http_app(mcp: AbstractGitGuardianFastMCP) -> Starlette:
+    """Wrap the server in its production StreamableHTTP ASGI app.
+
+    json_response=True and stateless_http=True allow horizontal scaling
+    without sticky sessions since no session state is maintained between
+    requests.
+    """
+    return create_streamable_http_app(
+        server=mcp,
+        streamable_http_path="/mcp",
+        auth=mcp.auth,
+        json_response=True,
+        stateless_http=True,
+    )
 
 
 @cache
@@ -34,13 +68,7 @@ def get_server() -> AbstractGitGuardianFastMCP:
     """
     init_sentry()
     configure_logging_from_settings(get_settings())
-    mcp = get_mcp_server(
-        "GitGuardian",
-        instructions=GITGUARDIAN_INSTRUCTIONS,
-    )
-    register_tools(mcp)
-    register_common_tools(mcp)
-    add_health_check(mcp)
+    mcp = build_server()
     logger.info("GitGuardian MCP server instance created and configured")
     return mcp
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ dev = [
     "pyyaml~=6.0",
     "pyrefly>=1.1.1",
     "respx~=0.22",
+    "pytest-socket~=0.7",
+    "pytest-voluptuous~=1.2",
 ]
 
 [project.scripts]
@@ -113,6 +115,8 @@ line-ending = "auto"
 docstring-code-format = true
 
 [tool.pytest.ini_options]
+# asyncio uses a local socketpair; TCP and UDP remain blocked by the e2e fixture.
+addopts = ["--allow-unix-socket"]
 asyncio_mode = "auto"
 python_files = ["test_*.py"]
 python_classes = ["Test*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
     "vcrpy~=8.0",
     "pyyaml~=6.0",
     "pyrefly>=1.1.1",
+    "respx~=0.22",
 ]
 
 [project.scripts]

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -6,8 +6,9 @@ StreamableHTTP transport in stateless JSON mode) and drives it with raw
 JSON-RPC 2.0 requests over an in-process httpx client.
 
 Only the outbound GitGuardian API is faked, with respx (which patches httpx's
-real AsyncHTTPTransport but not the ASGITransport used to reach the app). So
-each test exercises the full production path:
+real AsyncHTTPTransport but not the ASGITransport used to reach the app).
+pytest-socket blocks any other real network access. So each test exercises the
+full production path:
 
     JSON-RPC over HTTP -> auth middleware -> FastMCP -> scope filtering
     -> tool -> GitGuardianClient -> (respx-mocked) GitGuardian API
@@ -25,6 +26,11 @@ import respx
 from gg_mcp_server.server import build_http_app, build_server
 
 from tests.e2e.harness import GG_API_URL, MCP_BASE_URL, TEST_MEMBER_ID, token_info
+
+
+@pytest.fixture(autouse=True)
+def block_real_network(socket_disabled) -> None:
+    """Prevent the remote e2e suite from opening real network sockets."""
 
 
 @pytest.fixture

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,131 @@
+"""Fixtures for the remote MCP e2e suite (pure helpers live in harness.py).
+
+Builds the production ASGI app with the same ``build_server`` and
+``build_http_app`` used by ``gg_mcp_server.http_app`` (OAuth-proxy auth,
+StreamableHTTP transport in stateless JSON mode) and drives it with raw
+JSON-RPC 2.0 requests over an in-process httpx client.
+
+Only the outbound GitGuardian API is faked, with respx (which patches httpx's
+real AsyncHTTPTransport but not the ASGITransport used to reach the app). So
+each test exercises the full production path:
+
+    JSON-RPC over HTTP -> auth middleware -> FastMCP -> scope filtering
+    -> tool -> GitGuardianClient -> (respx-mocked) GitGuardian API
+
+Tests assert on the two boundaries only: the JSON-RPC response returned to the
+MCP client, and the HTTP requests sent to the GitGuardian API.
+"""
+
+import asyncio
+from contextlib import asynccontextmanager
+
+import httpx
+import pytest
+import respx
+from gg_mcp_server.server import build_http_app, build_server
+
+from tests.e2e.harness import GG_API_URL, MCP_BASE_URL, TEST_MEMBER_ID, token_info
+
+
+@pytest.fixture
+def remote_env(monkeypatch):
+    """Environment of the hosted multi-tenant deployment (OAuth proxy mode)."""
+    monkeypatch.setenv("MULTI_TENANCY_ENABLED", "true")
+    # The presence of MCP_PORT marks the server as HTTP-transport: it gates
+    # multi-tenant token extraction and the hosted-server behavior of tools
+    # like find_current_source_id.
+    monkeypatch.setenv("MCP_PORT", "8000")
+    monkeypatch.setenv("MCP_OAUTH_PROXY_ENABLED", "true")
+    monkeypatch.setenv("MCP_BASE_URL", MCP_BASE_URL)
+    monkeypatch.setenv("GITGUARDIAN_URL", "https://dashboard.gitguardian.com")
+    monkeypatch.setenv("ENABLE_LOCAL_OAUTH", "false")
+    monkeypatch.delenv("GITGUARDIAN_API_URL", raising=False)
+    monkeypatch.delenv("GITGUARDIAN_PERSONAL_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("GITGUARDIAN_API_KEY", raising=False)
+    monkeypatch.delenv("GITGUARDIAN_SCOPES", raising=False)
+    monkeypatch.delenv("GITGUARDIAN_REQUESTED_SCOPES", raising=False)
+
+
+@asynccontextmanager
+async def _run_lifespan(app):
+    """Run the app lifespan in a dedicated task.
+
+    The StreamableHTTP session manager opens an anyio task group in the
+    lifespan; anyio requires it to be entered and exited from the same task,
+    but pytest-asyncio runs fixture setup and teardown in different tasks.
+    """
+    started = asyncio.Event()
+    stop = asyncio.Event()
+
+    async def holder() -> None:
+        async with app.router.lifespan_context(app):
+            started.set()
+            await stop.wait()
+
+    task = asyncio.create_task(holder())
+    started_wait = asyncio.create_task(started.wait())
+    done, _ = await asyncio.wait({task, started_wait}, return_when=asyncio.FIRST_COMPLETED)
+    if task in done:
+        # Startup failed: surface the exception instead of hanging on started.
+        started_wait.cancel()
+        task.result()
+        raise RuntimeError("app lifespan exited before signaling startup")
+    try:
+        yield
+    finally:
+        stop.set()
+        await task
+
+
+@pytest.fixture
+async def remote_app(remote_env, gg_api):
+    """The production ASGI app, with its lifespan running.
+
+    Depends on gg_api so the outbound mock guards the app's whole lifetime,
+    startup included: any lifespan fetch against the real API fails loudly.
+    """
+    app = build_http_app(build_server())
+    async with _run_lifespan(app):
+        yield app
+
+
+@pytest.fixture
+async def mcp_client(remote_app):
+    """An httpx client playing the role of the remote MCP client."""
+    transport = httpx.ASGITransport(app=remote_app)
+    async with httpx.AsyncClient(transport=transport, base_url=MCP_BASE_URL) as client:
+        yield client
+
+
+@pytest.fixture
+def no_retry_delay(monkeypatch):
+    """Make retry tests instant by patching asyncio.sleep to yield without waiting.
+
+    The client awaits ``asyncio.sleep`` directly, so this patches the asyncio
+    module attribute: every ``asyncio.sleep`` in the process is affected for
+    the duration of the test, not just the client's backoff.
+    """
+    real_sleep = asyncio.sleep
+
+    async def instant(_delay):
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", instant)
+
+
+@pytest.fixture
+def gg_api():
+    """Mock of the GitGuardian API; unmocked outbound calls raise."""
+    with respx.mock(base_url=GG_API_URL, assert_all_called=False) as router:
+        yield router
+
+
+@pytest.fixture
+def mock_token_scopes(gg_api):
+    """Register GET /api_tokens/self; returns a re-arm callable for custom scopes."""
+
+    def _mock(scopes: list[str] | None = None, member_id: int | None = TEST_MEMBER_ID) -> respx.Route:
+        return gg_api.get("/api_tokens/self").respond(200, json=token_info(scopes, member_id))
+
+    _mock()
+    return _mock

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -55,9 +55,6 @@ def mcp_headers(token: str = TEST_PAT) -> dict[str, str]:
     }
 
 
-MCP_HEADERS = mcp_headers()
-
-
 def token_info(scopes: list[str] | None = None, member_id: int | None = TEST_MEMBER_ID) -> dict[str, Any]:
     """Payload of GET /v1/api_tokens/self for a token with the given scopes."""
     return {
@@ -79,7 +76,7 @@ async def rpc(
     **kwargs,
 ) -> httpx.Response:
     """POST a raw JSON-RPC 2.0 request to the /mcp endpoint."""
-    headers = kwargs.pop("headers", MCP_HEADERS)
+    headers = kwargs.pop("headers", mcp_headers())
     payload: dict[str, Any] = {"jsonrpc": "2.0", "id": request_id, "method": method}
     if params is not None:
         payload["params"] = params

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -1,0 +1,182 @@
+"""Pure helpers for the remote MCP e2e suite (fixtures live in conftest.py).
+
+Helpers assert on the two boundaries of the server: JSON-RPC requests and
+responses on the MCP side, HTTP requests captured by respx on the
+GitGuardian API side.
+"""
+
+import json
+from typing import Any
+
+import httpx
+import respx
+
+# The hosted server's own public URL (used for OAuth metadata) and the
+# GitGuardian SaaS API it talks to.
+MCP_BASE_URL = "https://mcp.gitguardian.com"
+GG_API_URL = "https://api.gitguardian.com/v1"
+
+# Bearer token the simulated MCP client sends. The server must forward it
+# verbatim to the GitGuardian API as ``Authorization: Token <PAT>``.
+TEST_PAT = "e2e-test-pat"
+
+TEST_MEMBER_ID = 4242
+
+# Keep this test oracle independent from ``gg_api_core.scopes.ALL_SCOPES``:
+# an accidental production-scope removal must fail the remote contract tests.
+EXPECTED_SCOPES = [
+    "scan",
+    "incidents:read",
+    "sources:read",
+    "honeytokens:read",
+    "honeytokens:write",
+    "incidents:write",
+    "incidents:share",
+    "audit_logs:read",
+    "api_tokens:write",
+    "api_tokens:read",
+    "ip_allowlist:read",
+    "ip_allowlist:write",
+    "sources:write",
+    "custom_tags:read",
+    "custom_tags:write",
+    "members:read",
+    "secrets:write",
+    "secrets:read",
+]
+
+
+def mcp_headers(token: str = TEST_PAT) -> dict[str, str]:
+    """Headers sent by an MCP client authenticated with ``token``."""
+    return {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+
+
+MCP_HEADERS = mcp_headers()
+
+
+def token_info(scopes: list[str] | None = None, member_id: int | None = TEST_MEMBER_ID) -> dict[str, Any]:
+    """Payload of GET /v1/api_tokens/self for a token with the given scopes."""
+    return {
+        "id": "5ddaad0c-5a0c-4674-beb5-1cd198d13360",
+        "name": "e2e token",
+        "workspace_id": 1,
+        "type": "personal_access_token",
+        "status": "active",
+        "member_id": member_id,
+        "scopes": scopes if scopes is not None else list(EXPECTED_SCOPES),
+    }
+
+
+async def rpc(
+    client: httpx.AsyncClient,
+    method: str,
+    params: dict[str, Any] | None = None,
+    request_id: int | str = 1,
+    **kwargs,
+) -> httpx.Response:
+    """POST a raw JSON-RPC 2.0 request to the /mcp endpoint."""
+    headers = kwargs.pop("headers", MCP_HEADERS)
+    payload: dict[str, Any] = {"jsonrpc": "2.0", "id": request_id, "method": method}
+    if params is not None:
+        payload["params"] = params
+    return await client.post("/mcp", json=payload, headers=headers, **kwargs)
+
+
+def rpc_result(response: httpx.Response, expected_id: int | str = 1) -> dict[str, Any]:
+    """Assert a successful JSON-RPC response and return its ``result``."""
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body.get("jsonrpc") == "2.0"
+    assert body.get("id") == expected_id
+    assert "error" not in body, body
+    return body["result"]
+
+
+async def call_tool(
+    client: httpx.AsyncClient,
+    name: str,
+    arguments: dict[str, Any] | None = None,
+    **kwargs,
+) -> dict[str, Any]:
+    """Call an MCP tool and return the JSON-RPC ``result`` (CallToolResult)."""
+    request_id = kwargs.pop("request_id", 1)
+    response = await rpc(
+        client,
+        "tools/call",
+        {"name": name, "arguments": arguments or {}},
+        request_id=request_id,
+        **kwargs,
+    )
+    return rpc_result(response, expected_id=request_id)
+
+
+def tool_output(result: dict[str, Any]) -> Any:
+    """Extract a successful tool call's output from a CallToolResult, verbatim.
+
+    Use for tools whose output shape is asserted exactly; use
+    :func:`unwrap_result` for union-typed tools whose output FastMCP wraps
+    in a ``result`` envelope.
+    """
+    assert result.get("isError") is not True, result
+    content = result.get("content")
+    assert isinstance(content, list) and content, result
+    assert content[0].get("type") == "text", result
+    text_content = json.loads(content[0]["text"])
+
+    if "structuredContent" in result:
+        structured_content = result["structuredContent"]
+        if result.get("_meta", {}).get("fastmcp", {}).get("wrap_result") is True:
+            assert structured_content == {"result": text_content}
+        else:
+            assert structured_content == text_content
+        return structured_content
+    return text_content
+
+
+def unwrap_result(result: dict[str, Any]) -> Any:
+    """Tool output minus the ``result`` envelope FastMCP adds for union-typed tools.
+
+    Asserts the envelope is present so a change in FastMCP's wire shape for
+    union-typed tools fails loudly instead of being silently absorbed.
+    """
+    output = tool_output(result)
+    assert isinstance(output, dict) and set(output) == {"result"}, output
+    return output["result"]
+
+
+def tool_error_text(result: dict[str, Any]) -> str:
+    """Extract the error message from a failed CallToolResult."""
+    assert result.get("isError") is True, result
+    return result["content"][0]["text"]
+
+
+def sent_body(route: respx.Route) -> Any:
+    """JSON body of the last request the GitGuardian API received on a route."""
+    content = route.calls.last.request.read()
+    return json.loads(content) if content else None
+
+
+def sent_params(route: respx.Route) -> dict[str, str]:
+    """Query params of the last request the GitGuardian API received on a route."""
+    return dict(route.calls.last.request.url.params)
+
+
+def assert_authenticated_request(route: respx.Route, token: str = TEST_PAT) -> None:
+    """Assert that a captured GitGuardian API request carries its tenant token."""
+    request = route.calls.last.request
+    assert request.headers["Authorization"] == f"Token {token}"
+    assert request.headers["X-Privacy-Mode"] == "true"
+
+
+async def list_tool_names(client: httpx.AsyncClient, **kwargs) -> set[str]:
+    """Call tools/list and return the visible tool names."""
+    request_id = kwargs.pop("request_id", 1)
+    result = rpc_result(
+        await rpc(client, "tools/list", request_id=request_id, **kwargs),
+        expected_id=request_id,
+    )
+    return {tool["name"] for tool in result["tools"]}

--- a/tests/e2e/test_api_failure_modes.py
+++ b/tests/e2e/test_api_failure_modes.py
@@ -2,7 +2,10 @@
 500 retries, network failures, and the downstream-401 re-auth bridge.
 """
 
+from http import HTTPStatus
+
 import httpx
+import pytest
 
 from tests.e2e.harness import call_tool, rpc, tool_error_text, tool_output
 
@@ -70,16 +73,22 @@ class TestNetworkFailures:
 
 
 class TestDownstreamUnauthorizedBridge:
-    async def test_a_downstream_401_during_a_tool_call_does_not_reach_the_reauth_bridge(
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SI-3891: FastMCP wraps downstream authorization failures before the reauthentication middleware",
+    )
+    async def test_a_downstream_401_during_a_tool_call_triggers_reauthentication(
         self, mcp_client, gg_api, mock_token_scopes
     ):
         """
         GIVEN a token the API rejects with 401 during a scan
         WHEN scan_secrets is called
-        THEN the response stays HTTP 200 with a tool error naming the 401,
-             and carries no re-auth metadata
+        THEN the response asks the MCP client to authenticate again
         """
-        gg_api.post("/multiscan").respond(401, json={"detail": "Invalid API key."})
+        gg_api.post("/multiscan").respond(
+            status_code=HTTPStatus.UNAUTHORIZED,
+            json={"detail": "Invalid API key."},
+        )
 
         response = await rpc(
             mcp_client,
@@ -90,12 +99,5 @@ class TestDownstreamUnauthorizedBridge:
             },
         )
 
-        # TODO(SI-3891): the re-auth bridge is dead code on this path. FastMCP
-        # v3 wraps the tool's DownstreamUnauthorizedError in a ToolError before
-        # DownstreamUnauthorizedMiddleware can catch it, so the response is
-        # never rewritten to HTTP 401 and clients cannot re-run the OAuth flow.
-        assert response.status_code == 200
-        assert "www-authenticate" not in response.headers
-        result = response.json()["result"]
-        assert result["isError"] is True
-        assert "401" in result["content"][0]["text"]
+        assert response.status_code == HTTPStatus.UNAUTHORIZED
+        assert "www-authenticate" in response.headers

--- a/tests/e2e/test_api_failure_modes.py
+++ b/tests/e2e/test_api_failure_modes.py
@@ -1,0 +1,101 @@
+"""Resilience of the client core (_request) observed through real tool calls:
+500 retries, network failures, and the downstream-401 re-auth bridge.
+"""
+
+import httpx
+
+from tests.e2e.harness import call_tool, rpc, tool_error_text, tool_output
+
+INCIDENT = {"id": 77, "status": "TRIGGERED"}
+
+
+class TestServerErrorRetries:
+    async def test_a_transient_500_is_retried_until_success(
+        self, mcp_client, gg_api, mock_token_scopes, no_retry_delay
+    ):
+        """
+        GIVEN the API failing once with 500 then recovering
+        WHEN get_incident is called
+        THEN the request is retried and the tool succeeds
+        """
+        route = gg_api.get("/incidents/secrets/77").mock(
+            side_effect=[httpx.Response(500, text="boom"), httpx.Response(200, json=INCIDENT)]
+        )
+
+        result = await call_tool(mcp_client, "get_incident", {"params": {"incident_id": 77}})
+
+        assert route.call_count == 2
+        assert tool_output(result) == {"incident": INCIDENT}
+
+    async def test_persistent_500s_fail_after_three_retries(
+        self, mcp_client, gg_api, mock_token_scopes, no_retry_delay
+    ):
+        """
+        GIVEN the API failing with 500 on every attempt
+        WHEN get_incident is called
+        THEN exactly four requests are made (initial + 3 retries) and the tool fails
+        """
+        route = gg_api.get("/incidents/secrets/77").respond(500, text="boom")
+
+        result = await call_tool(mcp_client, "get_incident", {"params": {"incident_id": 77}})
+
+        assert route.call_count == 4
+        assert "500" in tool_error_text(result)
+
+
+class TestNetworkFailures:
+    async def test_a_connection_error_surfaces_as_a_tool_error(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN the API being unreachable
+        WHEN get_incident is called
+        THEN the network failure surfaces as a tool error, not a protocol crash
+        """
+        gg_api.get("/incidents/secrets/77").mock(side_effect=httpx.ConnectError("connection refused"))
+
+        result = await call_tool(mcp_client, "get_incident", {"params": {"incident_id": 77}})
+
+        assert "connection refused" in tool_error_text(result)
+
+    async def test_a_read_timeout_surfaces_as_a_tool_error(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN the API hanging past the client timeout
+        WHEN get_incident is called
+        THEN the timeout surfaces as a tool error
+        """
+        gg_api.get("/incidents/secrets/77").mock(side_effect=httpx.ReadTimeout("timed out"))
+
+        result = await call_tool(mcp_client, "get_incident", {"params": {"incident_id": 77}})
+
+        assert "timed out" in tool_error_text(result)
+
+
+class TestDownstreamUnauthorizedBridge:
+    async def test_a_downstream_401_during_a_tool_call_does_not_reach_the_reauth_bridge(
+        self, mcp_client, gg_api, mock_token_scopes
+    ):
+        """
+        GIVEN a token the API rejects with 401 during a scan
+        WHEN scan_secrets is called
+        THEN the response stays HTTP 200 with a tool error naming the 401,
+             and carries no re-auth metadata
+        """
+        gg_api.post("/multiscan").respond(401, json={"detail": "Invalid API key."})
+
+        response = await rpc(
+            mcp_client,
+            "tools/call",
+            {
+                "name": "scan_secrets",
+                "arguments": {"params": {"documents": [{"document": "x", "filename": "x.py"}]}},
+            },
+        )
+
+        # TODO(SI-3891): the re-auth bridge is dead code on this path. FastMCP
+        # v3 wraps the tool's DownstreamUnauthorizedError in a ToolError before
+        # DownstreamUnauthorizedMiddleware can catch it, so the response is
+        # never rewritten to HTTP 401 and clients cannot re-run the OAuth flow.
+        assert response.status_code == 200
+        assert "www-authenticate" not in response.headers
+        result = response.json()["result"]
+        assert result["isError"] is True
+        assert "401" in result["content"][0]["text"]

--- a/tests/e2e/test_auth_and_tool_visibility.py
+++ b/tests/e2e/test_auth_and_tool_visibility.py
@@ -1,0 +1,410 @@
+"""Auth handshake and scope-based tool visibility of the remote MCP server.
+
+These are the behaviors every remote client depends on before any tool runs:
+requests without credentials must be rejected with re-auth metadata, and
+tools/list must reflect the token's actual scopes (fetched live from the
+GitGuardian API).
+"""
+
+import asyncio
+
+import httpx
+
+from tests.e2e.harness import (
+    EXPECTED_SCOPES,
+    TEST_PAT,
+    assert_authenticated_request,
+    call_tool,
+    list_tool_names,
+    mcp_headers,
+    rpc,
+    rpc_result,
+    token_info,
+    tool_output,
+    unwrap_result,
+)
+
+EXPECTED_FULL_TOOL_CATALOG = {
+    "assign_incident",
+    "assign_public_incident",
+    "count_incidents",
+    "create_code_fix_request",
+    "find_current_source_id",
+    "generate_honeytoken",
+    "get_authenticated_user_info",
+    "get_current_token_info",
+    "get_incident",
+    "get_member",
+    "get_public_incident",
+    "get_remediation_workflow",
+    "list_detectors",
+    "list_honeytokens",
+    "list_incident_activity_logs",
+    "list_incident_comments",
+    "list_incident_members",
+    "list_incident_teams",
+    "list_incidents",
+    "list_public_incident_activity_logs",
+    "list_public_incident_comments",
+    "list_public_incidents",
+    "list_public_occurrences",
+    "list_repo_occurrences",
+    "list_sources",
+    "list_users",
+    "manage_incident_comment",
+    "manage_private_incident",
+    "manage_public_incident_comment",
+    "read_custom_tags",
+    "remediate_secret_incidents",
+    "revoke_current_token",
+    "revoke_secret",
+    "scan_secrets",
+    "update_incident_severity",
+    "update_or_create_incident_custom_tags",
+    "update_public_incident_status",
+    "write_custom_tags",
+}
+
+EXPECTED_SCAN_ONLY_TOOL_CATALOG = {
+    "get_authenticated_user_info",
+    "list_detectors",
+    "revoke_current_token",
+    "scan_secrets",
+}
+
+
+class TestProtocolHandshake:
+    async def test_initialize_returns_the_production_server_identity_and_capabilities(self, mcp_client, gg_api):
+        """
+        GIVEN an authenticated MCP client beginning a protocol session
+        WHEN it sends initialize with a supported protocol version
+        THEN the server identifies itself and advertises its tool capability
+        """
+        response = await rpc(
+            mcp_client,
+            "initialize",
+            {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "e2e-client", "version": "1.0.0"},
+            },
+        )
+
+        result = rpc_result(response)
+        assert result["protocolVersion"] == "2025-06-18"
+        assert result["serverInfo"]["name"] == "GitGuardian"
+        assert "tools" in result["capabilities"]
+        assert result["instructions"]
+        assert not gg_api.calls
+
+
+class TestUnauthenticatedRequests:
+    async def test_missing_authorization_header_is_rejected_with_reauth_metadata(self, mcp_client, gg_api):
+        """
+        GIVEN the remote server
+        WHEN a tools/list request arrives without an Authorization header
+        THEN it is rejected with HTTP 401 and a WWW-Authenticate header pointing
+             to both the protected-resource and authorization-server metadata,
+             and the GitGuardian API is never contacted
+        """
+        response = await rpc(mcp_client, "tools/list", headers={"Accept": "application/json, text/event-stream"})
+
+        assert response.status_code == 401
+        www_authenticate = response.headers["www-authenticate"]
+        assert "resource_metadata=" in www_authenticate
+        assert 'as_metadata="https://mcp.gitguardian.com/.well-known/oauth-authorization-server"' in www_authenticate
+        assert not gg_api.calls
+
+
+class TestScopeBasedToolVisibility:
+    async def test_full_scopes_expose_the_whole_catalog(self, mcp_client, mock_token_scopes):
+        """
+        GIVEN a token holding every GitGuardian scope
+        WHEN tools/list is requested
+        THEN read, write, scan and honeytoken tools are all visible
+        """
+        names = await list_tool_names(mcp_client)
+
+        assert names == EXPECTED_FULL_TOOL_CATALOG
+
+    async def test_token_scopes_are_fetched_from_the_api_with_the_callers_token(
+        self, mcp_client, gg_api, mock_token_scopes
+    ):
+        """
+        GIVEN a bearer token sent by the MCP client
+        WHEN tools/list is requested
+        THEN the server resolves scopes via GET /api_tokens/self, forwarding
+             the caller's token in GitGuardian's Token scheme
+        """
+        await list_tool_names(mcp_client)
+
+        token_requests = [call.request for call in gg_api.calls if call.request.url.path == "/v1/api_tokens/self"]
+        assert token_requests, "expected a live scope fetch against /api_tokens/self"
+        assert token_requests[0].headers["Authorization"] == f"Token {TEST_PAT}"
+        assert token_requests[0].headers["X-Privacy-Mode"] == "true"
+
+    async def test_scan_only_token_hides_scope_gated_tools(self, mcp_client, mock_token_scopes):
+        """
+        GIVEN a token limited to the scan scope
+        WHEN tools/list is requested
+        THEN only scan-gated and ungated tools remain visible
+        """
+        mock_token_scopes(scopes=["scan"])
+
+        names = await list_tool_names(mcp_client)
+
+        assert "scan_secrets" in names
+        assert "list_detectors" in names
+        # get_authenticated_user_info has no required_scopes, so it always shows
+        assert "get_authenticated_user_info" in names
+        assert "list_incidents" not in names
+        assert "manage_private_incident" not in names
+        assert "list_sources" not in names
+        assert "get_current_token_info" not in names
+
+    async def test_incidents_read_token_gets_read_but_not_write_tools(self, mcp_client, mock_token_scopes):
+        """
+        GIVEN a token with incidents:read but not incidents:write
+        WHEN tools/list is requested
+        THEN incident read tools are visible and incident write tools are hidden
+        """
+        mock_token_scopes(scopes=["incidents:read"])
+
+        names = await list_tool_names(mcp_client)
+
+        assert {"list_incidents", "count_incidents", "get_incident", "get_remediation_workflow"} <= names
+        assert "manage_private_incident" not in names
+        assert "assign_incident" not in names
+        assert "update_incident_severity" not in names
+        # remediate needs sources:read on top of incidents:read
+        assert "remediate_secret_incidents" not in names
+
+    async def test_tool_visibility_is_isolated_between_tenants_on_one_server(self, mcp_client, gg_api):
+        """
+        GIVEN two tenants with different token scopes using the same server
+        WHEN each tenant requests tools/list
+        THEN each receives only the catalog authorized by its own token
+        """
+
+        def token_response(request: httpx.Request) -> httpx.Response:
+            authorization = request.headers["Authorization"]
+            if authorization == "Token full-scope-token":
+                return httpx.Response(200, json=token_info(EXPECTED_SCOPES))
+            if authorization == "Token scan-only-token":
+                return httpx.Response(200, json=token_info(["scan"]))
+            raise AssertionError(f"Unexpected tenant token: {authorization}")
+
+        token_route = gg_api.get("/api_tokens/self").mock(side_effect=token_response)
+
+        first_full_catalog = await list_tool_names(mcp_client, headers=mcp_headers("full-scope-token"))
+        scan_catalog = await list_tool_names(mcp_client, headers=mcp_headers("scan-only-token"))
+        second_full_catalog = await list_tool_names(mcp_client, headers=mcp_headers("full-scope-token"))
+
+        assert first_full_catalog == EXPECTED_FULL_TOOL_CATALOG
+        assert scan_catalog == EXPECTED_SCAN_ONLY_TOOL_CATALOG
+        assert second_full_catalog == EXPECTED_FULL_TOOL_CATALOG
+        assert token_route.call_count == 3
+
+    async def test_concurrent_requests_keep_tenant_context_isolated(self, mcp_client, gg_api):
+        """
+        GIVEN two tenants making overlapping discovery and tool requests
+        WHEN both requests execute concurrently on the same server instance
+        THEN each catalog and outbound API call retains its own tenant token
+        """
+        scope_requests_ready = asyncio.Event()
+        seen_scope_tokens: set[str] = set()
+
+        async def concurrent_token_response(request: httpx.Request) -> httpx.Response:
+            authorization = request.headers["Authorization"]
+            seen_scope_tokens.add(authorization)
+            if seen_scope_tokens == {"Token full-scope-token", "Token scan-only-token"}:
+                scope_requests_ready.set()
+            try:
+                await asyncio.wait_for(scope_requests_ready.wait(), timeout=1)
+            except TimeoutError as exc:
+                raise AssertionError(
+                    f"Concurrent scope requests did not overlap; observed tokens: {sorted(seen_scope_tokens)}"
+                ) from exc
+            scopes = EXPECTED_SCOPES if authorization == "Token full-scope-token" else ["scan"]
+            return httpx.Response(200, json=token_info(scopes))
+
+        token_route = gg_api.get("/api_tokens/self").mock(side_effect=concurrent_token_response)
+
+        full_catalog, scan_catalog = await asyncio.wait_for(
+            asyncio.gather(
+                list_tool_names(
+                    mcp_client,
+                    headers=mcp_headers("full-scope-token"),
+                    request_id=101,
+                ),
+                list_tool_names(
+                    mcp_client,
+                    headers=mcp_headers("scan-only-token"),
+                    request_id=102,
+                ),
+            ),
+            timeout=2,
+        )
+
+        assert full_catalog == EXPECTED_FULL_TOOL_CATALOG
+        assert scan_catalog == EXPECTED_SCAN_ONLY_TOOL_CATALOG
+        assert token_route.call_count == 2
+
+        tool_requests_ready = asyncio.Event()
+        seen_tool_names: set[str] = set()
+
+        async def incident_response(_request: httpx.Request) -> httpx.Response:
+            seen_tool_names.add("incident")
+            if seen_tool_names == {"incident", "scan"}:
+                tool_requests_ready.set()
+            try:
+                await asyncio.wait_for(tool_requests_ready.wait(), timeout=1)
+            except TimeoutError as exc:
+                raise AssertionError(
+                    f"Concurrent tool requests did not overlap; observed tools: {sorted(seen_tool_names)}"
+                ) from exc
+            return httpx.Response(200, json={"id": 77})
+
+        async def scan_response(_request: httpx.Request) -> httpx.Response:
+            seen_tool_names.add("scan")
+            if seen_tool_names == {"incident", "scan"}:
+                tool_requests_ready.set()
+            try:
+                await asyncio.wait_for(tool_requests_ready.wait(), timeout=1)
+            except TimeoutError as exc:
+                raise AssertionError(
+                    f"Concurrent tool requests did not overlap; observed tools: {sorted(seen_tool_names)}"
+                ) from exc
+            return httpx.Response(200, json=[{"policy_break_count": 0}])
+
+        incident_route = gg_api.get("/incidents/secrets/77").mock(side_effect=incident_response)
+        scan_route = gg_api.post("/multiscan").mock(side_effect=scan_response)
+
+        incident_result, scan_result = await asyncio.wait_for(
+            asyncio.gather(
+                call_tool(
+                    mcp_client,
+                    "get_incident",
+                    {"params": {"incident_id": 77}},
+                    headers=mcp_headers("full-scope-token"),
+                    request_id=201,
+                ),
+                call_tool(
+                    mcp_client,
+                    "scan_secrets",
+                    {"params": {"documents": [{"document": "x = 1", "filename": "x.py"}]}},
+                    headers=mcp_headers("scan-only-token"),
+                    request_id=202,
+                ),
+            ),
+            timeout=2,
+        )
+
+        assert tool_output(incident_result) == {"incident": {"id": 77}}
+        assert tool_output(scan_result) == {"scan_results": [{"policy_break_count": 0}]}
+        assert_authenticated_request(incident_route, "full-scope-token")
+        assert_authenticated_request(scan_route, "scan-only-token")
+
+    async def test_a_scope_hidden_tool_is_still_callable(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN a scan-only token, for which list_incidents is hidden
+        WHEN list_incidents is called anyway
+        THEN the tool executes and its request is forwarded to the API
+        """
+        mock_token_scopes(scopes=["scan"])
+        route = gg_api.get("/incidents-for-mcp").respond(200, json={"results": [], "next": None, "previous": None})
+
+        result = await call_tool(mcp_client, "list_incidents", {"params": {}})
+
+        # Scope filtering only controls visibility; enforcement happens at the
+        # GitGuardian API, which rejects tokens lacking the scope.
+        assert route.called
+        assert unwrap_result(result)["incidents"] == []
+
+
+class TestPerRequestScopeCost:
+    async def test_tool_dispatch_fetches_scopes_once_then_reuses_a_shared_cache(
+        self, mcp_client, gg_api, mock_token_scopes
+    ):
+        """
+        GIVEN the stateless remote deployment
+        WHEN the same tool is called twice
+        THEN the first dispatch resolves scopes upstream (tool-cache refresh)
+             and the second reuses the process-wide cache
+        """
+        gg_api.get("/incidents/secrets/77").respond(200, json={"id": 77})
+
+        await call_tool(mcp_client, "get_incident", {"params": {"incident_id": 77}})
+        await call_tool(mcp_client, "get_incident", {"params": {"incident_id": 77}})
+
+        # Only the dispatch path caches (per server instance, meaning
+        # process-wide in production). The scope-filtered tool list cached here
+        # is shared by all tenants of the process; per-call scope enforcement
+        # is delegated to the GitGuardian API rejecting tokens that lack the
+        # scope.
+        scope_fetches = [call for call in gg_api.calls if call.request.url.path == "/v1/api_tokens/self"]
+        assert len(scope_fetches) == 1
+
+    async def test_explicit_tools_list_refetches_scopes_every_time(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN the stateless remote deployment
+        WHEN tools/list is requested twice
+        THEN each request re-resolves the token's scopes upstream
+        """
+        await list_tool_names(mcp_client)
+        await list_tool_names(mcp_client)
+
+        scope_fetches = [call for call in gg_api.calls if call.request.url.path == "/v1/api_tokens/self"]
+        assert len(scope_fetches) == 2
+
+
+class TestAuthenticatedUserInfo:
+    async def test_get_authenticated_user_info_reports_proxy_mode_and_scopes(self, mcp_client, mock_token_scopes):
+        """
+        GIVEN the hosted server in OAuth proxy mode
+        WHEN get_authenticated_user_info is called
+        THEN it returns the token info, the OAUTH_PROXY mode marker, and the scopes
+        """
+        mock_token_scopes(scopes=["scan", "incidents:read"])
+
+        result = await call_tool(mcp_client, "get_authenticated_user_info")
+        output = tool_output(result)
+
+        assert output["authentication_mode"] == "OAUTH_PROXY"
+        assert set(output["available_scopes"]) == {"scan", "incidents:read"}
+        assert output["token_info"]["scopes"] == ["scan", "incidents:read"]
+
+
+class TestExpiredTokenOnToolsList:
+    async def test_rejected_token_on_scope_fetch_surfaces_as_json_rpc_error(self, mcp_client, gg_api):
+        """
+        GIVEN a token the GitGuardian API rejects with 401
+        WHEN tools/list triggers the scope fetch
+        THEN the request fails as a JSON-RPC error mentioning the downstream 401
+        """
+        gg_api.get("/api_tokens/self").respond(401, json={"detail": "Invalid API key."})
+
+        response = await rpc(mcp_client, "tools/list")
+
+        # TODO(SI-3891): the scope-filtering middleware raises outside the
+        # DownstreamUnauthorized middleware, so the response stays HTTP 200 and
+        # carries no WWW-Authenticate header; spec-abiding clients will not
+        # re-run the OAuth flow on an expired token discovered here.
+        assert response.status_code == 200
+        assert "www-authenticate" not in response.headers
+        body = response.json()
+        assert "error" in body
+        assert "401" in body["error"]["message"]
+
+
+async def test_health_endpoint_requires_no_auth(mcp_client, gg_api):
+    """
+    GIVEN the remote server
+    WHEN the load balancer probes /health without credentials
+    THEN it answers 200 OK without contacting the GitGuardian API
+    """
+    response = await mcp_client.get("/health")
+
+    assert response.status_code == 200
+    assert response.text == "OK"
+    assert not gg_api.calls

--- a/tests/e2e/test_auth_and_tool_visibility.py
+++ b/tests/e2e/test_auth_and_tool_visibility.py
@@ -7,8 +7,10 @@ GitGuardian API).
 """
 
 import asyncio
+from http import HTTPStatus
 
 import httpx
+import pytest
 
 from tests.e2e.harness import (
     EXPECTED_SCOPES,
@@ -153,14 +155,7 @@ class TestScopeBasedToolVisibility:
 
         names = await list_tool_names(mcp_client)
 
-        assert "scan_secrets" in names
-        assert "list_detectors" in names
-        # get_authenticated_user_info has no required_scopes, so it always shows
-        assert "get_authenticated_user_info" in names
-        assert "list_incidents" not in names
-        assert "manage_private_incident" not in names
-        assert "list_sources" not in names
-        assert "get_current_token_info" not in names
+        assert names == EXPECTED_SCAN_ONLY_TOOL_CATALOG
 
     async def test_incidents_read_token_gets_read_but_not_write_tools(self, mcp_client, mock_token_scopes):
         """
@@ -376,25 +371,25 @@ class TestAuthenticatedUserInfo:
 
 
 class TestExpiredTokenOnToolsList:
-    async def test_rejected_token_on_scope_fetch_surfaces_as_json_rpc_error(self, mcp_client, gg_api):
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SI-3891: scope-fetch failures do not reach the downstream reauthentication middleware",
+    )
+    async def test_rejected_token_on_scope_fetch_triggers_reauthentication(self, mcp_client, gg_api):
         """
         GIVEN a token the GitGuardian API rejects with 401
         WHEN tools/list triggers the scope fetch
-        THEN the request fails as a JSON-RPC error mentioning the downstream 401
+        THEN the response asks the MCP client to authenticate again
         """
-        gg_api.get("/api_tokens/self").respond(401, json={"detail": "Invalid API key."})
+        gg_api.get("/api_tokens/self").respond(
+            status_code=HTTPStatus.UNAUTHORIZED,
+            json={"detail": "Invalid API key."},
+        )
 
         response = await rpc(mcp_client, "tools/list")
 
-        # TODO(SI-3891): the scope-filtering middleware raises outside the
-        # DownstreamUnauthorized middleware, so the response stays HTTP 200 and
-        # carries no WWW-Authenticate header; spec-abiding clients will not
-        # re-run the OAuth flow on an expired token discovered here.
-        assert response.status_code == 200
-        assert "www-authenticate" not in response.headers
-        body = response.json()
-        assert "error" in body
-        assert "401" in body["error"]["message"]
+        assert response.status_code == HTTPStatus.UNAUTHORIZED
+        assert "www-authenticate" in response.headers
 
 
 async def test_health_endpoint_requires_no_auth(mcp_client, gg_api):

--- a/tests/e2e/test_incident_read_tools.py
+++ b/tests/e2e/test_incident_read_tools.py
@@ -8,8 +8,10 @@ functional core that drifts either side fails here.
 """
 
 import json
+from http import HTTPStatus
 
 import httpx
+import pytest
 
 from tests.e2e.harness import (
     TEST_MEMBER_ID,
@@ -113,6 +115,24 @@ class TestListIncidents:
         assert member.called
         assert sent_params(incidents)["assignee_member_id"] == str(TEST_MEMBER_ID)
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SI-3891: mine=True is not rejected clearly for service tokens",
+    )
+    async def test_service_token_without_member_id_rejects_mine_filter(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN a service token without a member ID
+        WHEN list_incidents is called with mine=True
+        THEN the tool fails clearly without querying unfiltered incidents
+        """
+        gg_api.get("/api_tokens/self").respond(200, json=token_info(member_id=None))
+        incidents = gg_api.get("/incidents-for-mcp").respond(200, json={"results": []})
+
+        result = await call_tool(mcp_client, "list_incidents", {"params": {"mine": True}})
+
+        assert "mine" in tool_error_text(result).lower()
+        assert not incidents.called
+
     async def test_mine_conflicting_with_assignee_id_short_circuits(self, mcp_client, gg_api, mock_token_scopes):
         """
         GIVEN mine=True together with a different explicit assignee_id
@@ -128,7 +148,9 @@ class TestListIncidents:
         assert output["error"].startswith(f"Conflict: 'mine=True' implies assignee_id={TEST_MEMBER_ID}")
         assert not incidents.called
 
-    async def test_get_all_accumulates_pages_until_the_api_is_exhausted(self, mcp_client, gg_api, mock_token_scopes):
+    async def test_get_all_accumulates_page_number_pagination_until_exhausted(
+        self, mcp_client, gg_api, mock_token_scopes
+    ):
         """
         GIVEN two pages of incidents
         WHEN list_incidents is called with get_all=True
@@ -149,24 +171,24 @@ class TestListIncidents:
         assert [i["id"] for i in output["incidents"]] == [1, 2]
         assert output["has_more"] is False
 
-    async def test_api_rejection_is_returned_as_an_error_payload_not_a_protocol_error(
-        self, mcp_client, gg_api, mock_token_scopes
-    ):
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SI-3891: list_incidents swallows downstream authorization failures into its result payload",
+    )
+    async def test_api_rejection_surfaces_as_a_tool_error(self, mcp_client, gg_api, mock_token_scopes):
         """
         GIVEN the API rejecting the token with 401
         WHEN list_incidents is called
-        THEN the tool reports a successful MCP result carrying an error message
+        THEN the call fails with a tool error naming the status
         """
-        gg_api.get("/incidents-for-mcp").respond(401, json={"detail": "Invalid API key."})
+        gg_api.get("/incidents-for-mcp").respond(
+            status_code=HTTPStatus.UNAUTHORIZED,
+            json={"detail": "Invalid API key."},
+        )
 
         result = await call_tool(mcp_client, "list_incidents", {"params": {}})
 
-        # TODO(SI-3891): fail-soft behavior; the downstream 401 is swallowed
-        # into the payload instead of triggering the MCP re-auth path.
-        assert result.get("isError") is not True
-        output = unwrap_result(result)
-        assert output["error"].startswith("Failed to list incidents:")
-        assert "401" in output["error"]
+        assert str(HTTPStatus.UNAUTHORIZED.value) in tool_error_text(result)
 
 
 class TestCountIncidents:
@@ -255,11 +277,15 @@ class TestGetIncident:
         WHEN get_incident is called
         THEN the call fails with a tool error naming the status
         """
-        gg_api.get("/incidents/secrets/404404").respond(404, json={"detail": "Not found."})
+        incident_id = 987654
+        gg_api.get(f"/incidents/secrets/{incident_id}").respond(
+            status_code=HTTPStatus.NOT_FOUND,
+            json={"detail": "Not found."},
+        )
 
-        result = await call_tool(mcp_client, "get_incident", {"params": {"incident_id": 404404}})
+        result = await call_tool(mcp_client, "get_incident", {"params": {"incident_id": incident_id}})
 
-        assert "404" in tool_error_text(result)
+        assert str(HTTPStatus.NOT_FOUND.value) in tool_error_text(result)
 
 
 class TestListRepoOccurrences:
@@ -307,19 +333,20 @@ class TestListRepoOccurrences:
 
         assert sent_params(route)["member_assignee_id"] == str(TEST_MEMBER_ID)
 
-    async def test_service_token_without_member_id_silently_drops_the_mine_filter(
-        self, mcp_client, gg_api, mock_token_scopes
-    ):
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SI-3891: mine=True silently drops the assignee filter for service tokens",
+    )
+    async def test_service_token_without_member_id_rejects_mine_filter(self, mcp_client, gg_api, mock_token_scopes):
         """
         GIVEN a service-account token whose member_id is null
         WHEN list_repo_occurrences is called with mine=True
-        THEN the occurrences query is sent unfiltered
+        THEN the tool fails clearly without querying unfiltered occurrences
         """
         gg_api.get("/api_tokens/self").respond(200, json=token_info(member_id=None))
-        route = gg_api.get("/occurrences/secrets").respond(200, json={"results": []})
+        occurrences = gg_api.get("/occurrences/secrets").respond(200, json={"results": []})
 
-        await call_tool(mcp_client, "list_repo_occurrences", {"params": {"mine": True}})
+        result = await call_tool(mcp_client, "list_repo_occurrences", {"params": {"mine": True}})
 
-        # TODO(SI-3891): fail-open; mine=True returns everyone's occurrences
-        # for tokens without a member (tracked as GH #154 behavior family).
-        assert "member_assignee_id" not in sent_params(route)
+        assert "mine" in tool_error_text(result).lower()
+        assert not occurrences.called

--- a/tests/e2e/test_incident_read_tools.py
+++ b/tests/e2e/test_incident_read_tools.py
@@ -1,0 +1,325 @@
+"""Read-path incident tools: list_incidents, count_incidents, get_incident,
+list_repo_occurrences.
+
+These are the highest-traffic tools of the remote server. The tests pin the
+exact wire contract with the GitGuardian API (paths, query params, and their
+serialization) and the reshaping applied to responses, so any refactor of the
+functional core that drifts either side fails here.
+"""
+
+import json
+
+import httpx
+
+from tests.e2e.harness import (
+    TEST_MEMBER_ID,
+    call_tool,
+    sent_params,
+    token_info,
+    tool_error_text,
+    tool_output,
+    unwrap_result,
+)
+
+INCIDENT = {"id": 77, "status": "TRIGGERED", "severity": "high", "detector": {"name": "aws_iam"}}
+
+DEFAULT_LIST_QUERY = {
+    "page": "1",
+    "page_size": "20",
+    "ordering": "-date",
+    "status__in": "TRIGGERED,ASSIGNED,RESOLVED",
+    "severity__in": "10,20,30,100",
+    "validity__in": "valid,failed_to_check,no_checker,not_checked",
+    "tags__nin": "TEST_FILE,FALSE_POSITIVE,CHECK_RUN_SKIP_FALSE_POSITIVE,CHECK_RUN_SKIP_LOW_RISK,CHECK_RUN_SKIP_TEST_CRED",
+}
+
+
+class TestListIncidents:
+    async def test_default_call_applies_the_opinionated_filters(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN no explicit filters
+        WHEN list_incidents is called
+        THEN the API receives the documented default filters (open statuses,
+             low/info severity excluded, noise tags excluded) and the response
+             is reshaped with pagination flags and the applied-filter echo
+        """
+        route = gg_api.get("/incidents-for-mcp").respond(
+            200, json={"results": [INCIDENT], "count": 1, "next": None, "previous": None}
+        )
+
+        result = await call_tool(mcp_client, "list_incidents", {"params": {}})
+
+        assert sent_params(route) == DEFAULT_LIST_QUERY
+        output = unwrap_result(result)
+        assert output["incidents"] == [INCIDENT]
+        assert output["page"] == 1
+        assert output["page_size"] == 20
+        assert output["has_next"] is False
+        assert output["has_previous"] is False
+        assert output["applied_filters"]["status"] == ["TRIGGERED", "ASSIGNED", "RESOLVED"]
+
+    async def test_filters_serialize_to_the_api_dialect(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN severity names, source ids, booleans, a count floor and a date
+        WHEN list_incidents is called
+        THEN they serialize as severity codes, source__in, lowercase booleans,
+             a ">=N" operator string, and a date-only bound
+        """
+        route = gg_api.get("/incidents-for-mcp").respond(200, json={"results": [], "next": None, "previous": None})
+
+        await call_tool(
+            mcp_client,
+            "list_incidents",
+            {
+                "params": {
+                    "severity": ["critical", "high"],
+                    "source_ids": [11, 22],
+                    "publicly_shared": True,
+                    "occurrence_count_min": 3,
+                    "date_after": "2026-07-01T15:30:00Z",
+                    "status": None,
+                    "validity": None,
+                    "exclude_tags": None,
+                }
+            },
+        )
+
+        params = sent_params(route)
+        assert params["severity__in"] == "10,20"
+        assert params["source__in"] == "11,22"
+        assert params["publicly_shared"] == "true"
+        assert params["occurrence_count"] == ">=3"
+        assert params["date__ge"] == "2026-07-01"
+        assert "status__in" not in params
+        assert "validity__in" not in params
+        assert "tags__nin" not in params
+
+    async def test_mine_resolves_the_caller_to_a_member_id_before_filtering(
+        self, mcp_client, gg_api, mock_token_scopes
+    ):
+        """
+        GIVEN mine=True
+        WHEN list_incidents is called
+        THEN the server resolves the caller via /api_tokens/self and /members/{id}
+             and filters incidents on assignee_member_id
+        """
+        member = gg_api.get(f"/members/{TEST_MEMBER_ID}").respond(
+            200, json={"id": TEST_MEMBER_ID, "email": "dev@corp.test"}
+        )
+        incidents = gg_api.get("/incidents-for-mcp").respond(200, json={"results": [], "next": None, "previous": None})
+
+        await call_tool(mcp_client, "list_incidents", {"params": {"mine": True}})
+
+        assert member.called
+        assert sent_params(incidents)["assignee_member_id"] == str(TEST_MEMBER_ID)
+
+    async def test_mine_conflicting_with_assignee_id_short_circuits(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN mine=True together with a different explicit assignee_id
+        WHEN list_incidents is called
+        THEN a conflict error is returned and the incidents API is never queried
+        """
+        gg_api.get(f"/members/{TEST_MEMBER_ID}").respond(200, json={"id": TEST_MEMBER_ID})
+        incidents = gg_api.get("/incidents-for-mcp").respond(200, json={"results": []})
+
+        result = await call_tool(mcp_client, "list_incidents", {"params": {"mine": True, "assignee_id": 1}})
+
+        output = unwrap_result(result)
+        assert output["error"].startswith(f"Conflict: 'mine=True' implies assignee_id={TEST_MEMBER_ID}")
+        assert not incidents.called
+
+    async def test_get_all_accumulates_pages_until_the_api_is_exhausted(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN two pages of incidents
+        WHEN list_incidents is called with get_all=True
+        THEN both pages are fetched and merged into a single response
+        """
+        pages = {
+            "1": {"results": [{"id": 1}], "next": "https://api.gitguardian.com/v1/incidents-for-mcp?page=2"},
+            "2": {"results": [{"id": 2}], "next": None},
+        }
+        route = gg_api.get("/incidents-for-mcp").mock(
+            side_effect=lambda request: httpx.Response(200, json=pages[request.url.params["page"]])
+        )
+
+        result = await call_tool(mcp_client, "list_incidents", {"params": {"get_all": True}})
+
+        assert route.call_count == 2
+        output = unwrap_result(result)
+        assert [i["id"] for i in output["incidents"]] == [1, 2]
+        assert output["has_more"] is False
+
+    async def test_api_rejection_is_returned_as_an_error_payload_not_a_protocol_error(
+        self, mcp_client, gg_api, mock_token_scopes
+    ):
+        """
+        GIVEN the API rejecting the token with 401
+        WHEN list_incidents is called
+        THEN the tool reports a successful MCP result carrying an error message
+        """
+        gg_api.get("/incidents-for-mcp").respond(401, json={"detail": "Invalid API key."})
+
+        result = await call_tool(mcp_client, "list_incidents", {"params": {}})
+
+        # TODO(SI-3891): fail-soft behavior; the downstream 401 is swallowed
+        # into the payload instead of triggering the MCP re-auth path.
+        assert result.get("isError") is not True
+        output = unwrap_result(result)
+        assert output["error"].startswith("Failed to list incidents:")
+        assert "401" in output["error"]
+
+
+class TestCountIncidents:
+    async def test_count_uses_the_dedicated_endpoint_with_the_same_filters(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN default filters
+        WHEN count_incidents is called
+        THEN /incidents-for-mcp/count receives the same filter dialect and the
+             count comes back with the applied-filter echo
+        """
+        route = gg_api.get("/incidents-for-mcp/count").respond(200, json={"count": 1337})
+
+        result = await call_tool(mcp_client, "count_incidents", {"params": {}})
+
+        params = sent_params(route)
+        assert params == {
+            key: value for key, value in DEFAULT_LIST_QUERY.items() if key not in ("page", "page_size", "ordering")
+        }
+        output = unwrap_result(result)
+        assert output["count"] == 1337
+        assert output["applied_filters"]["severity"] == [10, 20, 30, 100]
+
+    async def test_count_mine_filters_on_the_resolved_member(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN mine=True
+        WHEN count_incidents is called
+        THEN the count query filters on the caller's member id
+        """
+        gg_api.get(f"/members/{TEST_MEMBER_ID}").respond(200, json={"id": TEST_MEMBER_ID})
+        route = gg_api.get("/incidents-for-mcp/count").respond(200, json={"count": 2})
+
+        result = await call_tool(mcp_client, "count_incidents", {"params": {"mine": True}})
+
+        assert sent_params(route)["assignee_member_id"] == str(TEST_MEMBER_ID)
+        assert unwrap_result(result)["count"] == 2
+
+
+class TestGetIncident:
+    async def test_incident_is_fetched_by_id_and_wrapped(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN an incident id
+        WHEN get_incident is called with defaults
+        THEN the incident endpoint is hit without query params and the raw
+             incident is returned under the incident key
+        """
+        route = gg_api.get("/incidents/secrets/77").respond(200, json=INCIDENT)
+
+        result = await call_tool(mcp_client, "get_incident", {"params": {"incident_id": 77}})
+
+        assert str(route.calls.last.request.url) == "https://api.gitguardian.com/v1/incidents/secrets/77"
+        assert tool_output(result) == {"incident": INCIDENT}
+
+    async def test_call_tool_result_carries_both_structured_and_text_content(
+        self, mcp_client, gg_api, mock_token_scopes
+    ):
+        """
+        GIVEN a successful tool call in stateless JSON mode
+        WHEN the raw CallToolResult is inspected
+        THEN it carries the payload both as structuredContent and as JSON text,
+             with isError false
+        """
+        gg_api.get("/incidents/secrets/77").respond(200, json=INCIDENT)
+
+        result = await call_tool(mcp_client, "get_incident", {"params": {"incident_id": 77}})
+
+        assert result["isError"] is False
+        assert result["structuredContent"] == {"incident": INCIDENT}
+        assert result["content"][0]["type"] == "text"
+        assert json.loads(result["content"][0]["text"]) == {"incident": INCIDENT}
+
+    async def test_non_default_occurrence_count_is_forwarded(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN with_occurrences=50
+        WHEN get_incident is called
+        THEN the with_occurrences query param is sent
+        """
+        route = gg_api.get("/incidents/secrets/77").respond(200, json=INCIDENT)
+
+        await call_tool(mcp_client, "get_incident", {"params": {"incident_id": 77, "with_occurrences": 50}})
+
+        assert sent_params(route)["with_occurrences"] == "50"
+
+    async def test_unknown_incident_surfaces_as_a_tool_error(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN the API answering 404
+        WHEN get_incident is called
+        THEN the call fails with a tool error naming the status
+        """
+        gg_api.get("/incidents/secrets/404404").respond(404, json={"detail": "Not found."})
+
+        result = await call_tool(mcp_client, "get_incident", {"params": {"incident_id": 404404}})
+
+        assert "404" in tool_error_text(result)
+
+
+class TestListRepoOccurrences:
+    async def test_occurrences_query_and_cursor_pagination(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN a source id and a next page advertised via the Link header
+        WHEN list_repo_occurrences is called
+        THEN the query carries the default noise filters and the decoded cursor
+             is handed back with has_more=True
+        """
+        occurrence = {"id": 9, "incident": {"id": 77}, "filepath": "src/config.py"}
+        route = gg_api.get("/occurrences/secrets").respond(
+            200,
+            json={"results": [occurrence]},
+            headers={"Link": '<https://api.gitguardian.com/v1/occurrences/secrets?cursor=cD0yMDI2%3D%3D>; rel="next"'},
+        )
+
+        result = await call_tool(mcp_client, "list_repo_occurrences", {"params": {"source_id": 55}})
+
+        params = sent_params(route)
+        assert params["source_id"] == "55"
+        assert params["with_sources"] == "false"
+        assert params["per_page"] == "20"
+        assert params["status"] == "TRIGGERED,ASSIGNED,RESOLVED"
+        assert params["severity"] == "critical,high,medium,unknown"
+        assert params["validity"] == "valid,failed_to_check,no_checker,unknown"
+        assert params["exclude_tags"] == (
+            "TEST_FILE,FALSE_POSITIVE,CHECK_RUN_SKIP_FALSE_POSITIVE,CHECK_RUN_SKIP_LOW_RISK,CHECK_RUN_SKIP_TEST_CRED"
+        )
+        output = unwrap_result(result)
+        assert output["occurrences"] == [occurrence]
+        assert output["occurrences_count"] == 1
+        assert output["cursor"] == "cD0yMDI2=="
+        assert output["has_more"] is True
+
+    async def test_mine_filters_on_the_token_member_id(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN mine=True
+        WHEN list_repo_occurrences is called
+        THEN the member id from /api_tokens/self is sent as member_assignee_id
+        """
+        route = gg_api.get("/occurrences/secrets").respond(200, json={"results": []})
+
+        await call_tool(mcp_client, "list_repo_occurrences", {"params": {"mine": True}})
+
+        assert sent_params(route)["member_assignee_id"] == str(TEST_MEMBER_ID)
+
+    async def test_service_token_without_member_id_silently_drops_the_mine_filter(
+        self, mcp_client, gg_api, mock_token_scopes
+    ):
+        """
+        GIVEN a service-account token whose member_id is null
+        WHEN list_repo_occurrences is called with mine=True
+        THEN the occurrences query is sent unfiltered
+        """
+        gg_api.get("/api_tokens/self").respond(200, json=token_info(member_id=None))
+        route = gg_api.get("/occurrences/secrets").respond(200, json={"results": []})
+
+        await call_tool(mcp_client, "list_repo_occurrences", {"params": {"mine": True}})
+
+        # TODO(SI-3891): fail-open; mine=True returns everyone's occurrences
+        # for tokens without a member (tracked as GH #154 behavior family).
+        assert "member_assignee_id" not in sent_params(route)

--- a/tests/e2e/test_incident_write_tools.py
+++ b/tests/e2e/test_incident_write_tools.py
@@ -14,18 +14,30 @@ class TestManagePrivateIncident:
     @pytest.mark.parametrize(
         ("arguments", "expected_path", "expected_body"),
         [
-            (
+            pytest.param(
                 {"incident_id": 42, "action": "resolve", "secret_revoked": True},
                 "/incidents/secrets/42/resolve",
                 {"secret_revoked": True},
+                id="resolve-sends-secret-revoked",
             ),
-            (
+            pytest.param(
                 {"incident_id": 42, "action": "ignore", "ignore_reason": "low_risk"},
                 "/incidents/secrets/42/ignore",
                 {"ignore_reason": "low_risk"},
+                id="ignore-sends-ignore-reason",
             ),
-            ({"incident_id": 42, "action": "reopen"}, "/incidents/secrets/42/reopen", None),
-            ({"incident_id": 42, "action": "unassign"}, "/incidents/secrets/42/unassign", None),
+            pytest.param(
+                {"incident_id": 42, "action": "reopen"},
+                "/incidents/secrets/42/reopen",
+                None,
+                id="reopen-sends-no-body",
+            ),
+            pytest.param(
+                {"incident_id": 42, "action": "unassign"},
+                "/incidents/secrets/42/unassign",
+                None,
+                id="unassign-sends-no-body",
+            ),
         ],
     )
     async def test_each_action_hits_its_endpoint_with_the_exact_body(

--- a/tests/e2e/test_incident_write_tools.py
+++ b/tests/e2e/test_incident_write_tools.py
@@ -1,0 +1,161 @@
+"""Mutating incident tools: status changes, severity edits and assignment.
+
+These tools write to customer workspaces, so the tests pin the exact endpoint
+and JSON body for every action, and that guard rails (required reasons) block
+the HTTP call entirely.
+"""
+
+import pytest
+
+from tests.e2e.harness import call_tool, sent_body, tool_error_text, tool_output
+
+
+class TestManagePrivateIncident:
+    @pytest.mark.parametrize(
+        ("arguments", "expected_path", "expected_body"),
+        [
+            (
+                {"incident_id": 42, "action": "resolve", "secret_revoked": True},
+                "/incidents/secrets/42/resolve",
+                {"secret_revoked": True},
+            ),
+            (
+                {"incident_id": 42, "action": "ignore", "ignore_reason": "low_risk"},
+                "/incidents/secrets/42/ignore",
+                {"ignore_reason": "low_risk"},
+            ),
+            ({"incident_id": 42, "action": "reopen"}, "/incidents/secrets/42/reopen", None),
+            ({"incident_id": 42, "action": "unassign"}, "/incidents/secrets/42/unassign", None),
+        ],
+    )
+    async def test_each_action_hits_its_endpoint_with_the_exact_body(
+        self, mcp_client, gg_api, mock_token_scopes, arguments, expected_path, expected_body
+    ):
+        """
+        GIVEN a private incident action
+        WHEN manage_private_incident is called
+        THEN the matching status endpoint receives a POST with exactly the
+             documented body and the API response is returned verbatim
+        """
+        route = gg_api.post(expected_path).respond(200, json={"id": 42, "status": "UPDATED"})
+
+        result = await call_tool(mcp_client, "manage_private_incident", {"params": arguments})
+
+        assert route.called
+        assert sent_body(route) == expected_body
+        assert tool_output(result) == {"id": 42, "status": "UPDATED"}
+
+    async def test_resolving_without_the_revocation_answer_is_blocked_locally(
+        self, mcp_client, gg_api, mock_token_scopes
+    ):
+        """
+        GIVEN action=resolve without secret_revoked
+        WHEN manage_private_incident is called
+        THEN the tool refuses with guidance and no API call happens
+        """
+        route = gg_api.post("/incidents/secrets/42/resolve").respond(200, json={})
+
+        result = await call_tool(
+            mcp_client, "manage_private_incident", {"params": {"incident_id": 42, "action": "resolve"}}
+        )
+
+        assert "'secret_revoked' parameter is required" in tool_error_text(result)
+        assert not route.called
+
+    async def test_ignoring_without_a_reason_is_blocked_locally(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN action=ignore without ignore_reason
+        WHEN manage_private_incident is called
+        THEN the tool refuses with guidance and no API call happens
+        """
+        route = gg_api.post("/incidents/secrets/42/ignore").respond(200, json={})
+
+        result = await call_tool(
+            mcp_client, "manage_private_incident", {"params": {"incident_id": 42, "action": "ignore"}}
+        )
+
+        assert "'ignore_reason' parameter is required" in tool_error_text(result)
+        assert not route.called
+
+
+class TestUpdateIncidentSeverity:
+    async def test_severity_is_patched_on_the_incident(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN a severity change
+        WHEN update_incident_severity is called
+        THEN the incident is PATCHed with exactly the severity field
+        """
+        route = gg_api.patch("/incidents/secrets/42").respond(200, json={"id": 42, "severity": "high"})
+
+        result = await call_tool(
+            mcp_client, "update_incident_severity", {"params": {"incident_id": 42, "severity": "high"}}
+        )
+
+        assert sent_body(route) == {"severity": "high"}
+        assert tool_output(result) == {"id": 42, "severity": "high"}
+
+
+class TestAssignIncident:
+    async def test_mine_assigns_to_the_callers_member_id(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN mine=True
+        WHEN assign_incident is called
+        THEN the caller is resolved via /api_tokens/self and the assign body
+             carries the stringified member id with a null email
+        """
+        route = gg_api.post("/incidents/secrets/42/assign").respond(200, json={"id": 42, "assignee_id": 4242})
+
+        result = await call_tool(mcp_client, "assign_incident", {"params": {"incident_id": 42, "mine": True}})
+
+        assert sent_body(route) == {"member_id": "4242", "email": None}
+        output = tool_output(result)
+        assert output["assignee_id"] == 4242
+        assert output["success"] is True
+
+    async def test_assignment_by_email_sends_a_null_member_id(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN an assignee email
+        WHEN assign_incident is called
+        THEN the body carries the email and a null member_id
+        """
+        route = gg_api.post("/incidents/secrets/42/assign").respond(200, json={"id": 42})
+
+        await call_tool(mcp_client, "assign_incident", {"params": {"incident_id": 42, "email": "dev@corp.test"}})
+
+        assert sent_body(route) == {"member_id": None, "email": "dev@corp.test"}
+
+
+class TestUpdatePublicIncidentStatus:
+    async def test_resolving_a_public_incident_requires_and_sends_the_reason(
+        self, mcp_client, gg_api, mock_token_scopes
+    ):
+        """
+        GIVEN a public incident resolution with a reason
+        WHEN update_public_incident_status is called
+        THEN the public-incidents endpoint receives the resolve_reason body
+        """
+        route = gg_api.post("/public-incidents/secrets/7/resolve").respond(200, json={"id": 7, "status": "RESOLVED"})
+
+        result = await call_tool(
+            mcp_client,
+            "update_public_incident_status",
+            {"params": {"incident_id": 7, "action": "resolve", "resolve_reason": "revoked"}},
+        )
+
+        assert sent_body(route) == {"resolve_reason": "revoked"}
+        assert tool_output(result) == {"id": 7, "status": "RESOLVED"}
+
+    async def test_resolving_without_a_reason_is_blocked_locally(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN action=resolve without resolve_reason
+        WHEN update_public_incident_status is called
+        THEN the tool refuses with guidance and no API call happens
+        """
+        route = gg_api.post("/public-incidents/secrets/7/resolve").respond(200, json={})
+
+        result = await call_tool(
+            mcp_client, "update_public_incident_status", {"params": {"incident_id": 7, "action": "resolve"}}
+        )
+
+        assert "'resolve_reason' parameter is required" in tool_error_text(result)
+        assert not route.called

--- a/tests/e2e/test_oauth_proxy_endpoints.py
+++ b/tests/e2e/test_oauth_proxy_endpoints.py
@@ -7,6 +7,8 @@ exchange transformation regress, every remote user loses access.
 
 from urllib.parse import parse_qs, urlparse
 
+from pytest_voluptuous import S, Unordered
+
 from tests.e2e.harness import EXPECTED_SCOPES, MCP_BASE_URL, sent_body
 
 
@@ -21,16 +23,19 @@ class TestDiscoveryMetadata:
 
         assert response.status_code == 200
         metadata = response.json()
-        assert metadata["issuer"] == MCP_BASE_URL
-        assert metadata["authorization_endpoint"] == f"{MCP_BASE_URL}/authorize"
-        assert metadata["token_endpoint"] == f"{MCP_BASE_URL}/token"
-        assert metadata["registration_endpoint"] == f"{MCP_BASE_URL}/register"
-        assert metadata["code_challenge_methods_supported"] == ["S256"]
-        assert metadata["response_types_supported"] == ["code"]
-        assert metadata["grant_types_supported"] == ["authorization_code"]
-        assert metadata["token_endpoint_auth_methods_supported"] == ["none", "client_secret_post"]
-        assert len(metadata["scopes_supported"]) == len(set(metadata["scopes_supported"]))
-        assert set(metadata["scopes_supported"]) == set(EXPECTED_SCOPES)
+        assert metadata >= S(
+            {
+                "issuer": MCP_BASE_URL,
+                "authorization_endpoint": f"{MCP_BASE_URL}/authorize",
+                "token_endpoint": f"{MCP_BASE_URL}/token",
+                "registration_endpoint": f"{MCP_BASE_URL}/register",
+                "code_challenge_methods_supported": ["S256"],
+                "response_types_supported": ["code"],
+                "grant_types_supported": ["authorization_code"],
+                "token_endpoint_auth_methods_supported": ["none", "client_secret_post"],
+                "scopes_supported": Unordered(EXPECTED_SCOPES),
+            }
+        )
 
     async def test_protected_resource_metadata_advertises_this_authorization_server(self, mcp_client):
         """
@@ -42,11 +47,14 @@ class TestDiscoveryMetadata:
 
         assert response.status_code == 200
         metadata = response.json()
-        assert metadata["resource"] == f"{MCP_BASE_URL}/mcp"
-        assert metadata["authorization_servers"] == [MCP_BASE_URL]
-        assert metadata["bearer_methods_supported"] == ["header"]
-        assert len(metadata["scopes_supported"]) == len(set(metadata["scopes_supported"]))
-        assert set(metadata["scopes_supported"]) == set(EXPECTED_SCOPES)
+        assert metadata >= S(
+            {
+                "resource": f"{MCP_BASE_URL}/mcp",
+                "authorization_servers": [MCP_BASE_URL],
+                "bearer_methods_supported": ["header"],
+                "scopes_supported": Unordered(EXPECTED_SCOPES),
+            }
+        )
 
 
 class TestAuthorizeRedirect:

--- a/tests/e2e/test_oauth_proxy_endpoints.py
+++ b/tests/e2e/test_oauth_proxy_endpoints.py
@@ -1,0 +1,205 @@
+"""OAuth proxy surface of the remote MCP server.
+
+Claude.ai and other DCR clients authenticate through these same-origin
+endpoints; if discovery metadata, the authorize redirect, or the token
+exchange transformation regress, every remote user loses access.
+"""
+
+from urllib.parse import parse_qs, urlparse
+
+from tests.e2e.harness import EXPECTED_SCOPES, MCP_BASE_URL, sent_body
+
+
+class TestDiscoveryMetadata:
+    async def test_authorization_server_metadata_points_to_same_origin_endpoints(self, mcp_client):
+        """
+        GIVEN the hosted server
+        WHEN a client fetches RFC 8414 authorization-server metadata
+        THEN issuer and endpoints are all rooted at the server's own base URL
+        """
+        response = await mcp_client.get("/.well-known/oauth-authorization-server")
+
+        assert response.status_code == 200
+        metadata = response.json()
+        assert metadata["issuer"] == MCP_BASE_URL
+        assert metadata["authorization_endpoint"] == f"{MCP_BASE_URL}/authorize"
+        assert metadata["token_endpoint"] == f"{MCP_BASE_URL}/token"
+        assert metadata["registration_endpoint"] == f"{MCP_BASE_URL}/register"
+        assert metadata["code_challenge_methods_supported"] == ["S256"]
+        assert metadata["response_types_supported"] == ["code"]
+        assert metadata["grant_types_supported"] == ["authorization_code"]
+        assert metadata["token_endpoint_auth_methods_supported"] == ["none", "client_secret_post"]
+        assert len(metadata["scopes_supported"]) == len(set(metadata["scopes_supported"]))
+        assert set(metadata["scopes_supported"]) == set(EXPECTED_SCOPES)
+
+    async def test_protected_resource_metadata_advertises_this_authorization_server(self, mcp_client):
+        """
+        GIVEN the hosted server
+        WHEN a client fetches RFC 9728 protected-resource metadata
+        THEN the MCP endpoint is the resource and the server itself is the AS
+        """
+        response = await mcp_client.get("/.well-known/oauth-protected-resource/mcp")
+
+        assert response.status_code == 200
+        metadata = response.json()
+        assert metadata["resource"] == f"{MCP_BASE_URL}/mcp"
+        assert metadata["authorization_servers"] == [MCP_BASE_URL]
+        assert metadata["bearer_methods_supported"] == ["header"]
+        assert len(metadata["scopes_supported"]) == len(set(metadata["scopes_supported"]))
+        assert set(metadata["scopes_supported"]) == set(EXPECTED_SCOPES)
+
+
+class TestAuthorizeRedirect:
+    async def test_authorize_redirects_to_dashboard_login_with_client_params(self, mcp_client):
+        """
+        GIVEN a DCR client starting the OAuth flow
+        WHEN it hits /authorize with its own client_id and PKCE params
+        THEN it is redirected to the GitGuardian dashboard login, params intact,
+             with the GG-specific auth_mode added
+        """
+        response = await mcp_client.get(
+            "/authorize",
+            params={
+                "client_id": "my-dcr-client",
+                "redirect_uri": "https://claude.ai/api/mcp/auth_callback",
+                "code_challenge": "abc123",
+                "code_challenge_method": "S256",
+                "response_type": "code",
+                "scope": "scan incidents:read",
+                "state": "csrf-state-123",
+            },
+        )
+
+        assert response.status_code == 302
+        location = urlparse(response.headers["location"])
+        assert location.scheme == "https"
+        assert location.netloc == "dashboard.gitguardian.com"
+        assert location.path == "/auth/login"
+        query = parse_qs(location.query)
+        assert query["client_id"] == ["my-dcr-client"]
+        assert query["redirect_uri"] == ["https://claude.ai/api/mcp/auth_callback"]
+        assert query["code_challenge"] == ["abc123"]
+        assert query["code_challenge_method"] == ["S256"]
+        assert query["response_type"] == ["code"]
+        assert query["scope"] == ["scan incidents:read"]
+        assert query["state"] == ["csrf-state-123"]
+        assert query["auth_mode"] == ["oauth2_login"]
+
+    async def test_authorize_falls_back_to_the_ggshield_client_id(self, mcp_client):
+        """
+        GIVEN a client that omits client_id
+        WHEN it hits /authorize
+        THEN the redirect carries the default ggshield_oauth client_id
+        """
+        response = await mcp_client.get("/authorize", params={"response_type": "code"})
+
+        assert response.status_code == 302
+        query = parse_qs(urlparse(response.headers["location"]).query)
+        assert query["client_id"] == ["ggshield_oauth"]
+
+
+class TestDynamicClientRegistration:
+    async def test_registration_json_and_response_are_proxied_semantically_unchanged(self, mcp_client, gg_api):
+        """
+        GIVEN an MCP client dynamically registering its OAuth callback
+        WHEN it posts the registration document to the local proxy
+        THEN the same JSON document reaches GitGuardian and its response is relayed
+        """
+        registration = {
+            "client_name": "Claude",
+            "redirect_uris": ["https://claude.ai/api/mcp/auth_callback"],
+            "grant_types": ["authorization_code"],
+            "token_endpoint_auth_method": "none",
+        }
+        registered_client = {
+            **registration,
+            "client_id": "registered-client-id",
+        }
+        upstream = gg_api.post("/oauth/register").respond(201, json=registered_client)
+
+        response = await mcp_client.post("/register", json=registration)
+
+        assert response.status_code == 201
+        assert response.json() == registered_client
+        assert upstream.calls.last.request.headers["Content-Type"] == "application/json"
+        assert sent_body(upstream) == registration
+
+
+class TestTokenExchange:
+    async def test_token_exchange_transforms_gitguardian_key_into_oauth_access_token(self, mcp_client, gg_api):
+        """
+        GIVEN GitGuardian's token endpoint returning its non-standard {key: ...}
+        WHEN the client exchanges its authorization code at /token
+        THEN the upstream call carries the code plus the proxy's token name and
+             lifetime, and the response is reshaped to standard OAuth fields
+        """
+        upstream = gg_api.post("/oauth/token").respond(
+            200, json={"key": "gg-pat-from-exchange", "scope": ["scan", "incidents:read"]}
+        )
+
+        response = await mcp_client.post(
+            "/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": "auth-code-1",
+                "client_id": "my-dcr-client",
+                "code_verifier": "verifier",
+                "redirect_uri": "https://claude.ai/api/mcp/auth_callback",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "access_token": "gg-pat-from-exchange",
+            "token_type": "Bearer",
+            "scope": "scan incidents:read",
+        }
+        sent = parse_qs(upstream.calls.last.request.content.decode())
+        assert sent["grant_type"] == ["authorization_code"]
+        assert sent["code"] == ["auth-code-1"]
+        assert sent["client_id"] == ["my-dcr-client"]
+        assert sent["code_verifier"] == ["verifier"]
+        assert sent["redirect_uri"] == ["https://claude.ai/api/mcp/auth_callback"]
+        assert sent["name"] == ["MCP server token (OAuth Proxy)"]
+        assert sent["lifetime"] == ["90"]
+
+    async def test_confidential_client_secret_is_forwarded_in_the_form_body(self, mcp_client, gg_api):
+        """
+        GIVEN a registered confidential client using client_secret_post
+        WHEN it exchanges an authorization code
+        THEN its client secret and redirect binding reach GitGuardian unchanged
+        """
+        upstream = gg_api.post("/oauth/token").respond(200, json={"key": "confidential-client-pat"})
+
+        response = await mcp_client.post(
+            "/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": "confidential-auth-code",
+                "client_id": "confidential-client",
+                "client_secret": "test-client-secret",
+                "redirect_uri": "https://client.example.test/oauth/callback",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["access_token"] == "confidential-client-pat"
+        sent = parse_qs(upstream.calls.last.request.content.decode())
+        assert sent["grant_type"] == ["authorization_code"]
+        assert sent["code"] == ["confidential-auth-code"]
+        assert sent["client_id"] == ["confidential-client"]
+        assert sent["client_secret"] == ["test-client-secret"]
+        assert sent["redirect_uri"] == ["https://client.example.test/oauth/callback"]
+
+    async def test_token_exchange_passes_upstream_errors_through(self, mcp_client, gg_api):
+        """
+        GIVEN GitGuardian rejecting the code exchange
+        WHEN the client hits /token
+        THEN the upstream error body and status are relayed untransformed
+        """
+        gg_api.post("/oauth/token").respond(400, json={"error": "invalid_grant"})
+
+        response = await mcp_client.post("/token", data={"grant_type": "authorization_code", "code": "bad"})
+
+        assert response.status_code == 400
+        assert response.json() == {"error": "invalid_grant"}

--- a/tests/e2e/test_scan_secrets.py
+++ b/tests/e2e/test_scan_secrets.py
@@ -4,6 +4,8 @@ Pins the /multiscan wire contract (documents pass through verbatim, results
 come back untouched) and the input-validation and crash behavior around it.
 """
 
+import pytest
+
 from tests.e2e.harness import assert_authenticated_request, call_tool, sent_body, tool_error_text, tool_output
 
 SCAN_RESULT = {
@@ -41,23 +43,24 @@ class TestScanSecrets:
         assert sent_body(route) == documents
         assert tool_output(result) == {"scan_results": [SCAN_RESULT, {"policy_break_count": 0}]}
 
-    async def test_document_without_filename_crashes_before_reaching_the_api(
-        self, mcp_client, gg_api, mock_token_scopes
-    ):
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SI-3891: request logging crashes when a scan document has no filename",
+    )
+    async def test_document_without_filename_is_scanned(self, mcp_client, gg_api, mock_token_scopes):
         """
         GIVEN a document dict carrying only the document key
         WHEN scan_secrets is called
-        THEN the call fails with the request-logging crash and no API call is made
+        THEN the document is sent to the API and its result is returned
         """
         route = gg_api.post("/multiscan").respond(200, json=[SCAN_RESULT])
+        documents = [{"document": "x = 1\n"}]
 
-        result = await call_tool(mcp_client, "scan_secrets", {"params": {"documents": [{"document": "x = 1\n"}]}})
+        result = await call_tool(mcp_client, "scan_secrets", {"params": {"documents": documents}})
 
-        # TODO(SI-3891): known crash, the client's request-body debug logging
-        # does dict(list) on the multiscan payload; single-key documents blow
-        # up before the HTTP request is even sent (Sentry R1).
-        assert "dictionary update sequence" in tool_error_text(result)
-        assert not route.called
+        assert route.called
+        assert sent_body(route) == documents
+        assert tool_output(result) == {"scan_results": [SCAN_RESULT]}
 
     async def test_empty_document_list_is_rejected_without_an_api_call(self, mcp_client, gg_api, mock_token_scopes):
         """

--- a/tests/e2e/test_scan_secrets.py
+++ b/tests/e2e/test_scan_secrets.py
@@ -1,0 +1,89 @@
+"""scan_secrets: the highest-volume tool of the remote server.
+
+Pins the /multiscan wire contract (documents pass through verbatim, results
+come back untouched) and the input-validation and crash behavior around it.
+"""
+
+from tests.e2e.harness import assert_authenticated_request, call_tool, sent_body, tool_error_text, tool_output
+
+SCAN_RESULT = {
+    "policy_break_count": 1,
+    "policies": ["Secrets detection"],
+    "policy_breaks": [
+        {
+            "type": "AWS Keys",
+            "policy": "Secrets detection",
+            "matches": [{"type": "apikey", "match": "AKIA...", "line_start": 3}],
+        }
+    ],
+}
+
+
+class TestScanSecrets:
+    async def test_documents_are_posted_verbatim_and_results_returned_untouched(
+        self, mcp_client, gg_api, mock_token_scopes
+    ):
+        """
+        GIVEN two documents with filenames
+        WHEN scan_secrets is called
+        THEN the multiscan API receives the raw document list as JSON body and
+             the per-document results are returned verbatim under scan_results
+        """
+        documents = [
+            {"document": "aws_key = 'AKIA...'\n", "filename": "config.py"},
+            {"document": "clean file\n", "filename": "README.md"},
+        ]
+        route = gg_api.post("/multiscan").respond(200, json=[SCAN_RESULT, {"policy_break_count": 0}])
+
+        result = await call_tool(mcp_client, "scan_secrets", {"params": {"documents": documents}})
+
+        assert_authenticated_request(route)
+        assert sent_body(route) == documents
+        assert tool_output(result) == {"scan_results": [SCAN_RESULT, {"policy_break_count": 0}]}
+
+    async def test_document_without_filename_crashes_before_reaching_the_api(
+        self, mcp_client, gg_api, mock_token_scopes
+    ):
+        """
+        GIVEN a document dict carrying only the document key
+        WHEN scan_secrets is called
+        THEN the call fails with the request-logging crash and no API call is made
+        """
+        route = gg_api.post("/multiscan").respond(200, json=[SCAN_RESULT])
+
+        result = await call_tool(mcp_client, "scan_secrets", {"params": {"documents": [{"document": "x = 1\n"}]}})
+
+        # TODO(SI-3891): known crash, the client's request-body debug logging
+        # does dict(list) on the multiscan payload; single-key documents blow
+        # up before the HTTP request is even sent (Sentry R1).
+        assert "dictionary update sequence" in tool_error_text(result)
+        assert not route.called
+
+    async def test_empty_document_list_is_rejected_without_an_api_call(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN an empty documents list
+        WHEN scan_secrets is called
+        THEN validation fails locally and the API is never contacted
+        """
+        route = gg_api.post("/multiscan").respond(200, json=[])
+
+        result = await call_tool(mcp_client, "scan_secrets", {"params": {"documents": []}})
+
+        assert "non-empty list" in tool_error_text(result)
+        assert not route.called
+
+    async def test_api_rejection_bubbles_up_as_a_tool_error(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN the API rejecting the batch with 400
+        WHEN scan_secrets is called
+        THEN the failure surfaces as a tool error naming the status
+        """
+        gg_api.post("/multiscan").respond(400, json={"detail": "Too many documents."})
+
+        result = await call_tool(
+            mcp_client,
+            "scan_secrets",
+            {"params": {"documents": [{"document": "x", "filename": "x.py"}]}},
+        )
+
+        assert "400" in tool_error_text(result)

--- a/tests/e2e/test_workspace_tools.py
+++ b/tests/e2e/test_workspace_tools.py
@@ -1,0 +1,200 @@
+"""Workspace metadata and remediation tools: list_sources, read_custom_tags,
+find_current_source_id, remediate_secret_incidents.
+"""
+
+import httpx
+
+from tests.e2e.harness import (
+    TEST_MEMBER_ID,
+    assert_authenticated_request,
+    call_tool,
+    sent_params,
+    token_info,
+    tool_output,
+    unwrap_result,
+)
+
+
+class TestListSources:
+    async def test_filters_and_cursor_pagination(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN source filters and a next page advertised via the Link header
+        WHEN list_sources is called
+        THEN the query carries the filters (booleans lowercased) and the cursor
+             comes back decoded with has_more=True
+        """
+        source = {"id": 55, "name": "ggmcp", "type": "github"}
+        route = gg_api.get("/sources").respond(
+            200,
+            json=[source],
+            headers={"Link": '<https://api.gitguardian.com/v1/sources?cursor=abc%3D%3D>; rel="next"'},
+        )
+
+        result = await call_tool(
+            mcp_client,
+            "list_sources",
+            {"params": {"type": "github", "monitored": True, "search": "gg"}},
+        )
+
+        params = sent_params(route)
+        assert_authenticated_request(route)
+        assert params == {"search": "gg", "type": "github", "monitored": "true", "per_page": "20"}
+        output = tool_output(result)
+        assert output["sources"] == [source]
+        assert output["next_cursor"] == "abc=="
+        assert output["has_more"] is True
+
+
+class TestReadCustomTags:
+    async def test_list_tags_returns_the_first_page_verbatim(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN existing custom tags
+        WHEN read_custom_tags is called with action=list_tags
+        THEN /custom_tags is queried and the payload is returned untouched
+        """
+        tags = [{"id": "1", "key": "team", "value": "payments"}]
+        route = gg_api.get("/custom_tags").respond(200, json=tags)
+
+        # TODO(SI-3891): tag_id is required by the schema even for list_tags,
+        # where it is ignored.
+        result = await call_tool(mcp_client, "read_custom_tags", {"params": {"action": "list_tags", "tag_id": 0}})
+
+        assert route.called
+        assert sent_params(route) == {}
+        assert tool_output(result) == tags
+
+    async def test_get_tag_fetches_one_tag_by_id(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN a tag id
+        WHEN read_custom_tags is called with action=get_tag
+        THEN /custom_tags/{id} is queried and the tag returned verbatim
+        """
+        tag = {"id": "9", "key": "env", "value": "prod"}
+        route = gg_api.get("/custom_tags/9").respond(200, json=tag)
+
+        result = await call_tool(mcp_client, "read_custom_tags", {"params": {"action": "get_tag", "tag_id": 9}})
+
+        assert route.called
+        assert tool_output(result) == tag
+
+
+class TestFindCurrentSourceId:
+    async def test_remote_server_cannot_introspect_git_and_says_so(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN the hosted (HTTP) server, which has no access to the caller's repo
+        WHEN find_current_source_id is called without remote_url
+        THEN it returns the run-git-yourself suggestion without touching the API
+        """
+        result = await call_tool(mcp_client, "find_current_source_id", {})
+
+        output = unwrap_result(result)
+        assert "git config --get remote.origin.url" in output["suggestion"]
+        assert output["message"] == "The repository could not be detected server-side."
+        assert not [call for call in gg_api.calls if call.request.url.path == "/v1/sources"]
+
+    async def test_remote_url_is_parsed_and_matched_against_sources(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN a git remote URL
+        WHEN find_current_source_id is called
+        THEN sources are searched by the bare repository name and the exact
+             match's id is returned
+        """
+        route = gg_api.get("/sources").respond(
+            200, json=[{"id": 55, "name": "ggmcp", "full_name": "GitGuardian/ggmcp"}]
+        )
+
+        result = await call_tool(
+            mcp_client,
+            "find_current_source_id",
+            {"remote_url": "https://github.com/GitGuardian/ggmcp.git"},
+        )
+
+        params = sent_params(route)
+        assert params == {"search": "ggmcp", "per_page": "50"}
+        output = unwrap_result(result)
+        assert output["source_id"] == 55
+        assert output["repository_name"] == "ggmcp"
+
+    async def test_api_failure_is_reported_as_repository_not_found(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN the sources endpoint rejecting the token with 403
+        WHEN find_current_source_id is called
+        THEN the tool reports the repository as not found
+        """
+        gg_api.get("/sources").respond(403, json={"detail": "Forbidden"})
+
+        result = await call_tool(mcp_client, "find_current_source_id", {"remote_url": "git@github.com:acme/app.git"})
+
+        # TODO(SI-3891): fail-open; get_source_by_name swallows every exception
+        # and returns None, so an auth failure is indistinguishable from a
+        # repository that is not connected.
+        output = unwrap_result(result)
+        assert output["error"] == "Repository 'app' not found in GitGuardian"
+
+
+class TestRemediateSecretIncidents:
+    OCCURRENCES = [
+        {"id": 1, "incident": {"id": 501, "assignee_id": TEST_MEMBER_ID}, "filepath": "a.py"},
+        {"id": 2, "incident": {"id": 502, "assignee_id": 9999}, "filepath": "b.py"},
+    ]
+
+    async def test_default_flow_lists_default_branch_occurrences_and_renders_instructions(
+        self, mcp_client, gg_api, mock_token_scopes
+    ):
+        """
+        GIVEN a source with occurrences
+        WHEN remediate_secret_incidents is called
+        THEN occurrences are fetched restricted to the default branch and the
+             result carries remediation instructions plus the occurrence list
+        """
+        route = gg_api.get("/occurrences/secrets").respond(200, json={"results": self.OCCURRENCES})
+
+        result = await call_tool(mcp_client, "remediate_secret_incidents", {"params": {"source_id": 55}})
+
+        params = sent_params(route)
+        assert params["source_id"] == "55"
+        assert params["tags"] == "DEFAULT_BRANCH"
+        assert params["with_sources"] == "false"
+        output = unwrap_result(result)
+        assert output["occurrences_count"] == 2
+        assert output["suggested_occurrences_for_remediation_count"] == 2
+        assert output["remediation_instructions"]
+        assert output["sub_tools_results"]["list_repo_occurrences"]["occurrences"] == self.OCCURRENCES
+
+    async def test_mine_keeps_only_the_callers_occurrences(self, mcp_client, gg_api, mock_token_scopes):
+        """
+        GIVEN occurrences assigned to different members
+        WHEN remediate_secret_incidents is called with mine=True
+        THEN only occurrences whose incident is assigned to the caller remain
+        """
+        gg_api.get("/occurrences/secrets").respond(200, json={"results": self.OCCURRENCES})
+
+        result = await call_tool(mcp_client, "remediate_secret_incidents", {"params": {"source_id": 55, "mine": True}})
+
+        output = unwrap_result(result)
+        occurrences = output["sub_tools_results"]["list_repo_occurrences"]["occurrences"]
+        assert [occ["id"] for occ in occurrences] == [1]
+        assert output["occurrences_count"] == 1
+
+    async def test_mine_fails_open_when_the_member_lookup_breaks(
+        self, mcp_client, gg_api, mock_token_scopes, no_retry_delay
+    ):
+        """
+        GIVEN the token-info endpoint failing during the mine filter
+        WHEN remediate_secret_incidents is called with mine=True
+        THEN every occurrence is returned as if mine had not been requested
+        """
+        gg_api.get("/occurrences/secrets").respond(200, json={"results": self.OCCURRENCES})
+        # First call: the per-request scope fetch (must succeed for the tool to
+        # be dispatched at all). Second call: filter_mine's member lookup.
+        gg_api.get("/api_tokens/self").mock(
+            side_effect=[httpx.Response(200, json=token_info())] + [httpx.Response(500, text="boom")] * 4
+        )
+
+        result = await call_tool(mcp_client, "remediate_secret_incidents", {"params": {"source_id": 55, "mine": True}})
+
+        # TODO(SI-3891): filter_mine fails open; the caller asked for their own
+        # incidents but silently receives everyone's.
+        output = unwrap_result(result)
+        occurrences = output["sub_tools_results"]["list_repo_occurrences"]["occurrences"]
+        assert [occ["id"] for occ in occurrences] == [1, 2]

--- a/tests/e2e/test_workspace_tools.py
+++ b/tests/e2e/test_workspace_tools.py
@@ -2,7 +2,10 @@
 find_current_source_id, remediate_secret_incidents.
 """
 
+from http import HTTPStatus
+
 import httpx
+import pytest
 
 from tests.e2e.harness import (
     TEST_MEMBER_ID,
@@ -10,6 +13,7 @@ from tests.e2e.harness import (
     call_tool,
     sent_params,
     token_info,
+    tool_error_text,
     tool_output,
     unwrap_result,
 )
@@ -46,18 +50,20 @@ class TestListSources:
 
 
 class TestReadCustomTags:
-    async def test_list_tags_returns_the_first_page_verbatim(self, mcp_client, gg_api, mock_token_scopes):
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SI-3891: read_custom_tags requires tag_id even when listing tags",
+    )
+    async def test_list_tags_does_not_require_a_tag_id(self, mcp_client, gg_api, mock_token_scopes):
         """
         GIVEN existing custom tags
-        WHEN read_custom_tags is called with action=list_tags
+        WHEN read_custom_tags is called with action=list_tags and no tag ID
         THEN /custom_tags is queried and the payload is returned untouched
         """
         tags = [{"id": "1", "key": "team", "value": "payments"}]
         route = gg_api.get("/custom_tags").respond(200, json=tags)
 
-        # TODO(SI-3891): tag_id is required by the schema even for list_tags,
-        # where it is ignored.
-        result = await call_tool(mcp_client, "read_custom_tags", {"params": {"action": "list_tags", "tag_id": 0}})
+        result = await call_tool(mcp_client, "read_custom_tags", {"params": {"action": "list_tags"}})
 
         assert route.called
         assert sent_params(route) == {}
@@ -115,21 +121,24 @@ class TestFindCurrentSourceId:
         assert output["source_id"] == 55
         assert output["repository_name"] == "ggmcp"
 
-    async def test_api_failure_is_reported_as_repository_not_found(self, mcp_client, gg_api, mock_token_scopes):
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SI-3891: source lookup swallows API failures and reports the repository as missing",
+    )
+    async def test_api_failure_surfaces_as_a_tool_error(self, mcp_client, gg_api, mock_token_scopes):
         """
         GIVEN the sources endpoint rejecting the token with 403
         WHEN find_current_source_id is called
-        THEN the tool reports the repository as not found
+        THEN the API failure surfaces as a tool error
         """
-        gg_api.get("/sources").respond(403, json={"detail": "Forbidden"})
+        gg_api.get("/sources").respond(
+            status_code=HTTPStatus.FORBIDDEN,
+            json={"detail": "Forbidden"},
+        )
 
         result = await call_tool(mcp_client, "find_current_source_id", {"remote_url": "git@github.com:acme/app.git"})
 
-        # TODO(SI-3891): fail-open; get_source_by_name swallows every exception
-        # and returns None, so an auth failure is indistinguishable from a
-        # repository that is not connected.
-        output = unwrap_result(result)
-        assert output["error"] == "Repository 'app' not found in GitGuardian"
+        assert str(HTTPStatus.FORBIDDEN.value) in tool_error_text(result)
 
 
 class TestRemediateSecretIncidents:
@@ -176,13 +185,17 @@ class TestRemediateSecretIncidents:
         assert [occ["id"] for occ in occurrences] == [1]
         assert output["occurrences_count"] == 1
 
-    async def test_mine_fails_open_when_the_member_lookup_breaks(
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SI-3891: remediation silently returns every incident when the mine filter fails",
+    )
+    async def test_mine_fails_closed_when_the_member_lookup_breaks(
         self, mcp_client, gg_api, mock_token_scopes, no_retry_delay
     ):
         """
         GIVEN the token-info endpoint failing during the mine filter
         WHEN remediate_secret_incidents is called with mine=True
-        THEN every occurrence is returned as if mine had not been requested
+        THEN the API failure surfaces instead of returning everyone's incidents
         """
         gg_api.get("/occurrences/secrets").respond(200, json={"results": self.OCCURRENCES})
         # First call: the per-request scope fetch (must succeed for the tool to
@@ -193,8 +206,4 @@ class TestRemediateSecretIncidents:
 
         result = await call_tool(mcp_client, "remediate_secret_incidents", {"params": {"source_id": 55, "mine": True}})
 
-        # TODO(SI-3891): filter_mine fails open; the caller asked for their own
-        # incidents but silently receives everyone's.
-        output = unwrap_result(result)
-        occurrences = output["sub_tools_results"]["list_repo_occurrences"]["occurrences"]
-        assert [occ["id"] for occ in occurrences] == [1, 2]
+        assert "500" in tool_error_text(result)

--- a/tests/test_server_composition.py
+++ b/tests/test_server_composition.py
@@ -1,0 +1,40 @@
+"""Regression tests for the production server composition entry point."""
+
+from typing import Any
+
+from gg_mcp_server import server
+
+
+def test_get_server_initializes_observability_before_building_and_caches(monkeypatch):
+    """
+    GIVEN the production server entry point
+    WHEN get_server is called more than once
+    THEN observability is initialized before composition and the result is cached
+    """
+    events: list[str] = []
+    expected_settings = object()
+    expected_server = object()
+
+    def configure_logging(settings: Any) -> None:
+        assert settings is expected_settings
+        events.append("logging")
+
+    def build_server() -> object:
+        events.append("build")
+        return expected_server
+
+    monkeypatch.setattr(server, "init_sentry", lambda: events.append("sentry"))
+    monkeypatch.setattr(server, "get_settings", lambda: expected_settings)
+    monkeypatch.setattr(server, "configure_logging_from_settings", configure_logging)
+    monkeypatch.setattr(server, "build_server", build_server)
+    server.get_server.cache_clear()
+
+    try:
+        first_result = server.get_server()
+        second_result = server.get_server()
+    finally:
+        server.get_server.cache_clear()
+
+    assert first_result is expected_server
+    assert second_result is expected_server
+    assert events == ["sentry", "logging", "build"]

--- a/uv.lock
+++ b/uv.lock
@@ -595,6 +595,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pyyaml" },
+    { name = "respx" },
     { name = "ruff" },
     { name = "vcrpy" },
 ]
@@ -615,6 +616,7 @@ dev = [
     { name = "pytest-cov", specifier = "~=7.0" },
     { name = "pytest-mock", specifier = "~=3.15" },
     { name = "pyyaml", specifier = "~=6.0" },
+    { name = "respx", specifier = "~=0.22" },
     { name = "ruff", specifier = "~=0.14" },
     { name = "vcrpy", specifier = "~=8.0" },
 ]
@@ -1432,6 +1434,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -594,6 +594,8 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-socket" },
+    { name = "pytest-voluptuous" },
     { name = "pyyaml" },
     { name = "respx" },
     { name = "ruff" },
@@ -615,6 +617,8 @@ dev = [
     { name = "pytest-asyncio", specifier = "~=1.2" },
     { name = "pytest-cov", specifier = "~=7.0" },
     { name = "pytest-mock", specifier = "~=3.15" },
+    { name = "pytest-socket", specifier = "~=0.7" },
+    { name = "pytest-voluptuous", specifier = "~=1.2" },
     { name = "pyyaml", specifier = "~=6.0" },
     { name = "respx", specifier = "~=0.22" },
     { name = "ruff", specifier = "~=0.14" },
@@ -1322,6 +1326,30 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-socket"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/3c/f9b58e57830e58980dbe8867d0e348f45701d3f3ea065672d448f4366da5/pytest_socket-0.8.0.tar.gz", hash = "sha256:af9bb5f487da72be63573a6194cfac033b6c7a1c1561e150521105970f9e99f2", size = 13912, upload-time = "2026-05-21T16:50:22.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/e8/4a8568580bae3dcd678599ed8e86a82d505a44df71c1ced4246c1aa14b4b/pytest_socket-0.8.0-py3-none-any.whl", hash = "sha256:81821ba59f07d7600fe2b551d8714f40b068bd46e8b6704c48664e9d60cdacb8", size = 8414, upload-time = "2026-05-21T16:50:21.022Z" },
+]
+
+[[package]]
+name = "pytest-voluptuous"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "voluptuous" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/e1/07b3169ccc9a77b210a1fc0733af937dcfc423a8c1cd808c6a34fc3b8258/pytest_voluptuous-1.2.0-py2.py3-none-any.whl", hash = "sha256:a3856e9812b219fec1c3f2fd8249c0bac6927e1d5e52a3961e4ae903f54d494f", size = 10032, upload-time = "2020-06-09T14:11:48.154Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
@@ -1816,6 +1844,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f4/a5/f041a00e7a0b2de5b348aa6dbd8217bfc60787c06dfe985a4f83dec924d0/vcrpy-8.0.0.tar.gz", hash = "sha256:25622ec65c5c007597d417e6867ccb6e6ab0d5f8826e2a03feb5911b3011f8ad", size = 85884, upload-time = "2025-12-03T18:23:10.879Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/08/a66c3156a10ab360986a38a7e5c05ec46a654bae5e2df2b2084cb0563701/vcrpy-8.0.0-py2.py3-none-any.whl", hash = "sha256:3e5aae652bb1e2703e9a32869ebf903ff823420f98f80974aa99ceb7a5fdbb17", size = 42576, upload-time = "2025-12-03T18:23:09.95Z" },
+]
+
+[[package]]
+name = "voluptuous"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/f4/0738e6849858deae22218be3bbb8207ba83a96e9d0ec7e8e8cd67b30e5ca/voluptuous-0.16.0.tar.gz", hash = "sha256:006535e22fed944aec17bef6e8725472476194743c87bd233e912eb463f8ff05", size = 54238, upload-time = "2025-12-18T23:18:46.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/00/0e0da784245c93cf346150ab67634177bf277f93b7a162bb56c928c39c04/voluptuous-0.16.0-py3-none-any.whl", hash = "sha256:ee342095263e1b5afbd4d418cb5adc92810eebfd07696bb033a261210df33db4", size = 31931, upload-time = "2025-12-18T23:18:44.694Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> Merge order: foundation PR, merge before the stacked stdio PR #203. PR #204 is independent.

Part of [SI-3891](https://linear.app/gitguardian/issue/SI-3891/regression-safety-net-before-touching-the-functional-core): the regression safety net for the remote (hosted) MCP server, to land before any refactor of the functional core.

Adds 61 end-to-end tests in `tests/e2e/` that drive the real production ASGI app with raw JSON-RPC 2.0 over an in-process httpx client. Only the outbound GitGuardian API is faked (respx, dev-only dependency); auth middleware, FastMCP, scope filtering, tools and the GitGuardian client all run for real. Tests pin both boundaries: the exact outbound request (paths, query-param dialect, JSON bodies) and the exact JSON-RPC response. Known defects are pinned with TODO(SI-3891) comments rather than fixed here.
