### PR TITLE
test(vcr): anonymize recorded fixtures at record time

### DIFF
--- a/tests/cassettes/client/vcr/test_assign_public_incident_by_email.yaml
+++ b/tests/cassettes/client/vcr/test_assign_public_incident_by_email.yaml
@@ -177,9 +177,8 @@ interactions:
   response:
     body:
       string: '{"id": 480870, "role": "manager", "access_level": "manager", "email":
-        "timothe.delion@gitguardian.com", "name": "Timoth\u00e9 DELION", "created_at":
-        "2023-06-26T12:41:18.599497Z", "last_login": "2026-06-23T12:20:54.639679Z",
-        "active": true}'
+        "user-8e645c6e@example.com", "name": "User bb2e577e", "created_at": "2023-06-26T12:41:18.599497Z",
+        "last_login": "2026-06-23T12:20:54.639679Z", "active": true}'
     headers:
       CF-RAY:
       - a103a186781d2a4f-CDG
@@ -315,7 +314,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"email": "timothe.delion@gitguardian.com"}'
+    body: '{"email": "user-8e645c6e@example.com"}'
     headers:
       Accept:
       - '*/*'
@@ -347,7 +346,7 @@ interactions:
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "failed_to_check", "severity": "unknown", "assignee_id": 480870,
-        "assignee_email": "timothe.delion@gitguardian.com", "share_url": "[REDACTED]",
+        "assignee_email": "user-8e645c6e@example.com", "share_url": "[REDACTED]",
         "feedback_list": [], "risk_score": 44, "severity_rule_id": null, "is_vaulted":
         false, "declarative_secret_status": "active", "resolve_reason": null, "ignore_reason":
         null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/5",

--- a/tests/cassettes/client/vcr/test_assign_public_incident_by_member_id.yaml
+++ b/tests/cassettes/client/vcr/test_assign_public_incident_by_member_id.yaml
@@ -198,7 +198,7 @@ interactions:
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "unknown", "assignee_id": 480870,
-        "assignee_email": "timothe.delion@gitguardian.com", "share_url": "[REDACTED]",
+        "assignee_email": "user-8e645c6e@example.com", "share_url": "[REDACTED]",
         "feedback_list": [], "risk_score": 44, "severity_rule_id": null, "is_vaulted":
         false, "declarative_secret_status": "active", "resolve_reason": null, "ignore_reason":
         null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/4",

--- a/tests/cassettes/client/vcr/test_assign_public_incident_send_email_false.yaml
+++ b/tests/cassettes/client/vcr/test_assign_public_incident_send_email_false.yaml
@@ -197,8 +197,8 @@ interactions:
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "invalid", "severity": "unknown", "assignee_id": 480870, "assignee_email":
-        "timothe.delion@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "user-8e645c6e@example.com", "share_url": "[REDACTED]", "feedback_list": [],
+        "risk_score": 11, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/8", "tags":
         ["FROM_HISTORICAL_SCAN"], "custom_tags": [], "destination_tickets": [], "incident_name":

--- a/tests/cassettes/client/vcr/test_get_audit_logs.yaml
+++ b/tests/cassettes/client/vcr/test_get_audit_logs.yaml
@@ -21,46 +21,46 @@ interactions:
   response:
     body:
       string: '[{"id": 23983381, "api_token_id": null, "member_id": 480870, "member_email":
-        "timothe.delion@gitguardian.com", "member_name": "Timoth\u00e9 DELION", "date":
+        "user-8e645c6e@example.com", "member_name": "Timoth\u00e9 DELION", "date":
         "2026-06-23T12:23:58.297394Z", "data": null, "event_name": "custom_remediation_workflow.updated",
         "action_type": "UPDATE", "target_ids": ["6"], "ip_address": "92.128.35.47"},
         {"id": 23983251, "api_token_id": null, "member_id": 480870, "member_email":
-        "timothe.delion@gitguardian.com", "member_name": "Timoth\u00e9 DELION", "date":
+        "user-8e645c6e@example.com", "member_name": "Timoth\u00e9 DELION", "date":
         "2026-06-23T12:20:54.649674Z", "data": {"type": "saml_sso"}, "event_name":
         "user.logged_in", "action_type": "OTHER", "target_ids": ["480218"], "ip_address":
         "92.128.35.47"}, {"id": 23982412, "api_token_id": null, "member_id": 1301278,
-        "member_email": "zach.mccullough@gitguardian.com", "member_name": "Zachary
-        MCCULLOUGH", "date": "2026-06-23T11:59:32.903530Z", "data": {"type": "saml_sso"},
-        "event_name": "user.logged_in", "action_type": "OTHER", "target_ids": ["1299091"],
-        "ip_address": "73.8.249.128"}, {"id": 23982141, "api_token_id": null, "member_id":
-        363444, "member_email": "patrick.flanagan@gitguardian.com", "member_name":
-        "Patrick FLANAGAN", "date": "2026-06-23T11:47:23.624224Z", "data": {"issue_token":
-        73062}, "event_name": "secret_incident.shared_incident_viewed", "action_type":
-        "READ", "target_ids": ["34205503"], "ip_address": "185.175.151.131"}, {"id":
-        23982136, "api_token_id": null, "member_id": 363444, "member_email": "patrick.flanagan@gitguardian.com",
-        "member_name": "Patrick FLANAGAN", "date": "2026-06-23T11:47:02.338330Z",
-        "data": {"issue_id": 34205503, "expire_at": "2026-07-23T11:47:02.322847+00:00"},
-        "event_name": "incident_token.created", "action_type": "CREATE", "target_ids":
-        ["73062"], "ip_address": "185.175.151.131"}, {"id": 23982131, "api_token_id":
-        null, "member_id": 363444, "member_email": "patrick.flanagan@gitguardian.com",
-        "member_name": "Patrick FLANAGAN", "date": "2026-06-23T11:46:58.538857Z",
-        "data": null, "event_name": "secret_incident.viewed", "action_type": "READ",
-        "target_ids": ["34205503"], "ip_address": "185.175.151.131"}, {"id": 23981642,
-        "api_token_id": null, "member_id": 1754656, "member_email": "candidate.playground+eu@gitguardian.com",
-        "member_name": "CandidateEU DemoAccess", "date": "2026-06-23T11:26:44.352505Z",
-        "data": null, "event_name": "secret_incident.viewed", "action_type": "READ",
-        "target_ids": ["32828142"], "ip_address": "82.169.214.153"}, {"id": 23981549,
-        "api_token_id": null, "member_id": 1754656, "member_email": "candidate.playground+eu@gitguardian.com",
-        "member_name": "CandidateEU DemoAccess", "date": "2026-06-23T11:22:57.870942Z",
-        "data": null, "event_name": "secret_incident.viewed", "action_type": "READ",
-        "target_ids": ["32985083"], "ip_address": "82.169.214.153"}, {"id": 23981372,
-        "api_token_id": null, "member_id": 1754656, "member_email": "candidate.playground+eu@gitguardian.com",
-        "member_name": "CandidateEU DemoAccess", "date": "2026-06-23T11:13:34.045630Z",
-        "data": null, "event_name": "secret_incident.viewed", "action_type": "READ",
-        "target_ids": ["34205503"], "ip_address": "82.169.214.153"}, {"id": 23981370,
-        "api_token_id": null, "member_id": 1754656, "member_email": "candidate.playground+eu@gitguardian.com",
-        "member_name": "CandidateEU DemoAccess", "date": "2026-06-23T11:13:31.746525Z",
-        "data": {"issue_id": 34205503, "issue_hash": "HdPZ4cjZuziAqsakdlsUnJDapTz3ns5pX8vPzfhvGQvpWWWX25LITKmJimoqGr3z"},
+        "member_email": "user-6d755f01@example.com", "member_name": "Zachary MCCULLOUGH",
+        "date": "2026-06-23T11:59:32.903530Z", "data": {"type": "saml_sso"}, "event_name":
+        "user.logged_in", "action_type": "OTHER", "target_ids": ["1299091"], "ip_address":
+        "73.8.249.128"}, {"id": 23982141, "api_token_id": null, "member_id": 363444,
+        "member_email": "user-1aafc941@example.com", "member_name": "Patrick FLANAGAN",
+        "date": "2026-06-23T11:47:23.624224Z", "data": {"issue_token": 73062}, "event_name":
+        "secret_incident.shared_incident_viewed", "action_type": "READ", "target_ids":
+        ["34205503"], "ip_address": "185.175.151.131"}, {"id": 23982136, "api_token_id":
+        null, "member_id": 363444, "member_email": "user-1aafc941@example.com", "member_name":
+        "Patrick FLANAGAN", "date": "2026-06-23T11:47:02.338330Z", "data": {"issue_id":
+        34205503, "expire_at": "2026-07-23T11:47:02.322847+00:00"}, "event_name":
+        "incident_token.created", "action_type": "CREATE", "target_ids": ["73062"],
+        "ip_address": "185.175.151.131"}, {"id": 23982131, "api_token_id": null, "member_id":
+        363444, "member_email": "user-1aafc941@example.com", "member_name": "Patrick
+        FLANAGAN", "date": "2026-06-23T11:46:58.538857Z", "data": null, "event_name":
+        "secret_incident.viewed", "action_type": "READ", "target_ids": ["34205503"],
+        "ip_address": "185.175.151.131"}, {"id": 23981642, "api_token_id": null, "member_id":
+        1754656, "member_email": "user-1ffcf115@example.com", "member_name": "CandidateEU
+        DemoAccess", "date": "2026-06-23T11:26:44.352505Z", "data": null, "event_name":
+        "secret_incident.viewed", "action_type": "READ", "target_ids": ["32828142"],
+        "ip_address": "82.169.214.153"}, {"id": 23981549, "api_token_id": null, "member_id":
+        1754656, "member_email": "user-1ffcf115@example.com", "member_name": "CandidateEU
+        DemoAccess", "date": "2026-06-23T11:22:57.870942Z", "data": null, "event_name":
+        "secret_incident.viewed", "action_type": "READ", "target_ids": ["32985083"],
+        "ip_address": "82.169.214.153"}, {"id": 23981372, "api_token_id": null, "member_id":
+        1754656, "member_email": "user-1ffcf115@example.com", "member_name": "CandidateEU
+        DemoAccess", "date": "2026-06-23T11:13:34.045630Z", "data": null, "event_name":
+        "secret_incident.viewed", "action_type": "READ", "target_ids": ["34205503"],
+        "ip_address": "82.169.214.153"}, {"id": 23981370, "api_token_id": null, "member_id":
+        1754656, "member_email": "user-1ffcf115@example.com", "member_name": "CandidateEU
+        DemoAccess", "date": "2026-06-23T11:13:31.746525Z", "data": {"issue_id": 34205503,
+        "issue_hash": "HdPZ4cjZuziAqsakdlsUnJDapTz3ns5pX8vPzfhvGQvpWWWX25LITKmJimoqGr3z"},
         "event_name": "endpoint_discovered_secret.promoted_to_incident", "action_type":
         "CREATE", "target_ids": ["2013275"], "ip_address": "82.169.214.153"}]'
     headers:

--- a/tests/cassettes/client/vcr/test_get_audit_logs_with_limit.yaml
+++ b/tests/cassettes/client/vcr/test_get_audit_logs_with_limit.yaml
@@ -21,27 +21,27 @@ interactions:
   response:
     body:
       string: '[{"id": 23983381, "api_token_id": null, "member_id": 480870, "member_email":
-        "timothe.delion@gitguardian.com", "member_name": "Timoth\u00e9 DELION", "date":
+        "user-8e645c6e@example.com", "member_name": "Timoth\u00e9 DELION", "date":
         "2026-06-23T12:23:58.297394Z", "data": null, "event_name": "custom_remediation_workflow.updated",
         "action_type": "UPDATE", "target_ids": ["6"], "ip_address": "92.128.35.47"},
         {"id": 23983251, "api_token_id": null, "member_id": 480870, "member_email":
-        "timothe.delion@gitguardian.com", "member_name": "Timoth\u00e9 DELION", "date":
+        "user-8e645c6e@example.com", "member_name": "Timoth\u00e9 DELION", "date":
         "2026-06-23T12:20:54.649674Z", "data": {"type": "saml_sso"}, "event_name":
         "user.logged_in", "action_type": "OTHER", "target_ids": ["480218"], "ip_address":
         "92.128.35.47"}, {"id": 23982412, "api_token_id": null, "member_id": 1301278,
-        "member_email": "zach.mccullough@gitguardian.com", "member_name": "Zachary
-        MCCULLOUGH", "date": "2026-06-23T11:59:32.903530Z", "data": {"type": "saml_sso"},
-        "event_name": "user.logged_in", "action_type": "OTHER", "target_ids": ["1299091"],
-        "ip_address": "73.8.249.128"}, {"id": 23982141, "api_token_id": null, "member_id":
-        363444, "member_email": "patrick.flanagan@gitguardian.com", "member_name":
-        "Patrick FLANAGAN", "date": "2026-06-23T11:47:23.624224Z", "data": {"issue_token":
-        73062}, "event_name": "secret_incident.shared_incident_viewed", "action_type":
-        "READ", "target_ids": ["34205503"], "ip_address": "185.175.151.131"}, {"id":
-        23982136, "api_token_id": null, "member_id": 363444, "member_email": "patrick.flanagan@gitguardian.com",
-        "member_name": "Patrick FLANAGAN", "date": "2026-06-23T11:47:02.338330Z",
-        "data": {"issue_id": 34205503, "expire_at": "2026-07-23T11:47:02.322847+00:00"},
-        "event_name": "incident_token.created", "action_type": "CREATE", "target_ids":
-        ["73062"], "ip_address": "185.175.151.131"}]'
+        "member_email": "user-6d755f01@example.com", "member_name": "Zachary MCCULLOUGH",
+        "date": "2026-06-23T11:59:32.903530Z", "data": {"type": "saml_sso"}, "event_name":
+        "user.logged_in", "action_type": "OTHER", "target_ids": ["1299091"], "ip_address":
+        "73.8.249.128"}, {"id": 23982141, "api_token_id": null, "member_id": 363444,
+        "member_email": "user-1aafc941@example.com", "member_name": "Patrick FLANAGAN",
+        "date": "2026-06-23T11:47:23.624224Z", "data": {"issue_token": 73062}, "event_name":
+        "secret_incident.shared_incident_viewed", "action_type": "READ", "target_ids":
+        ["34205503"], "ip_address": "185.175.151.131"}, {"id": 23982136, "api_token_id":
+        null, "member_id": 363444, "member_email": "user-1aafc941@example.com", "member_name":
+        "Patrick FLANAGAN", "date": "2026-06-23T11:47:02.338330Z", "data": {"issue_id":
+        34205503, "expire_at": "2026-07-23T11:47:02.322847+00:00"}, "event_name":
+        "incident_token.created", "action_type": "CREATE", "target_ids": ["73062"],
+        "ip_address": "185.175.151.131"}]'
     headers:
       CF-RAY:
       - a10394cd4c7ea8bd-CDG

--- a/tests/cassettes/client/vcr/test_get_current_member.yaml
+++ b/tests/cassettes/client/vcr/test_get_current_member.yaml
@@ -99,9 +99,8 @@ interactions:
   response:
     body:
       string: '{"id": 480870, "role": "manager", "access_level": "manager", "email":
-        "timothe.delion@gitguardian.com", "name": "Timoth\u00e9 DELION", "created_at":
-        "2023-06-26T12:41:18.599497Z", "last_login": "2026-06-23T12:20:54.639679Z",
-        "active": true}'
+        "user-8e645c6e@example.com", "name": "User bb2e577e", "created_at": "2023-06-26T12:41:18.599497Z",
+        "last_login": "2026-06-23T12:20:54.639679Z", "active": true}'
     headers:
       CF-RAY:
       - a10397396d8f00c8-CDG

--- a/tests/cassettes/client/vcr/test_get_incident.yaml
+++ b/tests/cassettes/client/vcr/test_get_incident.yaml
@@ -30,24 +30,24 @@ interactions:
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
         "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
         "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
-        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
-        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
-        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
-        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
-        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
-        given access to any sensitive information or services?", "boolean": true},
-        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
-        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
-        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
-        "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
-        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
-        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["REVOCABLE_BY_GG",
-        "PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
+        "user-74281974@example.com", "share_url": "[REDACTED]", "feedback_list": [{"created_at":
+        "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "user-1a0bc62d@example.com", "member_id": null, "answers": [{"type":
+        "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is this an
+        actual secret?", "boolean": true}, {"type": "boolean", "field_ref": "access_to_sensitive_yes_no",
+        "field_label": "Does this secret give or has given access to any sensitive
+        information or services?", "boolean": true}, {"type": "boolean", "field_ref":
+        "revoked_yes_no", "field_label": "Has this secret been revoked?", "boolean":
+        false}, {"type": "text", "field_ref": "remarks_text", "field_label": "Additional
+        remarks", "text": "Hasn''t been revoked yet because X"}]}], "risk_score":
+        100, "severity_rule_id": null, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
+        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
+        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21460",
+        "tags": ["REVOCABLE_BY_GG", "PUBLICLY_LEAKED"], "incident_name": "AWS IAM
+        Keys", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "destination_tickets": [{"id":
+        "AEF-97", "type": "jira_cloud", "link": "https://tenant-b6250acd.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}]'
     headers:
       CF-RAY:
@@ -131,28 +131,27 @@ interactions:
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
         "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
         "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
-        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
-        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
-        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
-        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
-        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
-        given access to any sensitive information or services?", "boolean": true},
-        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
-        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
-        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
-        "ignore_reason": null, "occurrences": [{"id": 78197, "incident_id": 21460,
-        "date": "2020-10-29T13:20:05.797462Z", "filepath": "app.py", "kind": "realtime",
-        "presence": "removed", "matches": [{"name": "client_id", "indice_start": 49,
-        "indice_end": 69, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
-        null, "post_line_end": null}, {"name": "client_secret", "indice_start": 85,
-        "indice_end": 125, "pre_line_start": 4, "pre_line_end": 4, "post_line_start":
-        null, "post_line_end": null}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"], "url":
-        "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "user-74281974@example.com", "share_url": "[REDACTED]", "feedback_list": [{"created_at":
+        "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "user-1a0bc62d@example.com", "member_id": null, "answers": [{"type":
+        "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is this an
+        actual secret?", "boolean": true}, {"type": "boolean", "field_ref": "access_to_sensitive_yes_no",
+        "field_label": "Does this secret give or has given access to any sensitive
+        information or services?", "boolean": true}, {"type": "boolean", "field_ref":
+        "revoked_yes_no", "field_label": "Has this secret been revoked?", "boolean":
+        false}, {"type": "text", "field_ref": "remarks_text", "field_label": "Additional
+        remarks", "text": "Hasn''t been revoked yet because X"}]}], "risk_score":
+        100, "severity_rule_id": null, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": [{"id": 78197, "incident_id": 21460, "date": "2020-10-29T13:20:05.797462Z",
+        "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
+        [{"name": "client_id", "indice_start": 49, "indice_end": 69, "pre_line_start":
+        3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}, {"name":
+        "client_secret", "indice_start": 85, "indice_end": 125, "pre_line_start":
+        4, "pre_line_end": 4, "post_line_start": null, "post_line_end": null}], "tags":
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion", "source":
+        {"id": 12349, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
@@ -162,7 +161,7 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78198,
         "incident_id": 21460, "date": "2020-10-29T13:19:59.005564Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
@@ -170,10 +169,10 @@ interactions:
         null, "post_line_start": 3, "post_line_end": 3}, {"name": "client_secret",
         "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition", "source":
+        {"id": 12349, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
@@ -183,7 +182,7 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}], "secret_presence":
         {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
         "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
@@ -191,7 +190,7 @@ interactions:
         "tags": ["PUBLICLY_LEAKED", "REVOCABLE_BY_GG"], "incident_name": "AWS IAM
         Keys", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
         false, "leaked_outside_perimeter": false}, "destination_tickets": [{"id":
-        "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
+        "AEF-97", "type": "jira_cloud", "link": "https://tenant-b6250acd.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}'
     headers:
       CF-RAY:

--- a/tests/cassettes/client/vcr/test_get_incidents_batch.yaml
+++ b/tests/cassettes/client/vcr/test_get_incidents_batch.yaml
@@ -30,24 +30,24 @@ interactions:
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
         "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
         "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
-        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
-        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
-        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
-        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
-        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
-        given access to any sensitive information or services?", "boolean": true},
-        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
-        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
-        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
-        "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
-        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
-        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["REVOCABLE_BY_GG",
-        "PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
+        "user-74281974@example.com", "share_url": "[REDACTED]", "feedback_list": [{"created_at":
+        "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "user-1a0bc62d@example.com", "member_id": null, "answers": [{"type":
+        "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is this an
+        actual secret?", "boolean": true}, {"type": "boolean", "field_ref": "access_to_sensitive_yes_no",
+        "field_label": "Does this secret give or has given access to any sensitive
+        information or services?", "boolean": true}, {"type": "boolean", "field_ref":
+        "revoked_yes_no", "field_label": "Has this secret been revoked?", "boolean":
+        false}, {"type": "text", "field_ref": "remarks_text", "field_label": "Additional
+        remarks", "text": "Hasn''t been revoked yet because X"}]}], "risk_score":
+        100, "severity_rule_id": null, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
+        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
+        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21460",
+        "tags": ["REVOCABLE_BY_GG", "PUBLICLY_LEAKED"], "incident_name": "AWS IAM
+        Keys", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "destination_tickets": [{"id":
+        "AEF-97", "type": "jira_cloud", "link": "https://tenant-b6250acd.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}, {"id": 21461, "detector": {"name": "private_key_dsa",
         "display_name": "DSA Private Key", "nature": "specific", "family": "cryptographic_key",
         "category": "private_key", "detector_group_name": "private_key_dsa", "detector_group_display_name":
@@ -58,9 +58,9 @@ interactions:
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "critical", "assignee_id": 270722,
-        "assignee_email": "clement.tourriere@gitguardian.com", "share_url": "[REDACTED]",
+        "assignee_email": "user-4278f7fb@example.com", "share_url": "[REDACTED]",
         "feedback_list": [{"created_at": "2024-06-28T07:01:19.458759Z", "updated_at":
-        "2024-06-28T07:01:19.458771Z", "email": "lucius@protonmal.com", "member_id":
+        "2024-06-28T07:01:19.458771Z", "email": "user-e2de71a9@example.com", "member_id":
         null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
         "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
         "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
@@ -75,8 +75,8 @@ interactions:
         "https://dashboard.gitguardian.com/workspace/8/incidents/21461", "tags": ["PUBLICLY_LEAKED"],
         "incident_name": "DSA Private Key", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-15"},
-        {"id": "JB-14", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-14"}],
+        "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link": "https://tenant-e47c06f3.atlassian.net/browse/JB-15"},
+        {"id": "JB-14", "type": "jira_cloud", "link": "https://tenant-e47c06f3.atlassian.net/browse/JB-14"}],
         "custom_tags": []}, {"id": 21462, "detector": {"name": "salesforce_oauth2",
         "display_name": "Salesforce Oauth2 Keys", "nature": "specific", "family":
         "credentials", "category": "crm", "detector_group_name": "salesforce_oauth2_keys",
@@ -87,7 +87,7 @@ interactions:
         "ignored_at": "2025-07-28T09:27:09.871747Z", "ignorer_id": 492181, "ignorer_api_token_id":
         null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
         "secret_revoked": false, "validity": "invalid", "severity": "high", "assignee_id":
-        10, "assignee_email": "bruce-wayne-gg@protonmail.com", "share_url": "[REDACTED]",
+        10, "assignee_email": "user-324427de@example.com", "share_url": "[REDACTED]",
         "feedback_list": [], "risk_score": 23, "severity_rule_id": 31, "is_vaulted":
         false, "ignore_reason": "invalid", "occurrences": null, "secret_presence":
         {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
@@ -178,9 +178,9 @@ interactions:
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "critical", "assignee_id": 270722,
-        "assignee_email": "clement.tourriere@gitguardian.com", "share_url": "[REDACTED]",
+        "assignee_email": "user-4278f7fb@example.com", "share_url": "[REDACTED]",
         "feedback_list": [{"created_at": "2024-06-28T07:01:19.458759Z", "updated_at":
-        "2024-06-28T07:01:19.458771Z", "email": "lucius@protonmal.com", "member_id":
+        "2024-06-28T07:01:19.458771Z", "email": "user-e2de71a9@example.com", "member_id":
         null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
         "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
         "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
@@ -193,10 +193,10 @@ interactions:
         "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
         [{"name": "apikey", "indice_start": 48, "indice_end": 726, "pre_line_start":
         3, "pre_line_end": 14, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "333db3e12b3f863ebb02cac6f232fc44e4f46533", "change_type": "deletion",
-        "source": {"id": 12320, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-09",
+        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/ns-80126292/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "333db3e12b3f863ebb02cac6f232fc44e4f46533", "change_type": "deletion", "source":
+        {"id": 12320, "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-09",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
@@ -206,16 +206,16 @@ interactions:
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-09",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78200,
         "incident_id": 21461, "date": "2020-10-29T09:19:54.249454Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
         "indice_start": 91, "indice_end": 769, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 14}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "76dd4f31a31c78a151723031bfebff4d076751b2", "change_type": "addition",
-        "source": {"id": 12320, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-09",
+        "PUBLIC"], "url": "https://github.com/ns-80126292/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "76dd4f31a31c78a151723031bfebff4d076751b2", "change_type": "addition", "source":
+        {"id": 12320, "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-09",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
@@ -225,7 +225,7 @@ interactions:
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-09",
         "provider_metadata": {"archived": false}, "deleted": false}}], "secret_presence":
         {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
         "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
@@ -233,8 +233,8 @@ interactions:
         "tags": ["PUBLICLY_LEAKED"], "incident_name": "DSA Private Key", "public_exposure":
         {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
         false}, "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link":
-        "https://sandboxgitguardian.atlassian.net/browse/JB-15"}, {"id": "JB-14",
-        "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-14"}],
+        "https://tenant-e47c06f3.atlassian.net/browse/JB-15"}, {"id": "JB-14", "type":
+        "jira_cloud", "link": "https://tenant-e47c06f3.atlassian.net/browse/JB-14"}],
         "custom_tags": []}'
     headers:
       CF-RAY:
@@ -313,28 +313,27 @@ interactions:
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
         "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
         "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
-        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
-        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
-        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
-        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
-        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
-        given access to any sensitive information or services?", "boolean": true},
-        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
-        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
-        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
-        "ignore_reason": null, "occurrences": [{"id": 78197, "incident_id": 21460,
-        "date": "2020-10-29T13:20:05.797462Z", "filepath": "app.py", "kind": "realtime",
-        "presence": "removed", "matches": [{"name": "client_id", "indice_start": 49,
-        "indice_end": 69, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
-        null, "post_line_end": null}, {"name": "client_secret", "indice_start": 85,
-        "indice_end": 125, "pre_line_start": 4, "pre_line_end": 4, "post_line_start":
-        null, "post_line_end": null}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"], "url":
-        "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "user-74281974@example.com", "share_url": "[REDACTED]", "feedback_list": [{"created_at":
+        "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "user-1a0bc62d@example.com", "member_id": null, "answers": [{"type":
+        "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is this an
+        actual secret?", "boolean": true}, {"type": "boolean", "field_ref": "access_to_sensitive_yes_no",
+        "field_label": "Does this secret give or has given access to any sensitive
+        information or services?", "boolean": true}, {"type": "boolean", "field_ref":
+        "revoked_yes_no", "field_label": "Has this secret been revoked?", "boolean":
+        false}, {"type": "text", "field_ref": "remarks_text", "field_label": "Additional
+        remarks", "text": "Hasn''t been revoked yet because X"}]}], "risk_score":
+        100, "severity_rule_id": null, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": [{"id": 78197, "incident_id": 21460, "date": "2020-10-29T13:20:05.797462Z",
+        "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
+        [{"name": "client_id", "indice_start": 49, "indice_end": 69, "pre_line_start":
+        3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}, {"name":
+        "client_secret", "indice_start": 85, "indice_end": 125, "pre_line_start":
+        4, "pre_line_end": 4, "post_line_start": null, "post_line_end": null}], "tags":
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion", "source":
+        {"id": 12349, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
@@ -344,7 +343,7 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78198,
         "incident_id": 21460, "date": "2020-10-29T13:19:59.005564Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
@@ -352,10 +351,10 @@ interactions:
         null, "post_line_start": 3, "post_line_end": 3}, {"name": "client_secret",
         "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition", "source":
+        {"id": 12349, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
@@ -365,7 +364,7 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}], "secret_presence":
         {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
         "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
@@ -373,7 +372,7 @@ interactions:
         "tags": ["REVOCABLE_BY_GG", "PUBLICLY_LEAKED"], "incident_name": "AWS IAM
         Keys", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
         false, "leaked_outside_perimeter": false}, "destination_tickets": [{"id":
-        "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
+        "AEF-97", "type": "jira_cloud", "link": "https://tenant-b6250acd.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}'
     headers:
       CF-RAY:

--- a/tests/cassettes/client/vcr/test_get_member_by_id.yaml
+++ b/tests/cassettes/client/vcr/test_get_member_by_id.yaml
@@ -99,9 +99,8 @@ interactions:
   response:
     body:
       string: '{"id": 480870, "role": "manager", "access_level": "manager", "email":
-        "timothe.delion@gitguardian.com", "name": "Timoth\u00e9 DELION", "created_at":
-        "2023-06-26T12:41:18.599497Z", "last_login": "2026-06-23T12:20:54.639679Z",
-        "active": true}'
+        "user-8e645c6e@example.com", "name": "User bb2e577e", "created_at": "2023-06-26T12:41:18.599497Z",
+        "last_login": "2026-06-23T12:20:54.639679Z", "active": true}'
     headers:
       CF-RAY:
       - a103973f3dd2c627-CDG
@@ -170,9 +169,8 @@ interactions:
   response:
     body:
       string: '{"id": 480870, "role": "manager", "access_level": "manager", "email":
-        "timothe.delion@gitguardian.com", "name": "Timoth\u00e9 DELION", "created_at":
-        "2023-06-26T12:41:18.599497Z", "last_login": "2026-06-23T12:20:54.639679Z",
-        "active": true}'
+        "user-8e645c6e@example.com", "name": "User bb2e577e", "created_at": "2023-06-26T12:41:18.599497Z",
+        "last_login": "2026-06-23T12:20:54.639679Z", "active": true}'
     headers:
       CF-RAY:
       - a1039740eb816f8e-CDG

--- a/tests/cassettes/client/vcr/test_get_source_by_name.yaml
+++ b/tests/cassettes/client/vcr/test_get_source_by_name.yaml
@@ -20,15 +20,15 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?per_page=1
   response:
     body:
-      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
-        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
+      string: '[{"id": 12259, "type": "github", "full_name": "ns-1cb0f5a9/cowboy",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "23", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-6d1173c4",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:
@@ -99,18 +99,18 @@ interactions:
       X-Privacy-Mode:
       - 'true'
     method: GET
-    uri: https://api.gitguardian.com/v1/sources?search=lonely%2Fcowboy&per_page=50
+    uri: https://api.gitguardian.com/v1/sources?search=ns-1cb0f5a9%2Fcowboy&per_page=50
   response:
     body:
-      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
-        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
+      string: '[{"id": 12259, "type": "github", "full_name": "ns-1cb0f5a9/cowboy",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "23", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-6d1173c4",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/client/vcr/test_get_source_by_name_return_all_on_no_match.yaml
+++ b/tests/cassettes/client/vcr/test_get_source_by_name_return_all_on_no_match.yaml
@@ -20,7 +20,7 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?search=test&per_page=50
   response:
     body:
-      string: '[{"id": 12263, "type": "github", "full_name": "my-testing-org/christian_dior",
+      string: '[{"id": 12263, "type": "github", "full_name": "ns-242f04fd/christian_dior",
         "health": "safe", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         0, "last_scan": {"date": "2020-09-24T09:06:39.211442Z", "status": "finished",
@@ -30,9 +30,9 @@ interactions:
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-eb7dee60",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12264,
-        "type": "github", "full_name": "my-testing-org/armani_code", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/armani_code", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 1, "last_scan":
         {"date": "2020-06-04T09:06:33.833273Z", "status": "finished", "failing_reason":
@@ -42,9 +42,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 1}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/armani_code",
+        "info": 0, "unknown": 1}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-12b26c3e",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12265,
-        "type": "github", "full_name": "my-testing-org/louis_vuitton", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/louis_vuitton", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:32.770273Z", "status": "finished", "failing_reason":
@@ -54,9 +54,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/louis_vuitton",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-f6c46dcc",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12266,
-        "type": "github", "full_name": "my-testing-org/lagarfeld", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/lagarfeld", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:33.598712Z", "status": "finished", "failing_reason":
@@ -66,9 +66,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/lagarfeld",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-f7e0173c",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12267,
-        "type": "github", "full_name": "my-testing-org/saint_laurent", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/saint_laurent", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-10-09T12:55:14.542227Z", "status": "canceled", "failing_reason":
@@ -78,199 +78,199 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/saint_laurent",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-29961463",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 3342391,
-        "type": "github", "full_name": "github-app-test-eugene/test", "health": "unknown",
-        "source_criticality": "unknown", "default_branch": "master", "default_branch_head":
-        "739d8fc531ae1130672b694ef20d445be095266c", "open_incidents_count": 0, "closed_incidents_count":
-        6, "last_scan": null, "monitored": false, "monitoring_status": "deleted_on_remote",
-        "visibility": "public", "external_id": "157555465", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 6, "severity_breakdown": {"critical": 0, "high": 6, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/github-app-test-eugene/test",
+        "type": "github", "full_name": "ns-e587ab62/test", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": "master", "default_branch_head": "739d8fc531ae1130672b694ef20d445be095266c",
+        "open_incidents_count": 0, "closed_incidents_count": 6, "last_scan": null,
+        "monitored": false, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "157555465", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        6, "severity_breakdown": {"critical": 0, "high": 6, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-e587ab62/test",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 3342392,
-        "type": "github", "full_name": "github-app-test-eugene/test_preprod", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
+        "type": "github", "full_name": "ns-e587ab62/test_preprod", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
         "59ad17cf384bb8abdb3fd21bdc557382b8f85fbf", "open_incidents_count": 0, "closed_incidents_count":
         4, "last_scan": null, "monitored": false, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "327924619", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 4, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 4}}}, "url": "https://github.com/github-app-test-eugene/test_preprod",
+        "low": 0, "info": 0, "unknown": 4}}}, "url": "https://github.com/ns-e587ab62/test_preprod",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6088722,
-        "type": "github", "full_name": "github-app-test-eugene/test_local_1", "health":
-        "at_risk", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
+        "type": "github", "full_name": "ns-e587ab62/test_local_1", "health": "at_risk",
+        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
         "529672f724fe0cb58ec7db5753f1ba8c26e62b1f", "open_incidents_count": 13, "closed_incidents_count":
         8, "last_scan": null, "monitored": false, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "515202288", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 13, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 13}}, "closed_secret_incidents":
         {"total": 8, "severity_breakdown": {"critical": 0, "high": 4, "medium": 0,
-        "low": 0, "info": 0, "unknown": 4}}}, "url": "https://github.com/github-app-test-eugene/test_local_1",
+        "low": 0, "info": 0, "unknown": 4}}}, "url": "https://github.com/ns-e587ab62/test_local_1",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6088740,
-        "type": "github", "full_name": "github-app-test-eugene/test_local_2", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
+        "type": "github", "full_name": "ns-e587ab62/test_local_2", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
         "5f014343520d1baefd1dc34a9fca19ae210b052a", "open_incidents_count": 0, "closed_incidents_count":
         0, "last_scan": null, "monitored": false, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "515203110", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/github-app-test-eugene/test_local_2",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-e587ab62/test_local_2",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6088766,
-        "type": "github", "full_name": "github-app-test-eugene/test_local_3", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
+        "type": "github", "full_name": "ns-e587ab62/test_local_3", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
         "587f67ce9635b955452eb56a69ddae46e8bcbae6", "open_incidents_count": 0, "closed_incidents_count":
         1, "last_scan": null, "monitored": false, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "515204240", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://github.com/github-app-test-eugene/test_local_3",
+        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://github.com/ns-e587ab62/test_local_3",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863732,
-        "type": "gitlab", "full_name": "gmalle-test / gmalle-test-project", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        "type": "gitlab", "full_name": "ns-53e83fda/ns-a6594565", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
         "private", "external_id": "14127", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/gmalle1/gmalle-test-project",
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-4145525f/ns-a6594565",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863734,
-        "type": "gitlab", "full_name": "My Own Group nRIV 89FE7Z98F7E / test-98FEZF898",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14124", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-1acc77bd/ns-f5554d62", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14124", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/my-own-group-nriv-89fe7z98f7e/test-98fezf898",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-cb12172b/ns-d5b472fe",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863736,
-        "type": "gitlab", "full_name": "Stanislas Cr\u00e9pin / TestPrereceive", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        "type": "gitlab", "full_name": "ns-ff293a2b/ns-f5678860", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
         "private", "external_id": "14122", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/stanislas.crepin/testprereceive",
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-23bb8554/ns-f253772b",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863737,
-        "type": "gitlab", "full_name": "gim-qa-gitlabDoSandbox-auto  / gim-qa-gitlabDoSandbox-onpremise
-        ", "health": "unknown", "source_criticality": "unknown", "default_branch":
-        null, "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14121", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-9353127a/ns-a3d6c789", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14121", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qatesting/qatesting_onprem",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-8f0b4aa4/ns-086fe4cf",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863738,
-        "type": "gitlab", "full_name": "gim-qa-gitlabDoSandbox-auto  / gim-qa-gitlabDoSandbox-preprod",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14120", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-9353127a/ns-2c1f4ce8", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14120", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qatesting/qatesting_preprod",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-8f0b4aa4/ns-85fb2f03",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863739,
-        "type": "gitlab", "full_name": "gim-qa-gitlabDoSandbox-auto  / gim-qa-gitlabDoSandbox-staging",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14119", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-9353127a/ns-1aa15c2f", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14119", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qatesting/qatesting_staging",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-8f0b4aa4/ns-0179d3ac",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863742,
-        "type": "gitlab", "full_name": "QAGroupTest / Agitlabpresence", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        "type": "gitlab", "full_name": "ns-7b33b25f/ns-7364b71c", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
         "internal", "external_id": "14115", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qagrouptest/agitlabpresence",
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-927fd915/ns-4a5afc0f",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863745,
-        "type": "gitlab", "full_name": "Aur\u00e9lien G\u00e2teau / prereceive-test",
+        "type": "gitlab", "full_name": "ns-dc0072dc/ns-c13b82e3", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "internal", "external_id": "14112", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-f1e0fa0a/ns-c13b82e3",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863747,
+        "type": "gitlab", "full_name": "ns-c853c24a/ns-4c691df9/ns-869edaaf/ns-cf482c5d",
         "health": "unknown", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "internal", "external_id": "14112", "secret_incidents_breakdown":
+        "visibility": "private", "external_id": "14110", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/agateau/prereceive-test",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863747,
-        "type": "gitlab", "full_name": "QAgroupGitlabEntr / QASubGroupRepo / QATesting
-        / onprem_QATesting", "health": "unknown", "source_criticality": "unknown",
-        "default_branch": null, "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
-        "deleted_on_remote", "visibility": "private", "external_id": "14110", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qagroupgitlabentr/qasubgrouprepo/qatesting/onprem_qatesting",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-fccbd8cf/ns-44c21986/qatesting/onprem_qatesting",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863748,
-        "type": "gitlab", "full_name": "QAgroupGitlabEntr / QASubGroupRepo / QATesting
-        / preprod_QATesting", "health": "unknown", "source_criticality": "unknown",
-        "default_branch": null, "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
-        "deleted_on_remote", "visibility": "private", "external_id": "14109", "secret_incidents_breakdown":
+        "type": "gitlab", "full_name": "ns-c853c24a/ns-4c691df9/ns-869edaaf/ns-b57e148d",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "14109", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qagroupgitlabentr/qasubgrouprepo/qatesting/preprod_qatesting",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-fccbd8cf/ns-44c21986/qatesting/preprod_qatesting",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863749,
-        "type": "gitlab", "full_name": "QAgroupGitlabEntr / QASubGroupRepo / QATesting
-        / staging_QA", "health": "unknown", "source_criticality": "unknown", "default_branch":
-        null, "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        "type": "gitlab", "full_name": "ns-c853c24a/ns-4c691df9/ns-869edaaf/ns-70051156",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "14108", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qagroupgitlabentr/qasubgrouprepo/qatesting/staging_qa",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-fccbd8cf/ns-44c21986/qatesting/staging_qa",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863751,
-        "type": "gitlab", "full_name": "QAGroupTest / 1SubGroup / 1SubSubGroup / 1subsubsubGroup
-        / 1subsubsubsubgroup / 1subgroupLastRepo", "health": "unknown", "source_criticality":
-        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
-        "deleted_on_remote", "visibility": "public", "external_id": "14106", "secret_incidents_breakdown":
+        "type": "gitlab", "full_name": "ns-7b33b25f/ns-72db2127/ns-bcc048e1/ns-7957a5eb/ns-b32ea833/ns-dc6bd3db",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "14106", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qagrouptest/1subgroup/1subsubgroup/1subsubsubgroup/1subsubsubsubgroup/1subgrouplastrepo",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-927fd915/ns-f17f50c3/1subsubgroup/1subsubsubgroup/1subsubsubsubgroup/1subgrouplastrepo",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863752,
-        "type": "gitlab", "full_name": "QAGroupTest / 1SubGroup / 1SubSubGroup / 1subsubsubGroup
-        / 1subsubsubgroupFirstRepo", "health": "unknown", "source_criticality": "unknown",
-        "default_branch": null, "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
-        "deleted_on_remote", "visibility": "public", "external_id": "14105", "secret_incidents_breakdown":
+        "type": "gitlab", "full_name": "ns-7b33b25f/ns-72db2127/ns-bcc048e1/ns-7957a5eb/ns-64e648cd",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "public", "external_id": "14105", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qagrouptest/1subgroup/1subsubgroup/1subsubsubgroup/1subsubsubgroupfirstrepo",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-927fd915/ns-f17f50c3/1subsubgroup/1subsubsubgroup/1subsubsubgroupfirstrepo",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863753,
-        "type": "gitlab", "full_name": "QAGroupTest / 1SubGroup / 1SubSubGroup / 1subsubGroupSecondRepo
-        ", "health": "unknown", "source_criticality": "unknown", "default_branch":
-        null, "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        "type": "gitlab", "full_name": "ns-7b33b25f/ns-72db2127/ns-bcc048e1/ns-31d04b1b",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "14104", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qagrouptest/1subgroup/1subsubgroup/1subsubgroupsecondrepo",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-927fd915/ns-f17f50c3/1subsubgroup/1subsubgroupsecondrepo",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863754,
-        "type": "gitlab", "full_name": "QAGroupTest / 1SubGroup / 1SubSubGroup / 1subsubGroupFirstRepo",
+        "type": "gitlab", "full_name": "ns-7b33b25f/ns-72db2127/ns-bcc048e1/ns-073a126c",
         "health": "unknown", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
@@ -278,38 +278,39 @@ interactions:
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qagrouptest/1subgroup/1subsubgroup/1subsubgroupfirstrepo",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-927fd915/ns-f17f50c3/1subsubgroup/1subsubgroupfirstrepo",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863755,
-        "type": "gitlab", "full_name": "QATest_GitLabEnterRepos / QATest_Staging",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14102", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-b3a3c9a4/ns-a91b1f3a", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14102", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qatest_preprod/qatest_staging",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-842ff8a0/ns-01e5ff68",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863756,
-        "type": "gitlab", "full_name": "QATest_GitLabEnterRepos / QATest_Preprod",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14101", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-b3a3c9a4/ns-9ba4bc16", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14101", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/qatest_preprod/qa_preprod",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-842ff8a0/ns-ef64a700",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863772,
-        "type": "gitlab", "full_name": "test / test_local", "health": "unknown", "source_criticality":
-        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
-        "deleted_on_remote", "visibility": "private", "external_id": "14081", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-9f86d081/ns-8cf15d59", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14081", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/test/test_local",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-9f86d081/ns-8cf15d59",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863773,
-        "type": "gitlab", "full_name": "eugene_group / test_local", "health": "unknown",
+        "type": "gitlab", "full_name": "ns-83a8e20f/ns-8cf15d59", "health": "unknown",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
@@ -317,217 +318,217 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/eugene_group/test_local",
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-83a8e20f/ns-8cf15d59",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863774,
-        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-go-cty-funcs",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14079", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-19160eec/ns-28c546e9/ns-6e7e5105", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14079", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-go-cty-funcs",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-19160eec/ns-28c546e9/hashicorp-go-cty-funcs",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863775,
-        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-hashicat-gcp",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14078", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-19160eec/ns-28c546e9/ns-bf9bdf2c", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14078", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-hashicat-gcp",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-19160eec/ns-28c546e9/hashicorp-hashicat-gcp",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863776,
-        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-workshop-puzzles",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14077", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-19160eec/ns-28c546e9/ns-24957af2", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14077", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-workshop-puzzles",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-19160eec/ns-28c546e9/hashicorp-workshop-puzzles",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863777,
-        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-boundary",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14076", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-19160eec/ns-28c546e9/ns-6e7f9b4f", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14076", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-boundary",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-19160eec/ns-28c546e9/hashicorp-boundary",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863778,
-        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-terraform-cdk",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14075", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-19160eec/ns-28c546e9/ns-6542ce71", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14075", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-terraform-cdk",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-19160eec/ns-28c546e9/hashicorp-terraform-cdk",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863779,
-        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-hyparview-example",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14074", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-19160eec/ns-28c546e9/ns-8655de45", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14074", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-hyparview-example",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-19160eec/ns-28c546e9/hashicorp-hyparview-example",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863780,
-        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-tfc-workshops-sentinel",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14073", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-19160eec/ns-28c546e9/ns-20b75d82", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14073", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-tfc-workshops-sentinel",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-19160eec/ns-28c546e9/hashicorp-tfc-workshops-sentinel",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863781,
-        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-micron-vault-workshop",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14072", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-19160eec/ns-28c546e9/ns-12b00ae0", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14072", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-micron-vault-workshop",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-19160eec/ns-28c546e9/hashicorp-micron-vault-workshop",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863782,
-        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-learn-terraform-modules",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14071", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-19160eec/ns-28c546e9/ns-2d537a81", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14071", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-learn-terraform-modules",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-19160eec/ns-28c546e9/hashicorp-learn-terraform-modules",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863783,
-        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-terraform-helm",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14070", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-19160eec/ns-28c546e9/ns-f27ab700", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14070", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-terraform-helm",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-19160eec/ns-28c546e9/hashicorp-terraform-helm",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863784,
-        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-structure",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14069", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-19160eec/ns-28c546e9/ns-6663059e", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14069", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-structure",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-19160eec/ns-28c546e9/hashicorp-structure",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863785,
-        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-terraform-k8s",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14068", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-19160eec/ns-28c546e9/ns-21c61da4", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14068", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-terraform-k8s",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-19160eec/ns-28c546e9/hashicorp-terraform-k8s",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863786,
-        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-packer-builder-vsphere",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14067", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-19160eec/ns-28c546e9/ns-5e904418", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14067", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-packer-builder-vsphere",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-19160eec/ns-28c546e9/hashicorp-packer-builder-vsphere",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863787,
-        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-gokrb5",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14066", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-19160eec/ns-28c546e9/ns-110d1838", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14066", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-gokrb5",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-19160eec/ns-28c546e9/hashicorp-gokrb5",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863788,
-        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-cloud-consul-ama-api-spec",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14065", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-19160eec/ns-28c546e9/ns-d24c6529", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14065", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-cloud-consul-ama-api-spec",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-19160eec/ns-28c546e9/hashicorp-cloud-consul-ama-api-spec",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863789,
-        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-azure-sdk-for-go",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14064", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-19160eec/ns-28c546e9/ns-3b1b8d18", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14064", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-azure-sdk-for-go",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-19160eec/ns-28c546e9/hashicorp-azure-sdk-for-go",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863790,
-        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-kitchen-sync",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14063", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-19160eec/ns-28c546e9/ns-fa6bbf6c", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14063", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-kitchen-sync",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-19160eec/ns-28c546e9/hashicorp-kitchen-sync",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863791,
-        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-hyparview",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14062", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-19160eec/ns-28c546e9/ns-b3f3122b", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14062", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-hyparview",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-19160eec/ns-28c546e9/hashicorp-hyparview",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863792,
-        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-vault-plugin-secrets-mongodbatlas",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14061", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-19160eec/ns-28c546e9/ns-1292cf59", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14061", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-vault-plugin-secrets-mongodbatlas",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-19160eec/ns-28c546e9/hashicorp-vault-plugin-secrets-mongodbatlas",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863793,
-        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-vault-plugin-database-mongodbatlas",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14060", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-19160eec/ns-28c546e9/ns-818366fe", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14060", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-vault-plugin-database-mongodbatlas",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-19160eec/ns-28c546e9/hashicorp-vault-plugin-database-mongodbatlas",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6863794,
-        "type": "gitlab", "full_name": "prm-onprem-test / 500-27a346446ff192b2 / hashicorp-nomad-skeleton-device-plugin",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "14059", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
+        "type": "gitlab", "full_name": "ns-19160eec/ns-28c546e9/ns-51d5df18", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "14059", "secret_incidents_breakdown": {"open_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://gitlab.sandbox.do.gitguardian.ovh/prm-onprem-test/500-27a346446ff192b2/hashicorp-nomad-skeleton-device-plugin",
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-6c6e9bfe.example.com/ns-19160eec/ns-28c546e9/hashicorp-nomad-skeleton-device-plugin",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/client/vcr/test_list_incident_activity_logs.yaml
+++ b/tests/cassettes/client/vcr/test_list_incident_activity_logs.yaml
@@ -33,11 +33,11 @@ interactions:
         "created_at": "2021-08-30T17:29:48.326754Z", "updated_at": null, "content":
         {"type": "action", "content_key": "AUTO_UNSHARE", "data": {"issue_token_id":
         5706}}, "incident_id": 21460}, {"id": 2918023, "member": {"id": 104916, "name":
-        "Wassim HANA", "email": "wassim.hana@gitguardian.com", "access_level": "manager"},
+        "User f4c96fee", "email": "user-f548df99@example.com", "access_level": "manager"},
         "api_token_id": null, "created_at": "2022-02-10T17:23:01.713143Z", "updated_at":
         null, "content": {"type": "action", "content_key": "SHARE", "data": {"shared_at":
         "2022-02-10T17:23:01.710300+00:00"}}, "incident_id": 21460}, {"id": 2918040,
-        "member": {"id": 104916, "name": "Wassim HANA", "email": "wassim.hana@gitguardian.com",
+        "member": {"id": 104916, "name": "User f4c96fee", "email": "user-f548df99@example.com",
         "access_level": "manager"}, "api_token_id": null, "created_at": "2022-02-10T17:31:53.593799Z",
         "updated_at": null, "content": {"type": "action", "content_key": "UNSHARE",
         "data": {"unshared_at": "2022-02-10T17:31:53.590070+00:00"}}, "incident_id":
@@ -60,29 +60,29 @@ interactions:
         "created_at": "2022-02-23T08:46:36.367333Z", "updated_at": null, "content":
         {"type": "action", "content_key": "SET_SEVERITY", "data": {"severity": "critical",
         "previous_severity": "unknown"}}, "incident_id": 21460}, {"id": 3212289, "member":
-        {"id": 104916, "name": "Wassim HANA", "email": "wassim.hana@gitguardian.com",
+        {"id": 104916, "name": "User f4c96fee", "email": "user-f548df99@example.com",
         "access_level": "manager"}, "api_token_id": null, "created_at": "2022-03-21T15:29:47.748245Z",
         "updated_at": null, "content": {"type": "action", "content_key": "UNSHARE",
         "data": {"unshared_at": "2022-03-21T15:29:47.742352+00:00"}}, "incident_id":
-        21460}, {"id": 3212290, "member": {"id": 104916, "name": "Wassim HANA", "email":
-        "wassim.hana@gitguardian.com", "access_level": "manager"}, "api_token_id":
+        21460}, {"id": 3212290, "member": {"id": 104916, "name": "User f4c96fee",
+        "email": "user-f548df99@example.com", "access_level": "manager"}, "api_token_id":
         null, "created_at": "2022-03-21T15:29:49.559041Z", "updated_at": null, "content":
         {"type": "action", "content_key": "SHARE", "data": {"shared_at": "2022-03-21T15:29:49.555144+00:00"}},
-        "incident_id": 21460}, {"id": 3212296, "member": {"id": 104916, "name": "Wassim
-        HANA", "email": "wassim.hana@gitguardian.com", "access_level": "manager"},
+        "incident_id": 21460}, {"id": 3212296, "member": {"id": 104916, "name": "User
+        f4c96fee", "email": "user-f548df99@example.com", "access_level": "manager"},
         "api_token_id": null, "created_at": "2022-03-21T15:31:55.109710Z", "updated_at":
         null, "content": {"type": "action", "content_key": "UNSHARE", "data": {"unshared_at":
         "2022-03-21T15:31:55.102196+00:00"}}, "incident_id": 21460}, {"id": 3212297,
-        "member": {"id": 104916, "name": "Wassim HANA", "email": "wassim.hana@gitguardian.com",
+        "member": {"id": 104916, "name": "User f4c96fee", "email": "user-f548df99@example.com",
         "access_level": "manager"}, "api_token_id": null, "created_at": "2022-03-21T15:31:56.619889Z",
         "updated_at": null, "content": {"type": "action", "content_key": "SHARE",
         "data": {"shared_at": "2022-03-21T15:31:56.616061+00:00"}}, "incident_id":
-        21460}, {"id": 3375781, "member": {"id": 104916, "name": "Wassim HANA", "email":
-        "wassim.hana@gitguardian.com", "access_level": "manager"}, "api_token_id":
+        21460}, {"id": 3375781, "member": {"id": 104916, "name": "User f4c96fee",
+        "email": "user-f548df99@example.com", "access_level": "manager"}, "api_token_id":
         null, "created_at": "2022-04-07T08:57:17.261089Z", "updated_at": null, "content":
         {"type": "action", "content_key": "GRANT_ACCESS", "data": {"users": [235930]}},
-        "incident_id": 21460}, {"id": 3375810, "member": {"id": 104916, "name": "Wassim
-        HANA", "email": "wassim.hana@gitguardian.com", "access_level": "manager"},
+        "incident_id": 21460}, {"id": 3375810, "member": {"id": 104916, "name": "User
+        f4c96fee", "email": "user-f548df99@example.com", "access_level": "manager"},
         "api_token_id": null, "created_at": "2022-04-07T08:58:41.738456Z", "updated_at":
         null, "content": {"type": "action", "content_key": "REMOVE_ACCESS", "data":
         {"users": [235930]}}, "incident_id": 21460}, {"id": 3927232, "member": null,

--- a/tests/cassettes/client/vcr/test_list_incident_members.yaml
+++ b/tests/cassettes/client/vcr/test_list_incident_members.yaml
@@ -30,24 +30,24 @@ interactions:
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
         "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
         "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
-        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
-        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
-        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
-        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
-        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
-        given access to any sensitive information or services?", "boolean": true},
-        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
-        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
-        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
-        "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
-        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
-        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["REVOCABLE_BY_GG",
-        "PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
+        "user-74281974@example.com", "share_url": "[REDACTED]", "feedback_list": [{"created_at":
+        "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "user-1a0bc62d@example.com", "member_id": null, "answers": [{"type":
+        "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is this an
+        actual secret?", "boolean": true}, {"type": "boolean", "field_ref": "access_to_sensitive_yes_no",
+        "field_label": "Does this secret give or has given access to any sensitive
+        information or services?", "boolean": true}, {"type": "boolean", "field_ref":
+        "revoked_yes_no", "field_label": "Has this secret been revoked?", "boolean":
+        false}, {"type": "text", "field_ref": "remarks_text", "field_label": "Additional
+        remarks", "text": "Hasn''t been revoked yet because X"}]}], "risk_score":
+        100, "severity_rule_id": null, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
+        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
+        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21460",
+        "tags": ["REVOCABLE_BY_GG", "PUBLICLY_LEAKED"], "incident_name": "AWS IAM
+        Keys", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "destination_tickets": [{"id":
+        "AEF-97", "type": "jira_cloud", "link": "https://tenant-b6250acd.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}]'
     headers:
       CF-RAY:
@@ -121,52 +121,51 @@ interactions:
     uri: https://api.gitguardian.com/v1/incidents/secrets/21460/members
   response:
     body:
-      string: '[{"id": 10, "member_id": 10, "role": "manager", "name": "Bruce Wayne",
-        "email": "bruce-wayne-gg@protonmail.com", "incident_id": 21460, "incident_permission":
-        "full_access"}, {"id": 13, "member_id": 13, "role": "manager", "name": "Aymeric
-        SICARD", "email": "aymeric.sicard@gitguardian.com", "incident_id": 21460,
-        "incident_permission": "full_access"}, {"id": 2508, "member_id": 2508, "role":
-        "manager", "name": "Guillaume CHARPIAT", "email": "guillaume.charpiat@gitguardian.com",
-        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 37699,
-        "member_id": 37699, "role": "manager", "name": "Alexis LARNAUD", "email":
-        "alexis.larnaud@gitguardian.com", "incident_id": 21460, "incident_permission":
-        "full_access"}, {"id": 63809, "member_id": 63809, "role": "manager", "name":
-        "Orian ROTURIER", "email": "orian.roturier@gitguardian.com", "incident_id":
-        21460, "incident_permission": "full_access"}, {"id": 69474, "member_id": 69474,
-        "role": "member", "name": "Eric", "email": "elacaille0@gmail.com", "incident_id":
-        21460, "incident_permission": "can_edit"}, {"id": 104544, "member_id": 104544,
-        "role": "manager", "name": "Pierre LALANNE", "email": "pierre.lalanne@gitguardian.com",
+      string: '[{"id": 10, "member_id": 10, "role": "manager", "name": "User 2b03ad68",
+        "email": "user-324427de@example.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 13, "member_id": 13, "role": "manager", "name": "User
+        d0d18d7e", "email": "user-71ab73d0@example.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 2508, "member_id": 2508, "role": "manager", "name":
+        "User 793501dc", "email": "user-d9f863cd@example.com", "incident_id": 21460,
+        "incident_permission": "full_access"}, {"id": 37699, "member_id": 37699, "role":
+        "manager", "name": "User 40f52996", "email": "user-d3774a22@example.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 63809,
+        "member_id": 63809, "role": "manager", "name": "User 97a9750c", "email": "user-0222ba7e@example.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 69474,
+        "member_id": 69474, "role": "member", "name": "User 4cb39c1b", "email": "user-5af3cff5@example.com",
+        "incident_id": 21460, "incident_permission": "can_edit"}, {"id": 104544, "member_id":
+        104544, "role": "manager", "name": "User 9a67720c", "email": "user-aba104cf@example.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 104916,
-        "member_id": 104916, "role": "manager", "name": "Wassim HANA", "email": "wassim.hana@gitguardian.com",
-        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 113168,
-        "member_id": 113168, "role": "owner", "name": "Henri HUBERT", "email": "henri.hubert@gitguardian.com",
-        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 136170,
-        "member_id": 136170, "role": "manager", "name": "Eric FOURRIER", "email":
-        "eric.fourrier@gitguardian.com", "incident_id": 21460, "incident_permission":
-        "full_access"}, {"id": 160089, "member_id": 160089, "role": "manager", "name":
-        "Aur\u00e9lien G\u00c2TEAU", "email": "aurelien.gateau@gitguardian.com", "incident_id":
-        21460, "incident_permission": "full_access"}, {"id": 166199, "member_id":
-        166199, "role": "manager", "name": "Stanislas CR\u00c9PIN", "email": "stanislas.crepin@gitguardian.com",
-        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 183177,
-        "member_id": 183177, "role": "manager", "name": "H\u00e9l\u00e8ne HARTMANN",
-        "email": "helene.hartmann@gitguardian.com", "incident_id": 21460, "incident_permission":
-        "full_access"}, {"id": 203333, "member_id": 203333, "role": "member", "name":
-        "qa qa team", "email": "qa-team-testing@gitguardian.com", "incident_id": 21460,
-        "incident_permission": "can_edit"}, {"id": 269050, "member_id": 269050, "role":
-        "manager", "name": "Achille MASCIA", "email": "achille.mascia@gitguardian.com",
+        "member_id": 104916, "role": "manager", "name": "User f4c96fee", "email":
+        "user-f548df99@example.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 113168, "member_id": 113168, "role": "owner", "name":
+        "User 00d1c796", "email": "user-c010b87e@example.com", "incident_id": 21460,
+        "incident_permission": "full_access"}, {"id": 136170, "member_id": 136170,
+        "role": "manager", "name": "User 795904a4", "email": "user-db85bcf2@example.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 160089,
+        "member_id": 160089, "role": "manager", "name": "User 595a74b4", "email":
+        "user-90859989@example.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 166199, "member_id": 166199, "role": "manager", "name":
+        "User fbc68cb1", "email": "user-1a0bc62d@example.com", "incident_id": 21460,
+        "incident_permission": "full_access"}, {"id": 183177, "member_id": 183177,
+        "role": "manager", "name": "User 2b6e79bd", "email": "user-ef593bab@example.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 203333,
+        "member_id": 203333, "role": "member", "name": "User 5a421fd6", "email": "user-01b8eaba@example.com",
+        "incident_id": 21460, "incident_permission": "can_edit"}, {"id": 269050, "member_id":
+        269050, "role": "manager", "name": "User 4d672909", "email": "user-35a47503@example.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 270722,
-        "member_id": 270722, "role": "manager", "name": "Cl\u00e9ment TOURRIERE",
-        "email": "clement.tourriere@gitguardian.com", "incident_id": 21460, "incident_permission":
+        "member_id": 270722, "role": "manager", "name": "User 8fe9d75c", "email":
+        "user-4278f7fb@example.com", "incident_id": 21460, "incident_permission":
         "full_access"}, {"id": 296618, "member_id": 296618, "role": "manager", "name":
-        "Samuel GUILLAUME", "email": "samuel.guillaume@gitguardian.com", "incident_id":
-        21460, "incident_permission": "full_access"}, {"id": 297547, "member_id":
-        297547, "role": "manager", "name": "Antoine GAILLARD", "email": "antoine.gaillard@gitguardian.com",
+        "User 96d39e85", "email": "user-d44727e2@example.com", "incident_id": 21460,
+        "incident_permission": "full_access"}, {"id": 297547, "member_id": 297547,
+        "role": "manager", "name": "User 20c8435e", "email": "user-d740ff7b@example.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 302635,
-        "member_id": 302635, "role": "manager", "name": "Laurent TRAMOY", "email":
-        "laurent.tramoy@gitguardian.com", "incident_id": 21460, "incident_permission":
+        "member_id": 302635, "role": "manager", "name": "User ad60d43c", "email":
+        "user-8c839e26@example.com", "incident_id": 21460, "incident_permission":
         "full_access"}, {"id": 309802, "member_id": 309802, "role": "manager", "name":
-        "Pierre DE THOISY", "email": "pierre.dethoisy@gitguardian.com", "incident_id":
-        21460, "incident_permission": "full_access"}]'
+        "User cdfde6f6", "email": "user-6eedc04a@example.com", "incident_id": 21460,
+        "incident_permission": "full_access"}]'
     headers:
       CF-RAY:
       - a103954c1be6d8d2-CDG

--- a/tests/cassettes/client/vcr/test_list_incident_notes.yaml
+++ b/tests/cassettes/client/vcr/test_list_incident_notes.yaml
@@ -30,24 +30,24 @@ interactions:
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
         "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
         "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
-        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
-        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
-        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
-        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
-        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
-        given access to any sensitive information or services?", "boolean": true},
-        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
-        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
-        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
-        "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
-        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
-        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["REVOCABLE_BY_GG",
-        "PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
+        "user-74281974@example.com", "share_url": "[REDACTED]", "feedback_list": [{"created_at":
+        "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "user-1a0bc62d@example.com", "member_id": null, "answers": [{"type":
+        "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is this an
+        actual secret?", "boolean": true}, {"type": "boolean", "field_ref": "access_to_sensitive_yes_no",
+        "field_label": "Does this secret give or has given access to any sensitive
+        information or services?", "boolean": true}, {"type": "boolean", "field_ref":
+        "revoked_yes_no", "field_label": "Has this secret been revoked?", "boolean":
+        false}, {"type": "text", "field_ref": "remarks_text", "field_label": "Additional
+        remarks", "text": "Hasn''t been revoked yet because X"}]}], "risk_score":
+        100, "severity_rule_id": null, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
+        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
+        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21460",
+        "tags": ["REVOCABLE_BY_GG", "PUBLICLY_LEAKED"], "incident_name": "AWS IAM
+        Keys", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "destination_tickets": [{"id":
+        "AEF-97", "type": "jira_cloud", "link": "https://tenant-b6250acd.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/client/vcr/test_list_incidents_basic.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_basic.yaml
@@ -30,24 +30,24 @@ interactions:
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
         "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
         "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
-        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
-        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
-        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
-        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
-        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
-        given access to any sensitive information or services?", "boolean": true},
-        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
-        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
-        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
-        "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
-        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
-        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["REVOCABLE_BY_GG",
-        "PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
+        "user-74281974@example.com", "share_url": "[REDACTED]", "feedback_list": [{"created_at":
+        "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "user-1a0bc62d@example.com", "member_id": null, "answers": [{"type":
+        "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is this an
+        actual secret?", "boolean": true}, {"type": "boolean", "field_ref": "access_to_sensitive_yes_no",
+        "field_label": "Does this secret give or has given access to any sensitive
+        information or services?", "boolean": true}, {"type": "boolean", "field_ref":
+        "revoked_yes_no", "field_label": "Has this secret been revoked?", "boolean":
+        false}, {"type": "text", "field_ref": "remarks_text", "field_label": "Additional
+        remarks", "text": "Hasn''t been revoked yet because X"}]}], "risk_score":
+        100, "severity_rule_id": null, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
+        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
+        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21460",
+        "tags": ["REVOCABLE_BY_GG", "PUBLICLY_LEAKED"], "incident_name": "AWS IAM
+        Keys", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "destination_tickets": [{"id":
+        "AEF-97", "type": "jira_cloud", "link": "https://tenant-b6250acd.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}, {"id": 21461, "detector": {"name": "private_key_dsa",
         "display_name": "DSA Private Key", "nature": "specific", "family": "cryptographic_key",
         "category": "private_key", "detector_group_name": "private_key_dsa", "detector_group_display_name":
@@ -58,9 +58,9 @@ interactions:
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "critical", "assignee_id": 270722,
-        "assignee_email": "clement.tourriere@gitguardian.com", "share_url": "[REDACTED]",
+        "assignee_email": "user-4278f7fb@example.com", "share_url": "[REDACTED]",
         "feedback_list": [{"created_at": "2024-06-28T07:01:19.458759Z", "updated_at":
-        "2024-06-28T07:01:19.458771Z", "email": "lucius@protonmal.com", "member_id":
+        "2024-06-28T07:01:19.458771Z", "email": "user-e2de71a9@example.com", "member_id":
         null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
         "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
         "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
@@ -75,8 +75,8 @@ interactions:
         "https://dashboard.gitguardian.com/workspace/8/incidents/21461", "tags": ["PUBLICLY_LEAKED"],
         "incident_name": "DSA Private Key", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-15"},
-        {"id": "JB-14", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-14"}],
+        "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link": "https://tenant-e47c06f3.atlassian.net/browse/JB-15"},
+        {"id": "JB-14", "type": "jira_cloud", "link": "https://tenant-e47c06f3.atlassian.net/browse/JB-14"}],
         "custom_tags": []}, {"id": 21462, "detector": {"name": "salesforce_oauth2",
         "display_name": "Salesforce Oauth2 Keys", "nature": "specific", "family":
         "credentials", "category": "crm", "detector_group_name": "salesforce_oauth2_keys",
@@ -87,7 +87,7 @@ interactions:
         "ignored_at": "2025-07-28T09:27:09.871747Z", "ignorer_id": 492181, "ignorer_api_token_id":
         null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
         "secret_revoked": false, "validity": "invalid", "severity": "high", "assignee_id":
-        10, "assignee_email": "bruce-wayne-gg@protonmail.com", "share_url": "[REDACTED]",
+        10, "assignee_email": "user-324427de@example.com", "share_url": "[REDACTED]",
         "feedback_list": [], "risk_score": 23, "severity_rule_id": 31, "is_vaulted":
         false, "ignore_reason": "invalid", "occurrences": null, "secret_presence":
         {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
@@ -123,7 +123,7 @@ interactions:
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         "2026-03-11T22:41:04.525493Z", "resolver_id": 492181, "resolver_api_token_id":
         null, "secret_revoked": true, "validity": "invalid", "severity": "high", "assignee_id":
-        10, "assignee_email": "bruce-wayne-gg@protonmail.com", "share_url": "[REDACTED]",
+        10, "assignee_email": "user-324427de@example.com", "share_url": "[REDACTED]",
         "feedback_list": [], "risk_score": 100, "severity_rule_id": 28, "is_vaulted":
         false, "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
         0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
@@ -131,7 +131,7 @@ interactions:
         "https://dashboard.gitguardian.com/workspace/8/incidents/21464", "tags": ["REVOCABLE_BY_GG",
         "PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [{"id": "AEF-2326", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-2326"}],
+        "destination_tickets": [{"id": "AEF-2326", "type": "jira_cloud", "link": "https://tenant-b6250acd.atlassian.net/browse/AEF-2326"}],
         "custom_tags": []}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_basic.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_basic.yaml
@@ -34,15 +34,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274792885, "issue": 34205503, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
         "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
@@ -50,20 +50,19 @@ interactions:
         "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
         "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
-        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
-        34186239, "account": 8, "criterion": "Generic Password", "date": "2026-06-22T15:14:57Z",
-        "last_trigger_published_at": "2026-06-22T15:14:57Z", "last_triggered_at":
-        "2026-06-22T15:16:49.799821Z", "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z",
-        "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-23T11:13:31.325324Z", "last_presence_check_at": "2026-06-23T11:13:31.325324Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}, {"id": 34186239, "account": 8, "criterion":
+        "Generic Password", "date": "2026-06-22T15:14:57Z", "last_trigger_published_at":
+        "2026-06-22T15:14:57Z", "last_triggered_at": "2026-06-22T15:16:49.799821Z",
+        "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z", "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -71,21 +70,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
-        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
-        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 20, "score": 53, "displayed_occurrence": {"id":
+        274668904, "issue": 34186239, "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
         "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
         "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
-        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
@@ -106,21 +105,20 @@ interactions:
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2026-06-22T11:26:52.971214Z", "resolver":
         1751937, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "none", "ignorer_type": "none", "resolver_display_name": "candidate.playground+eu@gitguardian.com",
+        "none", "ignorer_type": "none", "resolver_display_name": "user-1ffcf115@example.com",
         "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
         "none", "status": "RESOLVED", "issue_name": "Microsoft Azure Storage Connection
         String", "severity_rule_config": null, "declarative_secret_status": "revoked",
         "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "", "name": "Kashyapa P.A. Jayasekera"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        "severity": 100, "authors": [{"info": "", "name": "User 801c5600"}], "user_permission":
+        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "GGFRLTA127
-        \u2014 kashyapap.jayasekera", "type": "endpoints", "path": "GGFRLTA127 \u2014
-        kashyapap.jayasekera", "source_criticality": "unknown", "monitoring_status":
-        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "endpoint-86a2394f",
+        "type": "endpoints", "path": "endpoint-86a2394f", "source_criticality": "unknown",
+        "monitoring_status": "active", "deleted_at": null}], "custom_tags": [], "vault_metadata":
+        null, "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
         {"id": 274639444, "issue": 34181686, "account": 8, "kind": "RLTM", "element":
-        "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "AAr6ayAj6Hs2pOICdVUlEyuXlsQ78K3HFGOJgWA/yAiQrRuQH9Kv1GxUH36IT99d",
         "published_at": "2026-06-22T11:25:45.739149Z", "date": "2026-06-22T11:25:45.739149Z",
@@ -128,20 +126,19 @@ interactions:
         "2026-06-22T11:25:45.739149Z", "last_seen_at": "2026-06-22T11:25:45.739149Z",
         "data": {"line": 20, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-22T11:25:45.739149Z", "last_presence_check_at":
-        "2026-06-22T11:25:45.739149Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 6}, {"id":
-        34122510, "account": 8, "criterion": "Generic Password", "date": "2026-06-19T13:41:03Z",
-        "last_trigger_published_at": "2026-06-19T13:41:03Z", "last_triggered_at":
-        "2026-06-19T13:43:05.020137Z", "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z",
-        "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-22T11:25:45.739149Z", "last_presence_check_at": "2026-06-22T11:25:45.739149Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 6}, {"id": 34122510, "account": 8, "criterion":
+        "Generic Password", "date": "2026-06-19T13:41:03Z", "last_trigger_published_at":
+        "2026-06-19T13:41:03Z", "last_triggered_at": "2026-06-19T13:43:05.020137Z",
+        "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z", "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -149,21 +146,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
-        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
-        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 6, "score": 63, "displayed_occurrence": {"id":
+        274099881, "issue": 34122510, "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
         "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
         "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
-        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
@@ -189,15 +186,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 273386288, "issue": 34038186, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
         "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
@@ -205,16 +202,16 @@ interactions:
         "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
         "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
-        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}]}'
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-16T18:55:43.166667Z", "last_presence_check_at": "2026-06-16T18:55:43.166667Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}]}'
     headers:
       CF-RAY:
       - a1039553ae06a40a-CDG

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_combined_filters.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_combined_filters.yaml
@@ -29,7 +29,7 @@ interactions:
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": 910203, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
-        "celine.agbo@gitguardian.com", "manual_severity_setter_type": "user", "status":
+        "user-faa5b70a@example.com", "manual_severity_setter_type": "user", "status":
         "ASSIGNED", "issue_name": "Artifactory Token", "severity_rule_config": {"id":
         11895, "gg_created_at": "2026-05-20T08:56:10.055460Z", "gg_updated_at": "2026-05-20T08:56:10.055463Z",
         "index": 130, "severity": 10, "rule": {"id": 513, "gg_created_at": "2025-03-18T08:57:54.142453Z",
@@ -39,23 +39,22 @@ interactions:
         "default": null}, "arg2": {"value": "package_registry"}}, "is_global": true,
         "scope": "private", "author": null}}, "declarative_secret_status": null, "assignee":
         550880, "last_presence_check_at": null, "secret": "[REDACTED]", "severity":
-        20, "authors": [{"info": "ggtestintegrations@proton.me", "name": "GG Test
-        Integrations"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"id": 27177247, "name": "gg-test-integrations / Payment Systems", "type":
-        "jira_cloud_project", "path": "gg-test-integrations / Payment Systems", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 86, "displayed_occurrence": {"id": 272781097, "issue": 33929626,
-        "account": 8, "kind": "RLTM", "element": "PAY-4", "element_type": "JIRA_TICKET",
-        "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "T71tr/N63V71e27iMbDQa9L9Oh/xkgVEZdomur2uk2WyqO/9fr4lNYuUjUFpuLDi",
+        20, "authors": [{"info": "user-556e25a3@example.com", "name": "User 4578e5a2"}],
+        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 0, "sources": [{"id": 27177247, "name": "gg-test-integrations
+        / Payment Systems", "type": "jira_cloud_project", "path": "gg-test-integrations
+        / Payment Systems", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 86, "displayed_occurrence":
+        {"id": 272781097, "issue": 33929626, "account": 8, "kind": "RLTM", "element":
+        "PAY-4", "element_type": "JIRA_TICKET", "author_name": "GG Test Integrations",
+        "author_info": "user-556e25a3@example.com", "value": null, "value_hash": "T71tr/N63V71e27iMbDQa9L9Oh/xkgVEZdomur2uk2WyqO/9fr4lNYuUjUFpuLDi",
         "published_at": "2026-06-12T10:26:58.151000Z", "date": "2026-06-12T10:26:58.151000Z",
         "detected_at": "2026-06-12T11:57:58.655858Z", "is_vcs_type": false, "last_detected_at":
         "2026-06-12T10:26:58.151000Z", "last_seen_at": "2026-06-12T10:26:58.151000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/PAY-4",
-        "source": {"id": 27177247, "url": "https://gg-test-integrations.atlassian.net/browse/PAY",
+        "data": {}, "url": "https://tenant-54c1a367.atlassian.net/browse/PAY-4", "source":
+        {"id": 27177247, "url": "https://tenant-54c1a367.atlassian.net/browse/PAY",
         "type": "jira_cloud_project", "display_name": "gg-test-integrations / Payment
         Systems", "visibility": "private", "monitored": true, "source_criticality":
         "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
@@ -88,9 +87,9 @@ interactions:
         {"path": "issue.secret.detector.nature", "default": null}, "arg2": {"value":
         "specific"}}]}, "is_global": true, "scope": "private", "author": null}}, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "romain.jouhannet@gitguardian.com",
-        "name": "Romain Jouhannet"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
+        "severity": 100, "authors": [{"info": "user-46c1d11b@example.com", "name":
+        "User b090f14f"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
         [{"id": 23485702, "name": "RomainJ / demo", "type": "gl_project", "path":
         "romain/demo", "source_criticality": "unknown", "monitoring_status": "active",
@@ -98,11 +97,11 @@ interactions:
         false, "similar_issue_count": 0, "score": 49, "displayed_occurrence": {"id":
         269728665, "issue": 33211589, "account": 8, "kind": "HIST", "element": "d189cab00bc31c4bed372402e031de0559fa9d70",
         "element_type": "GIT_COMMIT", "author_name": "Romain Jouhannet", "author_info":
-        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "4WO+NtMg1huWU4tghYRv7bPopKssi564RukxBZVA2Opur15IVmYm2YNGhd2mwbCp",
+        "user-46c1d11b@example.com", "value": null, "value_hash": "4WO+NtMg1huWU4tghYRv7bPopKssi564RukxBZVA2Opur15IVmYm2YNGhd2mwbCp",
         "published_at": "2026-05-27T09:42:47Z", "date": "2026-05-27T09:42:47Z", "detected_at":
         "2026-05-27T09:51:34.675578Z", "is_vcs_type": true, "last_detected_at": "2026-05-27T09:42:47Z",
-        "last_seen_at": "2026-05-27T09:42:47Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/d189cab00bc31c4bed372402e031de0559fa9d70#e1755a4a1df75fb12321bae878788f6ca914d373_None_1",
-        "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
+        "last_seen_at": "2026-05-27T09:42:47Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-eb459aed/ns-2a97516c/commit/d189cab00bc31c4bed372402e031de0559fa9d70#e1755a4a1df75fb12321bae878788f6ca914d373_None_1",
+        "source": {"id": 23485702, "url": "https://host-a31e7ce0.example.com/ns-eb459aed/ns-2a97516c",
         "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 164835166,
@@ -150,9 +149,9 @@ interactions:
         {"path": "issue.secret.detector.nature", "default": null}, "arg2": {"value":
         "specific"}}]}, "is_global": true, "scope": "private", "author": null}}, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "romain.jouhannet@gitguardian.com",
-        "name": "Romain Jouhannet"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        "severity": 100, "authors": [{"info": "user-46c1d11b@example.com", "name":
+        "User b090f14f"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
         [{"id": 23485702, "name": "RomainJ / demo", "type": "gl_project", "path":
         "romain/demo", "source_criticality": "unknown", "monitoring_status": "active",
@@ -160,11 +159,11 @@ interactions:
         false, "similar_issue_count": 1, "score": 49, "displayed_occurrence": {"id":
         269727691, "issue": 33211407, "account": 8, "kind": "RLTM", "element": "d6361a080aa92dc554cd2b55f6f3a7dcf26d1dcb",
         "element_type": "GIT_COMMIT", "author_name": "Romain Jouhannet", "author_info":
-        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "YU5lBhVgALxxn8rYMmJe6Uh0y3sUhot77BxviUqvi2cqEVzhNyDcgwtJW6F//p33",
+        "user-46c1d11b@example.com", "value": null, "value_hash": "YU5lBhVgALxxn8rYMmJe6Uh0y3sUhot77BxviUqvi2cqEVzhNyDcgwtJW6F//p33",
         "published_at": "2026-05-27T09:28:55Z", "date": "2026-05-27T09:28:55Z", "detected_at":
         "2026-05-27T09:32:59.686337Z", "is_vcs_type": true, "last_detected_at": "2026-05-27T09:28:55Z",
-        "last_seen_at": "2026-05-27T09:28:55Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/d6361a080aa92dc554cd2b55f6f3a7dcf26d1dcb#3a94abefa57e93ce6945d8a053c37e4e2598dbee_0_7",
-        "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
+        "last_seen_at": "2026-05-27T09:28:55Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-eb459aed/ns-2a97516c/commit/d6361a080aa92dc554cd2b55f6f3a7dcf26d1dcb#3a94abefa57e93ce6945d8a053c37e4e2598dbee_0_7",
+        "source": {"id": 23485702, "url": "https://host-a31e7ce0.example.com/ns-eb459aed/ns-2a97516c",
         "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 164831857,
@@ -211,9 +210,9 @@ interactions:
         {"path": "issue.secret.detector.nature", "default": null}, "arg2": {"value":
         "specific"}}]}, "is_global": true, "scope": "private", "author": null}}, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "romain.jouhannet@gitguardian.com",
-        "name": "Romain Jouhannet"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        "severity": 100, "authors": [{"info": "user-46c1d11b@example.com", "name":
+        "User b090f14f"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
         [{"id": 23485702, "name": "RomainJ / demo", "type": "gl_project", "path":
         "romain/demo", "source_criticality": "unknown", "monitoring_status": "active",
@@ -221,11 +220,11 @@ interactions:
         false, "similar_issue_count": 1, "score": 49, "displayed_occurrence": {"id":
         269727692, "issue": 33211409, "account": 8, "kind": "RLTM", "element": "d6361a080aa92dc554cd2b55f6f3a7dcf26d1dcb",
         "element_type": "GIT_COMMIT", "author_name": "Romain Jouhannet", "author_info":
-        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "dGSO0UNu3ir5xB1mNC4rhS2IL21oXm+7tSQPn+qUFGZ3HkBlVp3JYrpf4ubmlbDB",
+        "user-46c1d11b@example.com", "value": null, "value_hash": "dGSO0UNu3ir5xB1mNC4rhS2IL21oXm+7tSQPn+qUFGZ3HkBlVp3JYrpf4ubmlbDB",
         "published_at": "2026-05-27T09:28:55Z", "date": "2026-05-27T09:28:55Z", "detected_at":
         "2026-05-27T09:32:59.686337Z", "is_vcs_type": true, "last_detected_at": "2026-05-27T09:28:55Z",
-        "last_seen_at": "2026-05-27T09:28:55Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/d6361a080aa92dc554cd2b55f6f3a7dcf26d1dcb#7b83dc4c52bef56016855ec981bdf4b8425c6486_0_7",
-        "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
+        "last_seen_at": "2026-05-27T09:28:55Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-eb459aed/ns-2a97516c/commit/d6361a080aa92dc554cd2b55f6f3a7dcf26d1dcb#7b83dc4c52bef56016855ec981bdf4b8425c6486_0_7",
+        "source": {"id": 23485702, "url": "https://host-a31e7ce0.example.com/ns-eb459aed/ns-2a97516c",
         "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 164831858,
@@ -260,7 +259,7 @@ interactions:
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": 614347, "regression":
         true, "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
-        "none", "resolver_display_name": "romain.jouhannet@gitguardian.com", "resolver_type":
+        "none", "resolver_display_name": "user-46c1d11b@example.com", "resolver_type":
         "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
         "none", "status": "ASSIGNED", "issue_name": "MongoDB Credentials", "severity_rule_config":
         {"id": 11898, "gg_created_at": "2026-05-20T08:56:10.055489Z", "gg_updated_at":
@@ -273,21 +272,21 @@ interactions:
         "default": null}, "arg2": {"value": "specific"}}]}, "is_global": true, "scope":
         "private", "author": null}}, "declarative_secret_status": "revoked", "assignee":
         694621, "last_presence_check_at": null, "secret": "[REDACTED]", "severity":
-        100, "authors": [{"info": "romain.jouhannet@gitguardian.com", "name": "Romain
-        Jouhannet"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 6, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"id": 23485702, "name": "RomainJ / demo", "type": "gl_project", "path":
-        "romain/demo", "source_criticality": "unknown", "monitoring_status": "active",
-        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
-        false, "similar_issue_count": 5, "score": 49, "displayed_occurrence": {"id":
-        268701358, "issue": 33049834, "account": 8, "kind": "RLTM", "element": "f13f8127edb3e5d386cb44679c12e5d6c3ce05be",
+        100, "authors": [{"info": "user-46c1d11b@example.com", "name": "User b090f14f"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 0, "sources": [{"id": 23485702, "name": "RomainJ
+        / demo", "type": "gl_project", "path": "romain/demo", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 5,
+        "score": 49, "displayed_occurrence": {"id": 268701358, "issue": 33049834,
+        "account": 8, "kind": "RLTM", "element": "f13f8127edb3e5d386cb44679c12e5d6c3ce05be",
         "element_type": "GIT_COMMIT", "author_name": "Romain Jouhannet", "author_info":
-        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "ElUKHxkW6poM78sJZq6fX/NNHh82/5I40MrYWprOWor+UttOwqRf0MFMFvJD2sMv",
+        "user-46c1d11b@example.com", "value": null, "value_hash": "ElUKHxkW6poM78sJZq6fX/NNHh82/5I40MrYWprOWor+UttOwqRf0MFMFvJD2sMv",
         "published_at": "2026-05-21T12:49:39Z", "date": "2026-05-21T12:49:39Z", "detected_at":
         "2026-05-21T12:51:02.846566Z", "is_vcs_type": true, "last_detected_at": "2026-05-21T12:51:02.846566Z",
-        "last_seen_at": "2026-05-21T12:51:02.846566Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/f13f8127edb3e5d386cb44679c12e5d6c3ce05be#f9553d98ad319e9f50f10ef0cf086752c16a337b_5_6",
-        "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
+        "last_seen_at": "2026-05-21T12:51:02.846566Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-eb459aed/ns-2a97516c/commit/f13f8127edb3e5d386cb44679c12e5d6c3ce05be#f9553d98ad319e9f50f10ef0cf086752c16a337b_5_6",
+        "source": {"id": 23485702, "url": "https://host-a31e7ce0.example.com/ns-eb459aed/ns-2a97516c",
         "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": true, "content": 163473773,

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_pagination.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_pagination.yaml
@@ -34,15 +34,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274792885, "issue": 34205503, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
         "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
@@ -50,20 +50,19 @@ interactions:
         "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
         "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
-        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
-        34186239, "account": 8, "criterion": "Generic Password", "date": "2026-06-22T15:14:57Z",
-        "last_trigger_published_at": "2026-06-22T15:14:57Z", "last_triggered_at":
-        "2026-06-22T15:16:49.799821Z", "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z",
-        "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-23T11:13:31.325324Z", "last_presence_check_at": "2026-06-23T11:13:31.325324Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}, {"id": 34186239, "account": 8, "criterion":
+        "Generic Password", "date": "2026-06-22T15:14:57Z", "last_trigger_published_at":
+        "2026-06-22T15:14:57Z", "last_triggered_at": "2026-06-22T15:16:49.799821Z",
+        "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z", "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -71,21 +70,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
-        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
-        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 20, "score": 53, "displayed_occurrence": {"id":
+        274668904, "issue": 34186239, "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
         "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
         "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
-        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
@@ -176,21 +175,20 @@ interactions:
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2026-06-22T11:26:52.971214Z", "resolver":
         1751937, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "none", "ignorer_type": "none", "resolver_display_name": "candidate.playground+eu@gitguardian.com",
+        "none", "ignorer_type": "none", "resolver_display_name": "user-1ffcf115@example.com",
         "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
         "none", "status": "RESOLVED", "issue_name": "Microsoft Azure Storage Connection
         String", "severity_rule_config": null, "declarative_secret_status": "revoked",
         "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "", "name": "Kashyapa P.A. Jayasekera"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        "severity": 100, "authors": [{"info": "", "name": "User 801c5600"}], "user_permission":
+        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "GGFRLTA127
-        \u2014 kashyapap.jayasekera", "type": "endpoints", "path": "GGFRLTA127 \u2014
-        kashyapap.jayasekera", "source_criticality": "unknown", "monitoring_status":
-        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "endpoint-86a2394f",
+        "type": "endpoints", "path": "endpoint-86a2394f", "source_criticality": "unknown",
+        "monitoring_status": "active", "deleted_at": null}], "custom_tags": [], "vault_metadata":
+        null, "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
         {"id": 274639444, "issue": 34181686, "account": 8, "kind": "RLTM", "element":
-        "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "AAr6ayAj6Hs2pOICdVUlEyuXlsQ78K3HFGOJgWA/yAiQrRuQH9Kv1GxUH36IT99d",
         "published_at": "2026-06-22T11:25:45.739149Z", "date": "2026-06-22T11:25:45.739149Z",
@@ -198,20 +196,19 @@ interactions:
         "2026-06-22T11:25:45.739149Z", "last_seen_at": "2026-06-22T11:25:45.739149Z",
         "data": {"line": 20, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-22T11:25:45.739149Z", "last_presence_check_at":
-        "2026-06-22T11:25:45.739149Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 6}, {"id":
-        34122510, "account": 8, "criterion": "Generic Password", "date": "2026-06-19T13:41:03Z",
-        "last_trigger_published_at": "2026-06-19T13:41:03Z", "last_triggered_at":
-        "2026-06-19T13:43:05.020137Z", "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z",
-        "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-22T11:25:45.739149Z", "last_presence_check_at": "2026-06-22T11:25:45.739149Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 6}, {"id": 34122510, "account": 8, "criterion":
+        "Generic Password", "date": "2026-06-19T13:41:03Z", "last_trigger_published_at":
+        "2026-06-19T13:41:03Z", "last_triggered_at": "2026-06-19T13:43:05.020137Z",
+        "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z", "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -219,21 +216,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
-        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
-        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 6, "score": 63, "displayed_occurrence": {"id":
+        274099881, "issue": 34122510, "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
         "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
         "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
-        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_unassigned.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_unassigned.yaml
@@ -34,15 +34,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274792885, "issue": 34205503, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
         "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
@@ -50,20 +50,19 @@ interactions:
         "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
         "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
-        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
-        34186239, "account": 8, "criterion": "Generic Password", "date": "2026-06-22T15:14:57Z",
-        "last_trigger_published_at": "2026-06-22T15:14:57Z", "last_triggered_at":
-        "2026-06-22T15:16:49.799821Z", "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z",
-        "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-23T11:13:31.325324Z", "last_presence_check_at": "2026-06-23T11:13:31.325324Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}, {"id": 34186239, "account": 8, "criterion":
+        "Generic Password", "date": "2026-06-22T15:14:57Z", "last_trigger_published_at":
+        "2026-06-22T15:14:57Z", "last_triggered_at": "2026-06-22T15:16:49.799821Z",
+        "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z", "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -71,21 +70,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
-        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
-        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 20, "score": 53, "displayed_occurrence": {"id":
+        274668904, "issue": 34186239, "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
         "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
         "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
-        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
@@ -106,21 +105,20 @@ interactions:
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2026-06-22T11:26:52.971214Z", "resolver":
         1751937, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "none", "ignorer_type": "none", "resolver_display_name": "candidate.playground+eu@gitguardian.com",
+        "none", "ignorer_type": "none", "resolver_display_name": "user-1ffcf115@example.com",
         "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
         "none", "status": "RESOLVED", "issue_name": "Microsoft Azure Storage Connection
         String", "severity_rule_config": null, "declarative_secret_status": "revoked",
         "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "", "name": "Kashyapa P.A. Jayasekera"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        "severity": 100, "authors": [{"info": "", "name": "User 801c5600"}], "user_permission":
+        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "GGFRLTA127
-        \u2014 kashyapap.jayasekera", "type": "endpoints", "path": "GGFRLTA127 \u2014
-        kashyapap.jayasekera", "source_criticality": "unknown", "monitoring_status":
-        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "endpoint-86a2394f",
+        "type": "endpoints", "path": "endpoint-86a2394f", "source_criticality": "unknown",
+        "monitoring_status": "active", "deleted_at": null}], "custom_tags": [], "vault_metadata":
+        null, "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
         {"id": 274639444, "issue": 34181686, "account": 8, "kind": "RLTM", "element":
-        "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "AAr6ayAj6Hs2pOICdVUlEyuXlsQ78K3HFGOJgWA/yAiQrRuQH9Kv1GxUH36IT99d",
         "published_at": "2026-06-22T11:25:45.739149Z", "date": "2026-06-22T11:25:45.739149Z",
@@ -128,20 +126,19 @@ interactions:
         "2026-06-22T11:25:45.739149Z", "last_seen_at": "2026-06-22T11:25:45.739149Z",
         "data": {"line": 20, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-22T11:25:45.739149Z", "last_presence_check_at":
-        "2026-06-22T11:25:45.739149Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 6}, {"id":
-        34122510, "account": 8, "criterion": "Generic Password", "date": "2026-06-19T13:41:03Z",
-        "last_trigger_published_at": "2026-06-19T13:41:03Z", "last_triggered_at":
-        "2026-06-19T13:43:05.020137Z", "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z",
-        "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-22T11:25:45.739149Z", "last_presence_check_at": "2026-06-22T11:25:45.739149Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 6}, {"id": 34122510, "account": 8, "criterion":
+        "Generic Password", "date": "2026-06-19T13:41:03Z", "last_trigger_published_at":
+        "2026-06-19T13:41:03Z", "last_triggered_at": "2026-06-19T13:43:05.020137Z",
+        "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z", "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -149,21 +146,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
-        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
-        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 6, "score": 63, "displayed_occurrence": {"id":
+        274099881, "issue": 34122510, "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
         "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
         "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
-        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
@@ -189,15 +186,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 273386288, "issue": 34038186, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
         "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
@@ -205,16 +202,16 @@ interactions:
         "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
         "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
-        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}]}'
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-16T18:55:43.166667Z", "last_presence_check_at": "2026-06-16T18:55:43.166667Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}]}'
     headers:
       CF-RAY:
       - a103956f48b9bc81-CDG

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_date_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_date_filter.yaml
@@ -28,7 +28,7 @@ interactions:
         "ignored": true, "ignored_at": "2026-04-22T15:59:49.932528Z", "ignore_reason":
         "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
         null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
+        "user-7d8fb5e1@example.com", "ignorer_type": "user", "resolver_display_name":
         "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
         "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
         "Claude API Key", "severity_rule_config": null, "declarative_secret_status":
@@ -50,8 +50,8 @@ interactions:
         "last_seen_at": "2025-12-19T08:54:54Z", "data": {"blob_sha": "sha256:c8ebd6a8b0125c8cff3e4ca275c6438f986265c8a46a919821d67af68825af05",
         "image_tag": "v1", "manifest_sha": "sha256:55e18847e9d4e4ff60d0b8cde21c964dcad01d8960c15c7e43107957a198c8c0",
         "manifest_digest": "sha256:926faa6d63311f8bfe03a7cc10275b9a79fd544c78ae2d89bea790e2cc469103"},
-        "url": "https://gitguardianengineering.jfrog.io/ui/repos/tree/General/docker-trial/test/v1/sha256__c8ebd6a8b0125c8cff3e4ca275c6438f986265c8a46a919821d67af68825af05",
-        "source": {"id": 27612802, "url": "https://gitguardianengineering.jfrog.io/ui/repos/tree/General/docker-trial/test",
+        "url": "https://tenant-61b791c5.jfrog.io/ui/repos/tree/General/docker-trial/test/v1/sha256__c8ebd6a8b0125c8cff3e4ca275c6438f986265c8a46a919821d67af68825af05",
+        "source": {"id": 27612802, "url": "https://tenant-61b791c5.jfrog.io/ui/repos/tree/General/docker-trial/test",
         "type": "jfrog_container_registry_v2_repository", "display_name": "docker-trial/test",
         "visibility": "private", "monitored": true, "source_criticality": "unknown",
         "deleted_at": "2026-06-10T13:57:55.109144Z", "default_branch": null, "monitoring_status":
@@ -73,13 +73,13 @@ interactions:
         "ignored": true, "ignored_at": "2025-12-16T18:22:25.122585Z", "ignore_reason":
         "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
         null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
+        "user-7d8fb5e1@example.com", "ignorer_type": "user", "resolver_display_name":
         "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
         "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
         "AWS IAM Keys", "severity_rule_config": null, "declarative_secret_status":
         "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "name": "gg-tools"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        "severity": 100, "authors": [{"info": "user-dc06829d@example.com", "name":
+        "User 42397b98"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
         0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
         [{"id": 23920761, "name": "Alina''s site (document libraries) / Documents",
@@ -91,12 +91,12 @@ interactions:
         \"b!EFtsUNZdNkyikeU9z6xQzkUMGeBD9bdJo5M6BS3bW67zTZ14Z8npSqr01XpQaXIh\", \"parent_reference_path\":
         \"/drives/b!EFtsUNZdNkyikeU9z6xQzkUMGeBD9bdJo5M6BS3bW67zTZ14Z8npSqr01XpQaXIh/root:\",
         \"file_id\": \"01Y5MCAQY6HCFEWMVSWZCJJ2PCDHL3I2YO\"}", "element_type": "SHAREPOINT_ONEDRIVE_FILE",
-        "author_name": "gg-tools", "author_info": "gg-tools@gitguardianengineering.onmicrosoft.com",
-        "value": null, "value_hash": "iPtXjz0IchI3JPXhF9r8blhAWpYqtW42SnmwJ/Qm7urxC80Sii0L/QArnKtol4jI",
+        "author_name": "gg-tools", "author_info": "user-dc06829d@example.com", "value":
+        null, "value_hash": "iPtXjz0IchI3JPXhF9r8blhAWpYqtW42SnmwJ/Qm7urxC80Sii0L/QArnKtol4jI",
         "published_at": "2025-12-16T17:22:08Z", "date": "2025-12-16T17:22:08Z", "detected_at":
         "2025-12-16T18:15:30.167037Z", "is_vcs_type": false, "last_detected_at": "2025-12-16T17:22:08Z",
-        "last_seen_at": "2025-12-16T17:22:08Z", "data": {}, "url": "https://gitguardianengineering.sharepoint.com/sites/Alina%27ssite/Shared%20Documents/small_with_secret.csv.gz",
-        "source": {"id": 23920761, "url": "https://gitguardianengineering.sharepoint.com/sites/Alina%27ssite/Shared%20Documents",
+        "last_seen_at": "2025-12-16T17:22:08Z", "data": {}, "url": "https://tenant-4ecb9579.sharepoint.com/sites/Alina%27ssite/Shared%20Documents/small_with_secret.csv.gz",
+        "source": {"id": 23920761, "url": "https://tenant-4ecb9579.sharepoint.com/sites/Alina%27ssite/Shared%20Documents",
         "type": "sharepoint_online_drive", "display_name": "Alina''s site (document
         libraries) / Documents", "visibility": "private", "monitored": true, "source_criticality":
         "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
@@ -120,7 +120,7 @@ interactions:
         "ignored": true, "ignored_at": "2026-04-22T15:59:51.450807Z", "ignore_reason":
         "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
         null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
+        "user-7d8fb5e1@example.com", "ignorer_type": "user", "resolver_display_name":
         "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
         "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
         "OpenAI API Key", "severity_rule_config": null, "declarative_secret_status":
@@ -143,8 +143,8 @@ interactions:
         "image_tag": "sha256:8429ca6db5eb1a190b6aff32305fb849f8125ce3fdabbaa14dd8cec07ebdf3a7",
         "manifest_sha": "sha256:7617aed4ec1aa5b4f69e963b389a4c0e76e5aed1be9a8fc8baf2f0d34fbd34d1",
         "manifest_digest": "sha256:8429ca6db5eb1a190b6aff32305fb849f8125ce3fdabbaa14dd8cec07ebdf3a7"},
-        "url": "https://gitguardianengineering.jfrog.io/ui/repos/tree/General/docker-trial/nrivmultiarch/sha256:8429ca6db5eb1a190b6aff32305fb849f8125ce3fdabbaa14dd8cec07ebdf3a7/sha256__988b4e7f13c383b4893858fccf63b16d55b7cc11d83feef92a22ce06f7b59e90",
-        "source": {"id": 27612799, "url": "https://gitguardianengineering.jfrog.io/ui/repos/tree/General/docker-trial/nrivmultiarch",
+        "url": "https://tenant-61b791c5.jfrog.io/ui/repos/tree/General/docker-trial/nrivmultiarch/sha256:8429ca6db5eb1a190b6aff32305fb849f8125ce3fdabbaa14dd8cec07ebdf3a7/sha256__988b4e7f13c383b4893858fccf63b16d55b7cc11d83feef92a22ce06f7b59e90",
+        "source": {"id": 27612799, "url": "https://tenant-61b791c5.jfrog.io/ui/repos/tree/General/docker-trial/nrivmultiarch",
         "type": "jfrog_container_registry_v2_repository", "display_name": "docker-trial/nrivmultiarch",
         "visibility": "private", "monitored": true, "source_criticality": "unknown",
         "deleted_at": "2026-06-10T13:57:55.109144Z", "default_branch": null, "monitoring_status":
@@ -170,9 +170,9 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Square Token", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "romain.jouhannet@gitguardian.com",
-        "name": "Romain Jouhannet"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 4, "occurrences_presence_deleted_count":
+        "severity": 100, "authors": [{"info": "user-46c1d11b@example.com", "name":
+        "User b090f14f"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 4, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
         [{"id": 23485702, "name": "RomainJ / demo", "type": "gl_project", "path":
         "romain/demo", "source_criticality": "unknown", "monitoring_status": "active",
@@ -182,12 +182,12 @@ interactions:
         null, "is_vaulted": false, "similar_issue_count": 16, "score": 30, "displayed_occurrence":
         {"id": 241287721, "issue": 26805045, "account": 8, "kind": "HIST", "element":
         "fd56543c0a2594907b36ab59c885bd1d536a4957", "element_type": "GIT_COMMIT",
-        "author_name": "Romain Jouhannet", "author_info": "romain.jouhannet@gitguardian.com",
+        "author_name": "Romain Jouhannet", "author_info": "user-46c1d11b@example.com",
         "value": null, "value_hash": "WE9RdxAVX6gbgtYpkWDapCSNR52nN4Dtf6NepeWQWpH1122NxY2lk0p41XlD3KA6",
         "published_at": "2025-12-14T19:04:50Z", "date": "2025-12-14T19:04:50Z", "detected_at":
         "2026-02-04T13:38:46.386256Z", "is_vcs_type": true, "last_detected_at": "2025-12-14T19:04:50Z",
-        "last_seen_at": "2025-12-14T19:04:50Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/fd56543c0a2594907b36ab59c885bd1d536a4957#2ec5fbc02574c84a8b8e3dcae097ffd0be069994_None_20",
-        "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
+        "last_seen_at": "2025-12-14T19:04:50Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-eb459aed/ns-2a97516c/commit/fd56543c0a2594907b36ab59c885bd1d536a4957#2ec5fbc02574c84a8b8e3dcae097ffd0be069994_None_20",
+        "source": {"id": 23485702, "url": "https://host-a31e7ce0.example.com/ns-eb459aed/ns-2a97516c",
         "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 129708166,
@@ -209,13 +209,13 @@ interactions:
         "ignored": true, "ignored_at": "2026-02-04T13:38:52.095775Z", "ignore_reason":
         "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
         null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
+        "user-7d8fb5e1@example.com", "ignorer_type": "user", "resolver_display_name":
         "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
         "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
         "Google API Key", "severity_rule_config": null, "declarative_secret_status":
         "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"},
-        {"info": "romain.jouhannet@gitguardian.com", "name": "Romain Jouhannet"}],
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}, {"info": "user-46c1d11b@example.com", "name": "User b090f14f"}],
         "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         12, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
         null, "locations_count": 0, "sources": [{"id": 23485702, "name": "RomainJ
@@ -227,12 +227,12 @@ interactions:
         "is_vaulted": true, "similar_issue_count": 4, "score": 0, "displayed_occurrence":
         {"id": 241287716, "issue": 26805047, "account": 8, "kind": "HIST", "element":
         "fd56543c0a2594907b36ab59c885bd1d536a4957", "element_type": "GIT_COMMIT",
-        "author_name": "Romain Jouhannet", "author_info": "romain.jouhannet@gitguardian.com",
+        "author_name": "Romain Jouhannet", "author_info": "user-46c1d11b@example.com",
         "value": null, "value_hash": "SJwViF0/DsMYa+t+dBEiZx2csnwTDMqh1ro0cKTbBj5LYGqhjI9qf5LnmIYCvOW2",
         "published_at": "2025-12-14T19:04:50Z", "date": "2025-12-14T19:04:50Z", "detected_at":
         "2026-02-04T13:38:46.386256Z", "is_vcs_type": true, "last_detected_at": "2025-12-14T19:04:50Z",
-        "last_seen_at": "2025-12-14T19:04:50Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/fd56543c0a2594907b36ab59c885bd1d536a4957#2ec5fbc02574c84a8b8e3dcae097ffd0be069994_None_12",
-        "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
+        "last_seen_at": "2025-12-14T19:04:50Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-eb459aed/ns-2a97516c/commit/fd56543c0a2594907b36ab59c885bd1d536a4957#2ec5fbc02574c84a8b8e3dcae097ffd0be069994_None_12",
+        "source": {"id": 23485702, "url": "https://host-a31e7ce0.example.com/ns-eb459aed/ns-2a97516c",
         "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 129708166,

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_detector_category.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_detector_category.yaml
@@ -34,15 +34,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274792885, "issue": 34205503, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
         "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
@@ -50,20 +50,19 @@ interactions:
         "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
         "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
-        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
-        34186239, "account": 8, "criterion": "Generic Password", "date": "2026-06-22T15:14:57Z",
-        "last_trigger_published_at": "2026-06-22T15:14:57Z", "last_triggered_at":
-        "2026-06-22T15:16:49.799821Z", "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z",
-        "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-23T11:13:31.325324Z", "last_presence_check_at": "2026-06-23T11:13:31.325324Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}, {"id": 34186239, "account": 8, "criterion":
+        "Generic Password", "date": "2026-06-22T15:14:57Z", "last_trigger_published_at":
+        "2026-06-22T15:14:57Z", "last_triggered_at": "2026-06-22T15:16:49.799821Z",
+        "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z", "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -71,21 +70,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
-        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
-        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 20, "score": 53, "displayed_occurrence": {"id":
+        274668904, "issue": 34186239, "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
         "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
         "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
-        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
@@ -106,21 +105,20 @@ interactions:
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2026-06-22T11:26:52.971214Z", "resolver":
         1751937, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "none", "ignorer_type": "none", "resolver_display_name": "candidate.playground+eu@gitguardian.com",
+        "none", "ignorer_type": "none", "resolver_display_name": "user-1ffcf115@example.com",
         "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
         "none", "status": "RESOLVED", "issue_name": "Microsoft Azure Storage Connection
         String", "severity_rule_config": null, "declarative_secret_status": "revoked",
         "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "", "name": "Kashyapa P.A. Jayasekera"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        "severity": 100, "authors": [{"info": "", "name": "User 801c5600"}], "user_permission":
+        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "GGFRLTA127
-        \u2014 kashyapap.jayasekera", "type": "endpoints", "path": "GGFRLTA127 \u2014
-        kashyapap.jayasekera", "source_criticality": "unknown", "monitoring_status":
-        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "endpoint-86a2394f",
+        "type": "endpoints", "path": "endpoint-86a2394f", "source_criticality": "unknown",
+        "monitoring_status": "active", "deleted_at": null}], "custom_tags": [], "vault_metadata":
+        null, "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
         {"id": 274639444, "issue": 34181686, "account": 8, "kind": "RLTM", "element":
-        "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "AAr6ayAj6Hs2pOICdVUlEyuXlsQ78K3HFGOJgWA/yAiQrRuQH9Kv1GxUH36IT99d",
         "published_at": "2026-06-22T11:25:45.739149Z", "date": "2026-06-22T11:25:45.739149Z",
@@ -128,20 +126,19 @@ interactions:
         "2026-06-22T11:25:45.739149Z", "last_seen_at": "2026-06-22T11:25:45.739149Z",
         "data": {"line": 20, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-22T11:25:45.739149Z", "last_presence_check_at":
-        "2026-06-22T11:25:45.739149Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 6}, {"id":
-        34122510, "account": 8, "criterion": "Generic Password", "date": "2026-06-19T13:41:03Z",
-        "last_trigger_published_at": "2026-06-19T13:41:03Z", "last_triggered_at":
-        "2026-06-19T13:43:05.020137Z", "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z",
-        "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-22T11:25:45.739149Z", "last_presence_check_at": "2026-06-22T11:25:45.739149Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 6}, {"id": 34122510, "account": 8, "criterion":
+        "Generic Password", "date": "2026-06-19T13:41:03Z", "last_trigger_published_at":
+        "2026-06-19T13:41:03Z", "last_triggered_at": "2026-06-19T13:43:05.020137Z",
+        "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z", "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -149,21 +146,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
-        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
-        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 6, "score": 63, "displayed_occurrence": {"id":
+        274099881, "issue": 34122510, "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
         "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
         "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
-        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
@@ -189,15 +186,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 273386288, "issue": 34038186, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
         "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
@@ -205,16 +202,16 @@ interactions:
         "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
         "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
-        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}]}'
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-16T18:55:43.166667Z", "last_presence_check_at": "2026-06-16T18:55:43.166667Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}]}'
     headers:
       CF-RAY:
       - a1039594d8d03d5d-CDG

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_detector_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_detector_filter.yaml
@@ -34,15 +34,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274792885, "issue": 34205503, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
         "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
@@ -50,20 +50,19 @@ interactions:
         "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
         "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
-        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
-        34186239, "account": 8, "criterion": "Generic Password", "date": "2026-06-22T15:14:57Z",
-        "last_trigger_published_at": "2026-06-22T15:14:57Z", "last_triggered_at":
-        "2026-06-22T15:16:49.799821Z", "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z",
-        "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-23T11:13:31.325324Z", "last_presence_check_at": "2026-06-23T11:13:31.325324Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}, {"id": 34186239, "account": 8, "criterion":
+        "Generic Password", "date": "2026-06-22T15:14:57Z", "last_trigger_published_at":
+        "2026-06-22T15:14:57Z", "last_triggered_at": "2026-06-22T15:16:49.799821Z",
+        "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z", "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -71,21 +70,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
-        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
-        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 20, "score": 53, "displayed_occurrence": {"id":
+        274668904, "issue": 34186239, "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
         "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
         "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
-        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
@@ -106,21 +105,20 @@ interactions:
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2026-06-22T11:26:52.971214Z", "resolver":
         1751937, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "none", "ignorer_type": "none", "resolver_display_name": "candidate.playground+eu@gitguardian.com",
+        "none", "ignorer_type": "none", "resolver_display_name": "user-1ffcf115@example.com",
         "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
         "none", "status": "RESOLVED", "issue_name": "Microsoft Azure Storage Connection
         String", "severity_rule_config": null, "declarative_secret_status": "revoked",
         "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "", "name": "Kashyapa P.A. Jayasekera"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        "severity": 100, "authors": [{"info": "", "name": "User 801c5600"}], "user_permission":
+        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "GGFRLTA127
-        \u2014 kashyapap.jayasekera", "type": "endpoints", "path": "GGFRLTA127 \u2014
-        kashyapap.jayasekera", "source_criticality": "unknown", "monitoring_status":
-        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "endpoint-86a2394f",
+        "type": "endpoints", "path": "endpoint-86a2394f", "source_criticality": "unknown",
+        "monitoring_status": "active", "deleted_at": null}], "custom_tags": [], "vault_metadata":
+        null, "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
         {"id": 274639444, "issue": 34181686, "account": 8, "kind": "RLTM", "element":
-        "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "AAr6ayAj6Hs2pOICdVUlEyuXlsQ78K3HFGOJgWA/yAiQrRuQH9Kv1GxUH36IT99d",
         "published_at": "2026-06-22T11:25:45.739149Z", "date": "2026-06-22T11:25:45.739149Z",
@@ -128,20 +126,19 @@ interactions:
         "2026-06-22T11:25:45.739149Z", "last_seen_at": "2026-06-22T11:25:45.739149Z",
         "data": {"line": 20, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-22T11:25:45.739149Z", "last_presence_check_at":
-        "2026-06-22T11:25:45.739149Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 6}, {"id":
-        34122510, "account": 8, "criterion": "Generic Password", "date": "2026-06-19T13:41:03Z",
-        "last_trigger_published_at": "2026-06-19T13:41:03Z", "last_triggered_at":
-        "2026-06-19T13:43:05.020137Z", "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z",
-        "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-22T11:25:45.739149Z", "last_presence_check_at": "2026-06-22T11:25:45.739149Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 6}, {"id": 34122510, "account": 8, "criterion":
+        "Generic Password", "date": "2026-06-19T13:41:03Z", "last_trigger_published_at":
+        "2026-06-19T13:41:03Z", "last_triggered_at": "2026-06-19T13:43:05.020137Z",
+        "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z", "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -149,21 +146,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
-        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
-        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 6, "score": 63, "displayed_occurrence": {"id":
+        274099881, "issue": 34122510, "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
         "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
         "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
-        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
@@ -189,15 +186,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 273386288, "issue": 34038186, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
         "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
@@ -205,16 +202,16 @@ interactions:
         "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
         "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
-        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}]}'
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-16T18:55:43.166667Z", "last_presence_check_at": "2026-06-16T18:55:43.166667Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}]}'
     headers:
       CF-RAY:
       - a1039567b9bc250f-CDG

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_feedback.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_feedback.yaml
@@ -34,15 +34,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274792885, "issue": 34205503, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
         "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
@@ -50,20 +50,19 @@ interactions:
         "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
         "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
-        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
-        34186239, "account": 8, "criterion": "Generic Password", "date": "2026-06-22T15:14:57Z",
-        "last_trigger_published_at": "2026-06-22T15:14:57Z", "last_triggered_at":
-        "2026-06-22T15:16:49.799821Z", "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z",
-        "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-23T11:13:31.325324Z", "last_presence_check_at": "2026-06-23T11:13:31.325324Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}, {"id": 34186239, "account": 8, "criterion":
+        "Generic Password", "date": "2026-06-22T15:14:57Z", "last_trigger_published_at":
+        "2026-06-22T15:14:57Z", "last_triggered_at": "2026-06-22T15:16:49.799821Z",
+        "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z", "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -71,21 +70,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
-        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
-        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 20, "score": 53, "displayed_occurrence": {"id":
+        274668904, "issue": 34186239, "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
         "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
         "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
-        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
@@ -106,21 +105,20 @@ interactions:
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2026-06-22T11:26:52.971214Z", "resolver":
         1751937, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "none", "ignorer_type": "none", "resolver_display_name": "candidate.playground+eu@gitguardian.com",
+        "none", "ignorer_type": "none", "resolver_display_name": "user-1ffcf115@example.com",
         "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
         "none", "status": "RESOLVED", "issue_name": "Microsoft Azure Storage Connection
         String", "severity_rule_config": null, "declarative_secret_status": "revoked",
         "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "", "name": "Kashyapa P.A. Jayasekera"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        "severity": 100, "authors": [{"info": "", "name": "User 801c5600"}], "user_permission":
+        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "GGFRLTA127
-        \u2014 kashyapap.jayasekera", "type": "endpoints", "path": "GGFRLTA127 \u2014
-        kashyapap.jayasekera", "source_criticality": "unknown", "monitoring_status":
-        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "endpoint-86a2394f",
+        "type": "endpoints", "path": "endpoint-86a2394f", "source_criticality": "unknown",
+        "monitoring_status": "active", "deleted_at": null}], "custom_tags": [], "vault_metadata":
+        null, "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
         {"id": 274639444, "issue": 34181686, "account": 8, "kind": "RLTM", "element":
-        "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "AAr6ayAj6Hs2pOICdVUlEyuXlsQ78K3HFGOJgWA/yAiQrRuQH9Kv1GxUH36IT99d",
         "published_at": "2026-06-22T11:25:45.739149Z", "date": "2026-06-22T11:25:45.739149Z",
@@ -128,20 +126,19 @@ interactions:
         "2026-06-22T11:25:45.739149Z", "last_seen_at": "2026-06-22T11:25:45.739149Z",
         "data": {"line": 20, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-22T11:25:45.739149Z", "last_presence_check_at":
-        "2026-06-22T11:25:45.739149Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 6}, {"id":
-        34122510, "account": 8, "criterion": "Generic Password", "date": "2026-06-19T13:41:03Z",
-        "last_trigger_published_at": "2026-06-19T13:41:03Z", "last_triggered_at":
-        "2026-06-19T13:43:05.020137Z", "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z",
-        "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-22T11:25:45.739149Z", "last_presence_check_at": "2026-06-22T11:25:45.739149Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 6}, {"id": 34122510, "account": 8, "criterion":
+        "Generic Password", "date": "2026-06-19T13:41:03Z", "last_trigger_published_at":
+        "2026-06-19T13:41:03Z", "last_triggered_at": "2026-06-19T13:43:05.020137Z",
+        "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z", "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -149,21 +146,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
-        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
-        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 6, "score": 63, "displayed_occurrence": {"id":
+        274099881, "issue": 34122510, "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
         "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
         "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
-        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
@@ -189,15 +186,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 273386288, "issue": 34038186, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
         "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
@@ -205,16 +202,16 @@ interactions:
         "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
         "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
-        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}]}'
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-16T18:55:43.166667Z", "last_presence_check_at": "2026-06-16T18:55:43.166667Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}]}'
     headers:
       CF-RAY:
       - a103959cbee79e5b-CDG

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_issue_tracker.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_issue_tracker.yaml
@@ -32,21 +32,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
-        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
-        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 20, "score": 53, "displayed_occurrence": {"id":
+        274668904, "issue": 34186239, "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
         "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
         "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
-        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
@@ -71,21 +71,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
-        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
-        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 6, "score": 63, "displayed_occurrence": {"id":
+        274099881, "issue": 34122510, "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
         "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
         "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
-        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
@@ -107,7 +107,7 @@ interactions:
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": 910203, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
-        "celine.agbo@gitguardian.com", "manual_severity_setter_type": "user", "status":
+        "user-faa5b70a@example.com", "manual_severity_setter_type": "user", "status":
         "ASSIGNED", "issue_name": "Artifactory Token", "severity_rule_config": {"id":
         11895, "gg_created_at": "2026-05-20T08:56:10.055460Z", "gg_updated_at": "2026-05-20T08:56:10.055463Z",
         "index": 130, "severity": 10, "rule": {"id": 513, "gg_created_at": "2025-03-18T08:57:54.142453Z",
@@ -117,23 +117,22 @@ interactions:
         "default": null}, "arg2": {"value": "package_registry"}}, "is_global": true,
         "scope": "private", "author": null}}, "declarative_secret_status": null, "assignee":
         550880, "last_presence_check_at": null, "secret": "[REDACTED]", "severity":
-        20, "authors": [{"info": "ggtestintegrations@proton.me", "name": "GG Test
-        Integrations"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"id": 27177247, "name": "gg-test-integrations / Payment Systems", "type":
-        "jira_cloud_project", "path": "gg-test-integrations / Payment Systems", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 86, "displayed_occurrence": {"id": 272781097, "issue": 33929626,
-        "account": 8, "kind": "RLTM", "element": "PAY-4", "element_type": "JIRA_TICKET",
-        "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "T71tr/N63V71e27iMbDQa9L9Oh/xkgVEZdomur2uk2WyqO/9fr4lNYuUjUFpuLDi",
+        20, "authors": [{"info": "user-556e25a3@example.com", "name": "User 4578e5a2"}],
+        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 0, "sources": [{"id": 27177247, "name": "gg-test-integrations
+        / Payment Systems", "type": "jira_cloud_project", "path": "gg-test-integrations
+        / Payment Systems", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 86, "displayed_occurrence":
+        {"id": 272781097, "issue": 33929626, "account": 8, "kind": "RLTM", "element":
+        "PAY-4", "element_type": "JIRA_TICKET", "author_name": "GG Test Integrations",
+        "author_info": "user-556e25a3@example.com", "value": null, "value_hash": "T71tr/N63V71e27iMbDQa9L9Oh/xkgVEZdomur2uk2WyqO/9fr4lNYuUjUFpuLDi",
         "published_at": "2026-06-12T10:26:58.151000Z", "date": "2026-06-12T10:26:58.151000Z",
         "detected_at": "2026-06-12T11:57:58.655858Z", "is_vcs_type": false, "last_detected_at":
         "2026-06-12T10:26:58.151000Z", "last_seen_at": "2026-06-12T10:26:58.151000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/PAY-4",
-        "source": {"id": 27177247, "url": "https://gg-test-integrations.atlassian.net/browse/PAY",
+        "data": {}, "url": "https://tenant-54c1a367.atlassian.net/browse/PAY-4", "source":
+        {"id": 27177247, "url": "https://tenant-54c1a367.atlassian.net/browse/PAY",
         "type": "jira_cloud_project", "display_name": "gg-test-integrations / Payment
         Systems", "visibility": "private", "monitored": true, "source_criticality":
         "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
@@ -158,21 +157,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "GitLab Deploy Token", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 28664611, "name": "dev / plal_test",
-        "type": "gl_project", "path": "dev/plal_test", "source_criticality": "unknown",
-        "monitoring_status": "active", "deleted_at": null}], "custom_tags": [], "vault_metadata":
-        null, "is_vaulted": false, "similar_issue_count": 0, "score": 85, "displayed_occurrence":
-        {"id": 272645187, "issue": 33905111, "account": 8, "kind": "HIST", "element":
-        "0102329ae146f51358cff771dbdf860acbc78ef6", "element_type": "GIT_COMMIT",
-        "author_name": "dev", "author_info": "gim+dev@gitguardian.com", "value": null,
-        "value_hash": "vKgkDXA4NszdEvKqefnQ7tPG4AsADP5uV3carLt96S2ZoMa7KySfdZ9m9HlrAElh",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 28664611, "name": "dev / plal_test", "type": "gl_project", "path":
+        "dev/plal_test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 0, "score": 85, "displayed_occurrence": {"id":
+        272645187, "issue": 33905111, "account": 8, "kind": "HIST", "element": "0102329ae146f51358cff771dbdf860acbc78ef6",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
+        "value": null, "value_hash": "vKgkDXA4NszdEvKqefnQ7tPG4AsADP5uV3carLt96S2ZoMa7KySfdZ9m9HlrAElh",
         "published_at": "2026-06-11T12:29:43Z", "date": "2026-06-11T12:29:43Z", "detected_at":
         "2026-06-11T12:30:10.472937Z", "is_vcs_type": true, "last_detected_at": "2026-06-11T12:37:30.541974Z",
-        "last_seen_at": "2026-06-11T12:37:30.541974Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/dev/plal_test/commit/0102329ae146f51358cff771dbdf860acbc78ef6#5a06a4630a05426a25bc162c233d6cf8ed2462a0_None_5",
-        "source": {"id": 28664611, "url": "https://gitlab-01.aws-qa-gitguardian.com/dev/plal_test",
+        "last_seen_at": "2026-06-11T12:37:30.541974Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-ef260e9a/ns-c602f9c5/commit/0102329ae146f51358cff771dbdf860acbc78ef6#5a06a4630a05426a25bc162c233d6cf8ed2462a0_None_5",
+        "source": {"id": 28664611, "url": "https://host-a31e7ce0.example.com/ns-ef260e9a/ns-c602f9c5",
         "type": "gl_project", "display_name": "dev / plal_test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 168574637,
@@ -197,23 +196,23 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne.p@gmail.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        "severity": 100, "authors": [{"info": "user-783dd644@example.com", "name":
+        "User 3fcf209d"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
         0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"id": 17188087, "name": "pierrelalanne/test_repo", "type": "gh_repository",
-        "path": "pierrelalanne/test_repo", "source_criticality": "critical", "monitoring_status":
+        [{"id": 17188087, "name": "ns-f0afee16/test_repo", "type": "gh_repository",
+        "path": "ns-f0afee16/test_repo", "source_criticality": "critical", "monitoring_status":
         "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
         "is_vaulted": false, "similar_issue_count": 0, "score": 12, "displayed_occurrence":
         {"id": 271584642, "issue": 33677678, "account": 8, "kind": "RLTM", "element":
         "b355f606d5884cfbe83a19c83e6804c0fc9a95f0", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne.p@gmail.com",
+        "author_name": "Pierre Lalanne", "author_info": "user-783dd644@example.com",
         "value": null, "value_hash": "BwX3iCglyVyrnbQJ+uR2bcHgVmnkzFUUxyizOMJrHc3YG8H/gEDCz7InbgSdLTaR",
         "published_at": "2026-06-05T10:30:39Z", "date": "2026-06-05T10:30:39Z", "detected_at":
         "2026-06-05T10:30:40.398638Z", "is_vcs_type": true, "last_detected_at": "2026-06-05T10:30:39Z",
-        "last_seen_at": "2026-06-05T10:30:39Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/b355f606d5884cfbe83a19c83e6804c0fc9a95f0#diff-cf36aad2a70418098362b5fbd96a9fbbb199e931ccab1ee9713f5b5eb84eba94R67",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
+        "last_seen_at": "2026-06-05T10:30:39Z", "data": {}, "url": "https://github.com/ns-f0afee16/test_repo/commit/b355f606d5884cfbe83a19c83e6804c0fc9a95f0#diff-cf36aad2a70418098362b5fbd96a9fbbb199e931ccab1ee9713f5b5eb84eba94R67",
+        "source": {"id": 17188087, "url": "https://github.com/ns-f0afee16/test_repo",
+        "type": "gh_repository", "display_name": "ns-f0afee16/test_repo", "visibility":
         "private", "monitored": true, "source_criticality": "critical", "deleted_at":
         null, "default_branch": "main", "monitoring_status": "active"}, "regression":
         false, "content": 166970520, "secrets_engine_version": "2.164.0", "matches":

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_ordering.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_ordering.yaml
@@ -34,15 +34,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274792885, "issue": 34205503, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
         "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
@@ -50,20 +50,19 @@ interactions:
         "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
         "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
-        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
-        34186239, "account": 8, "criterion": "Generic Password", "date": "2026-06-22T15:14:57Z",
-        "last_trigger_published_at": "2026-06-22T15:14:57Z", "last_triggered_at":
-        "2026-06-22T15:16:49.799821Z", "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z",
-        "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-23T11:13:31.325324Z", "last_presence_check_at": "2026-06-23T11:13:31.325324Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}, {"id": 34186239, "account": 8, "criterion":
+        "Generic Password", "date": "2026-06-22T15:14:57Z", "last_trigger_published_at":
+        "2026-06-22T15:14:57Z", "last_triggered_at": "2026-06-22T15:16:49.799821Z",
+        "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z", "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -71,21 +70,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
-        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
-        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 20, "score": 53, "displayed_occurrence": {"id":
+        274668904, "issue": 34186239, "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
         "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
         "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
-        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
@@ -106,21 +105,20 @@ interactions:
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2026-06-22T11:26:52.971214Z", "resolver":
         1751937, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "none", "ignorer_type": "none", "resolver_display_name": "candidate.playground+eu@gitguardian.com",
+        "none", "ignorer_type": "none", "resolver_display_name": "user-1ffcf115@example.com",
         "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
         "none", "status": "RESOLVED", "issue_name": "Microsoft Azure Storage Connection
         String", "severity_rule_config": null, "declarative_secret_status": "revoked",
         "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "", "name": "Kashyapa P.A. Jayasekera"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        "severity": 100, "authors": [{"info": "", "name": "User 801c5600"}], "user_permission":
+        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "GGFRLTA127
-        \u2014 kashyapap.jayasekera", "type": "endpoints", "path": "GGFRLTA127 \u2014
-        kashyapap.jayasekera", "source_criticality": "unknown", "monitoring_status":
-        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "endpoint-86a2394f",
+        "type": "endpoints", "path": "endpoint-86a2394f", "source_criticality": "unknown",
+        "monitoring_status": "active", "deleted_at": null}], "custom_tags": [], "vault_metadata":
+        null, "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
         {"id": 274639444, "issue": 34181686, "account": 8, "kind": "RLTM", "element":
-        "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "AAr6ayAj6Hs2pOICdVUlEyuXlsQ78K3HFGOJgWA/yAiQrRuQH9Kv1GxUH36IT99d",
         "published_at": "2026-06-22T11:25:45.739149Z", "date": "2026-06-22T11:25:45.739149Z",
@@ -128,20 +126,19 @@ interactions:
         "2026-06-22T11:25:45.739149Z", "last_seen_at": "2026-06-22T11:25:45.739149Z",
         "data": {"line": 20, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-22T11:25:45.739149Z", "last_presence_check_at":
-        "2026-06-22T11:25:45.739149Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 6}, {"id":
-        34122510, "account": 8, "criterion": "Generic Password", "date": "2026-06-19T13:41:03Z",
-        "last_trigger_published_at": "2026-06-19T13:41:03Z", "last_triggered_at":
-        "2026-06-19T13:43:05.020137Z", "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z",
-        "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-22T11:25:45.739149Z", "last_presence_check_at": "2026-06-22T11:25:45.739149Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 6}, {"id": 34122510, "account": 8, "criterion":
+        "Generic Password", "date": "2026-06-19T13:41:03Z", "last_trigger_published_at":
+        "2026-06-19T13:41:03Z", "last_triggered_at": "2026-06-19T13:43:05.020137Z",
+        "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z", "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -149,21 +146,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
-        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
-        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 6, "score": 63, "displayed_occurrence": {"id":
+        274099881, "issue": 34122510, "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
         "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
         "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
-        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
@@ -189,15 +186,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 273386288, "issue": 34038186, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
         "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
@@ -205,16 +202,16 @@ interactions:
         "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
         "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
-        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}]}'
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-16T18:55:43.166667Z", "last_presence_check_at": "2026-06-16T18:55:43.166667Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}]}'
     headers:
       CF-RAY:
       - a10395605e939996-CDG

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_presence_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_presence_filter.yaml
@@ -34,15 +34,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274792885, "issue": 34205503, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
         "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
@@ -50,20 +50,19 @@ interactions:
         "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
         "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
-        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
-        34186239, "account": 8, "criterion": "Generic Password", "date": "2026-06-22T15:14:57Z",
-        "last_trigger_published_at": "2026-06-22T15:14:57Z", "last_triggered_at":
-        "2026-06-22T15:16:49.799821Z", "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z",
-        "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-23T11:13:31.325324Z", "last_presence_check_at": "2026-06-23T11:13:31.325324Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}, {"id": 34186239, "account": 8, "criterion":
+        "Generic Password", "date": "2026-06-22T15:14:57Z", "last_trigger_published_at":
+        "2026-06-22T15:14:57Z", "last_triggered_at": "2026-06-22T15:16:49.799821Z",
+        "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z", "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -71,21 +70,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
-        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
-        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 20, "score": 53, "displayed_occurrence": {"id":
+        274668904, "issue": 34186239, "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
         "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
         "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
-        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
@@ -106,21 +105,20 @@ interactions:
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2026-06-22T11:26:52.971214Z", "resolver":
         1751937, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "none", "ignorer_type": "none", "resolver_display_name": "candidate.playground+eu@gitguardian.com",
+        "none", "ignorer_type": "none", "resolver_display_name": "user-1ffcf115@example.com",
         "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
         "none", "status": "RESOLVED", "issue_name": "Microsoft Azure Storage Connection
         String", "severity_rule_config": null, "declarative_secret_status": "revoked",
         "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "", "name": "Kashyapa P.A. Jayasekera"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        "severity": 100, "authors": [{"info": "", "name": "User 801c5600"}], "user_permission":
+        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "GGFRLTA127
-        \u2014 kashyapap.jayasekera", "type": "endpoints", "path": "GGFRLTA127 \u2014
-        kashyapap.jayasekera", "source_criticality": "unknown", "monitoring_status":
-        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "endpoint-86a2394f",
+        "type": "endpoints", "path": "endpoint-86a2394f", "source_criticality": "unknown",
+        "monitoring_status": "active", "deleted_at": null}], "custom_tags": [], "vault_metadata":
+        null, "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
         {"id": 274639444, "issue": 34181686, "account": 8, "kind": "RLTM", "element":
-        "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "AAr6ayAj6Hs2pOICdVUlEyuXlsQ78K3HFGOJgWA/yAiQrRuQH9Kv1GxUH36IT99d",
         "published_at": "2026-06-22T11:25:45.739149Z", "date": "2026-06-22T11:25:45.739149Z",
@@ -128,20 +126,19 @@ interactions:
         "2026-06-22T11:25:45.739149Z", "last_seen_at": "2026-06-22T11:25:45.739149Z",
         "data": {"line": 20, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-22T11:25:45.739149Z", "last_presence_check_at":
-        "2026-06-22T11:25:45.739149Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 6}, {"id":
-        34122510, "account": 8, "criterion": "Generic Password", "date": "2026-06-19T13:41:03Z",
-        "last_trigger_published_at": "2026-06-19T13:41:03Z", "last_triggered_at":
-        "2026-06-19T13:43:05.020137Z", "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z",
-        "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-22T11:25:45.739149Z", "last_presence_check_at": "2026-06-22T11:25:45.739149Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 6}, {"id": 34122510, "account": 8, "criterion":
+        "Generic Password", "date": "2026-06-19T13:41:03Z", "last_trigger_published_at":
+        "2026-06-19T13:41:03Z", "last_triggered_at": "2026-06-19T13:43:05.020137Z",
+        "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z", "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -149,21 +146,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
-        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
-        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 6, "score": 63, "displayed_occurrence": {"id":
+        274099881, "issue": 34122510, "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
         "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
         "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
-        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
@@ -189,15 +186,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 273386288, "issue": 34038186, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
         "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
@@ -205,16 +202,16 @@ interactions:
         "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
         "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
-        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}]}'
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-16T18:55:43.166667Z", "last_presence_check_at": "2026-06-16T18:55:43.166667Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}]}'
     headers:
       CF-RAY:
       - a103956b384ad08f-CDG

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_publicly_shared.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_publicly_shared.yaml
@@ -34,15 +34,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274792885, "issue": 34205503, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
         "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
@@ -50,20 +50,19 @@ interactions:
         "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
         "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
-        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
-        34186239, "account": 8, "criterion": "Generic Password", "date": "2026-06-22T15:14:57Z",
-        "last_trigger_published_at": "2026-06-22T15:14:57Z", "last_triggered_at":
-        "2026-06-22T15:16:49.799821Z", "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z",
-        "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-23T11:13:31.325324Z", "last_presence_check_at": "2026-06-23T11:13:31.325324Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}, {"id": 34186239, "account": 8, "criterion":
+        "Generic Password", "date": "2026-06-22T15:14:57Z", "last_trigger_published_at":
+        "2026-06-22T15:14:57Z", "last_triggered_at": "2026-06-22T15:16:49.799821Z",
+        "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z", "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -71,21 +70,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
-        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
-        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 20, "score": 53, "displayed_occurrence": {"id":
+        274668904, "issue": 34186239, "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
         "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
         "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
-        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
@@ -106,21 +105,20 @@ interactions:
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2026-06-22T11:26:52.971214Z", "resolver":
         1751937, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "none", "ignorer_type": "none", "resolver_display_name": "candidate.playground+eu@gitguardian.com",
+        "none", "ignorer_type": "none", "resolver_display_name": "user-1ffcf115@example.com",
         "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
         "none", "status": "RESOLVED", "issue_name": "Microsoft Azure Storage Connection
         String", "severity_rule_config": null, "declarative_secret_status": "revoked",
         "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "", "name": "Kashyapa P.A. Jayasekera"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        "severity": 100, "authors": [{"info": "", "name": "User 801c5600"}], "user_permission":
+        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "GGFRLTA127
-        \u2014 kashyapap.jayasekera", "type": "endpoints", "path": "GGFRLTA127 \u2014
-        kashyapap.jayasekera", "source_criticality": "unknown", "monitoring_status":
-        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "endpoint-86a2394f",
+        "type": "endpoints", "path": "endpoint-86a2394f", "source_criticality": "unknown",
+        "monitoring_status": "active", "deleted_at": null}], "custom_tags": [], "vault_metadata":
+        null, "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
         {"id": 274639444, "issue": 34181686, "account": 8, "kind": "RLTM", "element":
-        "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "AAr6ayAj6Hs2pOICdVUlEyuXlsQ78K3HFGOJgWA/yAiQrRuQH9Kv1GxUH36IT99d",
         "published_at": "2026-06-22T11:25:45.739149Z", "date": "2026-06-22T11:25:45.739149Z",
@@ -128,20 +126,19 @@ interactions:
         "2026-06-22T11:25:45.739149Z", "last_seen_at": "2026-06-22T11:25:45.739149Z",
         "data": {"line": 20, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-22T11:25:45.739149Z", "last_presence_check_at":
-        "2026-06-22T11:25:45.739149Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 6}, {"id":
-        34122510, "account": 8, "criterion": "Generic Password", "date": "2026-06-19T13:41:03Z",
-        "last_trigger_published_at": "2026-06-19T13:41:03Z", "last_triggered_at":
-        "2026-06-19T13:43:05.020137Z", "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z",
-        "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-22T11:25:45.739149Z", "last_presence_check_at": "2026-06-22T11:25:45.739149Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 6}, {"id": 34122510, "account": 8, "criterion":
+        "Generic Password", "date": "2026-06-19T13:41:03Z", "last_trigger_published_at":
+        "2026-06-19T13:41:03Z", "last_triggered_at": "2026-06-19T13:43:05.020137Z",
+        "last_trigger_detected_at": "2026-06-19T13:43:05.020137Z", "hash": "ZrwgRkzkzFhTNLZ5+7Vy66dNh9edibFaWQu44rsMeP6/Ykt9fma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -149,21 +146,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
-        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
-        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 6, "score": 63, "displayed_occurrence": {"id":
+        274099881, "issue": 34122510, "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
         "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
         "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
-        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
@@ -189,15 +186,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 273386288, "issue": 34038186, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
         "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
@@ -205,16 +202,16 @@ interactions:
         "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
         "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
-        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}]}'
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-16T18:55:43.166667Z", "last_presence_check_at": "2026-06-16T18:55:43.166667Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}]}'
     headers:
       CF-RAY:
       - a10395a078011b44-CDG

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_score_filter_and_ordering.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_score_filter_and_ordering.yaml
@@ -28,8 +28,8 @@ interactions:
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2026-03-11T22:41:04.525493Z", "resolver":
         491414, "regression": false, "manual_severity_setter": 614347, "ignorer_display_name":
-        "none", "ignorer_type": "none", "resolver_display_name": "8@bot.gitguardian.com",
-        "resolver_type": "user", "manual_severity_setter_display_name": "romain.jouhannet@gitguardian.com",
+        "none", "ignorer_type": "none", "resolver_display_name": "user-7d8fb5e1@example.com",
+        "resolver_type": "user", "manual_severity_setter_display_name": "user-46c1d11b@example.com",
         "manual_severity_setter_type": "user", "status": "RESOLVED", "issue_name":
         "AWS IAM Keys", "severity_rule_config": {"id": 28, "gg_created_at": "2023-02-07T13:53:07.394202Z",
         "gg_updated_at": "2023-02-07T13:53:07.394210Z", "index": 200, "severity":
@@ -39,24 +39,24 @@ interactions:
         {"path": "issue.secret.detector.metadata.category", "default": null}, "arg2":
         {"value": "cloud_provider"}}, "is_global": true, "scope": "private", "author":
         104371}}, "declarative_secret_status": "revoked", "assignee": 245361, "last_presence_check_at":
-        null, "secret": "[REDACTED]", "severity": 30, "authors": [{"info": "lucius-fox-gg@protonmail.com",
-        "name": "Lucius Fox"}], "user_permission": 7, "is_publicly_shared": false,
+        null, "secret": "[REDACTED]", "severity": 30, "authors": [{"info": "user-4176d3f1@example.com",
+        "name": "User dc1e35f1"}], "user_permission": 7, "is_publicly_shared": false,
         "feedbacks_count": 1, "occurrences_presence_seen_count": 0, "occurrences_presence_deleted_count":
         2, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"id": 12349, "name": "wayne-enterprises-gg/public-app-gg-bis-2020-10", "type":
-        "gh_repository", "path": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "source_criticality": "unknown", "monitoring_status": "deleted_on_remote",
-        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
-        false, "similar_issue_count": 48, "score": 100, "displayed_occurrence": {"id":
-        78198, "issue": 21460, "account": 8, "kind": "RLTM", "element": "998deb2c88b0be31f72d117ac1238114334445e8",
+        [{"id": 12349, "name": "ns-80126292/public-app-gg-bis-2020-10", "type": "gh_repository",
+        "path": "ns-80126292/public-app-gg-bis-2020-10", "source_criticality": "unknown",
+        "monitoring_status": "deleted_on_remote", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 48,
+        "score": 100, "displayed_occurrence": {"id": 78198, "issue": 21460, "account":
+        8, "kind": "RLTM", "element": "998deb2c88b0be31f72d117ac1238114334445e8",
         "element_type": "GIT_COMMIT", "author_name": "Lucius Fox", "author_info":
-        "lucius-fox-gg@protonmail.com", "value": null, "value_hash": "1L9CNiJQrSoUY+DgKJLdtjuqHK0OaVUl1VVX1ysCO/lX8FQi+GgD01C2z8H3+skF",
+        "user-4176d3f1@example.com", "value": null, "value_hash": "1L9CNiJQrSoUY+DgKJLdtjuqHK0OaVUl1VVX1ysCO/lX8FQi+GgD01C2z8H3+skF",
         "published_at": "2020-10-29T13:19:59.005564Z", "date": "2020-10-29T13:19:59.005564Z",
         "detected_at": "2020-10-29T13:19:59.005564Z", "is_vcs_type": true, "last_detected_at":
         "2020-10-29T13:19:59.005564Z", "last_seen_at": "2020-10-29T13:19:59.005564Z",
-        "data": {}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "source": {"id": 12349, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
-        "type": "gh_repository", "display_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "data": {}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "source": {"id": 12349, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
+        "type": "gh_repository", "display_name": "ns-80126292/public-app-gg-bis-2020-10",
         "visibility": "public", "monitored": true, "source_criticality": "unknown",
         "deleted_at": null, "default_branch": null, "monitoring_status": "deleted_on_remote"},
         "regression": false, "content": 468, "secrets_engine_version": "unknown",
@@ -80,7 +80,7 @@ interactions:
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2026-03-11T22:41:04.525493Z", "resolver":
         491414, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "none", "ignorer_type": "none", "resolver_display_name": "8@bot.gitguardian.com",
+        "none", "ignorer_type": "none", "resolver_display_name": "user-7d8fb5e1@example.com",
         "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
         "none", "status": "RESOLVED", "issue_name": "AWS IAM Keys", "severity_rule_config":
         {"id": 28, "gg_created_at": "2023-02-07T13:53:07.394202Z", "gg_updated_at":
@@ -91,24 +91,23 @@ interactions:
         "default": null}, "arg2": {"value": "cloud_provider"}}, "is_global": true,
         "scope": "private", "author": 104371}}, "declarative_secret_status": "revoked",
         "assignee": 10, "last_presence_check_at": null, "secret": "[REDACTED]", "severity":
-        100, "authors": [{"info": "lucius-fox-gg@protonmail.com", "name": "Lucius
-        Fox"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 0, "occurrences_presence_deleted_count":
-        2, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"id": 12345, "name": "wayne-enterprises-gg/public-app-gg-bis-2020-09", "type":
-        "gh_repository", "path": "wayne-enterprises-gg/public-app-gg-bis-2020-09",
+        100, "authors": [{"info": "user-4176d3f1@example.com", "name": "User dc1e35f1"}],
+        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        0, "occurrences_presence_deleted_count": 2, "occurrences_presence_should_be_checked":
+        null, "locations_count": 0, "sources": [{"id": 12345, "name": "ns-80126292/public-app-gg-bis-2020-09",
+        "type": "gh_repository", "path": "ns-80126292/public-app-gg-bis-2020-09",
         "source_criticality": "unknown", "monitoring_status": "deleted_on_remote",
         "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
         false, "similar_issue_count": 48, "score": 100, "displayed_occurrence": {"id":
         78206, "issue": 21464, "account": 8, "kind": "RLTM", "element": "643bdce69ff4517e60c383e1a81d7d74244981a1",
         "element_type": "GIT_COMMIT", "author_name": "Lucius Fox", "author_info":
-        "lucius-fox-gg@protonmail.com", "value": null, "value_hash": "5lwvD42Y5SrxcOTVkytIeyBCp9rtT6ukEOtUT6LfHX42Psy7pxjjDYOGpRytJCpz",
+        "user-4176d3f1@example.com", "value": null, "value_hash": "5lwvD42Y5SrxcOTVkytIeyBCp9rtT6ukEOtUT6LfHX42Psy7pxjjDYOGpRytJCpz",
         "published_at": "2020-10-29T04:19:56.388169Z", "date": "2020-10-29T04:19:56.388169Z",
         "detected_at": "2020-10-29T04:19:56.388169Z", "is_vcs_type": true, "last_detected_at":
         "2020-10-29T04:19:56.388169Z", "last_seen_at": "2020-10-29T04:19:56.388169Z",
-        "data": {}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-09/commit/643bdce69ff4517e60c383e1a81d7d74244981a1#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "source": {"id": 12345, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-09",
-        "type": "gh_repository", "display_name": "wayne-enterprises-gg/public-app-gg-bis-2020-09",
+        "data": {}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-09/commit/643bdce69ff4517e60c383e1a81d7d74244981a1#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "source": {"id": 12345, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-09",
+        "type": "gh_repository", "display_name": "ns-80126292/public-app-gg-bis-2020-09",
         "visibility": "public", "monitored": true, "source_criticality": "unknown",
         "deleted_at": null, "default_branch": null, "monitoring_status": "deleted_on_remote"},
         "regression": false, "content": 476, "secrets_engine_version": "unknown",
@@ -143,24 +142,24 @@ interactions:
         "default": null}, "arg2": {"value": "cloud_provider"}}, "is_global": true,
         "scope": "private", "author": 104371}}, "declarative_secret_status": "active",
         "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "lucius-fox-gg@protonmail.com", "name":
-        "Lucius Fox"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        "severity": 100, "authors": [{"info": "user-4176d3f1@example.com", "name":
+        "User dc1e35f1"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
         1, "occurrences_presence_seen_count": 0, "occurrences_presence_deleted_count":
         2, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"id": 12325, "name": "wayne-enterprises-gg/private-app-gg-bis-2020-10",
-        "type": "gh_repository", "path": "wayne-enterprises-gg/private-app-gg-bis-2020-10",
-        "source_criticality": "unknown", "monitoring_status": "deleted_on_remote",
-        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
-        false, "similar_issue_count": 0, "score": 100, "displayed_occurrence": {"id":
-        78214, "issue": 21468, "account": 8, "kind": "RLTM", "element": "3bc35c67a11f7474629e762f2dce57e91c79e64f",
+        [{"id": 12325, "name": "ns-80126292/private-app-gg-bis-2020-10", "type": "gh_repository",
+        "path": "ns-80126292/private-app-gg-bis-2020-10", "source_criticality": "unknown",
+        "monitoring_status": "deleted_on_remote", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
+        "score": 100, "displayed_occurrence": {"id": 78214, "issue": 21468, "account":
+        8, "kind": "RLTM", "element": "3bc35c67a11f7474629e762f2dce57e91c79e64f",
         "element_type": "GIT_COMMIT", "author_name": "Lucius Fox", "author_info":
-        "lucius-fox-gg@protonmail.com", "value": null, "value_hash": "hG1diU79gB2CHQVjnqOs2/jzPWkypY0MPkfnzVId4etJxn1OKn9nKQTMTumsQ0DJ",
+        "user-4176d3f1@example.com", "value": null, "value_hash": "hG1diU79gB2CHQVjnqOs2/jzPWkypY0MPkfnzVId4etJxn1OKn9nKQTMTumsQ0DJ",
         "published_at": "2020-10-26T11:19:37.692890Z", "date": "2020-10-26T11:19:37.692890Z",
         "detected_at": "2020-10-26T11:19:37.692890Z", "is_vcs_type": true, "last_detected_at":
         "2020-10-26T11:19:37.692890Z", "last_seen_at": "2020-10-26T11:19:37.692890Z",
-        "data": {}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2020-10/commit/3bc35c67a11f7474629e762f2dce57e91c79e64f#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "source": {"id": 12325, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2020-10",
-        "type": "gh_repository", "display_name": "wayne-enterprises-gg/private-app-gg-bis-2020-10",
+        "data": {}, "url": "https://github.com/ns-80126292/private-app-gg-bis-2020-10/commit/3bc35c67a11f7474629e762f2dce57e91c79e64f#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "source": {"id": 12325, "url": "https://github.com/ns-80126292/private-app-gg-bis-2020-10",
+        "type": "gh_repository", "display_name": "ns-80126292/private-app-gg-bis-2020-10",
         "visibility": "public", "monitored": true, "source_criticality": "unknown",
         "deleted_at": null, "default_branch": null, "monitoring_status": "deleted_on_remote"},
         "regression": false, "content": 484, "secrets_engine_version": "unknown",
@@ -184,8 +183,8 @@ interactions:
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2023-11-06T09:02:20.011118Z", "resolver":
         491414, "regression": false, "manual_severity_setter": 9322, "ignorer_display_name":
-        "none", "ignorer_type": "none", "resolver_display_name": "8@bot.gitguardian.com",
-        "resolver_type": "user", "manual_severity_setter_display_name": "ramzi.lahoud@gitguardian.com",
+        "none", "ignorer_type": "none", "resolver_display_name": "user-7d8fb5e1@example.com",
+        "resolver_type": "user", "manual_severity_setter_display_name": "user-abb9c699@example.com",
         "manual_severity_setter_type": "user", "status": "RESOLVED", "issue_name":
         "AWS IAM Keys", "severity_rule_config": {"id": 28, "gg_created_at": "2023-02-07T13:53:07.394202Z",
         "gg_updated_at": "2023-02-07T13:53:07.394210Z", "index": 200, "severity":
@@ -195,24 +194,24 @@ interactions:
         {"path": "issue.secret.detector.metadata.category", "default": null}, "arg2":
         {"value": "cloud_provider"}}, "is_global": true, "scope": "private", "author":
         104371}}, "declarative_secret_status": "revoked", "assignee": null, "last_presence_check_at":
-        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "lucius-fox-gg@protonmail.com",
-        "name": "Lucius Fox"}], "user_permission": 7, "is_publicly_shared": false,
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "user-4176d3f1@example.com",
+        "name": "User dc1e35f1"}], "user_permission": 7, "is_publicly_shared": false,
         "feedbacks_count": 2, "occurrences_presence_seen_count": 0, "occurrences_presence_deleted_count":
         2, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"id": 12357, "name": "wayne-enterprises-gg/private-app-gg-bis-2020-09",
-        "type": "gh_repository", "path": "wayne-enterprises-gg/private-app-gg-bis-2020-09",
-        "source_criticality": "unknown", "monitoring_status": "deleted_on_remote",
-        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
-        false, "similar_issue_count": 42, "score": 100, "displayed_occurrence": {"id":
-        78220, "issue": 21471, "account": 8, "kind": "RLTM", "element": "0899f9d92a22cafba6d00ca1a56f216997c357d4",
+        [{"id": 12357, "name": "ns-80126292/private-app-gg-bis-2020-09", "type": "gh_repository",
+        "path": "ns-80126292/private-app-gg-bis-2020-09", "source_criticality": "unknown",
+        "monitoring_status": "deleted_on_remote", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 42,
+        "score": 100, "displayed_occurrence": {"id": 78220, "issue": 21471, "account":
+        8, "kind": "RLTM", "element": "0899f9d92a22cafba6d00ca1a56f216997c357d4",
         "element_type": "GIT_COMMIT", "author_name": "Lucius Fox", "author_info":
-        "lucius-fox-gg@protonmail.com", "value": null, "value_hash": "ut/784B4BzPAarLlCWhL4l5Nr1lqRpIlJuDcUvTqIuoAXbXeWeDKX6I61HmWOtHD",
+        "user-4176d3f1@example.com", "value": null, "value_hash": "ut/784B4BzPAarLlCWhL4l5Nr1lqRpIlJuDcUvTqIuoAXbXeWeDKX6I61HmWOtHD",
         "published_at": "2020-10-25T02:19:49.840699Z", "date": "2020-10-25T02:19:49.840699Z",
         "detected_at": "2020-10-25T02:19:49.840699Z", "is_vcs_type": true, "last_detected_at":
         "2020-10-25T02:19:49.840699Z", "last_seen_at": "2020-10-25T02:19:49.840699Z",
-        "data": {}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2020-09/commit/0899f9d92a22cafba6d00ca1a56f216997c357d4#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "source": {"id": 12357, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2020-09",
-        "type": "gh_repository", "display_name": "wayne-enterprises-gg/private-app-gg-bis-2020-09",
+        "data": {}, "url": "https://github.com/ns-80126292/private-app-gg-bis-2020-09/commit/0899f9d92a22cafba6d00ca1a56f216997c357d4#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "source": {"id": 12357, "url": "https://github.com/ns-80126292/private-app-gg-bis-2020-09",
+        "type": "gh_repository", "display_name": "ns-80126292/private-app-gg-bis-2020-09",
         "visibility": "public", "monitored": true, "source_criticality": "unknown",
         "deleted_at": null, "default_branch": null, "monitoring_status": "deleted_on_remote"},
         "regression": false, "content": 490, "secrets_engine_version": "unknown",
@@ -247,24 +246,24 @@ interactions:
         "default": null}, "arg2": {"value": "cloud_provider"}}, "is_global": true,
         "scope": "private", "author": 104371}}, "declarative_secret_status": "revoked",
         "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "lucius-fox-gg@protonmail.com", "name":
-        "Lucius Fox"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        "severity": 100, "authors": [{"info": "user-4176d3f1@example.com", "name":
+        "User dc1e35f1"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
         0, "occurrences_presence_seen_count": 0, "occurrences_presence_deleted_count":
         2, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"id": 12275, "name": "wayne-enterprises-gg/private-gg-bis-2020-08", "type":
-        "gh_repository", "path": "wayne-enterprises-gg/private-gg-bis-2020-08", "source_criticality":
-        "unknown", "monitoring_status": "deleted_on_remote", "deleted_at": null}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        64, "score": 100, "displayed_occurrence": {"id": 78239, "issue": 21481, "account":
+        [{"id": 12275, "name": "ns-80126292/private-gg-bis-2020-08", "type": "gh_repository",
+        "path": "ns-80126292/private-gg-bis-2020-08", "source_criticality": "unknown",
+        "monitoring_status": "deleted_on_remote", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 64,
+        "score": 100, "displayed_occurrence": {"id": 78239, "issue": 21481, "account":
         8, "kind": "RLTM", "element": "6877bb0b4fca9e7f125c027fb3c2254be9cb35b6",
         "element_type": "GIT_COMMIT", "author_name": "Lucius Fox", "author_info":
-        "lucius-fox-gg@protonmail.com", "value": null, "value_hash": "U3EYGTDUfl1mGIc+8BYoYEAqXHn8UtjhIVmlMZzpGdk451drrHgmRJdpiGpROYFv",
+        "user-4176d3f1@example.com", "value": null, "value_hash": "U3EYGTDUfl1mGIc+8BYoYEAqXHn8UtjhIVmlMZzpGdk451drrHgmRJdpiGpROYFv",
         "published_at": "2020-10-18T12:19:38.047282Z", "date": "2020-10-18T12:19:38.047282Z",
         "detected_at": "2020-10-18T12:19:38.047282Z", "is_vcs_type": true, "last_detected_at":
         "2020-10-18T12:19:38.047282Z", "last_seen_at": "2020-10-18T12:19:38.047282Z",
-        "data": {}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-08/commit/6877bb0b4fca9e7f125c027fb3c2254be9cb35b6#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "source": {"id": 12275, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-08",
-        "type": "gh_repository", "display_name": "wayne-enterprises-gg/private-gg-bis-2020-08",
+        "data": {}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-08/commit/6877bb0b4fca9e7f125c027fb3c2254be9cb35b6#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "source": {"id": 12275, "url": "https://github.com/ns-80126292/private-gg-bis-2020-08",
+        "type": "gh_repository", "display_name": "ns-80126292/private-gg-bis-2020-08",
         "visibility": "public", "monitored": true, "source_criticality": "unknown",
         "deleted_at": null, "default_branch": null, "monitoring_status": "deleted_on_remote"},
         "regression": false, "content": 509, "secrets_engine_version": "unknown",
@@ -289,7 +288,7 @@ interactions:
         "resolved": true, "resolved_at": "2022-09-06T09:06:08.295495Z", "resolver":
         null, "regression": false, "manual_severity_setter": 9322, "ignorer_display_name":
         "none", "ignorer_type": "none", "resolver_display_name": "unknown", "resolver_type":
-        "unknown", "manual_severity_setter_display_name": "ramzi.lahoud@gitguardian.com",
+        "unknown", "manual_severity_setter_display_name": "user-abb9c699@example.com",
         "manual_severity_setter_type": "user", "status": "RESOLVED", "issue_name":
         "AWS IAM Keys", "severity_rule_config": {"id": 28, "gg_created_at": "2023-02-07T13:53:07.394202Z",
         "gg_updated_at": "2023-02-07T13:53:07.394210Z", "index": 200, "severity":
@@ -299,24 +298,24 @@ interactions:
         {"path": "issue.secret.detector.metadata.category", "default": null}, "arg2":
         {"value": "cloud_provider"}}, "is_global": true, "scope": "private", "author":
         104371}}, "declarative_secret_status": "revoked", "assignee": null, "last_presence_check_at":
-        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "lucius-fox-gg@protonmail.com",
-        "name": "Lucius Fox"}], "user_permission": 7, "is_publicly_shared": false,
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "user-4176d3f1@example.com",
+        "name": "User dc1e35f1"}], "user_permission": 7, "is_publicly_shared": false,
         "feedbacks_count": 2, "occurrences_presence_seen_count": 0, "occurrences_presence_deleted_count":
         2, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"id": 12357, "name": "wayne-enterprises-gg/private-app-gg-bis-2020-09",
-        "type": "gh_repository", "path": "wayne-enterprises-gg/private-app-gg-bis-2020-09",
-        "source_criticality": "unknown", "monitoring_status": "deleted_on_remote",
-        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
-        false, "similar_issue_count": 25, "score": 100, "displayed_occurrence": {"id":
-        78242, "issue": 21483, "account": 8, "kind": "RLTM", "element": "21dfe9873dee987ce65df7cece464299ec359ded",
+        [{"id": 12357, "name": "ns-80126292/private-app-gg-bis-2020-09", "type": "gh_repository",
+        "path": "ns-80126292/private-app-gg-bis-2020-09", "source_criticality": "unknown",
+        "monitoring_status": "deleted_on_remote", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 25,
+        "score": 100, "displayed_occurrence": {"id": 78242, "issue": 21483, "account":
+        8, "kind": "RLTM", "element": "21dfe9873dee987ce65df7cece464299ec359ded",
         "element_type": "GIT_COMMIT", "author_name": "Lucius Fox", "author_info":
-        "lucius-fox-gg@protonmail.com", "value": null, "value_hash": "SVpvvlAm+mSkBreWHt3M0x1lYBT3+d+xuKt2jG4MHghesISKuoP/qcMyEiXAlxlC",
+        "user-4176d3f1@example.com", "value": null, "value_hash": "SVpvvlAm+mSkBreWHt3M0x1lYBT3+d+xuKt2jG4MHghesISKuoP/qcMyEiXAlxlC",
         "published_at": "2020-10-16T23:19:38.924991Z", "date": "2020-10-16T23:19:38.924991Z",
         "detected_at": "2020-10-16T23:19:38.924991Z", "is_vcs_type": true, "last_detected_at":
         "2020-10-16T23:19:38.924991Z", "last_seen_at": "2020-10-16T23:19:38.924991Z",
-        "data": {}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2020-09/commit/21dfe9873dee987ce65df7cece464299ec359ded#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "source": {"id": 12357, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2020-09",
-        "type": "gh_repository", "display_name": "wayne-enterprises-gg/private-app-gg-bis-2020-09",
+        "data": {}, "url": "https://github.com/ns-80126292/private-app-gg-bis-2020-09/commit/21dfe9873dee987ce65df7cece464299ec359ded#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "source": {"id": 12357, "url": "https://github.com/ns-80126292/private-app-gg-bis-2020-09",
+        "type": "gh_repository", "display_name": "ns-80126292/private-app-gg-bis-2020-09",
         "visibility": "public", "monitored": true, "source_criticality": "unknown",
         "deleted_at": null, "default_branch": null, "monitoring_status": "deleted_on_remote"},
         "regression": false, "content": 511, "secrets_engine_version": "unknown",
@@ -351,24 +350,24 @@ interactions:
         "default": null}, "arg2": {"value": "cloud_provider"}}, "is_global": true,
         "scope": "private", "author": 104371}}, "declarative_secret_status": "revoked",
         "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "lucius-fox-gg@protonmail.com", "name":
-        "Lucius Fox"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        "severity": 100, "authors": [{"info": "user-4176d3f1@example.com", "name":
+        "User dc1e35f1"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
         0, "occurrences_presence_seen_count": 0, "occurrences_presence_deleted_count":
         2, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"id": 12357, "name": "wayne-enterprises-gg/private-app-gg-bis-2020-09",
-        "type": "gh_repository", "path": "wayne-enterprises-gg/private-app-gg-bis-2020-09",
-        "source_criticality": "unknown", "monitoring_status": "deleted_on_remote",
-        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
-        false, "similar_issue_count": 1, "score": 100, "displayed_occurrence": {"id":
-        78265, "issue": 21496, "account": 8, "kind": "RLTM", "element": "503679d2088a4ad0ac8da4f7fa80f2d9dc8b53cb",
+        [{"id": 12357, "name": "ns-80126292/private-app-gg-bis-2020-09", "type": "gh_repository",
+        "path": "ns-80126292/private-app-gg-bis-2020-09", "source_criticality": "unknown",
+        "monitoring_status": "deleted_on_remote", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 1,
+        "score": 100, "displayed_occurrence": {"id": 78265, "issue": 21496, "account":
+        8, "kind": "RLTM", "element": "503679d2088a4ad0ac8da4f7fa80f2d9dc8b53cb",
         "element_type": "GIT_COMMIT", "author_name": "Lucius Fox", "author_info":
-        "lucius-fox-gg@protonmail.com", "value": null, "value_hash": "RaQzNWSHPE9wz4Q3ll9+QP43F7uaBELZtgsEuKU1K8k4T1TAIgmRXj0sSXd5i6Rh",
+        "user-4176d3f1@example.com", "value": null, "value_hash": "RaQzNWSHPE9wz4Q3ll9+QP43F7uaBELZtgsEuKU1K8k4T1TAIgmRXj0sSXd5i6Rh",
         "published_at": "2020-10-10T01:19:39.990914Z", "date": "2020-10-10T01:19:39.990914Z",
         "detected_at": "2020-10-10T01:19:39.990914Z", "is_vcs_type": true, "last_detected_at":
         "2020-10-10T01:19:39.990914Z", "last_seen_at": "2020-10-10T01:19:39.990914Z",
-        "data": {}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2020-09/commit/503679d2088a4ad0ac8da4f7fa80f2d9dc8b53cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "source": {"id": 12357, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2020-09",
-        "type": "gh_repository", "display_name": "wayne-enterprises-gg/private-app-gg-bis-2020-09",
+        "data": {}, "url": "https://github.com/ns-80126292/private-app-gg-bis-2020-09/commit/503679d2088a4ad0ac8da4f7fa80f2d9dc8b53cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "source": {"id": 12357, "url": "https://github.com/ns-80126292/private-app-gg-bis-2020-09",
+        "type": "gh_repository", "display_name": "ns-80126292/private-app-gg-bis-2020-09",
         "visibility": "public", "monitored": true, "source_criticality": "unknown",
         "deleted_at": null, "default_branch": null, "monitoring_status": "deleted_on_remote"},
         "regression": false, "content": 531, "secrets_engine_version": "unknown",
@@ -403,24 +402,24 @@ interactions:
         "default": null}, "arg2": {"value": "cloud_provider"}}, "is_global": true,
         "scope": "private", "author": 104371}}, "declarative_secret_status": "revoked",
         "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "lucius-fox-gg@protonmail.com", "name":
-        "Lucius Fox"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        "severity": 100, "authors": [{"info": "user-4176d3f1@example.com", "name":
+        "User dc1e35f1"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
         0, "occurrences_presence_seen_count": 0, "occurrences_presence_deleted_count":
         2, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"id": 12275, "name": "wayne-enterprises-gg/private-gg-bis-2020-08", "type":
-        "gh_repository", "path": "wayne-enterprises-gg/private-gg-bis-2020-08", "source_criticality":
-        "unknown", "monitoring_status": "deleted_on_remote", "deleted_at": null}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        1, "score": 100, "displayed_occurrence": {"id": 78280, "issue": 21504, "account":
+        [{"id": 12275, "name": "ns-80126292/private-gg-bis-2020-08", "type": "gh_repository",
+        "path": "ns-80126292/private-gg-bis-2020-08", "source_criticality": "unknown",
+        "monitoring_status": "deleted_on_remote", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 1,
+        "score": 100, "displayed_occurrence": {"id": 78280, "issue": 21504, "account":
         8, "kind": "RLTM", "element": "e3b9ca510380b3b675cf180fa5115b8ba4d310ed",
         "element_type": "GIT_COMMIT", "author_name": "Lucius Fox", "author_info":
-        "lucius-fox-gg@protonmail.com", "value": null, "value_hash": "Z0Wch+TvRD6TeD9XDcZKPlnZ3Y3JGuxreeOUwDUPu+2UhbRM53Aj3nPUanUM/HIG",
+        "user-4176d3f1@example.com", "value": null, "value_hash": "Z0Wch+TvRD6TeD9XDcZKPlnZ3Y3JGuxreeOUwDUPu+2UhbRM53Aj3nPUanUM/HIG",
         "published_at": "2020-10-07T22:19:40.847825Z", "date": "2020-10-07T22:19:40.847825Z",
         "detected_at": "2020-10-07T22:19:40.847825Z", "is_vcs_type": true, "last_detected_at":
         "2020-10-07T22:19:40.847825Z", "last_seen_at": "2020-10-07T22:19:40.847825Z",
-        "data": {}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-08/commit/e3b9ca510380b3b675cf180fa5115b8ba4d310ed#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "source": {"id": 12275, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-08",
-        "type": "gh_repository", "display_name": "wayne-enterprises-gg/private-gg-bis-2020-08",
+        "data": {}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-08/commit/e3b9ca510380b3b675cf180fa5115b8ba4d310ed#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "source": {"id": 12275, "url": "https://github.com/ns-80126292/private-gg-bis-2020-08",
+        "type": "gh_repository", "display_name": "ns-80126292/private-gg-bis-2020-08",
         "visibility": "public", "monitored": true, "source_criticality": "unknown",
         "deleted_at": null, "default_branch": null, "monitoring_status": "deleted_on_remote"},
         "regression": false, "content": 545, "secrets_engine_version": "unknown",
@@ -455,24 +454,24 @@ interactions:
         "default": null}, "arg2": {"value": "cloud_provider"}}, "is_global": true,
         "scope": "private", "author": 104371}}, "declarative_secret_status": "revoked",
         "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "lucius-fox-gg@protonmail.com", "name":
-        "Lucius Fox"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        "severity": 100, "authors": [{"info": "user-4176d3f1@example.com", "name":
+        "User dc1e35f1"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
         0, "occurrences_presence_seen_count": 0, "occurrences_presence_deleted_count":
         2, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"id": 12367, "name": "wayne-enterprises-gg/private-app-gg-2020-09", "type":
-        "gh_repository", "path": "wayne-enterprises-gg/private-app-gg-2020-09", "source_criticality":
-        "unknown", "monitoring_status": "deleted_on_remote", "deleted_at": null}],
-        "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
-        34, "score": 100, "displayed_occurrence": {"id": 78288, "issue": 21509, "account":
+        [{"id": 12367, "name": "ns-80126292/private-app-gg-2020-09", "type": "gh_repository",
+        "path": "ns-80126292/private-app-gg-2020-09", "source_criticality": "unknown",
+        "monitoring_status": "deleted_on_remote", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 34,
+        "score": 100, "displayed_occurrence": {"id": 78288, "issue": 21509, "account":
         8, "kind": "RLTM", "element": "2da0fd3222e537b3cd3c299a05def9aa223fd5b7",
         "element_type": "GIT_COMMIT", "author_name": "Lucius Fox", "author_info":
-        "lucius-fox-gg@protonmail.com", "value": null, "value_hash": "WTKEyEsI+qZmED0dwL5+kNWUFgmwPfWsJbdihtDLyNPNCG0ADOQMjLDua944vEw4",
+        "user-4176d3f1@example.com", "value": null, "value_hash": "WTKEyEsI+qZmED0dwL5+kNWUFgmwPfWsJbdihtDLyNPNCG0ADOQMjLDua944vEw4",
         "published_at": "2020-10-06T13:20:07.039345Z", "date": "2020-10-06T13:20:07.039345Z",
         "detected_at": "2020-10-06T13:20:07.039345Z", "is_vcs_type": true, "last_detected_at":
         "2020-10-06T13:20:07.039345Z", "last_seen_at": "2020-10-06T13:20:07.039345Z",
-        "data": {}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2020-09/commit/2da0fd3222e537b3cd3c299a05def9aa223fd5b7#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "source": {"id": 12367, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2020-09",
-        "type": "gh_repository", "display_name": "wayne-enterprises-gg/private-app-gg-2020-09",
+        "data": {}, "url": "https://github.com/ns-80126292/private-app-gg-2020-09/commit/2da0fd3222e537b3cd3c299a05def9aa223fd5b7#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "source": {"id": 12367, "url": "https://github.com/ns-80126292/private-app-gg-2020-09",
+        "type": "gh_repository", "display_name": "ns-80126292/private-app-gg-2020-09",
         "visibility": "public", "monitored": true, "source_criticality": "unknown",
         "deleted_at": null, "default_branch": null, "monitoring_status": "deleted_on_remote"},
         "regression": false, "content": 553, "secrets_engine_version": "unknown",
@@ -496,8 +495,8 @@ interactions:
         "ignored": true, "ignored_at": "2020-09-24T09:47:42.196767Z", "ignore_reason":
         null, "ignorer": 2503, "resolved": false, "resolved_at": null, "resolver":
         null, "regression": false, "manual_severity_setter": 9322, "ignorer_display_name":
-        "guillaume.charpiat@gitguardian.com", "ignorer_type": "user", "resolver_display_name":
-        "none", "resolver_type": "none", "manual_severity_setter_display_name": "ramzi.lahoud@gitguardian.com",
+        "user-d9f863cd@example.com", "ignorer_type": "user", "resolver_display_name":
+        "none", "resolver_type": "none", "manual_severity_setter_display_name": "user-abb9c699@example.com",
         "manual_severity_setter_type": "user", "status": "IGNORED", "issue_name":
         "AWS IAM Keys", "severity_rule_config": {"id": 28, "gg_created_at": "2023-02-07T13:53:07.394202Z",
         "gg_updated_at": "2023-02-07T13:53:07.394210Z", "index": 200, "severity":
@@ -507,24 +506,24 @@ interactions:
         {"path": "issue.secret.detector.metadata.category", "default": null}, "arg2":
         {"value": "cloud_provider"}}, "is_global": true, "scope": "private", "author":
         104371}}, "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
-        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "lucius-fox-gg@protonmail.com",
-        "name": "Lucius Fox"}], "user_permission": 7, "is_publicly_shared": false,
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "user-4176d3f1@example.com",
+        "name": "User dc1e35f1"}], "user_permission": 7, "is_publicly_shared": false,
         "feedbacks_count": 0, "occurrences_presence_seen_count": 0, "occurrences_presence_deleted_count":
         2, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"id": 12345, "name": "wayne-enterprises-gg/public-app-gg-bis-2020-09", "type":
-        "gh_repository", "path": "wayne-enterprises-gg/public-app-gg-bis-2020-09",
-        "source_criticality": "unknown", "monitoring_status": "deleted_on_remote",
-        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
-        false, "similar_issue_count": 101, "score": 100, "displayed_occurrence": {"id":
-        78335, "issue": 21536, "account": 8, "kind": "RLTM", "element": "1ccd84be4e607782519936669189dcdd44e95a8c",
+        [{"id": 12345, "name": "ns-80126292/public-app-gg-bis-2020-09", "type": "gh_repository",
+        "path": "ns-80126292/public-app-gg-bis-2020-09", "source_criticality": "unknown",
+        "monitoring_status": "deleted_on_remote", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 101,
+        "score": 100, "displayed_occurrence": {"id": 78335, "issue": 21536, "account":
+        8, "kind": "RLTM", "element": "1ccd84be4e607782519936669189dcdd44e95a8c",
         "element_type": "GIT_COMMIT", "author_name": "Lucius Fox", "author_info":
-        "lucius-fox-gg@protonmail.com", "value": null, "value_hash": "heNxh9k0jTZ05w7q9zGYibOwxsZMOq5rHxDweGWf4HsKPayxymxFnFW0QPDEKh3W",
+        "user-4176d3f1@example.com", "value": null, "value_hash": "heNxh9k0jTZ05w7q9zGYibOwxsZMOq5rHxDweGWf4HsKPayxymxFnFW0QPDEKh3W",
         "published_at": "2020-09-22T23:19:43.460578Z", "date": "2020-09-22T23:19:43.460578Z",
         "detected_at": "2020-09-22T23:19:43.460578Z", "is_vcs_type": true, "last_detected_at":
         "2020-09-22T23:19:43.460578Z", "last_seen_at": "2020-09-22T23:19:43.460578Z",
-        "data": {}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-09/commit/1ccd84be4e607782519936669189dcdd44e95a8c#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "source": {"id": 12345, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-09",
-        "type": "gh_repository", "display_name": "wayne-enterprises-gg/public-app-gg-bis-2020-09",
+        "data": {}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-09/commit/1ccd84be4e607782519936669189dcdd44e95a8c#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "source": {"id": 12345, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-09",
+        "type": "gh_repository", "display_name": "ns-80126292/public-app-gg-bis-2020-09",
         "visibility": "public", "monitored": true, "source_criticality": "unknown",
         "deleted_at": null, "default_branch": null, "monitoring_status": "deleted_on_remote"},
         "regression": false, "content": 593, "secrets_engine_version": "unknown",

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_search.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_search.yaml
@@ -28,14 +28,14 @@ interactions:
         "ignored": true, "ignored_at": "2026-05-13T15:25:06.323251Z", "ignore_reason":
         "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
         null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
+        "user-7d8fb5e1@example.com", "ignorer_type": "user", "resolver_display_name":
         "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
         "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
         "AWS IAM Keys", "severity_rule_config": null, "declarative_secret_status":
         "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "ggtestintegrations@proton.me", "name":
-        "GG Test Integrations"}, {"info": "<unknown>", "name": "GG Test Integrations"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        "severity": 100, "authors": [{"info": "user-556e25a3@example.com", "name":
+        "User 4578e5a2"}, {"info": "<unknown>", "name": "User 4578e5a2"}], "user_permission":
+        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         3, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
         null, "locations_count": 0, "sources": [{"id": 28093162, "name": "gg-test-integrations
         / QA SH Jira Space", "type": "jira_cloud_project", "path": "gg-test-integrations
@@ -44,12 +44,12 @@ interactions:
         "is_vaulted": false, "similar_issue_count": 0, "score": 0, "displayed_occurrence":
         {"id": 269409153, "issue": 32828142, "account": 8, "kind": "HIST", "element":
         "QJS-2", "element_type": "JIRA_TICKET", "author_name": "GG Test Integrations",
-        "author_info": "ggtestintegrations@proton.me", "value": null, "value_hash":
-        "mnhuCDXkjCXmXE4PfqGTgnchdepV6MVg3j0V4l5lv7W2jUxLFuVgLjxYdCAlSkbB", "published_at":
-        "2026-05-13T13:00:33.511000Z", "date": "2026-05-13T13:00:33.511000Z", "detected_at":
-        "2026-05-26T07:42:57.694929Z", "is_vcs_type": false, "last_detected_at": "2026-05-13T13:00:33.511000Z",
-        "last_seen_at": "2026-05-13T13:00:33.511000Z", "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/QJS-2",
-        "source": {"id": 28093162, "url": "https://gg-test-integrations.atlassian.net/browse/QJS",
+        "author_info": "user-556e25a3@example.com", "value": null, "value_hash": "mnhuCDXkjCXmXE4PfqGTgnchdepV6MVg3j0V4l5lv7W2jUxLFuVgLjxYdCAlSkbB",
+        "published_at": "2026-05-13T13:00:33.511000Z", "date": "2026-05-13T13:00:33.511000Z",
+        "detected_at": "2026-05-26T07:42:57.694929Z", "is_vcs_type": false, "last_detected_at":
+        "2026-05-13T13:00:33.511000Z", "last_seen_at": "2026-05-13T13:00:33.511000Z",
+        "data": {}, "url": "https://tenant-54c1a367.atlassian.net/browse/QJS-2", "source":
+        {"id": 28093162, "url": "https://tenant-54c1a367.atlassian.net/browse/QJS",
         "type": "jira_cloud_project", "display_name": "gg-test-integrations / QA SH
         Jira Space", "visibility": "private", "monitored": true, "source_criticality":
         "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
@@ -73,13 +73,13 @@ interactions:
         "ignored": true, "ignored_at": "2026-05-07T18:37:25.902297Z", "ignore_reason":
         "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
         null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
+        "user-7d8fb5e1@example.com", "ignorer_type": "user", "resolver_display_name":
         "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
         "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
         "AWS IAM Keys", "severity_rule_config": null, "declarative_secret_status":
         "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gg-tools@gitguardian.com", "name":
-        "gim-dev"}, {"info": "mathieu.bellon@gitguardian.com", "name": "Mathieu Bellon"}],
+        "severity": 100, "authors": [{"info": "user-7ec2e474@example.com", "name":
+        "User e307c118"}, {"info": "user-da872230@example.com", "name": "User 32444b0e"}],
         "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         7, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
         null, "locations_count": 0, "sources": [{"id": 27930579, "name": "gim-dev/snow-repro",
@@ -91,12 +91,12 @@ interactions:
         "is_vaulted": false, "similar_issue_count": 0, "score": 27, "displayed_occurrence":
         {"id": 266172913, "issue": 32567570, "account": 8, "kind": "RLTM", "element":
         "ee576e5cf318090b01602c5ffb24a9607fdd5be9", "element_type": "GIT_COMMIT",
-        "author_name": "gim-dev", "author_info": "gg-tools@gitguardian.com", "value":
+        "author_name": "gim-dev", "author_info": "user-7ec2e474@example.com", "value":
         null, "value_hash": "Wad93KyrKN6S2e6VpviT0T1KtPxF0Oav6XIf/DktZeaiy4obyw7Ogic3qDwsyV+Z",
         "published_at": "2026-05-07T18:37:22Z", "date": "2026-05-07T18:37:22Z", "detected_at":
         "2026-05-07T18:37:24.813406Z", "is_vcs_type": true, "last_detected_at": "2026-05-07T18:37:22Z",
-        "last_seen_at": "2026-05-07T18:37:22Z", "data": {}, "url": "https://ghe-01.aws-qa-gitguardian.com/gim-dev/snow-repro/commit/ee576e5cf318090b01602c5ffb24a9607fdd5be9#diff-b486b0402fa5438817157f04e64a1198fa657f9ce9de837cab3d7e48aaaa0748R7",
-        "source": {"id": 27930579, "url": "https://ghe-01.aws-qa-gitguardian.com/gim-dev/snow-repro",
+        "last_seen_at": "2026-05-07T18:37:22Z", "data": {}, "url": "https://host-8c9d8db9.example.com/ns-e307c118/ns-1de96672/commit/ee576e5cf318090b01602c5ffb24a9607fdd5be9#diff-b486b0402fa5438817157f04e64a1198fa657f9ce9de837cab3d7e48aaaa0748R7",
+        "source": {"id": 27930579, "url": "https://host-8c9d8db9.example.com/ns-e307c118/ns-1de96672",
         "type": "ghe_repository", "display_name": "gim-dev/snow-repro", "visibility":
         "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
         null, "default_branch": "main", "monitoring_status": "active"}, "regression":
@@ -124,7 +124,7 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic High Entropy Secret", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "admin@example.com", "name": "Administrator"}],
+        "severity": 100, "authors": [{"info": "admin@example.com", "name": "User e7d3e769"}],
         "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
         null, "locations_count": 1, "sources": [{"id": 27593417, "name": "analytics-report",
@@ -178,21 +178,22 @@ interactions:
         "gitlab_enterprise_token", "github_access_token", "aws_iam"]}}]}, "is_global":
         true, "scope": "any", "author": null}}, "declarative_secret_status": null,
         "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"id": 16218988, "name": "Martin Faucheux
-        / Repo A", "type": "gl_project", "path": "martin-faucheux/repo-a", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 36, "displayed_occurrence": {"id": 245063312, "issue": 27395126,
-        "account": 8, "kind": "RLTM", "element": "7a6a765a03f640cf002e7d23040dad8a17fe4255",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
-        "value": null, "value_hash": "dLLMC28h0JB8KLz6ViyG9URvAnikbB5BBECedrqc2JmDHqkd2KVpMdI0NbaCVmKj",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
+        [{"id": 16218988, "name": "Martin Faucheux / Repo A", "type": "gl_project",
+        "path": "martin-faucheux/repo-a", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 36, "displayed_occurrence":
+        {"id": 245063312, "issue": 27395126, "account": 8, "kind": "RLTM", "element":
+        "7a6a765a03f640cf002e7d23040dad8a17fe4255", "element_type": "GIT_COMMIT",
+        "author_name": "dev", "author_info": "user-1ca9c7a6@example.com", "value":
+        null, "value_hash": "dLLMC28h0JB8KLz6ViyG9URvAnikbB5BBECedrqc2JmDHqkd2KVpMdI0NbaCVmKj",
         "published_at": "2026-02-19T14:36:24Z", "date": "2026-02-19T14:36:24Z", "detected_at":
         "2026-02-19T14:40:06.772801Z", "is_vcs_type": true, "last_detected_at": "2026-02-19T14:36:24Z",
-        "last_seen_at": "2026-02-19T14:36:24Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/martin-faucheux/repo-a/commit/7a6a765a03f640cf002e7d23040dad8a17fe4255#710a727ecafa5cfe744810c543a838230918ff04_0_4",
-        "source": {"id": 16218988, "url": "https://gitlab-01.aws-qa-gitguardian.com/martin-faucheux/repo-a",
+        "last_seen_at": "2026-02-19T14:36:24Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-dfd48fc3/ns-b41c2aee/commit/7a6a765a03f640cf002e7d23040dad8a17fe4255#710a727ecafa5cfe744810c543a838230918ff04_0_4",
+        "source": {"id": 16218988, "url": "https://host-a31e7ce0.example.com/ns-dfd48fc3/ns-b41c2aee",
         "type": "gl_project", "display_name": "Martin Faucheux / Repo A", "visibility":
         "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
         null, "default_branch": "main", "monitoring_status": "active"}, "regression":
@@ -234,21 +235,22 @@ interactions:
         "gitlab_enterprise_token", "github_access_token", "aws_iam"]}}]}, "is_global":
         true, "scope": "any", "author": null}}, "declarative_secret_status": null,
         "assignee": 581873, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        12, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"id": 16219056, "name": "gim-qa-gitlabSandbox-auto
-        / gim-qa-gitlabSandbox-staging", "type": "gl_project", "path": "gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 12, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
+        [{"id": 16219056, "name": "gim-qa-gitlabSandbox-auto / gim-qa-gitlabSandbox-staging",
+        "type": "gl_project", "path": "gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
         "source_criticality": "critical", "monitoring_status": "active", "deleted_at":
         null}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
         0, "score": 97, "displayed_occurrence": {"id": 242021853, "issue": 26879946,
         "account": 8, "kind": "RLTM", "element": "e2cbc193a76a13b94e135c12a055d2083a233a89",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "7AkVngiwT5n4ZZihQovCHs2qrlx0MOfD853AYv4HHS0DiM0Vk9YtctC+FFM1Iw+v",
         "published_at": "2026-02-05T16:48:19Z", "date": "2026-02-05T16:48:19Z", "detected_at":
         "2026-02-05T16:51:53.166126Z", "is_vcs_type": true, "last_detected_at": "2026-02-05T16:48:19Z",
-        "last_seen_at": "2026-02-05T16:48:19Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging/commit/e2cbc193a76a13b94e135c12a055d2083a233a89#2dd906314026edd7e5fa25025afd4353424625a7_0_19",
-        "source": {"id": 16219056, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
+        "last_seen_at": "2026-02-05T16:48:19Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-88035254/ns-2405e744/commit/e2cbc193a76a13b94e135c12a055d2083a233a89#2dd906314026edd7e5fa25025afd4353424625a7_0_19",
+        "source": {"id": 16219056, "url": "https://host-a31e7ce0.example.com/ns-88035254/ns-2405e744",
         "type": "gl_project", "display_name": "gim-qa-gitlabSandbox-auto / gim-qa-gitlabSandbox-staging",
         "visibility": "private", "monitored": true, "source_criticality": "critical",
         "deleted_at": null, "default_branch": "main", "monitoring_status": "active"},

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_secret_manager_type.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_secret_manager_type.yaml
@@ -28,14 +28,14 @@ interactions:
         "ignored": true, "ignored_at": "2026-02-18T22:23:47.653867Z", "ignore_reason":
         "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
         null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
+        "user-7d8fb5e1@example.com", "ignorer_type": "user", "resolver_display_name":
         "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
         "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
         "OpenAI Project API Key v2", "severity_rule_config": null, "declarative_secret_status":
         "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"},
-        {"info": "xavier.blanchot@gitguardian.com", "name": "Xavier Blanchot"}], "user_permission":
-        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}, {"info": "user-fea77cfd@example.com", "name": "User f52aaa3c"}],
+        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         3, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
         null, "locations_count": 2, "sources": [{"id": 16218909, "name": "Xavier Blanchot
         / qa-sca", "type": "gl_project", "path": "xblanchot/qa-sca", "source_criticality":
@@ -46,12 +46,12 @@ interactions:
         "is_vaulted": true, "similar_issue_count": 0, "score": 45, "displayed_occurrence":
         {"id": 244951751, "issue": 27376615, "account": 8, "kind": "HIST", "element":
         "7f75f6e85952d5ac1c625bd3fcf40d003b0ba8c4", "element_type": "GIT_COMMIT",
-        "author_name": "Xavier Blanchot", "author_info": "xavier.blanchot@gitguardian.com",
+        "author_name": "Xavier Blanchot", "author_info": "user-fea77cfd@example.com",
         "value": null, "value_hash": "CBaS+/d/madbwvs/8T4WdjsExX8NK6aTuQDdGQA1GtNcnCtNB1WaTUij1r/0DT4F",
         "published_at": "2026-02-03T14:54:25Z", "date": "2026-02-03T14:54:25Z", "detected_at":
         "2026-02-18T22:33:23.391472Z", "is_vcs_type": true, "last_detected_at": "2026-02-03T14:54:25Z",
-        "last_seen_at": "2026-02-03T14:54:25Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/Loic/demo-shield/commit/7f75f6e85952d5ac1c625bd3fcf40d003b0ba8c4#06b6a8978505059f2298eeea18b85735506e50b0_None_10",
-        "source": {"id": 24090906, "url": "https://gitlab-01.aws-qa-gitguardian.com/Loic/demo-shield",
+        "last_seen_at": "2026-02-03T14:54:25Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-a00ab2e1/ns-31f452e6/commit/7f75f6e85952d5ac1c625bd3fcf40d003b0ba8c4#06b6a8978505059f2298eeea18b85735506e50b0_None_10",
+        "source": {"id": 24090906, "url": "https://host-a31e7ce0.example.com/ns-a00ab2e1/ns-31f452e6",
         "type": "gl_project", "display_name": "Loic / demo-shield", "visibility":
         "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
         null, "default_branch": "master", "monitoring_status": "active"}, "regression":
@@ -87,9 +87,9 @@ interactions:
         {"path": "issue.secret.detector.nature", "default": null}, "arg2": {"value":
         "specific"}}]}, "is_global": true, "scope": "private", "author": null}}, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"},
-        {"info": "xavier.blanchot@gitguardian.com", "name": "Xavier Blanchot"}], "user_permission":
-        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}, {"info": "user-fea77cfd@example.com", "name": "User f52aaa3c"}],
+        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         3, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
         null, "locations_count": 2, "sources": [{"id": 16218909, "name": "Xavier Blanchot
         / qa-sca", "type": "gl_project", "path": "xblanchot/qa-sca", "source_criticality":
@@ -100,12 +100,12 @@ interactions:
         "is_vaulted": true, "similar_issue_count": 0, "score": 36, "displayed_occurrence":
         {"id": 244951754, "issue": 27376617, "account": 8, "kind": "HIST", "element":
         "7f75f6e85952d5ac1c625bd3fcf40d003b0ba8c4", "element_type": "GIT_COMMIT",
-        "author_name": "Xavier Blanchot", "author_info": "xavier.blanchot@gitguardian.com",
+        "author_name": "Xavier Blanchot", "author_info": "user-fea77cfd@example.com",
         "value": null, "value_hash": "bkjQSYtajI81lN0vpeFk3i7WIys+D668iT37NvZh1WNr+R2mo0AV7BPnZLC8/g/J",
         "published_at": "2026-02-03T14:54:25Z", "date": "2026-02-03T14:54:25Z", "detected_at":
         "2026-02-18T22:33:23.391472Z", "is_vcs_type": true, "last_detected_at": "2026-02-03T14:54:25Z",
-        "last_seen_at": "2026-02-03T14:54:25Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/Loic/demo-shield/commit/7f75f6e85952d5ac1c625bd3fcf40d003b0ba8c4#06b6a8978505059f2298eeea18b85735506e50b0_None_25",
-        "source": {"id": 24090906, "url": "https://gitlab-01.aws-qa-gitguardian.com/Loic/demo-shield",
+        "last_seen_at": "2026-02-03T14:54:25Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-a00ab2e1/ns-31f452e6/commit/7f75f6e85952d5ac1c625bd3fcf40d003b0ba8c4#06b6a8978505059f2298eeea18b85735506e50b0_None_25",
+        "source": {"id": 24090906, "url": "https://host-a31e7ce0.example.com/ns-a00ab2e1/ns-31f452e6",
         "type": "gl_project", "display_name": "Loic / demo-shield", "visibility":
         "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
         null, "default_branch": "master", "monitoring_status": "active"}, "regression":
@@ -152,9 +152,9 @@ interactions:
         "EQ", "arg1": {"path": "issue.secret.detector.metadata.category", "default":
         null}, "arg2": {"value": "cloud_provider"}}, "is_global": true, "scope": "private",
         "author": null}}, "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
-        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "samuel.guillaume@gitguardian.com",
-        "name": "Samuel Guillaume"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "user-d44727e2@example.com",
+        "name": "User 282efbbc"}], "user_permission": 7, "is_publicly_shared": false,
+        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
         [{"id": 16219049, "name": "Samuel Guillaume / test", "type": "gl_project",
         "path": "sguillaume/test", "source_criticality": "unknown", "monitoring_status":
@@ -163,11 +163,11 @@ interactions:
         0, "displayed_occurrence": {"id": 244951457, "issue": 27376696, "account":
         8, "kind": "HIST", "element": "f0bc33647a2bf4772705f95900bdd1a92b0234f2",
         "element_type": "GIT_COMMIT", "author_name": "Samuel Guillaume", "author_info":
-        "samuel.guillaume@gitguardian.com", "value": null, "value_hash": "atE9KnGucJISLfh100fbsegn4JpS4siGXSQM0a+pNTyui2iCbwjMNjc6LwKuYut2",
+        "user-d44727e2@example.com", "value": null, "value_hash": "atE9KnGucJISLfh100fbsegn4JpS4siGXSQM0a+pNTyui2iCbwjMNjc6LwKuYut2",
         "published_at": "2026-01-09T10:56:17Z", "date": "2026-01-09T10:56:17Z", "detected_at":
         "2026-02-18T22:29:47.642007Z", "is_vcs_type": true, "last_detected_at": "2026-01-09T10:56:17Z",
-        "last_seen_at": "2026-01-09T10:56:17Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/sguillaume/test/commit/f0bc33647a2bf4772705f95900bdd1a92b0234f2#fa246d9d69470a1ac417e912ba7413239face5f4_None_4",
-        "source": {"id": 16219049, "url": "https://gitlab-01.aws-qa-gitguardian.com/sguillaume/test",
+        "last_seen_at": "2026-01-09T10:56:17Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-24b3c9fd/ns-9f86d081/commit/f0bc33647a2bf4772705f95900bdd1a92b0234f2#fa246d9d69470a1ac417e912ba7413239face5f4_None_4",
+        "source": {"id": 16219049, "url": "https://host-a31e7ce0.example.com/ns-24b3c9fd/ns-9f86d081",
         "type": "gl_project", "display_name": "Samuel Guillaume / test", "visibility":
         "internal", "monitored": true, "source_criticality": "unknown", "deleted_at":
         null, "default_branch": "master", "monitoring_status": "active"}, "regression":
@@ -196,13 +196,13 @@ interactions:
         "ignored": true, "ignored_at": "2026-02-04T13:38:52.095775Z", "ignore_reason":
         "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
         null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
+        "user-7d8fb5e1@example.com", "ignorer_type": "user", "resolver_display_name":
         "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
         "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
         "Google API Key", "severity_rule_config": null, "declarative_secret_status":
         "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"},
-        {"info": "romain.jouhannet@gitguardian.com", "name": "Romain Jouhannet"}],
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}, {"info": "user-46c1d11b@example.com", "name": "User b090f14f"}],
         "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         12, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
         null, "locations_count": 0, "sources": [{"id": 23485702, "name": "RomainJ
@@ -214,12 +214,12 @@ interactions:
         "is_vaulted": true, "similar_issue_count": 4, "score": 0, "displayed_occurrence":
         {"id": 241287716, "issue": 26805047, "account": 8, "kind": "HIST", "element":
         "fd56543c0a2594907b36ab59c885bd1d536a4957", "element_type": "GIT_COMMIT",
-        "author_name": "Romain Jouhannet", "author_info": "romain.jouhannet@gitguardian.com",
+        "author_name": "Romain Jouhannet", "author_info": "user-46c1d11b@example.com",
         "value": null, "value_hash": "SJwViF0/DsMYa+t+dBEiZx2csnwTDMqh1ro0cKTbBj5LYGqhjI9qf5LnmIYCvOW2",
         "published_at": "2025-12-14T19:04:50Z", "date": "2025-12-14T19:04:50Z", "detected_at":
         "2026-02-04T13:38:46.386256Z", "is_vcs_type": true, "last_detected_at": "2025-12-14T19:04:50Z",
-        "last_seen_at": "2025-12-14T19:04:50Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/fd56543c0a2594907b36ab59c885bd1d536a4957#2ec5fbc02574c84a8b8e3dcae097ffd0be069994_None_12",
-        "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
+        "last_seen_at": "2025-12-14T19:04:50Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-eb459aed/ns-2a97516c/commit/fd56543c0a2594907b36ab59c885bd1d536a4957#2ec5fbc02574c84a8b8e3dcae097ffd0be069994_None_12",
+        "source": {"id": 23485702, "url": "https://host-a31e7ce0.example.com/ns-eb459aed/ns-2a97516c",
         "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 129708166,
@@ -245,25 +245,25 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "GitLab Token", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gg-tools@gitguardian.com", "name":
-        "gg-tools"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        "severity": 100, "authors": [{"info": "user-7ec2e474@example.com", "name":
+        "User 42397b98"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
         0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
         [{"id": 16218911, "name": "Achille / sca-on-prem-test", "type": "gl_project",
         "path": "amascia/sca-on-prem-test", "source_criticality": "unknown", "monitoring_status":
-        "active", "deleted_at": null}, {"id": 24381556, "name": "jira-data-center.do.gitguardian.dev
-        / ChangingGCAM", "type": "jira_data_center_project", "path": "jira-data-center.do.gitguardian.dev
+        "active", "deleted_at": null}, {"id": 24381556, "name": "host-0bd28c47.example.com
+        / ChangingGCAM", "type": "jira_data_center_project", "path": "host-0bd28c47.example.com
         / ChangingGCAM", "source_criticality": "unknown", "monitoring_status": "active",
         "deleted_at": null}], "custom_tags": [], "vault_metadata": [{"source": "awssecretsmanager"}],
         "is_vaulted": true, "similar_issue_count": 0, "score": 9, "displayed_occurrence":
         {"id": 244950136, "issue": 23269327, "account": 8, "kind": "HIST", "element":
         "061e8042f5c82b5a51cea8e716b8183dca978d21", "element_type": "GIT_COMMIT",
-        "author_name": "gg-tools", "author_info": "gg-tools@gitguardian.com", "value":
+        "author_name": "gg-tools", "author_info": "user-7ec2e474@example.com", "value":
         null, "value_hash": "UAvJFhSJJaQysiJNVZIOK8xzO+87NbZwUxRtCLJ1jFEymRaDnLBWocIwrZ2EgJKH",
         "published_at": "2025-12-10T14:18:42Z", "date": "2025-12-10T14:18:42Z", "detected_at":
         "2026-02-18T22:23:46.672369Z", "is_vcs_type": true, "last_detected_at": "2025-12-10T14:18:42Z",
-        "last_seen_at": "2025-12-10T14:18:42Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/amascia/sca-on-prem-test/commit/061e8042f5c82b5a51cea8e716b8183dca978d21#2b0e2f260b21bb2873e28b33ac4ca7f72da36d5e_None_1",
-        "source": {"id": 16218911, "url": "https://gitlab-01.aws-qa-gitguardian.com/amascia/sca-on-prem-test",
+        "last_seen_at": "2025-12-10T14:18:42Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-f39985d5/ns-4add0707/commit/061e8042f5c82b5a51cea8e716b8183dca978d21#2b0e2f260b21bb2873e28b33ac4ca7f72da36d5e_None_1",
+        "source": {"id": 16218911, "url": "https://host-a31e7ce0.example.com/ns-f39985d5/ns-4add0707",
         "type": "gl_project", "display_name": "Achille / sca-on-prem-test", "visibility":
         "public", "monitored": true, "source_criticality": "unknown", "deleted_at":
         null, "default_branch": "main", "monitoring_status": "active"}, "regression":

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_severity_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_severity_filter.yaml
@@ -29,7 +29,7 @@ interactions:
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": 910203, "ignorer_display_name": "none", "ignorer_type":
         "none", "resolver_display_name": "none", "resolver_type": "none", "manual_severity_setter_display_name":
-        "celine.agbo@gitguardian.com", "manual_severity_setter_type": "user", "status":
+        "user-faa5b70a@example.com", "manual_severity_setter_type": "user", "status":
         "ASSIGNED", "issue_name": "Artifactory Token", "severity_rule_config": {"id":
         11895, "gg_created_at": "2026-05-20T08:56:10.055460Z", "gg_updated_at": "2026-05-20T08:56:10.055463Z",
         "index": 130, "severity": 10, "rule": {"id": 513, "gg_created_at": "2025-03-18T08:57:54.142453Z",
@@ -39,23 +39,22 @@ interactions:
         "default": null}, "arg2": {"value": "package_registry"}}, "is_global": true,
         "scope": "private", "author": null}}, "declarative_secret_status": null, "assignee":
         550880, "last_presence_check_at": null, "secret": "[REDACTED]", "severity":
-        20, "authors": [{"info": "ggtestintegrations@proton.me", "name": "GG Test
-        Integrations"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"id": 27177247, "name": "gg-test-integrations / Payment Systems", "type":
-        "jira_cloud_project", "path": "gg-test-integrations / Payment Systems", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 86, "displayed_occurrence": {"id": 272781097, "issue": 33929626,
-        "account": 8, "kind": "RLTM", "element": "PAY-4", "element_type": "JIRA_TICKET",
-        "author_name": "GG Test Integrations", "author_info": "ggtestintegrations@proton.me",
-        "value": null, "value_hash": "T71tr/N63V71e27iMbDQa9L9Oh/xkgVEZdomur2uk2WyqO/9fr4lNYuUjUFpuLDi",
+        20, "authors": [{"info": "user-556e25a3@example.com", "name": "User 4578e5a2"}],
+        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 0, "sources": [{"id": 27177247, "name": "gg-test-integrations
+        / Payment Systems", "type": "jira_cloud_project", "path": "gg-test-integrations
+        / Payment Systems", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 86, "displayed_occurrence":
+        {"id": 272781097, "issue": 33929626, "account": 8, "kind": "RLTM", "element":
+        "PAY-4", "element_type": "JIRA_TICKET", "author_name": "GG Test Integrations",
+        "author_info": "user-556e25a3@example.com", "value": null, "value_hash": "T71tr/N63V71e27iMbDQa9L9Oh/xkgVEZdomur2uk2WyqO/9fr4lNYuUjUFpuLDi",
         "published_at": "2026-06-12T10:26:58.151000Z", "date": "2026-06-12T10:26:58.151000Z",
         "detected_at": "2026-06-12T11:57:58.655858Z", "is_vcs_type": false, "last_detected_at":
         "2026-06-12T10:26:58.151000Z", "last_seen_at": "2026-06-12T10:26:58.151000Z",
-        "data": {}, "url": "https://gg-test-integrations.atlassian.net/browse/PAY-4",
-        "source": {"id": 27177247, "url": "https://gg-test-integrations.atlassian.net/browse/PAY",
+        "data": {}, "url": "https://tenant-54c1a367.atlassian.net/browse/PAY-4", "source":
+        {"id": 27177247, "url": "https://tenant-54c1a367.atlassian.net/browse/PAY",
         "type": "jira_cloud_project", "display_name": "gg-test-integrations / Payment
         Systems", "visibility": "private", "monitored": true, "source_criticality":
         "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
@@ -88,9 +87,9 @@ interactions:
         {"path": "issue.secret.detector.nature", "default": null}, "arg2": {"value":
         "specific"}}]}, "is_global": true, "scope": "private", "author": null}}, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "romain.jouhannet@gitguardian.com",
-        "name": "Romain Jouhannet"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
+        "severity": 100, "authors": [{"info": "user-46c1d11b@example.com", "name":
+        "User b090f14f"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
         [{"id": 23485702, "name": "RomainJ / demo", "type": "gl_project", "path":
         "romain/demo", "source_criticality": "unknown", "monitoring_status": "active",
@@ -98,11 +97,11 @@ interactions:
         false, "similar_issue_count": 0, "score": 49, "displayed_occurrence": {"id":
         269728665, "issue": 33211589, "account": 8, "kind": "HIST", "element": "d189cab00bc31c4bed372402e031de0559fa9d70",
         "element_type": "GIT_COMMIT", "author_name": "Romain Jouhannet", "author_info":
-        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "4WO+NtMg1huWU4tghYRv7bPopKssi564RukxBZVA2Opur15IVmYm2YNGhd2mwbCp",
+        "user-46c1d11b@example.com", "value": null, "value_hash": "4WO+NtMg1huWU4tghYRv7bPopKssi564RukxBZVA2Opur15IVmYm2YNGhd2mwbCp",
         "published_at": "2026-05-27T09:42:47Z", "date": "2026-05-27T09:42:47Z", "detected_at":
         "2026-05-27T09:51:34.675578Z", "is_vcs_type": true, "last_detected_at": "2026-05-27T09:42:47Z",
-        "last_seen_at": "2026-05-27T09:42:47Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/d189cab00bc31c4bed372402e031de0559fa9d70#e1755a4a1df75fb12321bae878788f6ca914d373_None_1",
-        "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
+        "last_seen_at": "2026-05-27T09:42:47Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-eb459aed/ns-2a97516c/commit/d189cab00bc31c4bed372402e031de0559fa9d70#e1755a4a1df75fb12321bae878788f6ca914d373_None_1",
+        "source": {"id": 23485702, "url": "https://host-a31e7ce0.example.com/ns-eb459aed/ns-2a97516c",
         "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 164835166,
@@ -150,9 +149,9 @@ interactions:
         {"path": "issue.secret.detector.nature", "default": null}, "arg2": {"value":
         "specific"}}]}, "is_global": true, "scope": "private", "author": null}}, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "romain.jouhannet@gitguardian.com",
-        "name": "Romain Jouhannet"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        "severity": 100, "authors": [{"info": "user-46c1d11b@example.com", "name":
+        "User b090f14f"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
         [{"id": 23485702, "name": "RomainJ / demo", "type": "gl_project", "path":
         "romain/demo", "source_criticality": "unknown", "monitoring_status": "active",
@@ -160,11 +159,11 @@ interactions:
         false, "similar_issue_count": 1, "score": 49, "displayed_occurrence": {"id":
         269727691, "issue": 33211407, "account": 8, "kind": "RLTM", "element": "d6361a080aa92dc554cd2b55f6f3a7dcf26d1dcb",
         "element_type": "GIT_COMMIT", "author_name": "Romain Jouhannet", "author_info":
-        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "YU5lBhVgALxxn8rYMmJe6Uh0y3sUhot77BxviUqvi2cqEVzhNyDcgwtJW6F//p33",
+        "user-46c1d11b@example.com", "value": null, "value_hash": "YU5lBhVgALxxn8rYMmJe6Uh0y3sUhot77BxviUqvi2cqEVzhNyDcgwtJW6F//p33",
         "published_at": "2026-05-27T09:28:55Z", "date": "2026-05-27T09:28:55Z", "detected_at":
         "2026-05-27T09:32:59.686337Z", "is_vcs_type": true, "last_detected_at": "2026-05-27T09:28:55Z",
-        "last_seen_at": "2026-05-27T09:28:55Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/d6361a080aa92dc554cd2b55f6f3a7dcf26d1dcb#3a94abefa57e93ce6945d8a053c37e4e2598dbee_0_7",
-        "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
+        "last_seen_at": "2026-05-27T09:28:55Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-eb459aed/ns-2a97516c/commit/d6361a080aa92dc554cd2b55f6f3a7dcf26d1dcb#3a94abefa57e93ce6945d8a053c37e4e2598dbee_0_7",
+        "source": {"id": 23485702, "url": "https://host-a31e7ce0.example.com/ns-eb459aed/ns-2a97516c",
         "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 164831857,
@@ -211,9 +210,9 @@ interactions:
         {"path": "issue.secret.detector.nature", "default": null}, "arg2": {"value":
         "specific"}}]}, "is_global": true, "scope": "private", "author": null}}, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "romain.jouhannet@gitguardian.com",
-        "name": "Romain Jouhannet"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        "severity": 100, "authors": [{"info": "user-46c1d11b@example.com", "name":
+        "User b090f14f"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
         [{"id": 23485702, "name": "RomainJ / demo", "type": "gl_project", "path":
         "romain/demo", "source_criticality": "unknown", "monitoring_status": "active",
@@ -221,11 +220,11 @@ interactions:
         false, "similar_issue_count": 1, "score": 49, "displayed_occurrence": {"id":
         269727692, "issue": 33211409, "account": 8, "kind": "RLTM", "element": "d6361a080aa92dc554cd2b55f6f3a7dcf26d1dcb",
         "element_type": "GIT_COMMIT", "author_name": "Romain Jouhannet", "author_info":
-        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "dGSO0UNu3ir5xB1mNC4rhS2IL21oXm+7tSQPn+qUFGZ3HkBlVp3JYrpf4ubmlbDB",
+        "user-46c1d11b@example.com", "value": null, "value_hash": "dGSO0UNu3ir5xB1mNC4rhS2IL21oXm+7tSQPn+qUFGZ3HkBlVp3JYrpf4ubmlbDB",
         "published_at": "2026-05-27T09:28:55Z", "date": "2026-05-27T09:28:55Z", "detected_at":
         "2026-05-27T09:32:59.686337Z", "is_vcs_type": true, "last_detected_at": "2026-05-27T09:28:55Z",
-        "last_seen_at": "2026-05-27T09:28:55Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/d6361a080aa92dc554cd2b55f6f3a7dcf26d1dcb#7b83dc4c52bef56016855ec981bdf4b8425c6486_0_7",
-        "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
+        "last_seen_at": "2026-05-27T09:28:55Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-eb459aed/ns-2a97516c/commit/d6361a080aa92dc554cd2b55f6f3a7dcf26d1dcb#7b83dc4c52bef56016855ec981bdf4b8425c6486_0_7",
+        "source": {"id": 23485702, "url": "https://host-a31e7ce0.example.com/ns-eb459aed/ns-2a97516c",
         "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 164831858,
@@ -260,7 +259,7 @@ interactions:
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": 614347, "regression":
         true, "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
-        "none", "resolver_display_name": "romain.jouhannet@gitguardian.com", "resolver_type":
+        "none", "resolver_display_name": "user-46c1d11b@example.com", "resolver_type":
         "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
         "none", "status": "ASSIGNED", "issue_name": "MongoDB Credentials", "severity_rule_config":
         {"id": 11898, "gg_created_at": "2026-05-20T08:56:10.055489Z", "gg_updated_at":
@@ -273,21 +272,21 @@ interactions:
         "default": null}, "arg2": {"value": "specific"}}]}, "is_global": true, "scope":
         "private", "author": null}}, "declarative_secret_status": "revoked", "assignee":
         694621, "last_presence_check_at": null, "secret": "[REDACTED]", "severity":
-        100, "authors": [{"info": "romain.jouhannet@gitguardian.com", "name": "Romain
-        Jouhannet"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 6, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
-        [{"id": 23485702, "name": "RomainJ / demo", "type": "gl_project", "path":
-        "romain/demo", "source_criticality": "unknown", "monitoring_status": "active",
-        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
-        false, "similar_issue_count": 5, "score": 49, "displayed_occurrence": {"id":
-        268701358, "issue": 33049834, "account": 8, "kind": "RLTM", "element": "f13f8127edb3e5d386cb44679c12e5d6c3ce05be",
+        100, "authors": [{"info": "user-46c1d11b@example.com", "name": "User b090f14f"}],
+        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 0, "sources": [{"id": 23485702, "name": "RomainJ
+        / demo", "type": "gl_project", "path": "romain/demo", "source_criticality":
+        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
+        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 5,
+        "score": 49, "displayed_occurrence": {"id": 268701358, "issue": 33049834,
+        "account": 8, "kind": "RLTM", "element": "f13f8127edb3e5d386cb44679c12e5d6c3ce05be",
         "element_type": "GIT_COMMIT", "author_name": "Romain Jouhannet", "author_info":
-        "romain.jouhannet@gitguardian.com", "value": null, "value_hash": "ElUKHxkW6poM78sJZq6fX/NNHh82/5I40MrYWprOWor+UttOwqRf0MFMFvJD2sMv",
+        "user-46c1d11b@example.com", "value": null, "value_hash": "ElUKHxkW6poM78sJZq6fX/NNHh82/5I40MrYWprOWor+UttOwqRf0MFMFvJD2sMv",
         "published_at": "2026-05-21T12:49:39Z", "date": "2026-05-21T12:49:39Z", "detected_at":
         "2026-05-21T12:51:02.846566Z", "is_vcs_type": true, "last_detected_at": "2026-05-21T12:51:02.846566Z",
-        "last_seen_at": "2026-05-21T12:51:02.846566Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo/commit/f13f8127edb3e5d386cb44679c12e5d6c3ce05be#f9553d98ad319e9f50f10ef0cf086752c16a337b_5_6",
-        "source": {"id": 23485702, "url": "https://gitlab-01.aws-qa-gitguardian.com/romain/demo",
+        "last_seen_at": "2026-05-21T12:51:02.846566Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-eb459aed/ns-2a97516c/commit/f13f8127edb3e5d386cb44679c12e5d6c3ce05be#f9553d98ad319e9f50f10ef0cf086752c16a337b_5_6",
+        "source": {"id": 23485702, "url": "https://host-a31e7ce0.example.com/ns-eb459aed/ns-2a97516c",
         "type": "gl_project", "display_name": "RomainJ / demo", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": true, "content": 163473773,

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_source_criticality.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_source_criticality.yaml
@@ -32,23 +32,23 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne.p@gmail.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        "severity": 100, "authors": [{"info": "user-783dd644@example.com", "name":
+        "User 3fcf209d"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
         0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"id": 17188087, "name": "pierrelalanne/test_repo", "type": "gh_repository",
-        "path": "pierrelalanne/test_repo", "source_criticality": "critical", "monitoring_status":
+        [{"id": 17188087, "name": "ns-f0afee16/test_repo", "type": "gh_repository",
+        "path": "ns-f0afee16/test_repo", "source_criticality": "critical", "monitoring_status":
         "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
         "is_vaulted": false, "similar_issue_count": 0, "score": 12, "displayed_occurrence":
         {"id": 271584642, "issue": 33677678, "account": 8, "kind": "RLTM", "element":
         "b355f606d5884cfbe83a19c83e6804c0fc9a95f0", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne.p@gmail.com",
+        "author_name": "Pierre Lalanne", "author_info": "user-783dd644@example.com",
         "value": null, "value_hash": "BwX3iCglyVyrnbQJ+uR2bcHgVmnkzFUUxyizOMJrHc3YG8H/gEDCz7InbgSdLTaR",
         "published_at": "2026-06-05T10:30:39Z", "date": "2026-06-05T10:30:39Z", "detected_at":
         "2026-06-05T10:30:40.398638Z", "is_vcs_type": true, "last_detected_at": "2026-06-05T10:30:39Z",
-        "last_seen_at": "2026-06-05T10:30:39Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/b355f606d5884cfbe83a19c83e6804c0fc9a95f0#diff-cf36aad2a70418098362b5fbd96a9fbbb199e931ccab1ee9713f5b5eb84eba94R67",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
+        "last_seen_at": "2026-06-05T10:30:39Z", "data": {}, "url": "https://github.com/ns-f0afee16/test_repo/commit/b355f606d5884cfbe83a19c83e6804c0fc9a95f0#diff-cf36aad2a70418098362b5fbd96a9fbbb199e931ccab1ee9713f5b5eb84eba94R67",
+        "source": {"id": 17188087, "url": "https://github.com/ns-f0afee16/test_repo",
+        "type": "gh_repository", "display_name": "ns-f0afee16/test_repo", "visibility":
         "private", "monitored": true, "source_criticality": "critical", "deleted_at":
         null, "default_branch": "main", "monitoring_status": "active"}, "regression":
         false, "content": 166970520, "secrets_engine_version": "2.164.0", "matches":
@@ -73,23 +73,23 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne.p@gmail.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        "severity": 100, "authors": [{"info": "user-783dd644@example.com", "name":
+        "User 3fcf209d"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
         0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"id": 17188087, "name": "pierrelalanne/test_repo", "type": "gh_repository",
-        "path": "pierrelalanne/test_repo", "source_criticality": "critical", "monitoring_status":
+        [{"id": 17188087, "name": "ns-f0afee16/test_repo", "type": "gh_repository",
+        "path": "ns-f0afee16/test_repo", "source_criticality": "critical", "monitoring_status":
         "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
         "is_vaulted": false, "similar_issue_count": 8, "score": 44, "displayed_occurrence":
         {"id": 271584100, "issue": 33677565, "account": 8, "kind": "RLTM", "element":
         "276bdd24d5b2ea7dd5d24065a874e7b38c4baf02", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne.p@gmail.com",
+        "author_name": "Pierre Lalanne", "author_info": "user-783dd644@example.com",
         "value": null, "value_hash": "dghMd9QxxXO40sNOZin7UwNQEofOjVvZPRnc0uuhC5UGTg3dHls6b/A69cLp1JsO",
         "published_at": "2026-06-05T10:22:50Z", "date": "2026-06-05T10:22:50Z", "detected_at":
         "2026-06-05T10:22:52.066950Z", "is_vcs_type": true, "last_detected_at": "2026-06-05T10:22:50Z",
-        "last_seen_at": "2026-06-05T10:22:50Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/276bdd24d5b2ea7dd5d24065a874e7b38c4baf02#diff-e6b5ea99d732f641a1ed2ab4a8c2d85f73f418a055112ef514157ff958ba8d09R1",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
+        "last_seen_at": "2026-06-05T10:22:50Z", "data": {}, "url": "https://github.com/ns-f0afee16/test_repo/commit/276bdd24d5b2ea7dd5d24065a874e7b38c4baf02#diff-e6b5ea99d732f641a1ed2ab4a8c2d85f73f418a055112ef514157ff958ba8d09R1",
+        "source": {"id": 17188087, "url": "https://github.com/ns-f0afee16/test_repo",
+        "type": "gh_repository", "display_name": "ns-f0afee16/test_repo", "visibility":
         "private", "monitored": true, "source_criticality": "critical", "deleted_at":
         null, "default_branch": "main", "monitoring_status": "active"}, "regression":
         false, "content": 166969572, "secrets_engine_version": "2.164.0", "matches":
@@ -110,27 +110,27 @@ interactions:
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2026-04-23T14:21:21.665606Z", "resolver":
         491414, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "none", "ignorer_type": "none", "resolver_display_name": "8@bot.gitguardian.com",
+        "none", "ignorer_type": "none", "resolver_display_name": "user-7d8fb5e1@example.com",
         "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
         "none", "status": "RESOLVED", "issue_name": "OpenAI Project API Key v2", "severity_rule_config":
         null, "declarative_secret_status": "revoked", "assignee": null, "last_presence_check_at":
-        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "pierre.lalanne.p@gmail.com",
-        "name": "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false,
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "user-783dd644@example.com",
+        "name": "User 3fcf209d"}], "user_permission": 7, "is_publicly_shared": false,
         "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"id": 17188087, "name": "pierrelalanne/test_repo", "type": "gh_repository",
-        "path": "pierrelalanne/test_repo", "source_criticality": "critical", "monitoring_status":
+        [{"id": 17188087, "name": "ns-f0afee16/test_repo", "type": "gh_repository",
+        "path": "ns-f0afee16/test_repo", "source_criticality": "critical", "monitoring_status":
         "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
         "is_vaulted": false, "similar_issue_count": 0, "score": 72, "displayed_occurrence":
         {"id": 262554997, "issue": 31373342, "account": 8, "kind": "RLTM", "element":
         "7a29784f96775c22382dd7597ea6b8eba6b0eb6e", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne.p@gmail.com",
+        "author_name": "Pierre Lalanne", "author_info": "user-783dd644@example.com",
         "value": null, "value_hash": "iOpliw67mpaH863gBvLPJI/gDBERPy3H1wOuCOS/FoHFmDU9QVFmWDntVjR7KBsQ",
         "published_at": "2026-04-23T14:12:47Z", "date": "2026-04-23T14:12:47Z", "detected_at":
         "2026-04-23T14:12:57.197663Z", "is_vcs_type": true, "last_detected_at": "2026-04-23T14:12:47Z",
-        "last_seen_at": "2026-04-23T14:12:47Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/7a29784f96775c22382dd7597ea6b8eba6b0eb6e#diff-424350c68ff6be273a06da5e45468d69074e9eaa0b0a9b19175a602dbb861531R1",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
+        "last_seen_at": "2026-04-23T14:12:47Z", "data": {}, "url": "https://github.com/ns-f0afee16/test_repo/commit/7a29784f96775c22382dd7597ea6b8eba6b0eb6e#diff-424350c68ff6be273a06da5e45468d69074e9eaa0b0a9b19175a602dbb861531R1",
+        "source": {"id": 17188087, "url": "https://github.com/ns-f0afee16/test_repo",
+        "type": "gh_repository", "display_name": "ns-f0afee16/test_repo", "visibility":
         "private", "monitored": true, "source_criticality": "critical", "deleted_at":
         null, "default_branch": "main", "monitoring_status": "active"}, "regression":
         false, "content": 155179630, "secrets_engine_version": "2.161.0", "matches":
@@ -151,28 +151,28 @@ interactions:
         "ignored": true, "ignored_at": "2026-03-26T16:10:55.689671Z", "ignore_reason":
         "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
         null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
+        "user-7d8fb5e1@example.com", "ignorer_type": "user", "resolver_display_name":
         "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
         "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
         "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
         "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        "severity": 100, "authors": [{"info": "user-aba104cf@example.com", "name":
+        "User 3fcf209d"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
         0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"id": 17188087, "name": "pierrelalanne/test_repo", "type": "gh_repository",
-        "path": "pierrelalanne/test_repo", "source_criticality": "critical", "monitoring_status":
+        [{"id": 17188087, "name": "ns-f0afee16/test_repo", "type": "gh_repository",
+        "path": "ns-f0afee16/test_repo", "source_criticality": "critical", "monitoring_status":
         "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
         "is_vaulted": false, "similar_issue_count": 0, "score": 22, "displayed_occurrence":
         {"id": 253938087, "issue": 29236129, "account": 8, "kind": "RLTM", "element":
         "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
+        "author_name": "Pierre Lalanne", "author_info": "user-aba104cf@example.com",
         "value": null, "value_hash": "CEL9N36auQTdl9e+bqgAsGyWN0vVPYlqvHWSQMXxC/1zmdQrKYk359La8N2L+SIi",
         "published_at": "2026-03-26T16:10:40Z", "date": "2026-03-26T16:10:40Z", "detected_at":
         "2026-03-26T16:10:51.878216Z", "is_vcs_type": true, "last_detected_at": "2026-03-26T16:10:40Z",
-        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R1",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
+        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/ns-f0afee16/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R1",
+        "source": {"id": 17188087, "url": "https://github.com/ns-f0afee16/test_repo",
+        "type": "gh_repository", "display_name": "ns-f0afee16/test_repo", "visibility":
         "private", "monitored": true, "source_criticality": "critical", "deleted_at":
         null, "default_branch": "main", "monitoring_status": "active"}, "regression":
         false, "content": 146712049, "secrets_engine_version": "2.159.0", "matches":
@@ -195,28 +195,28 @@ interactions:
         "ignored": true, "ignored_at": "2026-03-26T16:10:55.695057Z", "ignore_reason":
         "invalid", "ignorer": 491414, "resolved": false, "resolved_at": null, "resolver":
         null, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "8@bot.gitguardian.com", "ignorer_type": "user", "resolver_display_name":
+        "user-7d8fb5e1@example.com", "ignorer_type": "user", "resolver_display_name":
         "none", "resolver_type": "none", "manual_severity_setter_display_name": "none",
         "manual_severity_setter_type": "none", "status": "IGNORED", "issue_name":
         "Slack Bot Token", "severity_rule_config": null, "declarative_secret_status":
         "invalid", "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre Lalanne"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        "severity": 100, "authors": [{"info": "user-aba104cf@example.com", "name":
+        "User 3fcf209d"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
         0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"id": 17188087, "name": "pierrelalanne/test_repo", "type": "gh_repository",
-        "path": "pierrelalanne/test_repo", "source_criticality": "critical", "monitoring_status":
+        [{"id": 17188087, "name": "ns-f0afee16/test_repo", "type": "gh_repository",
+        "path": "ns-f0afee16/test_repo", "source_criticality": "critical", "monitoring_status":
         "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
         "is_vaulted": false, "similar_issue_count": 10, "score": 22, "displayed_occurrence":
         {"id": 253938082, "issue": 29236130, "account": 8, "kind": "RLTM", "element":
         "a6bbeb758a38c3b675189f0ef5693f94c5b865db", "element_type": "GIT_COMMIT",
-        "author_name": "Pierre Lalanne", "author_info": "pierre.lalanne@gitguardian.com",
+        "author_name": "Pierre Lalanne", "author_info": "user-aba104cf@example.com",
         "value": null, "value_hash": "8CeYKeR2kMER0aBlyGThkdNGWeRYfKFLPj1kOQJO8lH2bXzFs7jhuR1VfR21VK1W",
         "published_at": "2026-03-26T16:10:40Z", "date": "2026-03-26T16:10:40Z", "detected_at":
         "2026-03-26T16:10:51.878216Z", "is_vcs_type": true, "last_detected_at": "2026-03-26T16:10:40Z",
-        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/pierrelalanne/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R20",
-        "source": {"id": 17188087, "url": "https://github.com/pierrelalanne/test_repo",
-        "type": "gh_repository", "display_name": "pierrelalanne/test_repo", "visibility":
+        "last_seen_at": "2026-03-26T16:10:40Z", "data": {}, "url": "https://github.com/ns-f0afee16/test_repo/commit/a6bbeb758a38c3b675189f0ef5693f94c5b865db#diff-c318ddcb8028b7f023ee8a67737a24af2a6c37a69f7c385452cbaf6708673d49R20",
+        "source": {"id": 17188087, "url": "https://github.com/ns-f0afee16/test_repo",
+        "type": "gh_repository", "display_name": "ns-f0afee16/test_repo", "visibility":
         "private", "monitored": true, "source_criticality": "critical", "deleted_at":
         null, "default_branch": "main", "monitoring_status": "active"}, "regression":
         false, "content": 146712049, "secrets_engine_version": "2.159.0", "matches":

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_status_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_status_filter.yaml
@@ -34,15 +34,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274792885, "issue": 34205503, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
         "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
@@ -50,20 +50,19 @@ interactions:
         "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
         "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
-        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
-        34186239, "account": 8, "criterion": "Generic Password", "date": "2026-06-22T15:14:57Z",
-        "last_trigger_published_at": "2026-06-22T15:14:57Z", "last_triggered_at":
-        "2026-06-22T15:16:49.799821Z", "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z",
-        "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-23T11:13:31.325324Z", "last_presence_check_at": "2026-06-23T11:13:31.325324Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}, {"id": 34186239, "account": 8, "criterion":
+        "Generic Password", "date": "2026-06-22T15:14:57Z", "last_trigger_published_at":
+        "2026-06-22T15:14:57Z", "last_triggered_at": "2026-06-22T15:16:49.799821Z",
+        "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z", "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -71,21 +70,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
-        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
-        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 20, "score": 53, "displayed_occurrence": {"id":
+        274668904, "issue": 34186239, "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
         "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
         "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
-        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
@@ -110,21 +109,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
-        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
-        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 6, "score": 63, "displayed_occurrence": {"id":
+        274099881, "issue": 34122510, "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
         "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
         "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
-        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
@@ -150,15 +149,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 273386288, "issue": 34038186, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
         "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
@@ -166,20 +165,19 @@ interactions:
         "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
         "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
-        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
-        33905111, "account": 8, "criterion": "GitLab Deploy Token", "date": "2026-06-11T12:29:43Z",
-        "last_trigger_published_at": "2026-06-11T12:29:43Z", "last_triggered_at":
-        "2026-06-11T12:30:11.342010Z", "last_trigger_detected_at": "2026-06-11T12:30:11.342010Z",
-        "hash": "G0fVu31BJOKtUHJsvHbpcGhXGXhyr2/bQf6zzlhNv+czrK+KrGdxdFLGuJmYhmlq",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-16T18:55:43.166667Z", "last_presence_check_at": "2026-06-16T18:55:43.166667Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}, {"id": 33905111, "account": 8, "criterion":
+        "GitLab Deploy Token", "date": "2026-06-11T12:29:43Z", "last_trigger_published_at":
+        "2026-06-11T12:29:43Z", "last_triggered_at": "2026-06-11T12:30:11.342010Z",
+        "last_trigger_detected_at": "2026-06-11T12:30:11.342010Z", "hash": "G0fVu31BJOKtUHJsvHbpcGhXGXhyr2/bQf6zzlhNv+czrK+KrGdxdFLGuJmYhmlq",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -187,21 +185,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "GitLab Deploy Token", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 28664611, "name": "dev / plal_test",
-        "type": "gl_project", "path": "dev/plal_test", "source_criticality": "unknown",
-        "monitoring_status": "active", "deleted_at": null}], "custom_tags": [], "vault_metadata":
-        null, "is_vaulted": false, "similar_issue_count": 0, "score": 85, "displayed_occurrence":
-        {"id": 272645187, "issue": 33905111, "account": 8, "kind": "HIST", "element":
-        "0102329ae146f51358cff771dbdf860acbc78ef6", "element_type": "GIT_COMMIT",
-        "author_name": "dev", "author_info": "gim+dev@gitguardian.com", "value": null,
-        "value_hash": "vKgkDXA4NszdEvKqefnQ7tPG4AsADP5uV3carLt96S2ZoMa7KySfdZ9m9HlrAElh",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 28664611, "name": "dev / plal_test", "type": "gl_project", "path":
+        "dev/plal_test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 0, "score": 85, "displayed_occurrence": {"id":
+        272645187, "issue": 33905111, "account": 8, "kind": "HIST", "element": "0102329ae146f51358cff771dbdf860acbc78ef6",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
+        "value": null, "value_hash": "vKgkDXA4NszdEvKqefnQ7tPG4AsADP5uV3carLt96S2ZoMa7KySfdZ9m9HlrAElh",
         "published_at": "2026-06-11T12:29:43Z", "date": "2026-06-11T12:29:43Z", "detected_at":
         "2026-06-11T12:30:10.472937Z", "is_vcs_type": true, "last_detected_at": "2026-06-11T12:37:30.541974Z",
-        "last_seen_at": "2026-06-11T12:37:30.541974Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/dev/plal_test/commit/0102329ae146f51358cff771dbdf860acbc78ef6#5a06a4630a05426a25bc162c233d6cf8ed2462a0_None_5",
-        "source": {"id": 28664611, "url": "https://gitlab-01.aws-qa-gitguardian.com/dev/plal_test",
+        "last_seen_at": "2026-06-11T12:37:30.541974Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-ef260e9a/ns-c602f9c5/commit/0102329ae146f51358cff771dbdf860acbc78ef6#5a06a4630a05426a25bc162c233d6cf8ed2462a0_None_5",
+        "source": {"id": 28664611, "url": "https://host-a31e7ce0.example.com/ns-ef260e9a/ns-c602f9c5",
         "type": "gl_project", "display_name": "dev / plal_test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 168574637,

--- a/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_validity.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_for_mcp_with_validity.yaml
@@ -34,15 +34,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274792885, "issue": 34205503, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
         "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
@@ -50,38 +50,37 @@ interactions:
         "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
         "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
-        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
-        34181686, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
-        "date": "2026-06-22T11:25:45.739149Z", "last_trigger_published_at": "2026-06-22T11:25:45.739149Z",
-        "last_triggered_at": "2026-06-22T11:25:45.762592Z", "last_trigger_detected_at":
-        "2026-06-22T11:25:45.762592Z", "hash": "gVrL/pjjFLo7sSikPS1pWtPJbr+oWSSVz8IB6+2ViJDSJKiK25LITKmJimoqGr3z",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-23T11:13:31.325324Z", "last_presence_check_at": "2026-06-23T11:13:31.325324Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}, {"id": 34181686, "account": 8, "criterion":
+        "microsoft_azure_storage_connection_string", "date": "2026-06-22T11:25:45.739149Z",
+        "last_trigger_published_at": "2026-06-22T11:25:45.739149Z", "last_triggered_at":
+        "2026-06-22T11:25:45.762592Z", "last_trigger_detected_at": "2026-06-22T11:25:45.762592Z",
+        "hash": "gVrL/pjjFLo7sSikPS1pWtPJbr+oWSSVz8IB6+2ViJDSJKiK25LITKmJimoqGr3z",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2026-06-22T11:26:52.971214Z", "resolver":
         1751937, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "none", "ignorer_type": "none", "resolver_display_name": "candidate.playground+eu@gitguardian.com",
+        "none", "ignorer_type": "none", "resolver_display_name": "user-1ffcf115@example.com",
         "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
         "none", "status": "RESOLVED", "issue_name": "Microsoft Azure Storage Connection
         String", "severity_rule_config": null, "declarative_secret_status": "revoked",
         "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "", "name": "Kashyapa P.A. Jayasekera"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        "severity": 100, "authors": [{"info": "", "name": "User 801c5600"}], "user_permission":
+        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "GGFRLTA127
-        \u2014 kashyapap.jayasekera", "type": "endpoints", "path": "GGFRLTA127 \u2014
-        kashyapap.jayasekera", "source_criticality": "unknown", "monitoring_status":
-        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "endpoint-86a2394f",
+        "type": "endpoints", "path": "endpoint-86a2394f", "source_criticality": "unknown",
+        "monitoring_status": "active", "deleted_at": null}], "custom_tags": [], "vault_metadata":
+        null, "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
         {"id": 274639444, "issue": 34181686, "account": 8, "kind": "RLTM", "element":
-        "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "AAr6ayAj6Hs2pOICdVUlEyuXlsQ78K3HFGOJgWA/yAiQrRuQH9Kv1GxUH36IT99d",
         "published_at": "2026-06-22T11:25:45.739149Z", "date": "2026-06-22T11:25:45.739149Z",
@@ -89,20 +88,20 @@ interactions:
         "2026-06-22T11:25:45.739149Z", "last_seen_at": "2026-06-22T11:25:45.739149Z",
         "data": {"line": 20, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-22T11:25:45.739149Z", "last_presence_check_at":
-        "2026-06-22T11:25:45.739149Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 6}, {"id":
-        34038186, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
-        "date": "2026-06-16T18:55:43.166667Z", "last_trigger_published_at": "2026-06-16T18:55:43.166667Z",
-        "last_triggered_at": "2026-06-16T18:55:43.185061Z", "last_trigger_detected_at":
-        "2026-06-16T18:55:43.185061Z", "hash": "JFTpQX+4P/dEcXJJ2iw+u54JYDsJnqLtrdws1wjFQ8t9LtHh25LITKmJimoqGr3z",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-22T11:25:45.739149Z", "last_presence_check_at": "2026-06-22T11:25:45.739149Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 6}, {"id": 34038186, "account": 8, "criterion":
+        "microsoft_azure_storage_connection_string", "date": "2026-06-16T18:55:43.166667Z",
+        "last_trigger_published_at": "2026-06-16T18:55:43.166667Z", "last_triggered_at":
+        "2026-06-16T18:55:43.185061Z", "last_trigger_detected_at": "2026-06-16T18:55:43.185061Z",
+        "hash": "JFTpQX+4P/dEcXJJ2iw+u54JYDsJnqLtrdws1wjFQ8t9LtHh25LITKmJimoqGr3z",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -111,15 +110,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 273386288, "issue": 34038186, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
         "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
@@ -127,20 +126,19 @@ interactions:
         "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
         "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
-        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
-        32985083, "account": 8, "criterion": "Google API Key", "date": "2026-05-19T09:33:23Z",
-        "last_trigger_published_at": "2026-05-19T09:33:23Z", "last_triggered_at":
-        "2026-05-19T09:36:55.570755Z", "last_trigger_detected_at": "2026-05-19T09:36:55.570755Z",
-        "hash": "pHE0O7zGgt2lhT0TLQzB2cwgMuZgrhqH4vSIGV5fw5ao1EL3iwQ5Z8PP16EaJtIX",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-16T18:55:43.166667Z", "last_presence_check_at": "2026-06-16T18:55:43.166667Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}, {"id": 32985083, "account": 8, "criterion":
+        "Google API Key", "date": "2026-05-19T09:33:23Z", "last_trigger_published_at":
+        "2026-05-19T09:33:23Z", "last_triggered_at": "2026-05-19T09:36:55.570755Z",
+        "last_trigger_detected_at": "2026-05-19T09:36:55.570755Z", "hash": "pHE0O7zGgt2lhT0TLQzB2cwgMuZgrhqH4vSIGV5fw5ao1EL3iwQ5Z8PP16EaJtIX",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -156,21 +154,21 @@ interactions:
         "EQ", "arg1": {"path": "issue.secret.validity_status", "default": null}, "arg2":
         {"value": "invalid"}}}]}, "is_global": false, "scope": "private", "author":
         520858}}, "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
-        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com",
-        "name": "dev"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com",
+        "name": "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": false,
+        "feedbacks_count": 0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
         [{"id": 16218896, "name": "qa / test-nriv", "type": "gl_project", "path":
         "qa1/test-nriv", "source_criticality": "unknown", "monitoring_status": "active",
         "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
         false, "similar_issue_count": 0, "score": 64, "displayed_occurrence": {"id":
         268288466, "issue": 32985083, "account": 8, "kind": "RLTM", "element": "9181621d49e910c3d2393f2373e52c04b26c7adb",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "y0o7bgCt8InKo3/G0QE6WaG+gU32WlUdYH0N4oUFXredK2KoKwrhfI+hoCMCs6v6",
         "published_at": "2026-05-19T09:33:23Z", "date": "2026-05-19T09:33:23Z", "detected_at":
         "2026-05-19T09:36:53.339083Z", "is_vcs_type": true, "last_detected_at": "2026-05-19T09:33:23Z",
-        "last_seen_at": "2026-05-19T09:33:23Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa1/test-nriv/commit/9181621d49e910c3d2393f2373e52c04b26c7adb#a290632bbcae192e53c54337b3238d835c97e8a9_5_4",
-        "source": {"id": 16218896, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa1/test-nriv",
+        "last_seen_at": "2026-05-19T09:33:23Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-e5a6b85b/ns-9acfb06d/commit/9181621d49e910c3d2393f2373e52c04b26c7adb#a290632bbcae192e53c54337b3238d835c97e8a9_5_4",
+        "source": {"id": 16218896, "url": "https://host-a31e7ce0.example.com/ns-e5a6b85b/ns-9acfb06d",
         "type": "gl_project", "display_name": "qa / test-nriv", "visibility": "internal",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 162813398,
@@ -202,7 +200,7 @@ interactions:
         {"value": "valid"}}, "is_global": true, "scope": "private", "author": null}},
         "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "<unknown>",
-        "name": "Guy Le Gardien"}], "user_permission": 7, "is_publicly_shared": false,
+        "name": "User f043662d"}], "user_permission": 7, "is_publicly_shared": false,
         "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
         [{"id": 26936741, "name": "gitguardian-team-vxrpkdpl / Philippe Gablain",
@@ -216,8 +214,8 @@ interactions:
         "published_at": "2026-05-18T16:46:02.652000Z", "date": "2026-05-18T16:46:02.652000Z",
         "detected_at": "2026-05-18T21:53:58.368709Z", "is_vcs_type": false, "last_detected_at":
         "2026-05-18T16:46:02.652000Z", "last_seen_at": "2026-05-18T16:46:02.652000Z",
-        "data": {}, "url": "https://gitguardian-team-vxrpkdpl.atlassian.net/wiki/spaces/~62a76a05979e6e00690427b5/pages/14057485/test+gg+token",
-        "source": {"id": 26936741, "url": "https://gitguardian-team-vxrpkdpl.atlassian.net/wiki/spaces/~62a76a05979e6e00690427b5",
+        "data": {}, "url": "https://tenant-187af6b6.atlassian.net/wiki/spaces/~62a76a05979e6e00690427b5/pages/14057485/test+gg+token",
+        "source": {"id": 26936741, "url": "https://tenant-187af6b6.atlassian.net/wiki/spaces/~62a76a05979e6e00690427b5",
         "type": "confluence_cloud_space", "display_name": "gitguardian-team-vxrpkdpl
         / Philippe Gablain", "visibility": "private", "monitored": true, "source_criticality":
         "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":

--- a/tests/cassettes/client/vcr/test_list_incidents_get_all.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_get_all.yaml
@@ -30,24 +30,24 @@ interactions:
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
         "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
         "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
-        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
-        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
-        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
-        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
-        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
-        given access to any sensitive information or services?", "boolean": true},
-        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
-        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
-        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
-        "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
-        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
-        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["PUBLICLY_LEAKED",
-        "REVOCABLE_BY_GG"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
+        "user-74281974@example.com", "share_url": "[REDACTED]", "feedback_list": [{"created_at":
+        "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "user-1a0bc62d@example.com", "member_id": null, "answers": [{"type":
+        "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is this an
+        actual secret?", "boolean": true}, {"type": "boolean", "field_ref": "access_to_sensitive_yes_no",
+        "field_label": "Does this secret give or has given access to any sensitive
+        information or services?", "boolean": true}, {"type": "boolean", "field_ref":
+        "revoked_yes_no", "field_label": "Has this secret been revoked?", "boolean":
+        false}, {"type": "text", "field_ref": "remarks_text", "field_label": "Additional
+        remarks", "text": "Hasn''t been revoked yet because X"}]}], "risk_score":
+        100, "severity_rule_id": null, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
+        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
+        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21460",
+        "tags": ["PUBLICLY_LEAKED", "REVOCABLE_BY_GG"], "incident_name": "AWS IAM
+        Keys", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "destination_tickets": [{"id":
+        "AEF-97", "type": "jira_cloud", "link": "https://tenant-b6250acd.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}, {"id": 21461, "detector": {"name": "private_key_dsa",
         "display_name": "DSA Private Key", "nature": "specific", "family": "cryptographic_key",
         "category": "private_key", "detector_group_name": "private_key_dsa", "detector_group_display_name":
@@ -58,9 +58,9 @@ interactions:
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "critical", "assignee_id": 270722,
-        "assignee_email": "clement.tourriere@gitguardian.com", "share_url": "[REDACTED]",
+        "assignee_email": "user-4278f7fb@example.com", "share_url": "[REDACTED]",
         "feedback_list": [{"created_at": "2024-06-28T07:01:19.458759Z", "updated_at":
-        "2024-06-28T07:01:19.458771Z", "email": "lucius@protonmal.com", "member_id":
+        "2024-06-28T07:01:19.458771Z", "email": "user-e2de71a9@example.com", "member_id":
         null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
         "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
         "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
@@ -75,8 +75,8 @@ interactions:
         "https://dashboard.gitguardian.com/workspace/8/incidents/21461", "tags": ["PUBLICLY_LEAKED"],
         "incident_name": "DSA Private Key", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-15"},
-        {"id": "JB-14", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-14"}],
+        "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link": "https://tenant-e47c06f3.atlassian.net/browse/JB-15"},
+        {"id": "JB-14", "type": "jira_cloud", "link": "https://tenant-e47c06f3.atlassian.net/browse/JB-14"}],
         "custom_tags": []}, {"id": 21462, "detector": {"name": "salesforce_oauth2",
         "display_name": "Salesforce Oauth2 Keys", "nature": "specific", "family":
         "credentials", "category": "crm", "detector_group_name": "salesforce_oauth2_keys",
@@ -87,7 +87,7 @@ interactions:
         "ignored_at": "2025-07-28T09:27:09.871747Z", "ignorer_id": 492181, "ignorer_api_token_id":
         null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
         "secret_revoked": false, "validity": "invalid", "severity": "high", "assignee_id":
-        10, "assignee_email": "bruce-wayne-gg@protonmail.com", "share_url": "[REDACTED]",
+        10, "assignee_email": "user-324427de@example.com", "share_url": "[REDACTED]",
         "feedback_list": [], "risk_score": 23, "severity_rule_id": 31, "is_vaulted":
         false, "ignore_reason": "invalid", "occurrences": null, "secret_presence":
         {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
@@ -123,7 +123,7 @@ interactions:
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         "2026-03-11T22:41:04.525493Z", "resolver_id": 492181, "resolver_api_token_id":
         null, "secret_revoked": true, "validity": "invalid", "severity": "high", "assignee_id":
-        10, "assignee_email": "bruce-wayne-gg@protonmail.com", "share_url": "[REDACTED]",
+        10, "assignee_email": "user-324427de@example.com", "share_url": "[REDACTED]",
         "feedback_list": [], "risk_score": 100, "severity_rule_id": 28, "is_vaulted":
         false, "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
         0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
@@ -131,7 +131,7 @@ interactions:
         "https://dashboard.gitguardian.com/workspace/8/incidents/21464", "tags": ["PUBLICLY_LEAKED",
         "REVOCABLE_BY_GG"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [{"id": "AEF-2326", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-2326"}],
+        "destination_tickets": [{"id": "AEF-2326", "type": "jira_cloud", "link": "https://tenant-b6250acd.atlassian.net/browse/AEF-2326"}],
         "custom_tags": []}]'
     headers:
       CF-RAY:
@@ -217,18 +217,18 @@ interactions:
         "secret_revoked": false, "validity": "invalid", "severity": "high", "assignee_id":
         null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
         [{"created_at": "2023-05-26T11:34:39.007461Z", "updated_at": "2023-05-26T11:34:39.007478Z",
-        "email": "helene.hartmann@gitguardian.com", "member_id": null, "answers":
-        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
-        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
-        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
-        given access to any sensitive information or services?", "boolean": true},
-        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": true}, {"type": "text", "field_ref": "remarks_text",
-        "field_label": "Additional remarks", "text": "my bad"}]}], "risk_score": 23,
-        "severity_rule_id": 8220, "is_vaulted": false, "ignore_reason": "invalid",
-        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21465",
+        "email": "user-ef593bab@example.com", "member_id": null, "answers": [{"type":
+        "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is this an
+        actual secret?", "boolean": true}, {"type": "boolean", "field_ref": "access_to_sensitive_yes_no",
+        "field_label": "Does this secret give or has given access to any sensitive
+        information or services?", "boolean": true}, {"type": "boolean", "field_ref":
+        "revoked_yes_no", "field_label": "Has this secret been revoked?", "boolean":
+        true}, {"type": "text", "field_ref": "remarks_text", "field_label": "Additional
+        remarks", "text": "my bad"}]}], "risk_score": 23, "severity_rule_id": 8220,
+        "is_vaulted": false, "ignore_reason": "invalid", "occurrences": null, "secret_presence":
+        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
+        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
+        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21465",
         "tags": ["PUBLICLY_LEAKED"], "incident_name": "Salesforce Oauth2 Keys", "public_exposure":
         {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
         false}, "destination_tickets": [], "custom_tags": []}, {"id": 21466, "detector":
@@ -279,7 +279,7 @@ interactions:
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [{"created_at": "2023-03-31T09:17:59.282371Z",
-        "updated_at": "2023-03-31T09:17:59.282384Z", "email": "mackenzie.jackson@gitguardian.com",
+        "updated_at": "2023-03-31T09:17:59.282384Z", "email": "user-dbf97dd3@example.com",
         "member_id": null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
         "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
         "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
@@ -415,7 +415,7 @@ interactions:
         "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
         "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [{"created_at": "2022-07-05T18:00:41.598862Z",
-        "updated_at": "2022-07-05T18:00:41.599096Z", "email": "mackenzie.jackson@gitguardian.com",
+        "updated_at": "2022-07-05T18:00:41.599096Z", "email": "user-dbf97dd3@example.com",
         "member_id": null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
         "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
         "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
@@ -424,7 +424,7 @@ interactions:
         this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
         "remarks_text", "field_label": "Additional remarks", "text": "Notes"}]}, {"created_at":
         "2023-06-26T12:44:52.641388Z", "updated_at": "2023-06-26T12:44:52.641404Z",
-        "email": "aymeric.sicard@gitguardian.com", "member_id": 13, "answers": [{"type":
+        "email": "user-71ab73d0@example.com", "member_id": 13, "answers": [{"type":
         "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is this an
         actual secret?", "boolean": true}, {"type": "boolean", "field_ref": "access_to_sensitive_yes_no",
         "field_label": "Does this secret give or has given access to any sensitive

--- a/tests/cassettes/client/vcr/test_list_incidents_with_date_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_with_date_filter.yaml
@@ -30,24 +30,24 @@ interactions:
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
         "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
         "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
-        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
-        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
-        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
-        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
-        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
-        given access to any sensitive information or services?", "boolean": true},
-        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
-        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
-        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
-        "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
-        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
-        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["PUBLICLY_LEAKED",
-        "REVOCABLE_BY_GG"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
+        "user-74281974@example.com", "share_url": "[REDACTED]", "feedback_list": [{"created_at":
+        "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "user-1a0bc62d@example.com", "member_id": null, "answers": [{"type":
+        "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is this an
+        actual secret?", "boolean": true}, {"type": "boolean", "field_ref": "access_to_sensitive_yes_no",
+        "field_label": "Does this secret give or has given access to any sensitive
+        information or services?", "boolean": true}, {"type": "boolean", "field_ref":
+        "revoked_yes_no", "field_label": "Has this secret been revoked?", "boolean":
+        false}, {"type": "text", "field_ref": "remarks_text", "field_label": "Additional
+        remarks", "text": "Hasn''t been revoked yet because X"}]}], "risk_score":
+        100, "severity_rule_id": null, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
+        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
+        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21460",
+        "tags": ["PUBLICLY_LEAKED", "REVOCABLE_BY_GG"], "incident_name": "AWS IAM
+        Keys", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "destination_tickets": [{"id":
+        "AEF-97", "type": "jira_cloud", "link": "https://tenant-b6250acd.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}, {"id": 21461, "detector": {"name": "private_key_dsa",
         "display_name": "DSA Private Key", "nature": "specific", "family": "cryptographic_key",
         "category": "private_key", "detector_group_name": "private_key_dsa", "detector_group_display_name":
@@ -58,9 +58,9 @@ interactions:
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "critical", "assignee_id": 270722,
-        "assignee_email": "clement.tourriere@gitguardian.com", "share_url": "[REDACTED]",
+        "assignee_email": "user-4278f7fb@example.com", "share_url": "[REDACTED]",
         "feedback_list": [{"created_at": "2024-06-28T07:01:19.458759Z", "updated_at":
-        "2024-06-28T07:01:19.458771Z", "email": "lucius@protonmal.com", "member_id":
+        "2024-06-28T07:01:19.458771Z", "email": "user-e2de71a9@example.com", "member_id":
         null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
         "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
         "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
@@ -75,8 +75,8 @@ interactions:
         "https://dashboard.gitguardian.com/workspace/8/incidents/21461", "tags": ["PUBLICLY_LEAKED"],
         "incident_name": "DSA Private Key", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-15"},
-        {"id": "JB-14", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-14"}],
+        "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link": "https://tenant-e47c06f3.atlassian.net/browse/JB-15"},
+        {"id": "JB-14", "type": "jira_cloud", "link": "https://tenant-e47c06f3.atlassian.net/browse/JB-14"}],
         "custom_tags": []}, {"id": 21462, "detector": {"name": "salesforce_oauth2",
         "display_name": "Salesforce Oauth2 Keys", "nature": "specific", "family":
         "credentials", "category": "crm", "detector_group_name": "salesforce_oauth2_keys",
@@ -87,7 +87,7 @@ interactions:
         "ignored_at": "2025-07-28T09:27:09.871747Z", "ignorer_id": 492181, "ignorer_api_token_id":
         null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
         "secret_revoked": false, "validity": "invalid", "severity": "high", "assignee_id":
-        10, "assignee_email": "bruce-wayne-gg@protonmail.com", "share_url": "[REDACTED]",
+        10, "assignee_email": "user-324427de@example.com", "share_url": "[REDACTED]",
         "feedback_list": [], "risk_score": 23, "severity_rule_id": 31, "is_vaulted":
         false, "ignore_reason": "invalid", "occurrences": null, "secret_presence":
         {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
@@ -123,7 +123,7 @@ interactions:
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         "2026-03-11T22:41:04.525493Z", "resolver_id": 492181, "resolver_api_token_id":
         null, "secret_revoked": true, "validity": "invalid", "severity": "high", "assignee_id":
-        10, "assignee_email": "bruce-wayne-gg@protonmail.com", "share_url": "[REDACTED]",
+        10, "assignee_email": "user-324427de@example.com", "share_url": "[REDACTED]",
         "feedback_list": [], "risk_score": 100, "severity_rule_id": 28, "is_vaulted":
         false, "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
         0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
@@ -131,7 +131,7 @@ interactions:
         "https://dashboard.gitguardian.com/workspace/8/incidents/21464", "tags": ["PUBLICLY_LEAKED",
         "REVOCABLE_BY_GG"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [{"id": "AEF-2326", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-2326"}],
+        "destination_tickets": [{"id": "AEF-2326", "type": "jira_cloud", "link": "https://tenant-b6250acd.atlassian.net/browse/AEF-2326"}],
         "custom_tags": []}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/client/vcr/test_list_incidents_with_ordering.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_with_ordering.yaml
@@ -57,7 +57,7 @@ interactions:
         "tags": ["DEFAULT_BRANCH"], "incident_name": "Generic Password", "public_exposure":
         {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
         false}, "destination_tickets": [{"id": "AEF-2792", "type": "jira_cloud", "link":
-        "https://yanne-gg-integration.atlassian.net/browse/AEF-2792"}], "custom_tags":
+        "https://tenant-b6250acd.atlassian.net/browse/AEF-2792"}], "custom_tags":
         []}, {"id": 34181686, "detector": {"name": "microsoft_azure_storage_connection_string",
         "display_name": "Microsoft Azure Storage Connection String", "nature": "specific",
         "family": "credentials", "category": "cloud_provider", "detector_group_name":
@@ -95,7 +95,7 @@ interactions:
         "tags": ["DEFAULT_BRANCH"], "incident_name": "Generic Password", "public_exposure":
         {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
         false}, "destination_tickets": [{"id": "AEF-2791", "type": "jira_cloud", "link":
-        "https://yanne-gg-integration.atlassian.net/browse/AEF-2791"}], "custom_tags":
+        "https://tenant-b6250acd.atlassian.net/browse/AEF-2791"}], "custom_tags":
         []}, {"id": 34038186, "detector": {"name": "microsoft_azure_storage_connection_string",
         "display_name": "Microsoft Azure Storage Connection String", "nature": "specific",
         "family": "credentials", "category": "cloud_provider", "detector_group_name":

--- a/tests/cassettes/client/vcr/test_list_incidents_with_severity_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_with_severity_filter.yaml
@@ -30,9 +30,9 @@ interactions:
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "critical", "assignee_id": 270722,
-        "assignee_email": "clement.tourriere@gitguardian.com", "share_url": "[REDACTED]",
+        "assignee_email": "user-4278f7fb@example.com", "share_url": "[REDACTED]",
         "feedback_list": [{"created_at": "2024-06-28T07:01:19.458759Z", "updated_at":
-        "2024-06-28T07:01:19.458771Z", "email": "lucius@protonmal.com", "member_id":
+        "2024-06-28T07:01:19.458771Z", "email": "user-e2de71a9@example.com", "member_id":
         null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
         "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
         "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
@@ -47,8 +47,8 @@ interactions:
         "https://dashboard.gitguardian.com/workspace/8/incidents/21461", "tags": ["PUBLICLY_LEAKED"],
         "incident_name": "DSA Private Key", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-15"},
-        {"id": "JB-14", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-14"}],
+        "destination_tickets": [{"id": "JB-15", "type": "jira_cloud", "link": "https://tenant-e47c06f3.atlassian.net/browse/JB-15"},
+        {"id": "JB-14", "type": "jira_cloud", "link": "https://tenant-e47c06f3.atlassian.net/browse/JB-14"}],
         "custom_tags": []}, {"id": 21467, "detector": {"name": "newrelic_apm_license_key",
         "display_name": "New Relic APM License Key", "nature": "specific", "family":
         "token", "category": "monitoring", "detector_group_name": "newrelic_apm_license_key",

--- a/tests/cassettes/client/vcr/test_list_incidents_with_status_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_incidents_with_status_filter.yaml
@@ -105,23 +105,23 @@ interactions:
         false, "validity": "failed_to_check", "severity": "critical", "assignee_id":
         null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
         [{"created_at": "2024-10-27T19:07:31.647677Z", "updated_at": "2024-10-27T19:07:31.647687Z",
-        "email": "candidate.playground+1@gitguardian.com", "member_id": 582569, "answers":
-        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
-        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
-        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
-        given access to any sensitive information or services?", "boolean": true},
-        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
-        "field_label": "Additional remarks", "text": "Please take a look at this."}]}],
-        "risk_score": 57, "severity_rule_id": 11883, "is_vaulted": false, "ignore_reason":
-        null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
-        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
-        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21488", "tags": ["PUBLICLY_LEAKED",
-        "FROM_HISTORICAL_SCAN"], "incident_name": "OpenSSH Private Key", "public_exposure":
-        {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
-        false}, "destination_tickets": [{"id": "KAN-17", "type": "jira_cloud", "link":
-        "https://vboy.atlassian.net/browse/KAN-17"}], "custom_tags": []}]'
+        "email": "user-b5140a83@example.com", "member_id": 582569, "answers": [{"type":
+        "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is this an
+        actual secret?", "boolean": true}, {"type": "boolean", "field_ref": "access_to_sensitive_yes_no",
+        "field_label": "Does this secret give or has given access to any sensitive
+        information or services?", "boolean": true}, {"type": "boolean", "field_ref":
+        "revoked_yes_no", "field_label": "Has this secret been revoked?", "boolean":
+        false}, {"type": "text", "field_ref": "remarks_text", "field_label": "Additional
+        remarks", "text": "Please take a look at this."}]}], "risk_score": 57, "severity_rule_id":
+        11883, "is_vaulted": false, "ignore_reason": null, "occurrences": null, "secret_presence":
+        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
+        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
+        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21488",
+        "tags": ["PUBLICLY_LEAKED", "FROM_HISTORICAL_SCAN"], "incident_name": "OpenSSH
+        Private Key", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "destination_tickets": [{"id":
+        "KAN-17", "type": "jira_cloud", "link": "https://tenant-57893d51.atlassian.net/browse/KAN-17"}],
+        "custom_tags": []}]'
     headers:
       CF-RAY:
       - a10395291e7ecc0a-CDG

--- a/tests/cassettes/client/vcr/test_list_member_incidents.yaml
+++ b/tests/cassettes/client/vcr/test_list_member_incidents.yaml
@@ -99,9 +99,8 @@ interactions:
   response:
     body:
       string: '{"id": 480870, "role": "manager", "access_level": "manager", "email":
-        "timothe.delion@gitguardian.com", "name": "Timoth\u00e9 DELION", "created_at":
-        "2023-06-26T12:41:18.599497Z", "last_login": "2026-06-23T12:20:54.639679Z",
-        "active": true}'
+        "user-8e645c6e@example.com", "name": "User bb2e577e", "created_at": "2023-06-26T12:41:18.599497Z",
+        "last_login": "2026-06-23T12:20:54.639679Z", "active": true}'
     headers:
       CF-RAY:
       - a103972f5db63772-CDG
@@ -179,24 +178,24 @@ interactions:
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
         "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
         "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
-        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
-        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
-        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
-        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
-        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
-        given access to any sensitive information or services?", "boolean": true},
-        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
-        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
-        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
-        "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
-        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
-        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["PUBLICLY_LEAKED",
-        "REVOCABLE_BY_GG"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
+        "user-74281974@example.com", "share_url": "[REDACTED]", "feedback_list": [{"created_at":
+        "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "user-1a0bc62d@example.com", "member_id": null, "answers": [{"type":
+        "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is this an
+        actual secret?", "boolean": true}, {"type": "boolean", "field_ref": "access_to_sensitive_yes_no",
+        "field_label": "Does this secret give or has given access to any sensitive
+        information or services?", "boolean": true}, {"type": "boolean", "field_ref":
+        "revoked_yes_no", "field_label": "Has this secret been revoked?", "boolean":
+        false}, {"type": "text", "field_ref": "remarks_text", "field_label": "Additional
+        remarks", "text": "Hasn''t been revoked yet because X"}]}], "risk_score":
+        100, "severity_rule_id": null, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
+        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
+        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21460",
+        "tags": ["PUBLICLY_LEAKED", "REVOCABLE_BY_GG"], "incident_name": "AWS IAM
+        Keys", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "destination_tickets": [{"id":
+        "AEF-97", "type": "jira_cloud", "link": "https://tenant-b6250acd.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}, {"id": 21461, "detector": {"name": "private_key_dsa",
         "display_name": "DSA Private Key", "nature": "specific", "family": "cryptographic_key",
         "category": "private_key", "detector_group_name": "private_key_dsa", "detector_group_display_name":
@@ -207,9 +206,9 @@ interactions:
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "critical", "assignee_id": 270722,
-        "assignee_email": "clement.tourriere@gitguardian.com", "share_url": "[REDACTED]",
+        "assignee_email": "user-4278f7fb@example.com", "share_url": "[REDACTED]",
         "feedback_list": [{"created_at": "2024-06-28T07:01:19.458759Z", "updated_at":
-        "2024-06-28T07:01:19.458771Z", "email": "lucius@protonmal.com", "member_id":
+        "2024-06-28T07:01:19.458771Z", "email": "user-e2de71a9@example.com", "member_id":
         null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
         "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
         "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
@@ -224,8 +223,8 @@ interactions:
         "https://dashboard.gitguardian.com/workspace/8/incidents/21461", "tags": ["PUBLICLY_LEAKED"],
         "incident_name": "DSA Private Key", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [{"id": "JB-14", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-14"},
-        {"id": "JB-15", "type": "jira_cloud", "link": "https://sandboxgitguardian.atlassian.net/browse/JB-15"}],
+        "destination_tickets": [{"id": "JB-14", "type": "jira_cloud", "link": "https://tenant-e47c06f3.atlassian.net/browse/JB-14"},
+        {"id": "JB-15", "type": "jira_cloud", "link": "https://tenant-e47c06f3.atlassian.net/browse/JB-15"}],
         "custom_tags": []}, {"id": 21462, "detector": {"name": "salesforce_oauth2",
         "display_name": "Salesforce Oauth2 Keys", "nature": "specific", "family":
         "credentials", "category": "crm", "detector_group_name": "salesforce_oauth2_keys",
@@ -236,7 +235,7 @@ interactions:
         "ignored_at": "2025-07-28T09:27:09.871747Z", "ignorer_id": 492181, "ignorer_api_token_id":
         null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
         "secret_revoked": false, "validity": "invalid", "severity": "high", "assignee_id":
-        10, "assignee_email": "bruce-wayne-gg@protonmail.com", "share_url": "[REDACTED]",
+        10, "assignee_email": "user-324427de@example.com", "share_url": "[REDACTED]",
         "feedback_list": [], "risk_score": 23, "severity_rule_id": 31, "is_vaulted":
         false, "ignore_reason": "invalid", "occurrences": null, "secret_presence":
         {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
@@ -272,7 +271,7 @@ interactions:
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         "2026-03-11T22:41:04.525493Z", "resolver_id": 492181, "resolver_api_token_id":
         null, "secret_revoked": true, "validity": "invalid", "severity": "high", "assignee_id":
-        10, "assignee_email": "bruce-wayne-gg@protonmail.com", "share_url": "[REDACTED]",
+        10, "assignee_email": "user-324427de@example.com", "share_url": "[REDACTED]",
         "feedback_list": [], "risk_score": 100, "severity_rule_id": 28, "is_vaulted":
         false, "ignore_reason": null, "occurrences": null, "secret_presence": {"files_requiring_code_fix":
         0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
@@ -280,7 +279,7 @@ interactions:
         "https://dashboard.gitguardian.com/workspace/8/incidents/21464", "tags": ["PUBLICLY_LEAKED",
         "REVOCABLE_BY_GG"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
         true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [{"id": "AEF-2326", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-2326"}],
+        "destination_tickets": [{"id": "AEF-2326", "type": "jira_cloud", "link": "https://tenant-b6250acd.atlassian.net/browse/AEF-2326"}],
         "custom_tags": []}, {"id": 21465, "detector": {"name": "salesforce_oauth2",
         "display_name": "Salesforce Oauth2 Keys", "nature": "specific", "family":
         "credentials", "category": "crm", "detector_group_name": "salesforce_oauth2_keys",
@@ -293,18 +292,18 @@ interactions:
         "secret_revoked": false, "validity": "invalid", "severity": "high", "assignee_id":
         null, "assignee_email": null, "share_url": "[REDACTED]", "feedback_list":
         [{"created_at": "2023-05-26T11:34:39.007461Z", "updated_at": "2023-05-26T11:34:39.007478Z",
-        "email": "helene.hartmann@gitguardian.com", "member_id": null, "answers":
-        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
-        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
-        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
-        given access to any sensitive information or services?", "boolean": true},
-        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": true}, {"type": "text", "field_ref": "remarks_text",
-        "field_label": "Additional remarks", "text": "my bad"}]}], "risk_score": 23,
-        "severity_rule_id": 8220, "is_vaulted": false, "ignore_reason": "invalid",
-        "occurrences": null, "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
-        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
-        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21465",
+        "email": "user-ef593bab@example.com", "member_id": null, "answers": [{"type":
+        "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is this an
+        actual secret?", "boolean": true}, {"type": "boolean", "field_ref": "access_to_sensitive_yes_no",
+        "field_label": "Does this secret give or has given access to any sensitive
+        information or services?", "boolean": true}, {"type": "boolean", "field_ref":
+        "revoked_yes_no", "field_label": "Has this secret been revoked?", "boolean":
+        true}, {"type": "text", "field_ref": "remarks_text", "field_label": "Additional
+        remarks", "text": "my bad"}]}], "risk_score": 23, "severity_rule_id": 8220,
+        "is_vaulted": false, "ignore_reason": "invalid", "occurrences": null, "secret_presence":
+        {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
+        "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
+        2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21465",
         "tags": ["PUBLICLY_LEAKED"], "incident_name": "Salesforce Oauth2 Keys", "public_exposure":
         {"source_publicly_visible": true, "public_incident_linked": false, "leaked_outside_perimeter":
         false}, "destination_tickets": [], "custom_tags": []}, {"id": 21466, "detector":
@@ -355,7 +354,7 @@ interactions:
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [{"created_at": "2023-03-31T09:17:59.282371Z",
-        "updated_at": "2023-03-31T09:17:59.282384Z", "email": "mackenzie.jackson@gitguardian.com",
+        "updated_at": "2023-03-31T09:17:59.282384Z", "email": "user-dbf97dd3@example.com",
         "member_id": null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
         "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
         "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
@@ -418,7 +417,7 @@ interactions:
         "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
         "validity": "invalid", "severity": "high", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [{"created_at": "2022-07-05T18:00:41.598862Z",
-        "updated_at": "2022-07-05T18:00:41.599096Z", "email": "mackenzie.jackson@gitguardian.com",
+        "updated_at": "2022-07-05T18:00:41.599096Z", "email": "user-dbf97dd3@example.com",
         "member_id": null, "answers": [{"type": "boolean", "field_ref": "actual_secret_yes_no",
         "field_label": "Is this an actual secret?", "boolean": true}, {"type": "boolean",
         "field_ref": "access_to_sensitive_yes_no", "field_label": "Does this secret
@@ -427,7 +426,7 @@ interactions:
         this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
         "remarks_text", "field_label": "Additional remarks", "text": "Notes"}]}, {"created_at":
         "2023-06-26T12:44:52.641388Z", "updated_at": "2023-06-26T12:44:52.641404Z",
-        "email": "aymeric.sicard@gitguardian.com", "member_id": 13, "answers": [{"type":
+        "email": "user-71ab73d0@example.com", "member_id": 13, "answers": [{"type":
         "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is this an
         actual secret?", "boolean": true}, {"type": "boolean", "field_ref": "access_to_sensitive_yes_no",
         "field_label": "Does this secret give or has given access to any sensitive

--- a/tests/cassettes/client/vcr/test_list_members.yaml
+++ b/tests/cassettes/client/vcr/test_list_members.yaml
@@ -21,20 +21,20 @@ interactions:
   response:
     body:
       string: '[{"id": 10, "role": "manager", "access_level": "manager", "email":
-        "bruce-wayne-gg@protonmail.com", "name": "Bruce Wayne", "created_at": "2020-01-15T15:07:36.510559Z",
+        "user-324427de@example.com", "name": "User 2b03ad68", "created_at": "2020-01-15T15:07:36.510559Z",
         "last_login": "2020-09-30T12:21:19.319487Z", "active": true}, {"id": 13, "role":
-        "manager", "access_level": "manager", "email": "aymeric.sicard@gitguardian.com",
-        "name": "Aymeric SICARD", "created_at": "2020-01-21T09:35:47.907207Z", "last_login":
+        "manager", "access_level": "manager", "email": "user-71ab73d0@example.com",
+        "name": "User d0d18d7e", "created_at": "2020-01-21T09:35:47.907207Z", "last_login":
         "2026-06-22T14:20:46.680540Z", "active": true}, {"id": 2508, "role": "manager",
-        "access_level": "manager", "email": "guillaume.charpiat@gitguardian.com",
-        "name": "Guillaume CHARPIAT", "created_at": "2020-03-23T17:53:57.158457Z",
-        "last_login": "2026-06-10T11:29:54.420261Z", "active": true}, {"id": 37699,
-        "role": "manager", "access_level": "manager", "email": "alexis.larnaud@gitguardian.com",
-        "name": "Alexis LARNAUD", "created_at": "2020-09-03T11:16:05.980606Z", "last_login":
-        "2026-06-22T09:33:43.124144Z", "active": true}, {"id": 63809, "role": "manager",
-        "access_level": "manager", "email": "orian.roturier@gitguardian.com", "name":
-        "Orian ROTURIER", "created_at": "2020-11-25T14:01:01.749542Z", "last_login":
-        "2025-08-05T08:47:38.723615Z", "active": true}]'
+        "access_level": "manager", "email": "user-d9f863cd@example.com", "name": "User
+        793501dc", "created_at": "2020-03-23T17:53:57.158457Z", "last_login": "2026-06-10T11:29:54.420261Z",
+        "active": true}, {"id": 37699, "role": "manager", "access_level": "manager",
+        "email": "user-d3774a22@example.com", "name": "User 40f52996", "created_at":
+        "2020-09-03T11:16:05.980606Z", "last_login": "2026-06-22T09:33:43.124144Z",
+        "active": true}, {"id": 63809, "role": "manager", "access_level": "manager",
+        "email": "user-0222ba7e@example.com", "name": "User 97a9750c", "created_at":
+        "2020-11-25T14:01:01.749542Z", "last_login": "2025-08-05T08:47:38.723615Z",
+        "active": true}]'
     headers:
       CF-RAY:
       - a103973b4e4103f1-CDG

--- a/tests/cassettes/client/vcr/test_list_occurrences_basic.yaml
+++ b/tests/cassettes/client/vcr/test_list_occurrences_basic.yaml
@@ -26,10 +26,10 @@ interactions:
         3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}, {"name":
         "client_secret", "indice_start": 85, "indice_end": 125, "pre_line_start":
         4, "pre_line_end": 4, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion", "source":
+        {"id": 12349, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
@@ -39,7 +39,7 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78198,
         "incident_id": 21460, "date": "2020-10-29T13:19:59.005564Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
@@ -47,10 +47,10 @@ interactions:
         null, "post_line_start": 3, "post_line_end": 3}, {"name": "client_secret",
         "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition", "source":
+        {"id": 12349, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
@@ -60,16 +60,16 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78199,
         "incident_id": 21461, "date": "2020-10-29T10:19:39.723768Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
         "indice_start": 48, "indice_end": 726, "pre_line_start": 3, "pre_line_end":
         14, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "333db3e12b3f863ebb02cac6f232fc44e4f46533", "change_type": "deletion",
-        "source": {"id": 12320, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-09",
+        "url": "https://github.com/ns-80126292/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "333db3e12b3f863ebb02cac6f232fc44e4f46533", "change_type": "deletion", "source":
+        {"id": 12320, "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-09",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
@@ -79,16 +79,16 @@ interactions:
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-09",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78200,
         "incident_id": 21461, "date": "2020-10-29T09:19:54.249454Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
         "indice_start": 91, "indice_end": 769, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 14}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "76dd4f31a31c78a151723031bfebff4d076751b2", "change_type": "addition",
-        "source": {"id": 12320, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-09",
+        "url": "https://github.com/ns-80126292/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "76dd4f31a31c78a151723031bfebff4d076751b2", "change_type": "addition", "source":
+        {"id": 12320, "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-09",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
@@ -98,7 +98,7 @@ interactions:
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-09",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78201,
         "incident_id": 21462, "date": "2020-10-29T08:19:34.987039Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
@@ -106,10 +106,10 @@ interactions:
         3, "post_line_start": null, "post_line_end": null}, {"name": "client_secret",
         "indice_start": 150, "indice_end": 169, "pre_line_start": 4, "pre_line_end":
         4, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08/commit/970509ea87f9913d362d727ac4d178ac4332719a#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "970509ea87f9913d362d727ac4d178ac4332719a", "change_type": "deletion",
-        "source": {"id": 12297, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-08",
+        "url": "https://github.com/ns-80126292/private-gg-2020-08/commit/970509ea87f9913d362d727ac4d178ac4332719a#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "970509ea87f9913d362d727ac4d178ac4332719a", "change_type": "deletion", "source":
+        {"id": 12297, "type": "github", "full_name": "ns-80126292/private-gg-2020-08",
         "health": "safe", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         11, "last_scan": {"date": "2020-09-24T09:06:39.261262Z", "status": "finished",
@@ -119,7 +119,7 @@ interactions:
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 11, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-2020-08",
         "provider_metadata": {"archived": false}, "deleted": false}}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/client/vcr/test_list_occurrences_get_all.yaml
+++ b/tests/cassettes/client/vcr/test_list_occurrences_get_all.yaml
@@ -26,10 +26,10 @@ interactions:
         3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}, {"name":
         "client_secret", "indice_start": 85, "indice_end": 125, "pre_line_start":
         4, "pre_line_end": 4, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion", "source":
+        {"id": 12349, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
@@ -39,7 +39,7 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78198,
         "incident_id": 21460, "date": "2020-10-29T13:19:59.005564Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
@@ -47,10 +47,10 @@ interactions:
         null, "post_line_start": 3, "post_line_end": 3}, {"name": "client_secret",
         "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition", "source":
+        {"id": 12349, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
@@ -60,16 +60,16 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78199,
         "incident_id": 21461, "date": "2020-10-29T10:19:39.723768Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
         "indice_start": 48, "indice_end": 726, "pre_line_start": 3, "pre_line_end":
         14, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "333db3e12b3f863ebb02cac6f232fc44e4f46533", "change_type": "deletion",
-        "source": {"id": 12320, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-09",
+        "url": "https://github.com/ns-80126292/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "333db3e12b3f863ebb02cac6f232fc44e4f46533", "change_type": "deletion", "source":
+        {"id": 12320, "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-09",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
@@ -79,16 +79,16 @@ interactions:
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-09",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78200,
         "incident_id": 21461, "date": "2020-10-29T09:19:54.249454Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
         "indice_start": 91, "indice_end": 769, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 14}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "76dd4f31a31c78a151723031bfebff4d076751b2", "change_type": "addition",
-        "source": {"id": 12320, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-09",
+        "url": "https://github.com/ns-80126292/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "76dd4f31a31c78a151723031bfebff4d076751b2", "change_type": "addition", "source":
+        {"id": 12320, "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-09",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
@@ -98,7 +98,7 @@ interactions:
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-09",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78201,
         "incident_id": 21462, "date": "2020-10-29T08:19:34.987039Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
@@ -106,10 +106,10 @@ interactions:
         3, "post_line_start": null, "post_line_end": null}, {"name": "client_secret",
         "indice_start": 150, "indice_end": 169, "pre_line_start": 4, "pre_line_end":
         4, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08/commit/970509ea87f9913d362d727ac4d178ac4332719a#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "970509ea87f9913d362d727ac4d178ac4332719a", "change_type": "deletion",
-        "source": {"id": 12297, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-08",
+        "url": "https://github.com/ns-80126292/private-gg-2020-08/commit/970509ea87f9913d362d727ac4d178ac4332719a#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "970509ea87f9913d362d727ac4d178ac4332719a", "change_type": "deletion", "source":
+        {"id": 12297, "type": "github", "full_name": "ns-80126292/private-gg-2020-08",
         "health": "safe", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         11, "last_scan": {"date": "2020-09-24T09:06:39.261262Z", "status": "finished",
@@ -119,7 +119,7 @@ interactions:
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 11, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-2020-08",
         "provider_metadata": {"archived": false}, "deleted": false}}]'
     headers:
       CF-RAY:
@@ -199,10 +199,10 @@ interactions:
         null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 3}, {"name":
         "client_secret", "indice_start": 193, "indice_end": 212, "pre_line_start":
         null, "pre_line_end": null, "post_line_start": 4, "post_line_end": 4}], "tags":
-        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08/commit/d6b8ebd08ddbc7c02353c60beaa287e0262afd2e#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "d6b8ebd08ddbc7c02353c60beaa287e0262afd2e", "change_type": "addition",
-        "source": {"id": 12297, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-08",
+        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/ns-80126292/private-gg-2020-08/commit/d6b8ebd08ddbc7c02353c60beaa287e0262afd2e#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "d6b8ebd08ddbc7c02353c60beaa287e0262afd2e", "change_type": "addition", "source":
+        {"id": 12297, "type": "github", "full_name": "ns-80126292/private-gg-2020-08",
         "health": "safe", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         11, "last_scan": {"date": "2020-09-24T09:06:39.261262Z", "status": "finished",
@@ -212,16 +212,16 @@ interactions:
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 11, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-2020-08",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78203,
         "incident_id": 21463, "date": "2020-10-29T06:20:19.846592Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
         "indice_start": 48, "indice_end": 1842, "pre_line_start": 3, "pre_line_end":
         32, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-10/commit/65563d9586ec109e098c952559204dbb54e88d6f#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "65563d9586ec109e098c952559204dbb54e88d6f", "change_type": "deletion",
-        "source": {"id": 12308, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-10",
+        "PUBLIC"], "url": "https://github.com/ns-80126292/private-gg-2020-10/commit/65563d9586ec109e098c952559204dbb54e88d6f#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "65563d9586ec109e098c952559204dbb54e88d6f", "change_type": "deletion", "source":
+        {"id": 12308, "type": "github", "full_name": "ns-80126292/private-gg-2020-10",
         "health": "safe", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         9, "last_scan": {"date": "2020-12-10T10:45:12.767631Z", "status": "finished",
@@ -231,16 +231,16 @@ interactions:
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78204,
         "incident_id": 21463, "date": "2020-10-29T06:20:15.521071Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
         "indice_start": 91, "indice_end": 1885, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 32}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-10/commit/35a6a3b548c4bf220b347f2bcb0be46f3692d35d#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "35a6a3b548c4bf220b347f2bcb0be46f3692d35d", "change_type": "addition",
-        "source": {"id": 12308, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-10",
+        "PUBLIC"], "url": "https://github.com/ns-80126292/private-gg-2020-10/commit/35a6a3b548c4bf220b347f2bcb0be46f3692d35d#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "35a6a3b548c4bf220b347f2bcb0be46f3692d35d", "change_type": "addition", "source":
+        {"id": 12308, "type": "github", "full_name": "ns-80126292/private-gg-2020-10",
         "health": "safe", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         9, "last_scan": {"date": "2020-12-10T10:45:12.767631Z", "status": "finished",
@@ -250,7 +250,7 @@ interactions:
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78205,
         "incident_id": 21464, "date": "2020-10-29T04:20:15.661229Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
@@ -258,10 +258,10 @@ interactions:
         3, "post_line_start": null, "post_line_end": null}, {"name": "client_secret",
         "indice_start": 85, "indice_end": 125, "pre_line_start": 4, "pre_line_end":
         4, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-09/commit/793c4aa24d43972b28661fbbb8ce7ad857abd822#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "793c4aa24d43972b28661fbbb8ce7ad857abd822", "change_type": "deletion",
-        "source": {"id": 12345, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-09",
+        "PUBLIC"], "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-09/commit/793c4aa24d43972b28661fbbb8ce7ad857abd822#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "793c4aa24d43972b28661fbbb8ce7ad857abd822", "change_type": "deletion", "source":
+        {"id": 12345, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-09",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         7, "last_scan": {"date": "2020-12-10T10:45:12.792423Z", "status": "finished",
@@ -271,7 +271,7 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 7, "severity_breakdown": {"critical": 0, "high": 7, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-09",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-09",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78206,
         "incident_id": 21464, "date": "2020-10-29T04:19:56.388169Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
@@ -279,10 +279,10 @@ interactions:
         null, "post_line_start": 3, "post_line_end": 3}, {"name": "client_secret",
         "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-09/commit/643bdce69ff4517e60c383e1a81d7d74244981a1#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "643bdce69ff4517e60c383e1a81d7d74244981a1", "change_type": "addition",
-        "source": {"id": 12345, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-09",
+        "PUBLIC"], "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-09/commit/643bdce69ff4517e60c383e1a81d7d74244981a1#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "643bdce69ff4517e60c383e1a81d7d74244981a1", "change_type": "addition", "source":
+        {"id": 12345, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-09",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         7, "last_scan": {"date": "2020-12-10T10:45:12.792423Z", "status": "finished",
@@ -292,7 +292,7 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 7, "severity_breakdown": {"critical": 0, "high": 7, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-09",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-09",
         "provider_metadata": {"archived": false}, "deleted": false}}]'
     headers:
       CF-RAY:
@@ -373,10 +373,10 @@ interactions:
         3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}, {"name":
         "client_secret", "indice_start": 150, "indice_end": 169, "pre_line_start":
         4, "pre_line_end": 4, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-08/commit/ba6dee25b5c0196a9b4f4dc043413cfac77075e1#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "ba6dee25b5c0196a9b4f4dc043413cfac77075e1", "change_type": "deletion",
-        "source": {"id": 12275, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-08",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/ns-80126292/private-gg-bis-2020-08/commit/ba6dee25b5c0196a9b4f4dc043413cfac77075e1#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "ba6dee25b5c0196a9b4f4dc043413cfac77075e1", "change_type": "deletion", "source":
+        {"id": 12275, "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-08",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
         9, "last_scan": {"date": "2020-09-24T09:06:39.215897Z", "status": "finished",
@@ -386,7 +386,7 @@ interactions:
         {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
         1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-08",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-08",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78208,
         "incident_id": 21465, "date": "2020-10-28T21:20:05.533072Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
@@ -394,10 +394,10 @@ interactions:
         null, "post_line_start": 3, "post_line_end": 3}, {"name": "client_secret",
         "indice_start": 193, "indice_end": 212, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
-        "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-08/commit/2504a69e99e482a8be9ce5afb1328380416a62e4#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "2504a69e99e482a8be9ce5afb1328380416a62e4", "change_type": "addition",
-        "source": {"id": 12275, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-08",
+        "url": "https://github.com/ns-80126292/private-gg-bis-2020-08/commit/2504a69e99e482a8be9ce5afb1328380416a62e4#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "2504a69e99e482a8be9ce5afb1328380416a62e4", "change_type": "addition", "source":
+        {"id": 12275, "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-08",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
         9, "last_scan": {"date": "2020-09-24T09:06:39.215897Z", "status": "finished",
@@ -407,16 +407,16 @@ interactions:
         {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
         1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-08",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-08",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78209,
         "incident_id": 21466, "date": "2020-10-26T16:19:46.771637Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
         "indice_start": 46, "indice_end": 93, "pre_line_start": 3, "pre_line_end":
         3, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/da411b85bedcf9e3e3b5ade00f14649a449f2618#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "da411b85bedcf9e3e3b5ade00f14649a449f2618", "change_type": "deletion",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/da411b85bedcf9e3e3b5ade00f14649a449f2618#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "da411b85bedcf9e3e3b5ade00f14649a449f2618", "change_type": "deletion", "source":
+        {"id": 12349, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
@@ -426,16 +426,16 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78210,
         "incident_id": 21467, "date": "2020-10-26T16:19:44.303499Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
         "indice_start": 46, "indice_end": 86, "pre_line_start": 3, "pre_line_end":
         3, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-10/commit/a18096b36e00c74db6878ad3acb9221e27539b14#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "a18096b36e00c74db6878ad3acb9221e27539b14", "change_type": "deletion",
-        "source": {"id": 12350, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-2020-10",
+        "url": "https://github.com/ns-80126292/public-app-gg-2020-10/commit/a18096b36e00c74db6878ad3acb9221e27539b14#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "a18096b36e00c74db6878ad3acb9221e27539b14", "change_type": "deletion", "source":
+        {"id": 12350, "type": "github", "full_name": "ns-80126292/public-app-gg-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         8, "last_scan": {"date": "2020-12-29T16:39:57.616455Z", "status": "finished",
@@ -445,16 +445,16 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 8, "severity_breakdown": {"critical": 0, "high": 8, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78211,
         "incident_id": 21466, "date": "2020-10-26T15:19:37.812603Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
         "indice_start": 89, "indice_end": 136, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 3}], "tags": ["PUBLIC", "PUBLICLY_EXPOSED"],
-        "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/003d71fe8b183c4038bd1666cf30fd16c2f57dc5#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "003d71fe8b183c4038bd1666cf30fd16c2f57dc5", "change_type": "addition",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/003d71fe8b183c4038bd1666cf30fd16c2f57dc5#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "003d71fe8b183c4038bd1666cf30fd16c2f57dc5", "change_type": "addition", "source":
+        {"id": 12349, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
@@ -464,7 +464,7 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/client/vcr/test_list_occurrences_with_date_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_occurrences_with_date_filter.yaml
@@ -26,10 +26,10 @@ interactions:
         3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}, {"name":
         "client_secret", "indice_start": 85, "indice_end": 125, "pre_line_start":
         4, "pre_line_end": 4, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion", "source":
+        {"id": 12349, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
@@ -39,7 +39,7 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78198,
         "incident_id": 21460, "date": "2020-10-29T13:19:59.005564Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
@@ -47,10 +47,10 @@ interactions:
         null, "post_line_start": 3, "post_line_end": 3}, {"name": "client_secret",
         "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "PUBLIC"], "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition", "source":
+        {"id": 12349, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
@@ -60,16 +60,16 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78199,
         "incident_id": 21461, "date": "2020-10-29T10:19:39.723768Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
         "indice_start": 48, "indice_end": 726, "pre_line_start": 3, "pre_line_end":
         14, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "333db3e12b3f863ebb02cac6f232fc44e4f46533", "change_type": "deletion",
-        "source": {"id": 12320, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-09",
+        "PUBLIC"], "url": "https://github.com/ns-80126292/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "333db3e12b3f863ebb02cac6f232fc44e4f46533", "change_type": "deletion", "source":
+        {"id": 12320, "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-09",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
@@ -79,16 +79,16 @@ interactions:
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-09",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78200,
         "incident_id": 21461, "date": "2020-10-29T09:19:54.249454Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
         "indice_start": 91, "indice_end": 769, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 14}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "76dd4f31a31c78a151723031bfebff4d076751b2", "change_type": "addition",
-        "source": {"id": 12320, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-09",
+        "PUBLIC"], "url": "https://github.com/ns-80126292/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "76dd4f31a31c78a151723031bfebff4d076751b2", "change_type": "addition", "source":
+        {"id": 12320, "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-09",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
@@ -98,7 +98,7 @@ interactions:
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-09",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78201,
         "incident_id": 21462, "date": "2020-10-29T08:19:34.987039Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
@@ -106,10 +106,10 @@ interactions:
         3, "post_line_start": null, "post_line_end": null}, {"name": "client_secret",
         "indice_start": 150, "indice_end": 169, "pre_line_start": 4, "pre_line_end":
         4, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08/commit/970509ea87f9913d362d727ac4d178ac4332719a#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "970509ea87f9913d362d727ac4d178ac4332719a", "change_type": "deletion",
-        "source": {"id": 12297, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-08",
+        "PUBLIC"], "url": "https://github.com/ns-80126292/private-gg-2020-08/commit/970509ea87f9913d362d727ac4d178ac4332719a#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "970509ea87f9913d362d727ac4d178ac4332719a", "change_type": "deletion", "source":
+        {"id": 12297, "type": "github", "full_name": "ns-80126292/private-gg-2020-08",
         "health": "safe", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         11, "last_scan": {"date": "2020-09-24T09:06:39.261262Z", "status": "finished",
@@ -119,7 +119,7 @@ interactions:
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 11, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-2020-08",
         "provider_metadata": {"archived": false}, "deleted": false}}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/client/vcr/test_list_occurrences_with_member_assignee_id.yaml
+++ b/tests/cassettes/client/vcr/test_list_occurrences_with_member_assignee_id.yaml
@@ -99,9 +99,8 @@ interactions:
   response:
     body:
       string: '{"id": 480870, "role": "manager", "access_level": "manager", "email":
-        "timothe.delion@gitguardian.com", "name": "Timoth\u00e9 DELION", "created_at":
-        "2023-06-26T12:41:18.599497Z", "last_login": "2026-06-23T12:20:54.639679Z",
-        "active": true}'
+        "user-8e645c6e@example.com", "name": "User bb2e577e", "created_at": "2023-06-26T12:41:18.599497Z",
+        "last_login": "2026-06-23T12:20:54.639679Z", "active": true}'
     headers:
       CF-RAY:
       - a1039608bfbd11f4-CDG
@@ -175,10 +174,10 @@ interactions:
         3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}, {"name":
         "client_secret", "indice_start": 85, "indice_end": 125, "pre_line_start":
         4, "pre_line_end": 4, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion", "source":
+        {"id": 12349, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
@@ -188,7 +187,7 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78198,
         "incident_id": 21460, "date": "2020-10-29T13:19:59.005564Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
@@ -196,10 +195,10 @@ interactions:
         null, "post_line_start": 3, "post_line_end": 3}, {"name": "client_secret",
         "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "PUBLIC"], "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition", "source":
+        {"id": 12349, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
@@ -209,16 +208,16 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78199,
         "incident_id": 21461, "date": "2020-10-29T10:19:39.723768Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
         "indice_start": 48, "indice_end": 726, "pre_line_start": 3, "pre_line_end":
         14, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "333db3e12b3f863ebb02cac6f232fc44e4f46533", "change_type": "deletion",
-        "source": {"id": 12320, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-09",
+        "PUBLIC"], "url": "https://github.com/ns-80126292/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "333db3e12b3f863ebb02cac6f232fc44e4f46533", "change_type": "deletion", "source":
+        {"id": 12320, "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-09",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
@@ -228,16 +227,16 @@ interactions:
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-09",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78200,
         "incident_id": 21461, "date": "2020-10-29T09:19:54.249454Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
         "indice_start": 91, "indice_end": 769, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 14}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "76dd4f31a31c78a151723031bfebff4d076751b2", "change_type": "addition",
-        "source": {"id": 12320, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-09",
+        "PUBLIC"], "url": "https://github.com/ns-80126292/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "76dd4f31a31c78a151723031bfebff4d076751b2", "change_type": "addition", "source":
+        {"id": 12320, "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-09",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
@@ -247,7 +246,7 @@ interactions:
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-09",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78201,
         "incident_id": 21462, "date": "2020-10-29T08:19:34.987039Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
@@ -255,10 +254,10 @@ interactions:
         3, "post_line_start": null, "post_line_end": null}, {"name": "client_secret",
         "indice_start": 150, "indice_end": 169, "pre_line_start": 4, "pre_line_end":
         4, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08/commit/970509ea87f9913d362d727ac4d178ac4332719a#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "970509ea87f9913d362d727ac4d178ac4332719a", "change_type": "deletion",
-        "source": {"id": 12297, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-08",
+        "PUBLIC"], "url": "https://github.com/ns-80126292/private-gg-2020-08/commit/970509ea87f9913d362d727ac4d178ac4332719a#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "970509ea87f9913d362d727ac4d178ac4332719a", "change_type": "deletion", "source":
+        {"id": 12297, "type": "github", "full_name": "ns-80126292/private-gg-2020-08",
         "health": "safe", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         11, "last_scan": {"date": "2020-09-24T09:06:39.261262Z", "status": "finished",
@@ -268,7 +267,7 @@ interactions:
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 11, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-2020-08",
         "provider_metadata": {"archived": false}, "deleted": false}}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/client/vcr/test_list_occurrences_with_presence_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_occurrences_with_presence_filter.yaml
@@ -24,10 +24,10 @@ interactions:
         "filepath": "perfume.rb", "kind": "realtime", "presence": "present", "matches":
         [{"name": "apikey", "indice_start": 43, "indice_end": 107, "pre_line_start":
         null, "pre_line_end": null, "post_line_start": 2, "post_line_end": 2}], "tags":
-        [], "url": "https://ghe.dev.gitguardian.com/my-testing-org/armani_code/commit/21e85fff4c6df92b43b2b886613e271ac9f952fc#diff-dc5b406fd39db8f08f10d865c326035fecda819f4b375022b242dc2dbfc6dea7R2",
-        "author_info": "noreply@ghe.dev.gitguardian.com", "author_name": "GitHub Enterprise",
+        [], "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-12b26c3e/commit/21e85fff4c6df92b43b2b886613e271ac9f952fc#diff-dc5b406fd39db8f08f10d865c326035fecda819f4b375022b242dc2dbfc6dea7R2",
+        "author_info": "user-263277f1@example.com", "author_name": "GitHub Enterprise",
         "sha": "21e85fff4c6df92b43b2b886613e271ac9f952fc", "change_type": "addition",
-        "source": {"id": 12264, "type": "github", "full_name": "my-testing-org/armani_code",
+        "source": {"id": 12264, "type": "github", "full_name": "ns-242f04fd/armani_code",
         "health": "safe", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         1, "last_scan": {"date": "2020-06-04T09:06:33.833273Z", "status": "finished",
@@ -37,83 +37,83 @@ interactions:
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/armani_code",
+        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-12b26c3e",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 79389,
         "incident_id": 21985, "date": "2020-01-16T13:19:57Z", "filepath": "app.py",
         "kind": "historical", "presence": "present", "matches": [{"name": "apikey",
         "indice_start": 46, "indice_end": 93, "pre_line_start": 3, "pre_line_end":
         3, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLIC", "FROM_HISTORICAL_SCAN",
-        "PUBLICLY_EXPOSED", "DEFAULT_BRANCH"], "url": "https://github.com/wayne-enterprises-gg/business-app/commit/ceb205b6eb487342c3a5fa931d480cbef12efeb2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "change_type": "deletion",
-        "source": {"id": 12364, "type": "github", "full_name": "wayne-enterprises-gg/business-app",
-        "health": "safe", "source_criticality": "medium", "default_branch": "master",
-        "default_branch_head": "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count":
-        0, "closed_incidents_count": 76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 1242, "duration":
-        "9.779904", "branches_scanned": 1, "progress": 100}, "monitored": true, "monitoring_status":
-        "active", "visibility": "public", "external_id": "217533545", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 76, "severity_breakdown": {"critical": 3, "high": 73, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/business-app",
+        "PUBLICLY_EXPOSED", "DEFAULT_BRANCH"], "url": "https://github.com/ns-80126292/business-app/commit/ceb205b6eb487342c3a5fa931d480cbef12efeb2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "change_type": "deletion", "source":
+        {"id": 12364, "type": "github", "full_name": "ns-80126292/business-app", "health":
+        "safe", "source_criticality": "medium", "default_branch": "master", "default_branch_head":
+        "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count": 0, "closed_incidents_count":
+        76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1242, "duration": "9.779904", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "active", "visibility":
+        "public", "external_id": "217533545", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        76, "severity_breakdown": {"critical": 3, "high": 73, "medium": 0, "low":
+        0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/business-app",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 79390,
         "incident_id": 21986, "date": "2020-01-16T12:19:38Z", "filepath": "app.py",
         "kind": "historical", "presence": "present", "matches": [{"name": "apikey",
         "indice_start": 46, "indice_end": 83, "pre_line_start": 3, "pre_line_end":
         3, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLIC", "FROM_HISTORICAL_SCAN",
-        "PUBLICLY_EXPOSED", "DEFAULT_BRANCH"], "url": "https://github.com/wayne-enterprises-gg/business-app/commit/6e2c8fceda3f185139cd95d0d6e9d71faf529048#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "6e2c8fceda3f185139cd95d0d6e9d71faf529048", "change_type": "deletion",
-        "source": {"id": 12364, "type": "github", "full_name": "wayne-enterprises-gg/business-app",
-        "health": "safe", "source_criticality": "medium", "default_branch": "master",
-        "default_branch_head": "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count":
-        0, "closed_incidents_count": 76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 1242, "duration":
-        "9.779904", "branches_scanned": 1, "progress": 100}, "monitored": true, "monitoring_status":
-        "active", "visibility": "public", "external_id": "217533545", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 76, "severity_breakdown": {"critical": 3, "high": 73, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/business-app",
+        "PUBLICLY_EXPOSED", "DEFAULT_BRANCH"], "url": "https://github.com/ns-80126292/business-app/commit/6e2c8fceda3f185139cd95d0d6e9d71faf529048#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "6e2c8fceda3f185139cd95d0d6e9d71faf529048", "change_type": "deletion", "source":
+        {"id": 12364, "type": "github", "full_name": "ns-80126292/business-app", "health":
+        "safe", "source_criticality": "medium", "default_branch": "master", "default_branch_head":
+        "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count": 0, "closed_incidents_count":
+        76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1242, "duration": "9.779904", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "active", "visibility":
+        "public", "external_id": "217533545", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        76, "severity_breakdown": {"critical": 3, "high": 73, "medium": 0, "low":
+        0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/business-app",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 79391,
         "incident_id": 21985, "date": "2020-01-16T12:19:38Z", "filepath": "app.py",
         "kind": "historical", "presence": "present", "matches": [{"name": "apikey",
         "indice_start": 92, "indice_end": 139, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 3}], "tags": ["PUBLIC", "FROM_HISTORICAL_SCAN",
-        "PUBLICLY_EXPOSED", "DEFAULT_BRANCH"], "url": "https://github.com/wayne-enterprises-gg/business-app/commit/6e2c8fceda3f185139cd95d0d6e9d71faf529048#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "6e2c8fceda3f185139cd95d0d6e9d71faf529048", "change_type": "addition",
-        "source": {"id": 12364, "type": "github", "full_name": "wayne-enterprises-gg/business-app",
-        "health": "safe", "source_criticality": "medium", "default_branch": "master",
-        "default_branch_head": "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count":
-        0, "closed_incidents_count": 76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 1242, "duration":
-        "9.779904", "branches_scanned": 1, "progress": 100}, "monitored": true, "monitoring_status":
-        "active", "visibility": "public", "external_id": "217533545", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 76, "severity_breakdown": {"critical": 3, "high": 73, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/business-app",
+        "PUBLICLY_EXPOSED", "DEFAULT_BRANCH"], "url": "https://github.com/ns-80126292/business-app/commit/6e2c8fceda3f185139cd95d0d6e9d71faf529048#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "6e2c8fceda3f185139cd95d0d6e9d71faf529048", "change_type": "addition", "source":
+        {"id": 12364, "type": "github", "full_name": "ns-80126292/business-app", "health":
+        "safe", "source_criticality": "medium", "default_branch": "master", "default_branch_head":
+        "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count": 0, "closed_incidents_count":
+        76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1242, "duration": "9.779904", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "active", "visibility":
+        "public", "external_id": "217533545", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        76, "severity_breakdown": {"critical": 3, "high": 73, "medium": 0, "low":
+        0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/business-app",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 79392,
         "incident_id": 21986, "date": "2020-01-16T11:19:36Z", "filepath": "app.py",
         "kind": "historical", "presence": "present", "matches": [{"name": "apikey",
         "indice_start": 89, "indice_end": 126, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 3}], "tags": ["PUBLIC", "FROM_HISTORICAL_SCAN",
-        "PUBLICLY_EXPOSED", "DEFAULT_BRANCH"], "url": "https://github.com/wayne-enterprises-gg/business-app/commit/c2f01354e84ba1f5a88a2feb9d2a09be28451316#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "c2f01354e84ba1f5a88a2feb9d2a09be28451316", "change_type": "addition",
-        "source": {"id": 12364, "type": "github", "full_name": "wayne-enterprises-gg/business-app",
-        "health": "safe", "source_criticality": "medium", "default_branch": "master",
-        "default_branch_head": "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count":
-        0, "closed_incidents_count": 76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z",
-        "status": "finished", "failing_reason": "", "commits_scanned": 1242, "duration":
-        "9.779904", "branches_scanned": 1, "progress": 100}, "monitored": true, "monitoring_status":
-        "active", "visibility": "public", "external_id": "217533545", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 76, "severity_breakdown": {"critical": 3, "high": 73, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/business-app",
+        "PUBLICLY_EXPOSED", "DEFAULT_BRANCH"], "url": "https://github.com/ns-80126292/business-app/commit/c2f01354e84ba1f5a88a2feb9d2a09be28451316#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "c2f01354e84ba1f5a88a2feb9d2a09be28451316", "change_type": "addition", "source":
+        {"id": 12364, "type": "github", "full_name": "ns-80126292/business-app", "health":
+        "safe", "source_criticality": "medium", "default_branch": "master", "default_branch_head":
+        "ceb205b6eb487342c3a5fa931d480cbef12efeb2", "open_incidents_count": 0, "closed_incidents_count":
+        76, "last_scan": {"date": "2025-10-09T16:45:43.352908Z", "status": "finished",
+        "failing_reason": "", "commits_scanned": 1242, "duration": "9.779904", "branches_scanned":
+        1, "progress": 100}, "monitored": true, "monitoring_status": "active", "visibility":
+        "public", "external_id": "217533545", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        76, "severity_breakdown": {"critical": 3, "high": 73, "medium": 0, "low":
+        0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/business-app",
         "provider_metadata": {"archived": false}, "deleted": false}}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/client/vcr/test_list_occurrences_with_sources.yaml
+++ b/tests/cassettes/client/vcr/test_list_occurrences_with_sources.yaml
@@ -26,10 +26,10 @@ interactions:
         3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}, {"name":
         "client_secret", "indice_start": 85, "indice_end": 125, "pre_line_start":
         4, "pre_line_end": 4, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion", "source":
+        {"id": 12349, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
@@ -39,7 +39,7 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78198,
         "incident_id": 21460, "date": "2020-10-29T13:19:59.005564Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
@@ -47,10 +47,10 @@ interactions:
         null, "post_line_start": 3, "post_line_end": 3}, {"name": "client_secret",
         "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "PUBLIC"], "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition", "source":
+        {"id": 12349, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
@@ -60,16 +60,16 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78199,
         "incident_id": 21461, "date": "2020-10-29T10:19:39.723768Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
         "indice_start": 48, "indice_end": 726, "pre_line_start": 3, "pre_line_end":
         14, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "333db3e12b3f863ebb02cac6f232fc44e4f46533", "change_type": "deletion",
-        "source": {"id": 12320, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-09",
+        "PUBLIC"], "url": "https://github.com/ns-80126292/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "333db3e12b3f863ebb02cac6f232fc44e4f46533", "change_type": "deletion", "source":
+        {"id": 12320, "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-09",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
@@ -79,16 +79,16 @@ interactions:
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-09",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78200,
         "incident_id": 21461, "date": "2020-10-29T09:19:54.249454Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "apikey",
         "indice_start": 91, "indice_end": 769, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 14}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "76dd4f31a31c78a151723031bfebff4d076751b2", "change_type": "addition",
-        "source": {"id": 12320, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-09",
+        "PUBLIC"], "url": "https://github.com/ns-80126292/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "76dd4f31a31c78a151723031bfebff4d076751b2", "change_type": "addition", "source":
+        {"id": 12320, "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-09",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
         13, "last_scan": {"date": "2020-12-10T10:45:12.775987Z", "status": "finished",
@@ -98,7 +98,7 @@ interactions:
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 13, "severity_breakdown": {"critical": 1, "high": 12, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-09",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78201,
         "incident_id": 21462, "date": "2020-10-29T08:19:34.987039Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
@@ -106,10 +106,10 @@ interactions:
         3, "post_line_start": null, "post_line_end": null}, {"name": "client_secret",
         "indice_start": 150, "indice_end": 169, "pre_line_start": 4, "pre_line_end":
         4, "post_line_start": null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08/commit/970509ea87f9913d362d727ac4d178ac4332719a#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "970509ea87f9913d362d727ac4d178ac4332719a", "change_type": "deletion",
-        "source": {"id": 12297, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-08",
+        "PUBLIC"], "url": "https://github.com/ns-80126292/private-gg-2020-08/commit/970509ea87f9913d362d727ac4d178ac4332719a#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "970509ea87f9913d362d727ac4d178ac4332719a", "change_type": "deletion", "source":
+        {"id": 12297, "type": "github", "full_name": "ns-80126292/private-gg-2020-08",
         "health": "safe", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         11, "last_scan": {"date": "2020-09-24T09:06:39.261262Z", "status": "finished",
@@ -119,7 +119,7 @@ interactions:
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 11, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-2020-08",
         "provider_metadata": {"archived": false}, "deleted": false}}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/client/vcr/test_list_public_incident_activity_logs.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incident_activity_logs.yaml
@@ -23,11 +23,11 @@ interactions:
       string: '[{"id": 3632, "member": null, "api_token_id": null, "created_at": "2025-01-07T18:59:16.484428Z",
         "updated_at": null, "content": {"type": "action", "content_key": "TRIGGER",
         "data": {"triggered_at": "2023-03-03T15:22:18+00:00"}}, "incident_id": 3759},
-        {"id": 5132786, "member": {"id": 480870, "name": "Timoth\u00e9 DELION", "email":
-        "timothe.delion@gitguardian.com", "access_level": "manager"}, "api_token_id":
-        "d0ca9877-641f-4c37-8857-c08e0ae148c4", "created_at": "2026-06-23T14:12:49.055117Z",
-        "updated_at": "2026-06-23T14:12:49.360819Z", "content": {"type": "note", "comment":
-        "Actor confirmed rotation"}, "incident_id": 3759}]'
+        {"id": 5132786, "member": {"id": 480870, "name": "User bb2e577e", "email":
+        "user-8e645c6e@example.com", "access_level": "manager"}, "api_token_id": "d0ca9877-641f-4c37-8857-c08e0ae148c4",
+        "created_at": "2026-06-23T14:12:49.055117Z", "updated_at": "2026-06-23T14:12:49.360819Z",
+        "content": {"type": "note", "comment": "Actor confirmed rotation"}, "incident_id":
+        3759}]'
     headers:
       CF-RAY:
       - a113f7bf6987ee96-CDG

--- a/tests/cassettes/client/vcr/test_list_public_incidents_multi_value_severity.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_multi_value_severity.yaml
@@ -75,15 +75,16 @@ interactions:
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "valid", "severity": "critical", "assignee_id": 1778296,
-        "assignee_email": "zeke@binion.io", "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2026-04-23T00:37:26.701645Z", "updated_at": "2026-04-23T00:37:26.701660Z",
-        "email": "zeke@binion.io", "member_id": 1778296, "answers": [{"type": "boolean",
-        "field_ref": "revoked_yes_no", "field_label": "Has this secret been revoked?",
-        "boolean": true}, {"type": "text", "field_ref": "remarks_text", "field_label":
-        "Additional remarks", "text": ""}]}], "risk_score": 27, "severity_rule_id":
-        11891, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/57",
-        "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "assignee_email": "user-9c0c34df@example.com", "share_url": "[REDACTED]",
+        "feedback_list": [{"created_at": "2026-04-23T00:37:26.701645Z", "updated_at":
+        "2026-04-23T00:37:26.701660Z", "email": "user-9c0c34df@example.com", "member_id":
+        1778296, "answers": [{"type": "boolean", "field_ref": "revoked_yes_no", "field_label":
+        "Has this secret been revoked?", "boolean": true}, {"type": "text", "field_ref":
+        "remarks_text", "field_label": "Additional remarks", "text": ""}]}], "risk_score":
+        27, "severity_rule_id": 11891, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/57", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
         "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
         "GitGuardian Test Token Checked"}, {"id": 59, "detector": {"name": "mysql_assignment",
         "display_name": "MySQL Credentials", "nature": "specific", "family": "identifiers",

--- a/tests/cassettes/client/vcr/test_list_public_incidents_multi_value_validity.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_multi_value_validity.yaml
@@ -104,15 +104,16 @@ interactions:
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "valid", "severity": "critical", "assignee_id": 1778296,
-        "assignee_email": "zeke@binion.io", "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2026-04-23T00:37:26.701645Z", "updated_at": "2026-04-23T00:37:26.701660Z",
-        "email": "zeke@binion.io", "member_id": 1778296, "answers": [{"type": "boolean",
-        "field_ref": "revoked_yes_no", "field_label": "Has this secret been revoked?",
-        "boolean": true}, {"type": "text", "field_ref": "remarks_text", "field_label":
-        "Additional remarks", "text": ""}]}], "risk_score": 27, "severity_rule_id":
-        11891, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/57",
-        "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "assignee_email": "user-9c0c34df@example.com", "share_url": "[REDACTED]",
+        "feedback_list": [{"created_at": "2026-04-23T00:37:26.701645Z", "updated_at":
+        "2026-04-23T00:37:26.701660Z", "email": "user-9c0c34df@example.com", "member_id":
+        1778296, "answers": [{"type": "boolean", "field_ref": "revoked_yes_no", "field_label":
+        "Has this secret been revoked?", "boolean": true}, {"type": "text", "field_ref":
+        "remarks_text", "field_label": "Additional remarks", "text": ""}]}], "risk_score":
+        27, "severity_rule_id": 11891, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/57", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
         "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
         "GitGuardian Test Token Checked"}, {"id": 59, "detector": {"name": "mysql_assignment",
         "display_name": "MySQL Credentials", "nature": "specific", "family": "identifiers",

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_assignee_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_assignee_filter.yaml
@@ -30,15 +30,16 @@ interactions:
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "valid", "severity": "critical", "assignee_id": 1778296,
-        "assignee_email": "zeke@binion.io", "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2026-04-23T00:37:26.701645Z", "updated_at": "2026-04-23T00:37:26.701660Z",
-        "email": "zeke@binion.io", "member_id": 1778296, "answers": [{"type": "boolean",
-        "field_ref": "revoked_yes_no", "field_label": "Has this secret been revoked?",
-        "boolean": true}, {"type": "text", "field_ref": "remarks_text", "field_label":
-        "Additional remarks", "text": ""}]}], "risk_score": 27, "severity_rule_id":
-        11891, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/57",
-        "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "assignee_email": "user-9c0c34df@example.com", "share_url": "[REDACTED]",
+        "feedback_list": [{"created_at": "2026-04-23T00:37:26.701645Z", "updated_at":
+        "2026-04-23T00:37:26.701660Z", "email": "user-9c0c34df@example.com", "member_id":
+        1778296, "answers": [{"type": "boolean", "field_ref": "revoked_yes_no", "field_label":
+        "Has this secret been revoked?", "boolean": true}, {"type": "text", "field_ref":
+        "remarks_text", "field_label": "Additional remarks", "text": ""}]}], "risk_score":
+        27, "severity_rule_id": 11891, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/57", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
         "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
         "GitGuardian Test Token Checked"}, {"id": 2816, "detector": {"name": "postgres_assignment_attached_port",
         "display_name": "PostgreSQL Credentials", "nature": "specific", "family":
@@ -50,7 +51,7 @@ interactions:
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "failed_to_check", "severity": "unknown", "assignee_id":
-        269050, "assignee_email": "achille.mascia@gitguardian.com", "share_url": "[REDACTED]",
+        269050, "assignee_email": "user-35a47503@example.com", "share_url": "[REDACTED]",
         "feedback_list": [], "risk_score": 84, "severity_rule_id": null, "is_vaulted":
         false, "declarative_secret_status": "active", "resolve_reason": null, "ignore_reason":
         null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/2816",
@@ -65,7 +66,7 @@ interactions:
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "no_checker", "severity": "unknown", "assignee_id": 795293,
-        "assignee_email": "yanne.bensafia@gitguardian.com", "share_url": "[REDACTED]",
+        "assignee_email": "user-e9005b71@example.com", "share_url": "[REDACTED]",
         "feedback_list": [], "risk_score": 53, "severity_rule_id": null, "is_vaulted":
         false, "declarative_secret_status": "active", "resolve_reason": null, "ignore_reason":
         null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1965689",
@@ -80,8 +81,8 @@ interactions:
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "invalid", "severity": "unknown", "assignee_id": 795293, "assignee_email":
-        "yanne.bensafia@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "user-e9005b71@example.com", "share_url": "[REDACTED]", "feedback_list": [],
+        "risk_score": 9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/2171929",
         "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -95,8 +96,8 @@ interactions:
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": null,
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "invalid", "severity": "unknown", "assignee_id": 795293, "assignee_email":
-        "yanne.bensafia@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
-        [], "risk_score": 9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "user-e9005b71@example.com", "share_url": "[REDACTED]", "feedback_list": [],
+        "risk_score": 9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
         "https://dashboard.gitguardian.com/workspace/8/public-incidents/2174697",
         "tags": [], "custom_tags": [], "destination_tickets": [], "incident_name":
@@ -182,15 +183,16 @@ interactions:
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "valid", "severity": "critical", "assignee_id": 1778296,
-        "assignee_email": "zeke@binion.io", "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2026-04-23T00:37:26.701645Z", "updated_at": "2026-04-23T00:37:26.701660Z",
-        "email": "zeke@binion.io", "member_id": 1778296, "answers": [{"type": "boolean",
-        "field_ref": "revoked_yes_no", "field_label": "Has this secret been revoked?",
-        "boolean": true}, {"type": "text", "field_ref": "remarks_text", "field_label":
-        "Additional remarks", "text": ""}]}], "risk_score": 27, "severity_rule_id":
-        11891, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/57",
-        "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "assignee_email": "user-9c0c34df@example.com", "share_url": "[REDACTED]",
+        "feedback_list": [{"created_at": "2026-04-23T00:37:26.701645Z", "updated_at":
+        "2026-04-23T00:37:26.701660Z", "email": "user-9c0c34df@example.com", "member_id":
+        1778296, "answers": [{"type": "boolean", "field_ref": "revoked_yes_no", "field_label":
+        "Has this secret been revoked?", "boolean": true}, {"type": "text", "field_ref":
+        "remarks_text", "field_label": "Additional remarks", "text": ""}]}], "risk_score":
+        27, "severity_rule_id": 11891, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/57", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
         "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
         "GitGuardian Test Token Checked"}]'
     headers:

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_feedback.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_feedback.yaml
@@ -30,15 +30,16 @@ interactions:
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "valid", "severity": "critical", "assignee_id": 1778296,
-        "assignee_email": "zeke@binion.io", "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2026-04-23T00:37:26.701645Z", "updated_at": "2026-04-23T00:37:26.701660Z",
-        "email": "zeke@binion.io", "member_id": 1778296, "answers": [{"type": "boolean",
-        "field_ref": "revoked_yes_no", "field_label": "Has this secret been revoked?",
-        "boolean": true}, {"type": "text", "field_ref": "remarks_text", "field_label":
-        "Additional remarks", "text": ""}]}], "risk_score": 27, "severity_rule_id":
-        11891, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/57",
-        "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "assignee_email": "user-9c0c34df@example.com", "share_url": "[REDACTED]",
+        "feedback_list": [{"created_at": "2026-04-23T00:37:26.701645Z", "updated_at":
+        "2026-04-23T00:37:26.701660Z", "email": "user-9c0c34df@example.com", "member_id":
+        1778296, "answers": [{"type": "boolean", "field_ref": "revoked_yes_no", "field_label":
+        "Has this secret been revoked?", "boolean": true}, {"type": "text", "field_ref":
+        "remarks_text", "field_label": "Additional remarks", "text": ""}]}], "risk_score":
+        27, "severity_rule_id": 11891, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/57", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
         "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
         "GitGuardian Test Token Checked"}, {"id": 6987, "detector": {"name": "aws_iam",
         "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",
@@ -51,7 +52,7 @@ interactions:
         "resolver_id": null, "resolver_api_token_id": null, "secret_revoked": false,
         "validity": "valid", "severity": "critical", "assignee_id": null, "assignee_email":
         null, "share_url": "[REDACTED]", "feedback_list": [{"created_at": "2025-07-10T09:52:12.844648Z",
-        "updated_at": "2025-07-10T09:52:12.844658Z", "email": "candidate.playground+eu4@gitguardian.com",
+        "updated_at": "2025-07-10T09:52:12.844658Z", "email": "user-c11de935@example.com",
         "member_id": 937472, "answers": [{"type": "boolean", "field_ref": "revoked_yes_no",
         "field_label": "Has this secret been revoked?", "boolean": true}, {"type":
         "text", "field_ref": "remarks_text", "field_label": "Additional remarks",
@@ -71,9 +72,9 @@ interactions:
         false, "validity": "no_checker", "severity": "unknown", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [{"created_at":
         "2025-09-26T13:41:25.581098Z", "updated_at": "2025-09-26T13:41:25.581115Z",
-        "email": "pierre.dethoisy@gitguardian.com", "member_id": 309802, "answers":
-        [{"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
+        "email": "user-6eedc04a@example.com", "member_id": 309802, "answers": [{"type":
+        "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this secret
+        been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
         "field_label": "Additional remarks", "text": "hello, first message"}]}], "risk_score":
         83, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
@@ -89,15 +90,15 @@ interactions:
         "ignored_at": "2026-04-27T11:43:00.636684Z", "ignorer_id": 790733, "ignorer_api_token_id":
         null, "resolved_at": null, "resolver_id": null, "resolver_api_token_id": null,
         "secret_revoked": false, "validity": "no_checker", "severity": "low", "assignee_id":
-        790733, "assignee_email": "romain.jouhannet@gitguardian.com", "share_url":
-        "[REDACTED]", "feedback_list": [{"created_at": "2026-04-27T11:34:43.510449Z",
-        "updated_at": "2026-04-27T11:34:43.510469Z", "email": "romain.jouhannet@gitguardian.com",
-        "member_id": 790733, "answers": [{"type": "boolean", "field_ref": "revoked_yes_no",
-        "field_label": "Has this secret been revoked?", "boolean": false}, {"type":
-        "text", "field_ref": "remarks_text", "field_label": "Additional remarks",
-        "text": "hello world 2"}]}], "risk_score": 9, "severity_rule_id": null, "is_vaulted":
-        false, "declarative_secret_status": "fp", "resolve_reason": null, "ignore_reason":
-        "false_positive", "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/1554830",
+        790733, "assignee_email": "user-46c1d11b@example.com", "share_url": "[REDACTED]",
+        "feedback_list": [{"created_at": "2026-04-27T11:34:43.510449Z", "updated_at":
+        "2026-04-27T11:34:43.510469Z", "email": "user-46c1d11b@example.com", "member_id":
+        790733, "answers": [{"type": "boolean", "field_ref": "revoked_yes_no", "field_label":
+        "Has this secret been revoked?", "boolean": false}, {"type": "text", "field_ref":
+        "remarks_text", "field_label": "Additional remarks", "text": "hello world
+        2"}]}], "risk_score": 9, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
+        "fp", "resolve_reason": null, "ignore_reason": "false_positive", "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/1554830",
         "tags": ["FALSE_POSITIVE"], "custom_tags": [], "destination_tickets": [],
         "incident_name": "Generic High Entropy Secret"}, {"id": 2268786, "detector":
         {"name": "openai_apikey", "display_name": "OpenAI API Key", "nature": "specific",
@@ -111,9 +112,9 @@ interactions:
         false, "validity": "invalid", "severity": "unknown", "assignee_id": null,
         "assignee_email": null, "share_url": "[REDACTED]", "feedback_list": [{"created_at":
         "2026-06-03T08:25:41.332652Z", "updated_at": "2026-06-03T08:25:41.332665Z",
-        "email": "romain.jouhannet@gitguardian.com", "member_id": 790733, "answers":
-        [{"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
+        "email": "user-46c1d11b@example.com", "member_id": 790733, "answers": [{"type":
+        "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this secret
+        been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
         "field_label": "Additional remarks", "text": "Hello <@M319222>"}]}], "risk_score":
         6, "severity_rule_id": null, "is_vaulted": false, "declarative_secret_status":
         "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":

--- a/tests/cassettes/client/vcr/test_list_public_incidents_with_validity_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_incidents_with_validity_filter.yaml
@@ -44,15 +44,16 @@ interactions:
         "ignored_at": null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at":
         null, "resolver_id": null, "resolver_api_token_id": null, "secret_revoked":
         false, "validity": "valid", "severity": "critical", "assignee_id": 1778296,
-        "assignee_email": "zeke@binion.io", "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2026-04-23T00:37:26.701645Z", "updated_at": "2026-04-23T00:37:26.701660Z",
-        "email": "zeke@binion.io", "member_id": 1778296, "answers": [{"type": "boolean",
-        "field_ref": "revoked_yes_no", "field_label": "Has this secret been revoked?",
-        "boolean": true}, {"type": "text", "field_ref": "remarks_text", "field_label":
-        "Additional remarks", "text": ""}]}], "risk_score": 27, "severity_rule_id":
-        11891, "is_vaulted": false, "declarative_secret_status": "active", "resolve_reason":
-        null, "ignore_reason": null, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/public-incidents/57",
-        "tags": ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
+        "assignee_email": "user-9c0c34df@example.com", "share_url": "[REDACTED]",
+        "feedback_list": [{"created_at": "2026-04-23T00:37:26.701645Z", "updated_at":
+        "2026-04-23T00:37:26.701660Z", "email": "user-9c0c34df@example.com", "member_id":
+        1778296, "answers": [{"type": "boolean", "field_ref": "revoked_yes_no", "field_label":
+        "Has this secret been revoked?", "boolean": true}, {"type": "text", "field_ref":
+        "remarks_text", "field_label": "Additional remarks", "text": ""}]}], "risk_score":
+        27, "severity_rule_id": 11891, "is_vaulted": false, "declarative_secret_status":
+        "active", "resolve_reason": null, "ignore_reason": null, "gitguardian_url":
+        "https://dashboard.gitguardian.com/workspace/8/public-incidents/57", "tags":
+        ["COMPANY_NAME_IN_COMMIT", "DOMAIN", "FROM_HISTORICAL_SCAN", "TEST_FILE",
         "INTERNALLY_LEAKED"], "custom_tags": [], "destination_tickets": [], "incident_name":
         "GitGuardian Test Token Checked"}, {"id": 123, "detector": {"name": "aws_iam",
         "display_name": "AWS IAM Keys", "nature": "specific", "family": "credentials",

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_basic.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_basic.yaml
@@ -25,11 +25,11 @@ interactions:
         "presence": "removed", "matches": [{"name": "apikey", "indice_start": 295,
         "indice_end": 335, "pre_line_start": null, "pre_line_end": null, "post_line_start":
         14, "post_line_end": 14}], "tags": ["FROM_HISTORICAL_SCAN"], "sha": "2c9877a3019d6c2e261054f8e2fe6c11032ed880",
-        "url": "https://github.com/pypi-data/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
-        "source": {"id": 455, "type": "github", "name": "pypi-data/pypi-code-2", "url":
-        "https://github.com/pypi-data/pypi-code-2"}, "actor": {"id": 11, "type": "github_user",
-        "name": "orf", "email": "tom@tomforb.es", "url": "https://github.com/orf"},
-        "attachment_reasons": ["by_dev_from_perimeter"]}]'
+        "url": "https://github.com/ns-0a01c59e/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
+        "source": {"id": 455, "type": "github", "name": "ns-0a01c59e/pypi-code-2",
+        "url": "https://github.com/ns-0a01c59e/pypi-code-2"}, "actor": {"id": 11,
+        "type": "github_user", "name": "User 234e2507", "email": "user-b8dfd76c@example.com",
+        "url": "https://github.com/ns-234e2507"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
       - a10396814911b1ea-CDG

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_get_all.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_get_all.yaml
@@ -25,11 +25,11 @@ interactions:
         "presence": "removed", "matches": [{"name": "apikey", "indice_start": 295,
         "indice_end": 335, "pre_line_start": null, "pre_line_end": null, "post_line_start":
         14, "post_line_end": 14}], "tags": ["FROM_HISTORICAL_SCAN"], "sha": "2c9877a3019d6c2e261054f8e2fe6c11032ed880",
-        "url": "https://github.com/pypi-data/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
-        "source": {"id": 455, "type": "github", "name": "pypi-data/pypi-code-2", "url":
-        "https://github.com/pypi-data/pypi-code-2"}, "actor": {"id": 11, "type": "github_user",
-        "name": "orf", "email": "tom@tomforb.es", "url": "https://github.com/orf"},
-        "attachment_reasons": ["by_dev_from_perimeter"]}]'
+        "url": "https://github.com/ns-0a01c59e/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
+        "source": {"id": 455, "type": "github", "name": "ns-0a01c59e/pypi-code-2",
+        "url": "https://github.com/ns-0a01c59e/pypi-code-2"}, "actor": {"id": 11,
+        "type": "github_user", "name": "User 234e2507", "email": "user-b8dfd76c@example.com",
+        "url": "https://github.com/ns-234e2507"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
       - a10396b41ffa2a7f-CDG

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_attachment_reason.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_attachment_reason.yaml
@@ -25,11 +25,11 @@ interactions:
         "presence": "removed", "matches": [{"name": "apikey", "indice_start": 295,
         "indice_end": 335, "pre_line_start": null, "pre_line_end": null, "post_line_start":
         14, "post_line_end": 14}], "tags": ["FROM_HISTORICAL_SCAN"], "sha": "2c9877a3019d6c2e261054f8e2fe6c11032ed880",
-        "url": "https://github.com/pypi-data/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
-        "source": {"id": 455, "type": "github", "name": "pypi-data/pypi-code-2", "url":
-        "https://github.com/pypi-data/pypi-code-2"}, "actor": {"id": 11, "type": "github_user",
-        "name": "orf", "email": "tom@tomforb.es", "url": "https://github.com/orf"},
-        "attachment_reasons": ["by_dev_from_perimeter"]}]'
+        "url": "https://github.com/ns-0a01c59e/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
+        "source": {"id": 455, "type": "github", "name": "ns-0a01c59e/pypi-code-2",
+        "url": "https://github.com/ns-0a01c59e/pypi-code-2"}, "actor": {"id": 11,
+        "type": "github_user", "name": "User 234e2507", "email": "user-b8dfd76c@example.com",
+        "url": "https://github.com/ns-234e2507"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
       - a10396a20944d136-CDG

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_cursor.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_cursor.yaml
@@ -388,11 +388,11 @@ interactions:
         "apikey", "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
         "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
-        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+        "https://github.com/ns-255bd396/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
       - a10396b02b9c99c8-CDG
@@ -470,11 +470,11 @@ interactions:
         "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
         "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290", "url":
-        "https://github.com/guillaume-malle/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+        "https://github.com/ns-255bd396/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
       - a10396b20a0f8825-CDG

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_date_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_date_filter.yaml
@@ -25,11 +25,11 @@ interactions:
         "presence": "removed", "matches": [{"name": "apikey", "indice_start": 295,
         "indice_end": 335, "pre_line_start": null, "pre_line_end": null, "post_line_start":
         14, "post_line_end": 14}], "tags": ["FROM_HISTORICAL_SCAN"], "sha": "2c9877a3019d6c2e261054f8e2fe6c11032ed880",
-        "url": "https://github.com/pypi-data/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
-        "source": {"id": 455, "type": "github", "name": "pypi-data/pypi-code-2", "url":
-        "https://github.com/pypi-data/pypi-code-2"}, "actor": {"id": 11, "type": "github_user",
-        "name": "orf", "email": "tom@tomforb.es", "url": "https://github.com/orf"},
-        "attachment_reasons": ["by_dev_from_perimeter"]}]'
+        "url": "https://github.com/ns-0a01c59e/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
+        "source": {"id": 455, "type": "github", "name": "ns-0a01c59e/pypi-code-2",
+        "url": "https://github.com/ns-0a01c59e/pypi-code-2"}, "actor": {"id": 11,
+        "type": "github_user", "name": "User 234e2507", "email": "user-b8dfd76c@example.com",
+        "url": "https://github.com/ns-234e2507"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
       - a1039683083eb6b4-CDG

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_filepath.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_filepath.yaml
@@ -388,50 +388,47 @@ interactions:
         "apikey", "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
         "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
-        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290", "url":
-        "https://github.com/guillaume-malle/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
-        3, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url":
-        "https://github.com/guillaume-malle/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 2733, "incident_id": 1, "date": "2023-03-14T13:42:20Z", "filepath":
-        "stripe1.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 23, "indice_end": 55, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 1, "post_line_end": 1}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "2b9ef5781791f7f4a54af30a254bab215cf97e51", "url":
-        "https://github.com/ssokgg/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
-        "source": {"id": 11, "type": "github", "name": "ssokgg/tetris1", "url": "https://github.com/ssokgg/tetris1"},
-        "actor": {"id": 85, "type": "github_user", "name": "ssokgg", "email": "sandra.sok@gitguardian.com",
-        "url": "https://github.com/ssokgg"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
-        3, "post_line_start": null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url":
-        "https://github.com/guillaume-malle/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+        "https://github.com/ns-255bd396/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 3}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290",
+        "url": "https://github.com/ns-255bd396/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start":
+        3, "pre_line_end": 3, "post_line_start": 3, "post_line_end": 3}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527",
+        "url": "https://github.com/ns-255bd396/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 2733, "incident_id": 1, "date": "2023-03-14T13:42:20Z",
+        "filepath": "stripe1.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 23, "indice_end": 55, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 1, "post_line_end": 1}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "2b9ef5781791f7f4a54af30a254bab215cf97e51",
+        "url": "https://github.com/ns-e843d958/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
+        "source": {"id": 11, "type": "github", "name": "ns-e843d958/tetris1", "url":
+        "https://github.com/ns-e843d958/tetris1"}, "actor": {"id": 85, "type": "github_user",
+        "name": "User e843d958", "email": "user-f709bf8d@example.com", "url": "https://github.com/ns-e843d958"},
+        "attachment_reasons": ["by_dev_from_perimeter"]}, {"id": 4691, "incident_id":
+        1, "date": "2022-09-21T12:45:39Z", "filepath": "hello.py", "kind": "historical",
+        "presence": "present", "matches": [{"name": "apikey", "indice_start": 50,
+        "indice_end": 82, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
+        null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"],
+        "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url": "https://github.com/ns-255bd396/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
       - a103969d59f77854-CDG
@@ -508,41 +505,38 @@ interactions:
         "apikey", "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
         "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
-        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290", "url":
-        "https://github.com/guillaume-malle/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
-        3, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url":
-        "https://github.com/guillaume-malle/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
-        3, "post_line_start": null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url":
-        "https://github.com/guillaume-malle/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+        "https://github.com/ns-255bd396/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 3}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290",
+        "url": "https://github.com/ns-255bd396/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start":
+        3, "pre_line_end": 3, "post_line_start": 3, "post_line_end": 3}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527",
+        "url": "https://github.com/ns-255bd396/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start":
+        3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97",
+        "url": "https://github.com/ns-255bd396/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
       - a103969f4ba0468e-CDG

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_ordering.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_ordering.yaml
@@ -25,11 +25,11 @@ interactions:
         "presence": "removed", "matches": [{"name": "apikey", "indice_start": 295,
         "indice_end": 335, "pre_line_start": null, "pre_line_end": null, "post_line_start":
         14, "post_line_end": 14}], "tags": ["FROM_HISTORICAL_SCAN"], "sha": "2c9877a3019d6c2e261054f8e2fe6c11032ed880",
-        "url": "https://github.com/pypi-data/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
-        "source": {"id": 455, "type": "github", "name": "pypi-data/pypi-code-2", "url":
-        "https://github.com/pypi-data/pypi-code-2"}, "actor": {"id": 11, "type": "github_user",
-        "name": "orf", "email": "tom@tomforb.es", "url": "https://github.com/orf"},
-        "attachment_reasons": ["by_dev_from_perimeter"]}]'
+        "url": "https://github.com/ns-0a01c59e/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
+        "source": {"id": 455, "type": "github", "name": "ns-0a01c59e/pypi-code-2",
+        "url": "https://github.com/ns-0a01c59e/pypi-code-2"}, "actor": {"id": 11,
+        "type": "github_user", "name": "User 234e2507", "email": "user-b8dfd76c@example.com",
+        "url": "https://github.com/ns-234e2507"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
       - a10396aaeeddd141-CDG

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_presence.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_presence.yaml
@@ -388,50 +388,47 @@ interactions:
         "apikey", "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
         "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
-        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290", "url":
-        "https://github.com/guillaume-malle/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
-        3, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url":
-        "https://github.com/guillaume-malle/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 2733, "incident_id": 1, "date": "2023-03-14T13:42:20Z", "filepath":
-        "stripe1.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 23, "indice_end": 55, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 1, "post_line_end": 1}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "2b9ef5781791f7f4a54af30a254bab215cf97e51", "url":
-        "https://github.com/ssokgg/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
-        "source": {"id": 11, "type": "github", "name": "ssokgg/tetris1", "url": "https://github.com/ssokgg/tetris1"},
-        "actor": {"id": 85, "type": "github_user", "name": "ssokgg", "email": "sandra.sok@gitguardian.com",
-        "url": "https://github.com/ssokgg"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
-        3, "post_line_start": null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url":
-        "https://github.com/guillaume-malle/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+        "https://github.com/ns-255bd396/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 3}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290",
+        "url": "https://github.com/ns-255bd396/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start":
+        3, "pre_line_end": 3, "post_line_start": 3, "post_line_end": 3}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527",
+        "url": "https://github.com/ns-255bd396/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 2733, "incident_id": 1, "date": "2023-03-14T13:42:20Z",
+        "filepath": "stripe1.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 23, "indice_end": 55, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 1, "post_line_end": 1}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "2b9ef5781791f7f4a54af30a254bab215cf97e51",
+        "url": "https://github.com/ns-e843d958/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
+        "source": {"id": 11, "type": "github", "name": "ns-e843d958/tetris1", "url":
+        "https://github.com/ns-e843d958/tetris1"}, "actor": {"id": 85, "type": "github_user",
+        "name": "User e843d958", "email": "user-f709bf8d@example.com", "url": "https://github.com/ns-e843d958"},
+        "attachment_reasons": ["by_dev_from_perimeter"]}, {"id": 4691, "incident_id":
+        1, "date": "2022-09-21T12:45:39Z", "filepath": "hello.py", "kind": "historical",
+        "presence": "present", "matches": [{"name": "apikey", "indice_start": 50,
+        "indice_end": 82, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
+        null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"],
+        "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url": "https://github.com/ns-255bd396/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
       - a103968e9e878c76-CDG
@@ -508,50 +505,47 @@ interactions:
         "apikey", "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
         "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
-        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290", "url":
-        "https://github.com/guillaume-malle/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
-        3, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url":
-        "https://github.com/guillaume-malle/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 2733, "incident_id": 1, "date": "2023-03-14T13:42:20Z", "filepath":
-        "stripe1.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 23, "indice_end": 55, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 1, "post_line_end": 1}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "2b9ef5781791f7f4a54af30a254bab215cf97e51", "url":
-        "https://github.com/ssokgg/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
-        "source": {"id": 11, "type": "github", "name": "ssokgg/tetris1", "url": "https://github.com/ssokgg/tetris1"},
-        "actor": {"id": 85, "type": "github_user", "name": "ssokgg", "email": "sandra.sok@gitguardian.com",
-        "url": "https://github.com/ssokgg"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
-        3, "post_line_start": null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url":
-        "https://github.com/guillaume-malle/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+        "https://github.com/ns-255bd396/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 3}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290",
+        "url": "https://github.com/ns-255bd396/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start":
+        3, "pre_line_end": 3, "post_line_start": 3, "post_line_end": 3}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527",
+        "url": "https://github.com/ns-255bd396/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 2733, "incident_id": 1, "date": "2023-03-14T13:42:20Z",
+        "filepath": "stripe1.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 23, "indice_end": 55, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 1, "post_line_end": 1}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "2b9ef5781791f7f4a54af30a254bab215cf97e51",
+        "url": "https://github.com/ns-e843d958/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
+        "source": {"id": 11, "type": "github", "name": "ns-e843d958/tetris1", "url":
+        "https://github.com/ns-e843d958/tetris1"}, "actor": {"id": 85, "type": "github_user",
+        "name": "User e843d958", "email": "user-f709bf8d@example.com", "url": "https://github.com/ns-e843d958"},
+        "attachment_reasons": ["by_dev_from_perimeter"]}, {"id": 4691, "incident_id":
+        1, "date": "2022-09-21T12:45:39Z", "filepath": "hello.py", "kind": "historical",
+        "presence": "present", "matches": [{"name": "apikey", "indice_start": 50,
+        "indice_end": 82, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
+        null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"],
+        "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url": "https://github.com/ns-255bd396/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
       - a1039690899a9ede-CDG

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_severity.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_severity.yaml
@@ -25,11 +25,11 @@ interactions:
         "presence": "removed", "matches": [{"name": "apikey", "indice_start": 295,
         "indice_end": 335, "pre_line_start": null, "pre_line_end": null, "post_line_start":
         14, "post_line_end": 14}], "tags": ["FROM_HISTORICAL_SCAN"], "sha": "2c9877a3019d6c2e261054f8e2fe6c11032ed880",
-        "url": "https://github.com/pypi-data/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
-        "source": {"id": 455, "type": "github", "name": "pypi-data/pypi-code-2", "url":
-        "https://github.com/pypi-data/pypi-code-2"}, "actor": {"id": 11, "type": "github_user",
-        "name": "orf", "email": "tom@tomforb.es", "url": "https://github.com/orf"},
-        "attachment_reasons": ["by_dev_from_perimeter"]}]'
+        "url": "https://github.com/ns-0a01c59e/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
+        "source": {"id": 455, "type": "github", "name": "ns-0a01c59e/pypi-code-2",
+        "url": "https://github.com/ns-0a01c59e/pypi-code-2"}, "actor": {"id": 11,
+        "type": "github_user", "name": "User 234e2507", "email": "user-b8dfd76c@example.com",
+        "url": "https://github.com/ns-234e2507"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
       - a10396a3b825d121-CDG

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_sha.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_sha.yaml
@@ -388,50 +388,47 @@ interactions:
         "apikey", "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
         "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
-        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290", "url":
-        "https://github.com/guillaume-malle/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
-        3, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url":
-        "https://github.com/guillaume-malle/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 2733, "incident_id": 1, "date": "2023-03-14T13:42:20Z", "filepath":
-        "stripe1.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 23, "indice_end": 55, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 1, "post_line_end": 1}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "2b9ef5781791f7f4a54af30a254bab215cf97e51", "url":
-        "https://github.com/ssokgg/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
-        "source": {"id": 11, "type": "github", "name": "ssokgg/tetris1", "url": "https://github.com/ssokgg/tetris1"},
-        "actor": {"id": 85, "type": "github_user", "name": "ssokgg", "email": "sandra.sok@gitguardian.com",
-        "url": "https://github.com/ssokgg"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
-        3, "post_line_start": null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url":
-        "https://github.com/guillaume-malle/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+        "https://github.com/ns-255bd396/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 3}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290",
+        "url": "https://github.com/ns-255bd396/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start":
+        3, "pre_line_end": 3, "post_line_start": 3, "post_line_end": 3}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527",
+        "url": "https://github.com/ns-255bd396/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 2733, "incident_id": 1, "date": "2023-03-14T13:42:20Z",
+        "filepath": "stripe1.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 23, "indice_end": 55, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 1, "post_line_end": 1}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "2b9ef5781791f7f4a54af30a254bab215cf97e51",
+        "url": "https://github.com/ns-e843d958/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
+        "source": {"id": 11, "type": "github", "name": "ns-e843d958/tetris1", "url":
+        "https://github.com/ns-e843d958/tetris1"}, "actor": {"id": 85, "type": "github_user",
+        "name": "User e843d958", "email": "user-f709bf8d@example.com", "url": "https://github.com/ns-e843d958"},
+        "attachment_reasons": ["by_dev_from_perimeter"]}, {"id": 4691, "incident_id":
+        1, "date": "2022-09-21T12:45:39Z", "filepath": "hello.py", "kind": "historical",
+        "presence": "present", "matches": [{"name": "apikey", "indice_start": 50,
+        "indice_end": 82, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
+        null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"],
+        "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url": "https://github.com/ns-255bd396/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
       - a1039695c9450168-CDG
@@ -508,11 +505,11 @@ interactions:
         "apikey", "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
         "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
-        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+        "https://github.com/ns-255bd396/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
       - a1039697aa85f4e7-CDG

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_source_id.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_source_id.yaml
@@ -388,50 +388,47 @@ interactions:
         "apikey", "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
         "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
-        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290", "url":
-        "https://github.com/guillaume-malle/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
-        3, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url":
-        "https://github.com/guillaume-malle/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 2733, "incident_id": 1, "date": "2023-03-14T13:42:20Z", "filepath":
-        "stripe1.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 23, "indice_end": 55, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 1, "post_line_end": 1}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "2b9ef5781791f7f4a54af30a254bab215cf97e51", "url":
-        "https://github.com/ssokgg/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
-        "source": {"id": 11, "type": "github", "name": "ssokgg/tetris1", "url": "https://github.com/ssokgg/tetris1"},
-        "actor": {"id": 85, "type": "github_user", "name": "ssokgg", "email": "sandra.sok@gitguardian.com",
-        "url": "https://github.com/ssokgg"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
-        3, "post_line_start": null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url":
-        "https://github.com/guillaume-malle/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+        "https://github.com/ns-255bd396/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 3}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290",
+        "url": "https://github.com/ns-255bd396/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start":
+        3, "pre_line_end": 3, "post_line_start": 3, "post_line_end": 3}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527",
+        "url": "https://github.com/ns-255bd396/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 2733, "incident_id": 1, "date": "2023-03-14T13:42:20Z",
+        "filepath": "stripe1.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 23, "indice_end": 55, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 1, "post_line_end": 1}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "2b9ef5781791f7f4a54af30a254bab215cf97e51",
+        "url": "https://github.com/ns-e843d958/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
+        "source": {"id": 11, "type": "github", "name": "ns-e843d958/tetris1", "url":
+        "https://github.com/ns-e843d958/tetris1"}, "actor": {"id": 85, "type": "github_user",
+        "name": "User e843d958", "email": "user-f709bf8d@example.com", "url": "https://github.com/ns-e843d958"},
+        "attachment_reasons": ["by_dev_from_perimeter"]}, {"id": 4691, "incident_id":
+        1, "date": "2022-09-21T12:45:39Z", "filepath": "hello.py", "kind": "historical",
+        "presence": "present", "matches": [{"name": "apikey", "indice_start": 50,
+        "indice_end": 82, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
+        null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"],
+        "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url": "https://github.com/ns-255bd396/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
       - a10396881edfc702-CDG
@@ -508,41 +505,38 @@ interactions:
         "apikey", "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
         "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
-        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290", "url":
-        "https://github.com/guillaume-malle/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
-        3, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url":
-        "https://github.com/guillaume-malle/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
-        3, "post_line_start": null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url":
-        "https://github.com/guillaume-malle/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+        "https://github.com/ns-255bd396/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 3}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290",
+        "url": "https://github.com/ns-255bd396/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start":
+        3, "pre_line_end": 3, "post_line_start": 3, "post_line_end": 3}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527",
+        "url": "https://github.com/ns-255bd396/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start":
+        3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97",
+        "url": "https://github.com/ns-255bd396/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
       - a1039689ca58f6a9-CDG

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_status.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_status.yaml
@@ -25,11 +25,11 @@ interactions:
         "presence": "removed", "matches": [{"name": "apikey", "indice_start": 295,
         "indice_end": 335, "pre_line_start": null, "pre_line_end": null, "post_line_start":
         14, "post_line_end": 14}], "tags": ["FROM_HISTORICAL_SCAN"], "sha": "2c9877a3019d6c2e261054f8e2fe6c11032ed880",
-        "url": "https://github.com/pypi-data/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
-        "source": {"id": 455, "type": "github", "name": "pypi-data/pypi-code-2", "url":
-        "https://github.com/pypi-data/pypi-code-2"}, "actor": {"id": 11, "type": "github_user",
-        "name": "orf", "email": "tom@tomforb.es", "url": "https://github.com/orf"},
-        "attachment_reasons": ["by_dev_from_perimeter"]}]'
+        "url": "https://github.com/ns-0a01c59e/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
+        "source": {"id": 455, "type": "github", "name": "ns-0a01c59e/pypi-code-2",
+        "url": "https://github.com/ns-0a01c59e/pypi-code-2"}, "actor": {"id": 11,
+        "type": "github_user", "name": "User 234e2507", "email": "user-b8dfd76c@example.com",
+        "url": "https://github.com/ns-234e2507"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
       - a10396a57fe16ed2-CDG

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_tags.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_tags.yaml
@@ -25,11 +25,11 @@ interactions:
         "presence": "removed", "matches": [{"name": "apikey", "indice_start": 295,
         "indice_end": 335, "pre_line_start": null, "pre_line_end": null, "post_line_start":
         14, "post_line_end": 14}], "tags": ["FROM_HISTORICAL_SCAN"], "sha": "2c9877a3019d6c2e261054f8e2fe6c11032ed880",
-        "url": "https://github.com/pypi-data/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
-        "source": {"id": 455, "type": "github", "name": "pypi-data/pypi-code-2", "url":
-        "https://github.com/pypi-data/pypi-code-2"}, "actor": {"id": 11, "type": "github_user",
-        "name": "orf", "email": "tom@tomforb.es", "url": "https://github.com/orf"},
-        "attachment_reasons": ["by_dev_from_perimeter"]}]'
+        "url": "https://github.com/ns-0a01c59e/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
+        "source": {"id": 455, "type": "github", "name": "ns-0a01c59e/pypi-code-2",
+        "url": "https://github.com/ns-0a01c59e/pypi-code-2"}, "actor": {"id": 11,
+        "type": "github_user", "name": "User 234e2507", "email": "user-b8dfd76c@example.com",
+        "url": "https://github.com/ns-234e2507"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
       - a10396a91d162a11-CDG

--- a/tests/cassettes/client/vcr/test_list_public_occurrences_with_validity.yaml
+++ b/tests/cassettes/client/vcr/test_list_public_occurrences_with_validity.yaml
@@ -25,11 +25,11 @@ interactions:
         "presence": "removed", "matches": [{"name": "apikey", "indice_start": 295,
         "indice_end": 335, "pre_line_start": null, "pre_line_end": null, "post_line_start":
         14, "post_line_end": 14}], "tags": ["FROM_HISTORICAL_SCAN"], "sha": "2c9877a3019d6c2e261054f8e2fe6c11032ed880",
-        "url": "https://github.com/pypi-data/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
-        "source": {"id": 455, "type": "github", "name": "pypi-data/pypi-code-2", "url":
-        "https://github.com/pypi-data/pypi-code-2"}, "actor": {"id": 11, "type": "github_user",
-        "name": "orf", "email": "tom@tomforb.es", "url": "https://github.com/orf"},
-        "attachment_reasons": ["by_dev_from_perimeter"]}]'
+        "url": "https://github.com/ns-0a01c59e/pypi-code-2/commit/2c9877a3019d6c2e261054f8e2fe6c11032ed880#diff-63ebc151c08e8db0fd7e76e4d9329829c970d3ce7d3cc38b81ba0ab27107a282R14",
+        "source": {"id": 455, "type": "github", "name": "ns-0a01c59e/pypi-code-2",
+        "url": "https://github.com/ns-0a01c59e/pypi-code-2"}, "actor": {"id": 11,
+        "type": "github_user", "name": "User 234e2507", "email": "user-b8dfd76c@example.com",
+        "url": "https://github.com/ns-234e2507"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
       - a10396a73cc0022d-CDG

--- a/tests/cassettes/client/vcr/test_list_source_incidents.yaml
+++ b/tests/cassettes/client/vcr/test_list_source_incidents.yaml
@@ -20,15 +20,15 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?per_page=1
   response:
     body:
-      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
-        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
+      string: '[{"id": 12259, "type": "github", "full_name": "ns-1cb0f5a9/cowboy",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "23", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-6d1173c4",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/client/vcr/test_list_sources_basic.yaml
+++ b/tests/cassettes/client/vcr/test_list_sources_basic.yaml
@@ -20,45 +20,46 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?per_page=5
   response:
     body:
-      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
-        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
-        "type": "github", "full_name": "lonely/hunter", "health": "unknown", "source_criticality":
-        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
-        "deleted_on_remote", "visibility": "public", "external_id": "22", "secret_incidents_breakdown":
+      string: '[{"id": 12259, "type": "github", "full_name": "ns-1cb0f5a9/cowboy",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "23", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/hunter",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-6d1173c4",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
+        "type": "github", "full_name": "ns-1cb0f5a9/hunter", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "22", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-e9a63a4e",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12261,
-        "type": "github", "full_name": "lonely/time", "health": "unknown", "source_criticality":
+        "type": "github", "full_name": "ns-1cb0f5a9/time", "health": "unknown", "source_criticality":
         "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
         0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
         "deleted_on_remote", "visibility": "public", "external_id": "25", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/time",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-33607480",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12262,
-        "type": "github", "full_name": "lonely/tower", "health": "unknown", "source_criticality":
+        "type": "github", "full_name": "ns-1cb0f5a9/tower", "health": "unknown", "source_criticality":
         "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
         0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
         "deleted_on_remote", "visibility": "public", "external_id": "24", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/tower",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-ad201526",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12263,
-        "type": "github", "full_name": "my-testing-org/christian_dior", "health":
-        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        "type": "github", "full_name": "ns-242f04fd/christian_dior", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:39.211442Z", "status": "finished", "failing_reason":
         "", "commits_scanned": 1, "duration": "1.218169", "branches_scanned": 1, "progress":
@@ -67,7 +68,7 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-eb7dee60",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/client/vcr/test_list_sources_get_all.yaml
+++ b/tests/cassettes/client/vcr/test_list_sources_get_all.yaml
@@ -20,45 +20,46 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?per_page=5
   response:
     body:
-      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
-        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
-        "type": "github", "full_name": "lonely/hunter", "health": "unknown", "source_criticality":
-        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
-        "deleted_on_remote", "visibility": "public", "external_id": "22", "secret_incidents_breakdown":
+      string: '[{"id": 12259, "type": "github", "full_name": "ns-1cb0f5a9/cowboy",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "23", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/hunter",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-6d1173c4",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
+        "type": "github", "full_name": "ns-1cb0f5a9/hunter", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "22", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-e9a63a4e",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12261,
-        "type": "github", "full_name": "lonely/time", "health": "unknown", "source_criticality":
+        "type": "github", "full_name": "ns-1cb0f5a9/time", "health": "unknown", "source_criticality":
         "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
         0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
         "deleted_on_remote", "visibility": "public", "external_id": "25", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/time",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-33607480",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12262,
-        "type": "github", "full_name": "lonely/tower", "health": "unknown", "source_criticality":
+        "type": "github", "full_name": "ns-1cb0f5a9/tower", "health": "unknown", "source_criticality":
         "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
         0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
         "deleted_on_remote", "visibility": "public", "external_id": "24", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/tower",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-ad201526",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12263,
-        "type": "github", "full_name": "my-testing-org/christian_dior", "health":
-        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        "type": "github", "full_name": "ns-242f04fd/christian_dior", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:39.211442Z", "status": "finished", "failing_reason":
         "", "commits_scanned": 1, "duration": "1.218169", "branches_scanned": 1, "progress":
@@ -67,7 +68,7 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-eb7dee60",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:
@@ -141,7 +142,7 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?per_page=5&cursor=cD0xMjI2Mw%3D%3D
   response:
     body:
-      string: '[{"id": 12264, "type": "github", "full_name": "my-testing-org/armani_code",
+      string: '[{"id": 12264, "type": "github", "full_name": "ns-242f04fd/armani_code",
         "health": "safe", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         1, "last_scan": {"date": "2020-06-04T09:06:33.833273Z", "status": "finished",
@@ -151,9 +152,9 @@ interactions:
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/armani_code",
+        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-12b26c3e",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12265,
-        "type": "github", "full_name": "my-testing-org/louis_vuitton", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/louis_vuitton", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:32.770273Z", "status": "finished", "failing_reason":
@@ -163,9 +164,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/louis_vuitton",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-f6c46dcc",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12266,
-        "type": "github", "full_name": "my-testing-org/lagarfeld", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/lagarfeld", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:33.598712Z", "status": "finished", "failing_reason":
@@ -175,9 +176,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/lagarfeld",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-f7e0173c",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12267,
-        "type": "github", "full_name": "my-testing-org/saint_laurent", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/saint_laurent", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-10-09T12:55:14.542227Z", "status": "canceled", "failing_reason":
@@ -187,19 +188,19 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/saint_laurent",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-29961463",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12268,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2021-04",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
-        3, "last_scan": {"date": "2021-05-12T13:40:00.812612Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 686, "duration": "2.80448", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-gg-2021-04", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 2, "closed_incidents_count": 3, "last_scan":
+        {"date": "2021-05-12T13:40:00.812612Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 686, "duration": "2.80448", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "353525015", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         1, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 3, "severity_breakdown": {"critical": 0, "high": 3, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2021-04",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-2021-04",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:
@@ -274,7 +275,7 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?per_page=5&cursor=cD0xMjI2OA%3D%3D
   response:
     body:
-      string: '[{"id": 12269, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2021-02",
+      string: '[{"id": 12269, "type": "github", "full_name": "ns-80126292/private-gg-bis-2021-02",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
         9, "last_scan": {"date": "2021-05-12T13:40:00.842952Z", "status": "finished",
@@ -284,55 +285,55 @@ interactions:
         {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
         2, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2021-02",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2021-02",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12270,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2021-04",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
-        4, "last_scan": {"date": "2021-05-12T13:40:00.804955Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 419, "duration": "2.634533", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-bis-2021-04", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 1, "closed_incidents_count": 4, "last_scan":
+        {"date": "2021-05-12T13:40:00.804955Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 419, "duration": "2.634533", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "358427683", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 1}}, "closed_secret_incidents":
         {"total": 4, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0,
-        "low": 0, "info": 1, "unknown": 2}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2021-04",
+        "low": 0, "info": 1, "unknown": 2}}}, "url": "https://github.com/ns-80126292/private-app-gg-bis-2021-04",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12271,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2021-03",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
-        7, "last_scan": {"date": "2021-05-12T13:40:00.809898Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1216, "duration": "8.598146", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-2021-03", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 2, "closed_incidents_count": 7, "last_scan":
+        {"date": "2021-05-12T13:40:00.809898Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1216, "duration": "8.598146", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "343245836", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 2}}, "closed_secret_incidents":
         {"total": 7, "severity_breakdown": {"critical": 0, "high": 2, "medium": 0,
-        "low": 0, "info": 4, "unknown": 1}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2021-03",
+        "low": 0, "info": 4, "unknown": 1}}}, "url": "https://github.com/ns-80126292/private-app-gg-2021-03",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12272,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2021-03",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
-        1, "last_scan": {"date": "2021-05-12T13:40:00.801498Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 940, "duration": "6.936519", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-bis-2021-03", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 1, "closed_incidents_count": 1, "last_scan":
+        {"date": "2021-05-12T13:40:00.801498Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 940, "duration": "6.936519", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "348161051", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 1}}, "closed_secret_incidents":
         {"total": 1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2021-03",
+        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://github.com/ns-80126292/private-app-gg-bis-2021-03",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12273,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2021-03",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
-        6, "last_scan": {"date": "2021-05-12T13:40:00.818740Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 990, "duration": "6.295876", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-gg-bis-2021-03", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 3, "closed_incidents_count": 6, "last_scan":
+        {"date": "2021-05-12T13:40:00.818740Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 990, "duration": "6.295876", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "348161060", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
         3, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 6, "severity_breakdown": {"critical": 0, "high": 6, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2021-03",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2021-03",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:
@@ -407,7 +408,7 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?per_page=5&cursor=cD0xMjI3Mw%3D%3D
   response:
     body:
-      string: '[{"id": 12274, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-07",
+      string: '[{"id": 12274, "type": "github", "full_name": "ns-80126292/private-gg-2020-07",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
         6, "last_scan": {"date": "2020-09-24T09:06:39.253667Z", "status": "finished",
@@ -417,55 +418,55 @@ interactions:
         {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
         3, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 6, "severity_breakdown": {"critical": 0, "high": 6, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-07",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-2020-07",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12275,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-08",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
-        9, "last_scan": {"date": "2020-09-24T09:06:39.215897Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 656, "duration": "5.5968", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "public", "external_id": "287845935", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
-        1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-08",
+        "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-08", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 1, "closed_incidents_count": 9, "last_scan":
+        {"date": "2020-09-24T09:06:39.215897Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 656, "duration": "5.5968", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "287845935", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 1, "severity_breakdown": {"critical": 1, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-08",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12276,
-        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-2020-12",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
-        6, "last_scan": {"date": "2021-02-01T15:38:48.535700Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1040, "duration": "2.651208", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/public-app-gg-2020-12", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 1, "closed_incidents_count": 6, "last_scan":
+        {"date": "2021-02-01T15:38:48.535700Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1040, "duration": "2.651208", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "317380020", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
         1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 6, "severity_breakdown": {"critical": 0, "high": 6, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-12",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-2020-12",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12277,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2020-08",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
-        4, "last_scan": {"date": "2020-09-24T09:06:39.225976Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 913, "duration": "2.608482", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-2020-08", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 1, "closed_incidents_count": 4, "last_scan":
+        {"date": "2020-09-24T09:06:39.225976Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 913, "duration": "2.608482", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "284154416", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
         1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 4, "severity_breakdown": {"critical": 0, "high": 4, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2020-08",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-app-gg-2020-08",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12278,
-        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-11",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
-        7, "last_scan": {"date": "2021-02-01T15:38:48.535276Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1282, "duration": "3.557603", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-11", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 3, "closed_incidents_count": 7, "last_scan":
+        {"date": "2021-02-01T15:38:48.535276Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1282, "duration": "3.557603", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "313150729", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
         3, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 7, "severity_breakdown": {"critical": 0, "high": 7, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-11",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-11",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:
@@ -540,7 +541,7 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?per_page=5&cursor=cD0xMjI3OA%3D%3D
   response:
     body:
-      string: '[{"id": 12279, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-01",
+      string: '[{"id": 12279, "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-01",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
         3, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
@@ -548,22 +549,22 @@ interactions:
         {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
         1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 3, "severity_breakdown": {"critical": 0, "high": 3, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-01",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-01",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12280,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2020-12",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
-        7, "last_scan": {"date": "2021-03-05T16:32:08.931273Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1343, "duration": "3.700622", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-bis-2020-12", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 1, "closed_incidents_count": 7, "last_scan":
+        {"date": "2021-03-05T16:32:08.931273Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1343, "duration": "3.700622", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "321822525", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
         1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 7, "severity_breakdown": {"critical": 0, "high": 7, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2020-12",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-app-gg-bis-2020-12",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12281,
-        "type": "github", "full_name": "wayne-enterprises-gg/empty-repo", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        "type": "github", "full_name": "ns-80126292/empty-repo", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-01-27T09:14:01.990109Z", "status": "failed", "failing_reason":
         "Unknown error", "commits_scanned": 0, "duration": "0.0", "branches_scanned":
@@ -572,31 +573,31 @@ interactions:
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/empty-repo",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/empty-repo",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12282,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-07",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
-        9, "last_scan": {"date": "2020-09-24T09:06:39.281285Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1146, "duration": "5.695658", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-07", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 2, "closed_incidents_count": 9, "last_scan":
+        {"date": "2020-09-24T09:06:39.281285Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1146, "duration": "5.695658", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "280012005", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-07",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-07",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12283,
-        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-2020-09",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
-        5, "last_scan": {"date": "2020-09-24T09:06:39.249695Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 405, "duration": "4.641103", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/public-app-gg-2020-09", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 2, "closed_incidents_count": 5, "last_scan":
+        {"date": "2020-09-24T09:06:39.249695Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 405, "duration": "4.641103", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "291853911", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 5, "severity_breakdown": {"critical": 0, "high": 5, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-09",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-2020-09",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/client/vcr/test_list_sources_monitored_only.yaml
+++ b/tests/cassettes/client/vcr/test_list_sources_monitored_only.yaml
@@ -20,45 +20,46 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?monitored=true&per_page=5
   response:
     body:
-      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
-        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
-        "type": "github", "full_name": "lonely/hunter", "health": "unknown", "source_criticality":
-        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
-        "deleted_on_remote", "visibility": "public", "external_id": "22", "secret_incidents_breakdown":
+      string: '[{"id": 12259, "type": "github", "full_name": "ns-1cb0f5a9/cowboy",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "23", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/hunter",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-6d1173c4",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
+        "type": "github", "full_name": "ns-1cb0f5a9/hunter", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "22", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-e9a63a4e",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12261,
-        "type": "github", "full_name": "lonely/time", "health": "unknown", "source_criticality":
+        "type": "github", "full_name": "ns-1cb0f5a9/time", "health": "unknown", "source_criticality":
         "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
         0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
         "deleted_on_remote", "visibility": "public", "external_id": "25", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/time",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-33607480",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12262,
-        "type": "github", "full_name": "lonely/tower", "health": "unknown", "source_criticality":
+        "type": "github", "full_name": "ns-1cb0f5a9/tower", "health": "unknown", "source_criticality":
         "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
         0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
         "deleted_on_remote", "visibility": "public", "external_id": "24", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/tower",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-ad201526",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12263,
-        "type": "github", "full_name": "my-testing-org/christian_dior", "health":
-        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        "type": "github", "full_name": "ns-242f04fd/christian_dior", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:39.211442Z", "status": "finished", "failing_reason":
         "", "commits_scanned": 1, "duration": "1.218169", "branches_scanned": 1, "progress":
@@ -67,7 +68,7 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-eb7dee60",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/client/vcr/test_list_sources_with_search.yaml
+++ b/tests/cassettes/client/vcr/test_list_sources_with_search.yaml
@@ -20,7 +20,7 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?search=test&per_page=5
   response:
     body:
-      string: '[{"id": 12263, "type": "github", "full_name": "my-testing-org/christian_dior",
+      string: '[{"id": 12263, "type": "github", "full_name": "ns-242f04fd/christian_dior",
         "health": "safe", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         0, "last_scan": {"date": "2020-09-24T09:06:39.211442Z", "status": "finished",
@@ -30,9 +30,9 @@ interactions:
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-eb7dee60",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12264,
-        "type": "github", "full_name": "my-testing-org/armani_code", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/armani_code", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 1, "last_scan":
         {"date": "2020-06-04T09:06:33.833273Z", "status": "finished", "failing_reason":
@@ -42,9 +42,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 1}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/armani_code",
+        "info": 0, "unknown": 1}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-12b26c3e",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12265,
-        "type": "github", "full_name": "my-testing-org/louis_vuitton", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/louis_vuitton", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:32.770273Z", "status": "finished", "failing_reason":
@@ -54,9 +54,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/louis_vuitton",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-f6c46dcc",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12266,
-        "type": "github", "full_name": "my-testing-org/lagarfeld", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/lagarfeld", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:33.598712Z", "status": "finished", "failing_reason":
@@ -66,9 +66,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/lagarfeld",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-f7e0173c",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12267,
-        "type": "github", "full_name": "my-testing-org/saint_laurent", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/saint_laurent", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-10-09T12:55:14.542227Z", "status": "canceled", "failing_reason":
@@ -78,7 +78,7 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/saint_laurent",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-29961463",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/client/vcr/test_list_sources_with_visibility_filter.yaml
+++ b/tests/cassettes/client/vcr/test_list_sources_with_visibility_filter.yaml
@@ -20,17 +20,17 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?visibility=private&per_page=5
   response:
     body:
-      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
-        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
+      string: '[{"id": 12259, "type": "github", "full_name": "ns-1cb0f5a9/cowboy",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "23", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-6d1173c4",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12265,
-        "type": "github", "full_name": "my-testing-org/louis_vuitton", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/louis_vuitton", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:32.770273Z", "status": "finished", "failing_reason":
@@ -40,9 +40,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/louis_vuitton",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-f6c46dcc",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12266,
-        "type": "github", "full_name": "my-testing-org/lagarfeld", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/lagarfeld", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:33.598712Z", "status": "finished", "failing_reason":
@@ -52,31 +52,31 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/lagarfeld",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-f7e0173c",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12270,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2021-04",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
-        4, "last_scan": {"date": "2021-05-12T13:40:00.804955Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 419, "duration": "2.634533", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-bis-2021-04", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 1, "closed_incidents_count": 4, "last_scan":
+        {"date": "2021-05-12T13:40:00.804955Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 419, "duration": "2.634533", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "358427683", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 1}}, "closed_secret_incidents":
         {"total": 4, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0,
-        "low": 0, "info": 1, "unknown": 2}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2021-04",
+        "low": 0, "info": 1, "unknown": 2}}}, "url": "https://github.com/ns-80126292/private-app-gg-bis-2021-04",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12271,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2021-03",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
-        7, "last_scan": {"date": "2021-05-12T13:40:00.809898Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1216, "duration": "8.598146", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-2021-03", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 2, "closed_incidents_count": 7, "last_scan":
+        {"date": "2021-05-12T13:40:00.809898Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1216, "duration": "8.598146", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "343245836", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 2}}, "closed_secret_incidents":
         {"total": 7, "severity_breakdown": {"critical": 0, "high": 2, "medium": 0,
-        "low": 0, "info": 4, "unknown": 1}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2021-03",
+        "low": 0, "info": 4, "unknown": 1}}}, "url": "https://github.com/ns-80126292/private-app-gg-2021-03",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/tools/vcr/test_get_incident_basic.yaml
+++ b/tests/cassettes/tools/vcr/test_get_incident_basic.yaml
@@ -30,28 +30,27 @@ interactions:
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
         "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
         "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
-        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
-        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
-        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
-        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
-        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
-        given access to any sensitive information or services?", "boolean": true},
-        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
-        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
-        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
-        "ignore_reason": null, "occurrences": [{"id": 78197, "incident_id": 21460,
-        "date": "2020-10-29T13:20:05.797462Z", "filepath": "app.py", "kind": "realtime",
-        "presence": "removed", "matches": [{"name": "client_id", "indice_start": 49,
-        "indice_end": 69, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
-        null, "post_line_end": null}, {"name": "client_secret", "indice_start": 85,
-        "indice_end": 125, "pre_line_start": 4, "pre_line_end": 4, "post_line_start":
-        null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED", "PUBLIC"], "url":
-        "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "user-74281974@example.com", "share_url": "[REDACTED]", "feedback_list": [{"created_at":
+        "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "user-1a0bc62d@example.com", "member_id": null, "answers": [{"type":
+        "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is this an
+        actual secret?", "boolean": true}, {"type": "boolean", "field_ref": "access_to_sensitive_yes_no",
+        "field_label": "Does this secret give or has given access to any sensitive
+        information or services?", "boolean": true}, {"type": "boolean", "field_ref":
+        "revoked_yes_no", "field_label": "Has this secret been revoked?", "boolean":
+        false}, {"type": "text", "field_ref": "remarks_text", "field_label": "Additional
+        remarks", "text": "Hasn''t been revoked yet because X"}]}], "risk_score":
+        100, "severity_rule_id": null, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": [{"id": 78197, "incident_id": 21460, "date": "2020-10-29T13:20:05.797462Z",
+        "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
+        [{"name": "client_id", "indice_start": 49, "indice_end": 69, "pre_line_start":
+        3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}, {"name":
+        "client_secret", "indice_start": 85, "indice_end": 125, "pre_line_start":
+        4, "pre_line_end": 4, "post_line_start": null, "post_line_end": null}], "tags":
+        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion", "source":
+        {"id": 12349, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
@@ -61,7 +60,7 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78198,
         "incident_id": 21460, "date": "2020-10-29T13:19:59.005564Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
@@ -69,10 +68,10 @@ interactions:
         null, "post_line_start": 3, "post_line_end": 3}, {"name": "client_secret",
         "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "PUBLIC"], "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition", "source":
+        {"id": 12349, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
@@ -82,7 +81,7 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}], "secret_presence":
         {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
         "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
@@ -90,7 +89,7 @@ interactions:
         "tags": ["REVOCABLE_BY_GG", "PUBLICLY_LEAKED"], "incident_name": "AWS IAM
         Keys", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
         false, "leaked_outside_perimeter": false}, "destination_tickets": [{"id":
-        "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
+        "AEF-97", "type": "jira_cloud", "link": "https://tenant-b6250acd.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}'
     headers:
       CF-RAY:

--- a/tests/cassettes/tools/vcr/test_get_incident_has_detector_info.yaml
+++ b/tests/cassettes/tools/vcr/test_get_incident_has_detector_info.yaml
@@ -30,28 +30,27 @@ interactions:
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
         "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
         "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
-        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
-        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
-        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
-        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
-        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
-        given access to any sensitive information or services?", "boolean": true},
-        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
-        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
-        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
-        "ignore_reason": null, "occurrences": [{"id": 78197, "incident_id": 21460,
-        "date": "2020-10-29T13:20:05.797462Z", "filepath": "app.py", "kind": "realtime",
-        "presence": "removed", "matches": [{"name": "client_id", "indice_start": 49,
-        "indice_end": 69, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
-        null, "post_line_end": null}, {"name": "client_secret", "indice_start": 85,
-        "indice_end": 125, "pre_line_start": 4, "pre_line_end": 4, "post_line_start":
-        null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED", "PUBLIC"], "url":
-        "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "user-74281974@example.com", "share_url": "[REDACTED]", "feedback_list": [{"created_at":
+        "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "user-1a0bc62d@example.com", "member_id": null, "answers": [{"type":
+        "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is this an
+        actual secret?", "boolean": true}, {"type": "boolean", "field_ref": "access_to_sensitive_yes_no",
+        "field_label": "Does this secret give or has given access to any sensitive
+        information or services?", "boolean": true}, {"type": "boolean", "field_ref":
+        "revoked_yes_no", "field_label": "Has this secret been revoked?", "boolean":
+        false}, {"type": "text", "field_ref": "remarks_text", "field_label": "Additional
+        remarks", "text": "Hasn''t been revoked yet because X"}]}], "risk_score":
+        100, "severity_rule_id": null, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": [{"id": 78197, "incident_id": 21460, "date": "2020-10-29T13:20:05.797462Z",
+        "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
+        [{"name": "client_id", "indice_start": 49, "indice_end": 69, "pre_line_start":
+        3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}, {"name":
+        "client_secret", "indice_start": 85, "indice_end": 125, "pre_line_start":
+        4, "pre_line_end": 4, "post_line_start": null, "post_line_end": null}], "tags":
+        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion", "source":
+        {"id": 12349, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
@@ -61,7 +60,7 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78198,
         "incident_id": 21460, "date": "2020-10-29T13:19:59.005564Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
@@ -69,10 +68,10 @@ interactions:
         null, "post_line_start": 3, "post_line_end": 3}, {"name": "client_secret",
         "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "PUBLIC"], "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition", "source":
+        {"id": 12349, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
@@ -82,7 +81,7 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}], "secret_presence":
         {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
         "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
@@ -90,7 +89,7 @@ interactions:
         "tags": ["REVOCABLE_BY_GG", "PUBLICLY_LEAKED"], "incident_name": "AWS IAM
         Keys", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
         false, "leaked_outside_perimeter": false}, "destination_tickets": [{"id":
-        "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
+        "AEF-97", "type": "jira_cloud", "link": "https://tenant-b6250acd.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}'
     headers:
       CF-RAY:

--- a/tests/cassettes/tools/vcr/test_get_incident_no_occurrences.yaml
+++ b/tests/cassettes/tools/vcr/test_get_incident_no_occurrences.yaml
@@ -30,24 +30,24 @@ interactions:
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
         "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
         "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
-        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
-        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
-        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
-        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
-        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
-        given access to any sensitive information or services?", "boolean": true},
-        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
-        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
-        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
-        "ignore_reason": null, "occurrences": [], "secret_presence": {"files_requiring_code_fix":
-        0, "files_pending_merge": 0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs":
-        0, "in_vcs": 0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url":
-        "https://dashboard.gitguardian.com/workspace/8/incidents/21460", "tags": ["REVOCABLE_BY_GG",
-        "PUBLICLY_LEAKED"], "incident_name": "AWS IAM Keys", "public_exposure": {"source_publicly_visible":
-        true, "public_incident_linked": false, "leaked_outside_perimeter": false},
-        "destination_tickets": [{"id": "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
+        "user-74281974@example.com", "share_url": "[REDACTED]", "feedback_list": [{"created_at":
+        "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "user-1a0bc62d@example.com", "member_id": null, "answers": [{"type":
+        "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is this an
+        actual secret?", "boolean": true}, {"type": "boolean", "field_ref": "access_to_sensitive_yes_no",
+        "field_label": "Does this secret give or has given access to any sensitive
+        information or services?", "boolean": true}, {"type": "boolean", "field_ref":
+        "revoked_yes_no", "field_label": "Has this secret been revoked?", "boolean":
+        false}, {"type": "text", "field_ref": "remarks_text", "field_label": "Additional
+        remarks", "text": "Hasn''t been revoked yet because X"}]}], "risk_score":
+        100, "severity_rule_id": null, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": [], "secret_presence": {"files_requiring_code_fix": 0, "files_pending_merge":
+        0, "files_fixed": 0, "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs":
+        0, "removed_in_vcs": 2}, "regression": false, "gitguardian_url": "https://dashboard.gitguardian.com/workspace/8/incidents/21460",
+        "tags": ["REVOCABLE_BY_GG", "PUBLICLY_LEAKED"], "incident_name": "AWS IAM
+        Keys", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
+        false, "leaked_outside_perimeter": false}, "destination_tickets": [{"id":
+        "AEF-97", "type": "jira_cloud", "link": "https://tenant-b6250acd.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}'
     headers:
       CF-RAY:

--- a/tests/cassettes/tools/vcr/test_get_incident_with_occurrences.yaml
+++ b/tests/cassettes/tools/vcr/test_get_incident_with_occurrences.yaml
@@ -30,28 +30,27 @@ interactions:
         null, "ignorer_id": null, "ignorer_api_token_id": null, "resolved_at": "2026-03-11T22:41:04.525493Z",
         "resolver_id": 492181, "resolver_api_token_id": null, "secret_revoked": true,
         "validity": "invalid", "severity": "medium", "assignee_id": null, "assignee_email":
-        "vincent.boyer@gitguardian.com", "share_url": "[REDACTED]", "feedback_list":
-        [{"created_at": "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
-        "email": "stanislas.crepin@gitguardian.com", "member_id": null, "answers":
-        [{"type": "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is
-        this an actual secret?", "boolean": true}, {"type": "boolean", "field_ref":
-        "access_to_sensitive_yes_no", "field_label": "Does this secret give or has
-        given access to any sensitive information or services?", "boolean": true},
-        {"type": "boolean", "field_ref": "revoked_yes_no", "field_label": "Has this
-        secret been revoked?", "boolean": false}, {"type": "text", "field_ref": "remarks_text",
-        "field_label": "Additional remarks", "text": "Hasn''t been revoked yet because
-        X"}]}], "risk_score": 100, "severity_rule_id": null, "is_vaulted": false,
-        "ignore_reason": null, "occurrences": [{"id": 78197, "incident_id": 21460,
-        "date": "2020-10-29T13:20:05.797462Z", "filepath": "app.py", "kind": "realtime",
-        "presence": "removed", "matches": [{"name": "client_id", "indice_start": 49,
-        "indice_end": 69, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
-        null, "post_line_end": null}, {"name": "client_secret", "indice_start": 85,
-        "indice_end": 125, "pre_line_start": 4, "pre_line_end": 4, "post_line_start":
-        null, "post_line_end": null}], "tags": ["PUBLICLY_EXPOSED", "PUBLIC"], "url":
-        "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "user-74281974@example.com", "share_url": "[REDACTED]", "feedback_list": [{"created_at":
+        "2022-07-20T13:22:52.756189Z", "updated_at": "2022-07-20T13:22:52.756207Z",
+        "email": "user-1a0bc62d@example.com", "member_id": null, "answers": [{"type":
+        "boolean", "field_ref": "actual_secret_yes_no", "field_label": "Is this an
+        actual secret?", "boolean": true}, {"type": "boolean", "field_ref": "access_to_sensitive_yes_no",
+        "field_label": "Does this secret give or has given access to any sensitive
+        information or services?", "boolean": true}, {"type": "boolean", "field_ref":
+        "revoked_yes_no", "field_label": "Has this secret been revoked?", "boolean":
+        false}, {"type": "text", "field_ref": "remarks_text", "field_label": "Additional
+        remarks", "text": "Hasn''t been revoked yet because X"}]}], "risk_score":
+        100, "severity_rule_id": null, "is_vaulted": false, "ignore_reason": null,
+        "occurrences": [{"id": 78197, "incident_id": 21460, "date": "2020-10-29T13:20:05.797462Z",
+        "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
+        [{"name": "client_id", "indice_start": 49, "indice_end": 69, "pre_line_start":
+        3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}, {"name":
+        "client_secret", "indice_start": 85, "indice_end": 125, "pre_line_start":
+        4, "pre_line_end": 4, "post_line_start": null, "post_line_end": null}], "tags":
+        ["PUBLICLY_EXPOSED", "PUBLIC"], "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/4c2166bbf37e361fe9a818bffb63c3a43f89a1cb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "4c2166bbf37e361fe9a818bffb63c3a43f89a1cb", "change_type": "deletion", "source":
+        {"id": 12349, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
@@ -61,7 +60,7 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}, {"id": 78198,
         "incident_id": 21460, "date": "2020-10-29T13:19:59.005564Z", "filepath": "app.py",
         "kind": "realtime", "presence": "removed", "matches": [{"name": "client_id",
@@ -69,10 +68,10 @@ interactions:
         null, "post_line_start": 3, "post_line_end": 3}, {"name": "client_secret",
         "indice_start": 128, "indice_end": 168, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 4, "post_line_end": 4}], "tags": ["PUBLICLY_EXPOSED",
-        "PUBLIC"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition",
-        "source": {"id": 12349, "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "PUBLIC"], "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10/commit/998deb2c88b0be31f72d117ac1238114334445e8#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R4",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "998deb2c88b0be31f72d117ac1238114334445e8", "change_type": "addition", "source":
+        {"id": 12349, "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-10",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
         11, "last_scan": {"date": "2020-12-10T10:45:12.795972Z", "status": "finished",
@@ -82,7 +81,7 @@ interactions:
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 9, "medium": 2,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}}], "secret_presence":
         {"files_requiring_code_fix": 0, "files_pending_merge": 0, "files_fixed": 0,
         "outside_vcs": 0, "removed_outside_vcs": 0, "in_vcs": 0, "removed_in_vcs":
@@ -90,7 +89,7 @@ interactions:
         "tags": ["REVOCABLE_BY_GG", "PUBLICLY_LEAKED"], "incident_name": "AWS IAM
         Keys", "public_exposure": {"source_publicly_visible": true, "public_incident_linked":
         false, "leaked_outside_perimeter": false}, "destination_tickets": [{"id":
-        "AEF-97", "type": "jira_cloud", "link": "https://yanne-gg-integration.atlassian.net/browse/AEF-97"}],
+        "AEF-97", "type": "jira_cloud", "link": "https://tenant-b6250acd.atlassian.net/browse/AEF-97"}],
         "custom_tags": []}'
     headers:
       CF-RAY:

--- a/tests/cassettes/tools/vcr/test_get_member_basic.yaml
+++ b/tests/cassettes/tools/vcr/test_get_member_basic.yaml
@@ -20,8 +20,8 @@ interactions:
     uri: https://api.gitguardian.com/v1/members/13
   response:
     body:
-      string: '{"id": 13, "role": "manager", "access_level": "manager", "email": "aymeric.sicard@gitguardian.com",
-        "name": "Aymeric SICARD", "created_at": "2020-01-21T09:35:47.907207Z", "last_login":
+      string: '{"id": 13, "role": "manager", "access_level": "manager", "email": "user-71ab73d0@example.com",
+        "name": "User d0d18d7e", "created_at": "2020-01-21T09:35:47.907207Z", "last_login":
         "2026-06-22T14:20:46.680540Z", "active": true}'
     headers:
       CF-RAY:

--- a/tests/cassettes/tools/vcr/test_get_member_has_timestamps.yaml
+++ b/tests/cassettes/tools/vcr/test_get_member_has_timestamps.yaml
@@ -20,8 +20,8 @@ interactions:
     uri: https://api.gitguardian.com/v1/members/13
   response:
     body:
-      string: '{"id": 13, "role": "manager", "access_level": "manager", "email": "aymeric.sicard@gitguardian.com",
-        "name": "Aymeric SICARD", "created_at": "2020-01-21T09:35:47.907207Z", "last_login":
+      string: '{"id": 13, "role": "manager", "access_level": "manager", "email": "user-71ab73d0@example.com",
+        "name": "User d0d18d7e", "created_at": "2020-01-21T09:35:47.907207Z", "last_login":
         "2026-06-22T14:20:46.680540Z", "active": true}'
     headers:
       CF-RAY:

--- a/tests/cassettes/tools/vcr/test_get_member_verifies_id.yaml
+++ b/tests/cassettes/tools/vcr/test_get_member_verifies_id.yaml
@@ -20,8 +20,8 @@ interactions:
     uri: https://api.gitguardian.com/v1/members/13
   response:
     body:
-      string: '{"id": 13, "role": "manager", "access_level": "manager", "email": "aymeric.sicard@gitguardian.com",
-        "name": "Aymeric SICARD", "created_at": "2020-01-21T09:35:47.907207Z", "last_login":
+      string: '{"id": 13, "role": "manager", "access_level": "manager", "email": "user-71ab73d0@example.com",
+        "name": "User d0d18d7e", "created_at": "2020-01-21T09:35:47.907207Z", "last_login":
         "2026-06-22T14:20:46.680540Z", "active": true}'
     headers:
       CF-RAY:

--- a/tests/cassettes/tools/vcr/test_list_incident_members_basic.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incident_members_basic.yaml
@@ -20,18 +20,17 @@ interactions:
     uri: https://api.gitguardian.com/v1/incidents/secrets/21460/members?per_page=5
   response:
     body:
-      string: '[{"id": 10, "member_id": 10, "role": "manager", "name": "Bruce Wayne",
-        "email": "bruce-wayne-gg@protonmail.com", "incident_id": 21460, "incident_permission":
-        "full_access"}, {"id": 13, "member_id": 13, "role": "manager", "name": "Aymeric
-        SICARD", "email": "aymeric.sicard@gitguardian.com", "incident_id": 21460,
-        "incident_permission": "full_access"}, {"id": 2508, "member_id": 2508, "role":
-        "manager", "name": "Guillaume CHARPIAT", "email": "guillaume.charpiat@gitguardian.com",
-        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 37699,
-        "member_id": 37699, "role": "manager", "name": "Alexis LARNAUD", "email":
-        "alexis.larnaud@gitguardian.com", "incident_id": 21460, "incident_permission":
-        "full_access"}, {"id": 63809, "member_id": 63809, "role": "manager", "name":
-        "Orian ROTURIER", "email": "orian.roturier@gitguardian.com", "incident_id":
-        21460, "incident_permission": "full_access"}]'
+      string: '[{"id": 10, "member_id": 10, "role": "manager", "name": "User 2b03ad68",
+        "email": "user-324427de@example.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 13, "member_id": 13, "role": "manager", "name": "User
+        d0d18d7e", "email": "user-71ab73d0@example.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 2508, "member_id": 2508, "role": "manager", "name":
+        "User 793501dc", "email": "user-d9f863cd@example.com", "incident_id": 21460,
+        "incident_permission": "full_access"}, {"id": 37699, "member_id": 37699, "role":
+        "manager", "name": "User 40f52996", "email": "user-d3774a22@example.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 63809,
+        "member_id": 63809, "role": "manager", "name": "User 97a9750c", "email": "user-0222ba7e@example.com",
+        "incident_id": 21460, "incident_permission": "full_access"}]'
     headers:
       CF-RAY:
       - a10397acfd17d343-CDG

--- a/tests/cassettes/tools/vcr/test_list_incident_members_with_access_level.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incident_members_with_access_level.yaml
@@ -20,29 +20,28 @@ interactions:
     uri: https://api.gitguardian.com/v1/incidents/secrets/21460/members?per_page=10&access_level=owner
   response:
     body:
-      string: '[{"id": 10, "member_id": 10, "role": "manager", "name": "Bruce Wayne",
-        "email": "bruce-wayne-gg@protonmail.com", "incident_id": 21460, "incident_permission":
-        "full_access"}, {"id": 13, "member_id": 13, "role": "manager", "name": "Aymeric
-        SICARD", "email": "aymeric.sicard@gitguardian.com", "incident_id": 21460,
-        "incident_permission": "full_access"}, {"id": 2508, "member_id": 2508, "role":
-        "manager", "name": "Guillaume CHARPIAT", "email": "guillaume.charpiat@gitguardian.com",
-        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 37699,
-        "member_id": 37699, "role": "manager", "name": "Alexis LARNAUD", "email":
-        "alexis.larnaud@gitguardian.com", "incident_id": 21460, "incident_permission":
-        "full_access"}, {"id": 63809, "member_id": 63809, "role": "manager", "name":
-        "Orian ROTURIER", "email": "orian.roturier@gitguardian.com", "incident_id":
-        21460, "incident_permission": "full_access"}, {"id": 69474, "member_id": 69474,
-        "role": "member", "name": "Eric", "email": "elacaille0@gmail.com", "incident_id":
-        21460, "incident_permission": "can_edit"}, {"id": 104544, "member_id": 104544,
-        "role": "manager", "name": "Pierre LALANNE", "email": "pierre.lalanne@gitguardian.com",
+      string: '[{"id": 10, "member_id": 10, "role": "manager", "name": "User 2b03ad68",
+        "email": "user-324427de@example.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 13, "member_id": 13, "role": "manager", "name": "User
+        d0d18d7e", "email": "user-71ab73d0@example.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 2508, "member_id": 2508, "role": "manager", "name":
+        "User 793501dc", "email": "user-d9f863cd@example.com", "incident_id": 21460,
+        "incident_permission": "full_access"}, {"id": 37699, "member_id": 37699, "role":
+        "manager", "name": "User 40f52996", "email": "user-d3774a22@example.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 63809,
+        "member_id": 63809, "role": "manager", "name": "User 97a9750c", "email": "user-0222ba7e@example.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 69474,
+        "member_id": 69474, "role": "member", "name": "User 4cb39c1b", "email": "user-5af3cff5@example.com",
+        "incident_id": 21460, "incident_permission": "can_edit"}, {"id": 104544, "member_id":
+        104544, "role": "manager", "name": "User 9a67720c", "email": "user-aba104cf@example.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 104916,
-        "member_id": 104916, "role": "manager", "name": "Wassim HANA", "email": "wassim.hana@gitguardian.com",
-        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 113168,
-        "member_id": 113168, "role": "owner", "name": "Henri HUBERT", "email": "henri.hubert@gitguardian.com",
-        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 136170,
-        "member_id": 136170, "role": "manager", "name": "Eric FOURRIER", "email":
-        "eric.fourrier@gitguardian.com", "incident_id": 21460, "incident_permission":
-        "full_access"}]'
+        "member_id": 104916, "role": "manager", "name": "User f4c96fee", "email":
+        "user-f548df99@example.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 113168, "member_id": 113168, "role": "owner", "name":
+        "User 00d1c796", "email": "user-c010b87e@example.com", "incident_id": 21460,
+        "incident_permission": "full_access"}, {"id": 136170, "member_id": 136170,
+        "role": "manager", "name": "User 795904a4", "email": "user-db85bcf2@example.com",
+        "incident_id": 21460, "incident_permission": "full_access"}]'
     headers:
       CF-RAY:
       - a10397b0aa709dae-CDG

--- a/tests/cassettes/tools/vcr/test_list_incident_members_with_direct_access.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incident_members_with_direct_access.yaml
@@ -20,29 +20,28 @@ interactions:
     uri: https://api.gitguardian.com/v1/incidents/secrets/21460/members?per_page=10&direct_access=true
   response:
     body:
-      string: '[{"id": 10, "member_id": 10, "role": "manager", "name": "Bruce Wayne",
-        "email": "bruce-wayne-gg@protonmail.com", "incident_id": 21460, "incident_permission":
-        "full_access"}, {"id": 13, "member_id": 13, "role": "manager", "name": "Aymeric
-        SICARD", "email": "aymeric.sicard@gitguardian.com", "incident_id": 21460,
-        "incident_permission": "full_access"}, {"id": 2508, "member_id": 2508, "role":
-        "manager", "name": "Guillaume CHARPIAT", "email": "guillaume.charpiat@gitguardian.com",
-        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 37699,
-        "member_id": 37699, "role": "manager", "name": "Alexis LARNAUD", "email":
-        "alexis.larnaud@gitguardian.com", "incident_id": 21460, "incident_permission":
-        "full_access"}, {"id": 63809, "member_id": 63809, "role": "manager", "name":
-        "Orian ROTURIER", "email": "orian.roturier@gitguardian.com", "incident_id":
-        21460, "incident_permission": "full_access"}, {"id": 69474, "member_id": 69474,
-        "role": "member", "name": "Eric", "email": "elacaille0@gmail.com", "incident_id":
-        21460, "incident_permission": "can_edit"}, {"id": 104544, "member_id": 104544,
-        "role": "manager", "name": "Pierre LALANNE", "email": "pierre.lalanne@gitguardian.com",
+      string: '[{"id": 10, "member_id": 10, "role": "manager", "name": "User 2b03ad68",
+        "email": "user-324427de@example.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 13, "member_id": 13, "role": "manager", "name": "User
+        d0d18d7e", "email": "user-71ab73d0@example.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 2508, "member_id": 2508, "role": "manager", "name":
+        "User 793501dc", "email": "user-d9f863cd@example.com", "incident_id": 21460,
+        "incident_permission": "full_access"}, {"id": 37699, "member_id": 37699, "role":
+        "manager", "name": "User 40f52996", "email": "user-d3774a22@example.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 63809,
+        "member_id": 63809, "role": "manager", "name": "User 97a9750c", "email": "user-0222ba7e@example.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 69474,
+        "member_id": 69474, "role": "member", "name": "User 4cb39c1b", "email": "user-5af3cff5@example.com",
+        "incident_id": 21460, "incident_permission": "can_edit"}, {"id": 104544, "member_id":
+        104544, "role": "manager", "name": "User 9a67720c", "email": "user-aba104cf@example.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 104916,
-        "member_id": 104916, "role": "manager", "name": "Wassim HANA", "email": "wassim.hana@gitguardian.com",
-        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 113168,
-        "member_id": 113168, "role": "owner", "name": "Henri HUBERT", "email": "henri.hubert@gitguardian.com",
-        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 136170,
-        "member_id": 136170, "role": "manager", "name": "Eric FOURRIER", "email":
-        "eric.fourrier@gitguardian.com", "incident_id": 21460, "incident_permission":
-        "full_access"}]'
+        "member_id": 104916, "role": "manager", "name": "User f4c96fee", "email":
+        "user-f548df99@example.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 113168, "member_id": 113168, "role": "owner", "name":
+        "User 00d1c796", "email": "user-c010b87e@example.com", "incident_id": 21460,
+        "incident_permission": "full_access"}, {"id": 136170, "member_id": 136170,
+        "role": "manager", "name": "User 795904a4", "email": "user-db85bcf2@example.com",
+        "incident_id": 21460, "incident_permission": "full_access"}]'
     headers:
       CF-RAY:
       - a10397b40d96d10c-CDG

--- a/tests/cassettes/tools/vcr/test_list_incident_members_with_ordering.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incident_members_with_ordering.yaml
@@ -20,29 +20,28 @@ interactions:
     uri: https://api.gitguardian.com/v1/incidents/secrets/21460/members?per_page=10&ordering=-created_at
   response:
     body:
-      string: '[{"id": 10, "member_id": 10, "role": "manager", "name": "Bruce Wayne",
-        "email": "bruce-wayne-gg@protonmail.com", "incident_id": 21460, "incident_permission":
-        "full_access"}, {"id": 13, "member_id": 13, "role": "manager", "name": "Aymeric
-        SICARD", "email": "aymeric.sicard@gitguardian.com", "incident_id": 21460,
-        "incident_permission": "full_access"}, {"id": 2508, "member_id": 2508, "role":
-        "manager", "name": "Guillaume CHARPIAT", "email": "guillaume.charpiat@gitguardian.com",
-        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 37699,
-        "member_id": 37699, "role": "manager", "name": "Alexis LARNAUD", "email":
-        "alexis.larnaud@gitguardian.com", "incident_id": 21460, "incident_permission":
-        "full_access"}, {"id": 63809, "member_id": 63809, "role": "manager", "name":
-        "Orian ROTURIER", "email": "orian.roturier@gitguardian.com", "incident_id":
-        21460, "incident_permission": "full_access"}, {"id": 69474, "member_id": 69474,
-        "role": "member", "name": "Eric", "email": "elacaille0@gmail.com", "incident_id":
-        21460, "incident_permission": "can_edit"}, {"id": 104544, "member_id": 104544,
-        "role": "manager", "name": "Pierre LALANNE", "email": "pierre.lalanne@gitguardian.com",
+      string: '[{"id": 10, "member_id": 10, "role": "manager", "name": "User 2b03ad68",
+        "email": "user-324427de@example.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 13, "member_id": 13, "role": "manager", "name": "User
+        d0d18d7e", "email": "user-71ab73d0@example.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 2508, "member_id": 2508, "role": "manager", "name":
+        "User 793501dc", "email": "user-d9f863cd@example.com", "incident_id": 21460,
+        "incident_permission": "full_access"}, {"id": 37699, "member_id": 37699, "role":
+        "manager", "name": "User 40f52996", "email": "user-d3774a22@example.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 63809,
+        "member_id": 63809, "role": "manager", "name": "User 97a9750c", "email": "user-0222ba7e@example.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 69474,
+        "member_id": 69474, "role": "member", "name": "User 4cb39c1b", "email": "user-5af3cff5@example.com",
+        "incident_id": 21460, "incident_permission": "can_edit"}, {"id": 104544, "member_id":
+        104544, "role": "manager", "name": "User 9a67720c", "email": "user-aba104cf@example.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 104916,
-        "member_id": 104916, "role": "manager", "name": "Wassim HANA", "email": "wassim.hana@gitguardian.com",
-        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 113168,
-        "member_id": 113168, "role": "owner", "name": "Henri HUBERT", "email": "henri.hubert@gitguardian.com",
-        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 136170,
-        "member_id": 136170, "role": "manager", "name": "Eric FOURRIER", "email":
-        "eric.fourrier@gitguardian.com", "incident_id": 21460, "incident_permission":
-        "full_access"}]'
+        "member_id": 104916, "role": "manager", "name": "User f4c96fee", "email":
+        "user-f548df99@example.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 113168, "member_id": 113168, "role": "owner", "name":
+        "User 00d1c796", "email": "user-c010b87e@example.com", "incident_id": 21460,
+        "incident_permission": "full_access"}, {"id": 136170, "member_id": 136170,
+        "role": "manager", "name": "User 795904a4", "email": "user-db85bcf2@example.com",
+        "incident_id": 21460, "incident_permission": "full_access"}]'
     headers:
       CF-RAY:
       - a10397b25a4dd146-CDG

--- a/tests/cassettes/tools/vcr/test_list_incident_members_with_search.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incident_members_with_search.yaml
@@ -20,28 +20,28 @@ interactions:
     uri: https://api.gitguardian.com/v1/incidents/secrets/21460/members?per_page=10&search=gitguardian
   response:
     body:
-      string: '[{"id": 13, "member_id": 13, "role": "manager", "name": "Aymeric SICARD",
-        "email": "aymeric.sicard@gitguardian.com", "incident_id": 21460, "incident_permission":
+      string: '[{"id": 13, "member_id": 13, "role": "manager", "name": "User d0d18d7e",
+        "email": "user-71ab73d0@example.com", "incident_id": 21460, "incident_permission":
         "full_access"}, {"id": 2508, "member_id": 2508, "role": "manager", "name":
-        "Guillaume CHARPIAT", "email": "guillaume.charpiat@gitguardian.com", "incident_id":
-        21460, "incident_permission": "full_access"}, {"id": 37699, "member_id": 37699,
-        "role": "manager", "name": "Alexis LARNAUD", "email": "alexis.larnaud@gitguardian.com",
+        "User 793501dc", "email": "user-d9f863cd@example.com", "incident_id": 21460,
+        "incident_permission": "full_access"}, {"id": 37699, "member_id": 37699, "role":
+        "manager", "name": "User 40f52996", "email": "user-d3774a22@example.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 63809,
-        "member_id": 63809, "role": "manager", "name": "Orian ROTURIER", "email":
-        "orian.roturier@gitguardian.com", "incident_id": 21460, "incident_permission":
-        "full_access"}, {"id": 104544, "member_id": 104544, "role": "manager", "name":
-        "Pierre LALANNE", "email": "pierre.lalanne@gitguardian.com", "incident_id":
-        21460, "incident_permission": "full_access"}, {"id": 104916, "member_id":
-        104916, "role": "manager", "name": "Wassim HANA", "email": "wassim.hana@gitguardian.com",
-        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 113168,
-        "member_id": 113168, "role": "owner", "name": "Henri HUBERT", "email": "henri.hubert@gitguardian.com",
+        "member_id": 63809, "role": "manager", "name": "User 97a9750c", "email": "user-0222ba7e@example.com",
+        "incident_id": 21460, "incident_permission": "full_access"}, {"id": 104544,
+        "member_id": 104544, "role": "manager", "name": "User 9a67720c", "email":
+        "user-aba104cf@example.com", "incident_id": 21460, "incident_permission":
+        "full_access"}, {"id": 104916, "member_id": 104916, "role": "manager", "name":
+        "User f4c96fee", "email": "user-f548df99@example.com", "incident_id": 21460,
+        "incident_permission": "full_access"}, {"id": 113168, "member_id": 113168,
+        "role": "owner", "name": "User 00d1c796", "email": "user-c010b87e@example.com",
         "incident_id": 21460, "incident_permission": "full_access"}, {"id": 136170,
-        "member_id": 136170, "role": "manager", "name": "Eric FOURRIER", "email":
-        "eric.fourrier@gitguardian.com", "incident_id": 21460, "incident_permission":
+        "member_id": 136170, "role": "manager", "name": "User 795904a4", "email":
+        "user-db85bcf2@example.com", "incident_id": 21460, "incident_permission":
         "full_access"}, {"id": 160089, "member_id": 160089, "role": "manager", "name":
-        "Aur\u00e9lien G\u00c2TEAU", "email": "aurelien.gateau@gitguardian.com", "incident_id":
-        21460, "incident_permission": "full_access"}, {"id": 166199, "member_id":
-        166199, "role": "manager", "name": "Stanislas CR\u00c9PIN", "email": "stanislas.crepin@gitguardian.com",
+        "User 595a74b4", "email": "user-90859989@example.com", "incident_id": 21460,
+        "incident_permission": "full_access"}, {"id": 166199, "member_id": 166199,
+        "role": "manager", "name": "User fbc68cb1", "email": "user-1a0bc62d@example.com",
         "incident_id": 21460, "incident_permission": "full_access"}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/tools/vcr/test_list_incidents_coerce_multiple_single_values.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incidents_coerce_multiple_single_values.yaml
@@ -40,21 +40,21 @@ interactions:
         "EQ", "arg1": {"path": "issue.secret.validity_status", "default": null}, "arg2":
         {"value": "invalid"}}}]}, "is_global": false, "scope": "private", "author":
         520858}}, "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
-        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com",
-        "name": "dev"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com",
+        "name": "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": false,
+        "feedbacks_count": 0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
         [{"id": 16218896, "name": "qa / test-nriv", "type": "gl_project", "path":
         "qa1/test-nriv", "source_criticality": "unknown", "monitoring_status": "active",
         "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
         false, "similar_issue_count": 0, "score": 64, "displayed_occurrence": {"id":
         268288466, "issue": 32985083, "account": 8, "kind": "RLTM", "element": "9181621d49e910c3d2393f2373e52c04b26c7adb",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "y0o7bgCt8InKo3/G0QE6WaG+gU32WlUdYH0N4oUFXredK2KoKwrhfI+hoCMCs6v6",
         "published_at": "2026-05-19T09:33:23Z", "date": "2026-05-19T09:33:23Z", "detected_at":
         "2026-05-19T09:36:53.339083Z", "is_vcs_type": true, "last_detected_at": "2026-05-19T09:33:23Z",
-        "last_seen_at": "2026-05-19T09:33:23Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa1/test-nriv/commit/9181621d49e910c3d2393f2373e52c04b26c7adb#a290632bbcae192e53c54337b3238d835c97e8a9_5_4",
-        "source": {"id": 16218896, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa1/test-nriv",
+        "last_seen_at": "2026-05-19T09:33:23Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-e5a6b85b/ns-9acfb06d/commit/9181621d49e910c3d2393f2373e52c04b26c7adb#a290632bbcae192e53c54337b3238d835c97e8a9_5_4",
+        "source": {"id": 16218896, "url": "https://host-a31e7ce0.example.com/ns-e5a6b85b/ns-9acfb06d",
         "type": "gl_project", "display_name": "qa / test-nriv", "visibility": "internal",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 162813398,
@@ -92,21 +92,22 @@ interactions:
         "gitlab_enterprise_token", "github_access_token", "aws_iam"]}}]}, "is_global":
         true, "scope": "any", "author": null}}, "declarative_secret_status": null,
         "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 0, "sources": [{"id": 16219056, "name": "gim-qa-gitlabSandbox-auto
-        / gim-qa-gitlabSandbox-staging", "type": "gl_project", "path": "gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
+        [{"id": 16219056, "name": "gim-qa-gitlabSandbox-auto / gim-qa-gitlabSandbox-staging",
+        "type": "gl_project", "path": "gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
         "source_criticality": "critical", "monitoring_status": "active", "deleted_at":
         null}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
         1, "score": 97, "displayed_occurrence": {"id": 226113779, "issue": 22515404,
         "account": 8, "kind": "RLTM", "element": "95c8ae28ae02f1182bfa5ae2f6cabb69fab3ece9",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "yEDhOhQ6p7D5/7TcJR5YtztO3INO1WgqiWd2qPiA0XRele/bong1Td3XczdQcVM3",
         "published_at": "2025-11-17T17:16:25Z", "date": "2025-11-17T17:16:25Z", "detected_at":
         "2025-11-17T17:18:16.645938Z", "is_vcs_type": true, "last_detected_at": "2025-11-17T17:16:25Z",
-        "last_seen_at": "2025-11-17T17:16:25Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging/commit/95c8ae28ae02f1182bfa5ae2f6cabb69fab3ece9#34c8dc1a12161a07003ebd2c3145185257f0cd94_0_3",
-        "source": {"id": 16219056, "url": "https://gitlab-01.aws-qa-gitguardian.com/gim-qa-gitlabsandbox-auto/gim-qa-gitlabsandbox-staging",
+        "last_seen_at": "2025-11-17T17:16:25Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-88035254/ns-2405e744/commit/95c8ae28ae02f1182bfa5ae2f6cabb69fab3ece9#34c8dc1a12161a07003ebd2c3145185257f0cd94_0_3",
+        "source": {"id": 16219056, "url": "https://host-a31e7ce0.example.com/ns-88035254/ns-2405e744",
         "type": "gl_project", "display_name": "gim-qa-gitlabSandbox-auto / gim-qa-gitlabSandbox-staging",
         "visibility": "private", "monitored": true, "source_criticality": "critical",
         "deleted_at": null, "default_branch": "main", "monitoring_status": "active"},
@@ -142,8 +143,8 @@ interactions:
         {"value": "invalid"}}}]}, "is_global": false, "scope": "private", "author":
         520858}}, "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "GitGuardian Sandbox [internal]"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 3, "occurrences_presence_deleted_count":
+        "User d156fffd"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 3, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
         [{"id": 22879703, "name": "GitHub Gist Public Testing", "type": "custom_source",
         "path": "GitHub Gist Public Testing", "source_criticality": "unknown", "monitoring_status":
@@ -191,8 +192,8 @@ interactions:
         {"value": "invalid"}}}]}, "is_global": false, "scope": "private", "author":
         520858}}, "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "GitGuardian Sandbox [internal]"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        "User d156fffd"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
         [{"id": 22879703, "name": "GitHub Gist Public Testing", "type": "custom_source",
         "path": "GitHub Gist Public Testing", "source_criticality": "unknown", "monitoring_status":
@@ -240,8 +241,8 @@ interactions:
         "default": null}, "arg2": {"value": "invalid"}}}]}, "is_global": false, "scope":
         "private", "author": 520858}}, "declarative_secret_status": null, "assignee":
         null, "last_presence_check_at": null, "secret": "[REDACTED]", "severity":
-        100, "authors": [{"info": "", "name": "GitGuardian Sandbox [internal]"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        100, "authors": [{"info": "", "name": "User d156fffd"}], "user_permission":
+        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
         null, "locations_count": 0, "sources": [{"id": 22879703, "name": "GitHub Gist
         Public Testing", "type": "custom_source", "path": "GitHub Gist Public Testing",

--- a/tests/cassettes/tools/vcr/test_list_incidents_coerce_single_severity.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incidents_coerce_single_severity.yaml
@@ -40,21 +40,21 @@ interactions:
         "EQ", "arg1": {"path": "issue.secret.validity_status", "default": null}, "arg2":
         {"value": "invalid"}}}]}, "is_global": false, "scope": "private", "author":
         520858}}, "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
-        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com",
-        "name": "dev"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com",
+        "name": "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": false,
+        "feedbacks_count": 0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
         [{"id": 16218896, "name": "qa / test-nriv", "type": "gl_project", "path":
         "qa1/test-nriv", "source_criticality": "unknown", "monitoring_status": "active",
         "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
         false, "similar_issue_count": 0, "score": 64, "displayed_occurrence": {"id":
         268288466, "issue": 32985083, "account": 8, "kind": "RLTM", "element": "9181621d49e910c3d2393f2373e52c04b26c7adb",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "y0o7bgCt8InKo3/G0QE6WaG+gU32WlUdYH0N4oUFXredK2KoKwrhfI+hoCMCs6v6",
         "published_at": "2026-05-19T09:33:23Z", "date": "2026-05-19T09:33:23Z", "detected_at":
         "2026-05-19T09:36:53.339083Z", "is_vcs_type": true, "last_detected_at": "2026-05-19T09:33:23Z",
-        "last_seen_at": "2026-05-19T09:33:23Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa1/test-nriv/commit/9181621d49e910c3d2393f2373e52c04b26c7adb#a290632bbcae192e53c54337b3238d835c97e8a9_5_4",
-        "source": {"id": 16218896, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa1/test-nriv",
+        "last_seen_at": "2026-05-19T09:33:23Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-e5a6b85b/ns-9acfb06d/commit/9181621d49e910c3d2393f2373e52c04b26c7adb#a290632bbcae192e53c54337b3238d835c97e8a9_5_4",
+        "source": {"id": 16218896, "url": "https://host-a31e7ce0.example.com/ns-e5a6b85b/ns-9acfb06d",
         "type": "gl_project", "display_name": "qa / test-nriv", "visibility": "internal",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 162813398,
@@ -85,21 +85,21 @@ interactions:
         "arg1": {"path": "issue.secret.detector.metadata.category", "default": null},
         "arg2": {"value": "package_registry"}}, "is_global": true, "scope": "private",
         "author": null}}, "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
-        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "gg-tools@gitguardian.com",
-        "name": "gim-dev"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "user-7ec2e474@example.com",
+        "name": "User e307c118"}], "user_permission": 7, "is_publicly_shared": false,
+        "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
         [{"id": 27907812, "name": "gim-dev/ra24091", "type": "ghe_repository", "path":
         "gim-dev/ra24091", "source_criticality": "unknown", "monitoring_status": "active",
         "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
         false, "similar_issue_count": 0, "score": 86, "displayed_occurrence": {"id":
         271124127, "issue": 33596487, "account": 8, "kind": "HIST", "element": "726d6e14f4865b2ae7fa5d03972347e479880620",
-        "element_type": "GIT_COMMIT", "author_name": "gim-dev", "author_info": "gg-tools@gitguardian.com",
+        "element_type": "GIT_COMMIT", "author_name": "gim-dev", "author_info": "user-7ec2e474@example.com",
         "value": null, "value_hash": "bopfgjC9/ZqBM1Kl5mY7IsWivqih2CFAsisDVRqeRik1/8IJmhFA3PTcIootBtrN",
         "published_at": "2026-04-23T07:03:59Z", "date": "2026-04-23T07:03:59Z", "detected_at":
         "2026-06-03T06:07:39.990226Z", "is_vcs_type": true, "last_detected_at": "2026-04-23T07:03:59Z",
-        "last_seen_at": "2026-04-23T07:03:59Z", "data": {}, "url": "https://ghe-01.aws-qa-gitguardian.com/gim-dev/ra24091/commit/726d6e14f4865b2ae7fa5d03972347e479880620#diff-a8f520d6712a82ea3d0013a99d2a9dd590c10c78a334a1933e7a553458799877R4",
-        "source": {"id": 27907812, "url": "https://ghe-01.aws-qa-gitguardian.com/gim-dev/ra24091",
+        "last_seen_at": "2026-04-23T07:03:59Z", "data": {}, "url": "https://host-8c9d8db9.example.com/ns-e307c118/ns-00303b10/commit/726d6e14f4865b2ae7fa5d03972347e479880620#diff-a8f520d6712a82ea3d0013a99d2a9dd590c10c78a334a1933e7a553458799877R4",
+        "source": {"id": 27907812, "url": "https://host-8c9d8db9.example.com/ns-e307c118/ns-00303b10",
         "type": "ghe_repository", "display_name": "gim-dev/ra24091", "visibility":
         "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
         null, "default_branch": "main", "monitoring_status": "active"}, "regression":
@@ -130,21 +130,21 @@ interactions:
         "arg1": {"path": "issue.secret.detector.metadata.category", "default": null},
         "arg2": {"value": "package_registry"}}, "is_global": true, "scope": "private",
         "author": null}}, "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
-        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "gg-tools@gitguardian.com",
-        "name": "gim-dev"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "user-7ec2e474@example.com",
+        "name": "User e307c118"}], "user_permission": 7, "is_publicly_shared": false,
+        "feedbacks_count": 0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
         [{"id": 27907812, "name": "gim-dev/ra24091", "type": "ghe_repository", "path":
         "gim-dev/ra24091", "source_criticality": "unknown", "monitoring_status": "active",
         "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
         false, "similar_issue_count": 0, "score": 86, "displayed_occurrence": {"id":
         271124128, "issue": 33596488, "account": 8, "kind": "HIST", "element": "aa11f9f443e865a8ec50290ee90fe169c21aef9b",
-        "element_type": "GIT_COMMIT", "author_name": "gim-dev", "author_info": "gg-tools@gitguardian.com",
+        "element_type": "GIT_COMMIT", "author_name": "gim-dev", "author_info": "user-7ec2e474@example.com",
         "value": null, "value_hash": "dukMeDq1taBlF0eO3eWtf2S+5XlcRbPvGW2jrR30ibxFu9h2SqU+DWCwq6Cxp/hP",
         "published_at": "2026-04-23T07:01:34Z", "date": "2026-04-23T07:01:34Z", "detected_at":
         "2026-06-03T06:07:39.990226Z", "is_vcs_type": true, "last_detected_at": "2026-04-23T07:01:34Z",
-        "last_seen_at": "2026-04-23T07:01:34Z", "data": {}, "url": "https://ghe-01.aws-qa-gitguardian.com/gim-dev/ra24091/commit/aa11f9f443e865a8ec50290ee90fe169c21aef9b#diff-a8f520d6712a82ea3d0013a99d2a9dd590c10c78a334a1933e7a553458799877R3",
-        "source": {"id": 27907812, "url": "https://ghe-01.aws-qa-gitguardian.com/gim-dev/ra24091",
+        "last_seen_at": "2026-04-23T07:01:34Z", "data": {}, "url": "https://host-8c9d8db9.example.com/ns-e307c118/ns-00303b10/commit/aa11f9f443e865a8ec50290ee90fe169c21aef9b#diff-a8f520d6712a82ea3d0013a99d2a9dd590c10c78a334a1933e7a553458799877R3",
+        "source": {"id": 27907812, "url": "https://host-8c9d8db9.example.com/ns-e307c118/ns-00303b10",
         "type": "ghe_repository", "display_name": "gim-dev/ra24091", "visibility":
         "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
         null, "default_branch": "main", "monitoring_status": "active"}, "regression":
@@ -175,21 +175,21 @@ interactions:
         "arg1": {"path": "issue.secret.detector.metadata.category", "default": null},
         "arg2": {"value": "package_registry"}}, "is_global": true, "scope": "private",
         "author": null}}, "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
-        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "gg-tools@gitguardian.com",
-        "name": "gim-dev"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "user-7ec2e474@example.com",
+        "name": "User e307c118"}], "user_permission": 7, "is_publicly_shared": false,
+        "feedbacks_count": 0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
         [{"id": 27907812, "name": "gim-dev/ra24091", "type": "ghe_repository", "path":
         "gim-dev/ra24091", "source_criticality": "unknown", "monitoring_status": "active",
         "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
         false, "similar_issue_count": 0, "score": 86, "displayed_occurrence": {"id":
         271124122, "issue": 33596489, "account": 8, "kind": "HIST", "element": "aa11f9f443e865a8ec50290ee90fe169c21aef9b",
-        "element_type": "GIT_COMMIT", "author_name": "gim-dev", "author_info": "gg-tools@gitguardian.com",
+        "element_type": "GIT_COMMIT", "author_name": "gim-dev", "author_info": "user-7ec2e474@example.com",
         "value": null, "value_hash": "72AJ4l7ikuNODzwNuaxjTIxDURGLw+/dPaAUz7IaWGID7D5e7+TNTxbhgBuHYpK2",
         "published_at": "2026-04-23T07:01:34Z", "date": "2026-04-23T07:01:34Z", "detected_at":
         "2026-06-03T06:07:39.990226Z", "is_vcs_type": true, "last_detected_at": "2026-04-23T07:01:34Z",
-        "last_seen_at": "2026-04-23T07:01:34Z", "data": {}, "url": "https://ghe-01.aws-qa-gitguardian.com/gim-dev/ra24091/commit/aa11f9f443e865a8ec50290ee90fe169c21aef9b#diff-a8f520d6712a82ea3d0013a99d2a9dd590c10c78a334a1933e7a553458799877R4",
-        "source": {"id": 27907812, "url": "https://ghe-01.aws-qa-gitguardian.com/gim-dev/ra24091",
+        "last_seen_at": "2026-04-23T07:01:34Z", "data": {}, "url": "https://host-8c9d8db9.example.com/ns-e307c118/ns-00303b10/commit/aa11f9f443e865a8ec50290ee90fe169c21aef9b#diff-a8f520d6712a82ea3d0013a99d2a9dd590c10c78a334a1933e7a553458799877R4",
+        "source": {"id": 27907812, "url": "https://host-8c9d8db9.example.com/ns-e307c118/ns-00303b10",
         "type": "ghe_repository", "display_name": "gim-dev/ra24091", "visibility":
         "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
         null, "default_branch": "main", "monitoring_status": "active"}, "regression":
@@ -223,22 +223,21 @@ interactions:
         "default": null}, "arg2": {"value": "invalid"}}}]}, "is_global": false, "scope":
         "private", "author": 520858}}, "declarative_secret_status": null, "assignee":
         null, "last_presence_check_at": null, "secret": "[REDACTED]", "severity":
-        100, "authors": [{"info": "alina.tuholukova@gitguardian.com", "name": "Alina
-        Tuholukova"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
-        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
-        [{"id": 24066096, "name": "group3 / Guillaume testing", "type": "gl_project",
-        "path": "group2/guillaume-testing", "source_criticality": "unknown", "monitoring_status":
-        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 55, "displayed_occurrence":
-        {"id": 261408101, "issue": 30544091, "account": 8, "kind": "RLTM", "element":
-        "5e35304d12f5207f72dc3da8e7033494e3d49a90", "element_type": "GIT_COMMIT",
-        "author_name": "Alina Tuholukova", "author_info": "alina.tuholukova@gitguardian.com",
-        "value": null, "value_hash": "dmdGBLQCcXWDEKckkQGMvXTikhk7Qkpaml86yoY9X4Xmx+Oc7u2brhHr47K73UWF",
+        100, "authors": [{"info": "user-1ee838f7@example.com", "name": "User 68b10723"}],
+        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
+        null, "locations_count": 1, "sources": [{"id": 24066096, "name": "group3 /
+        Guillaume testing", "type": "gl_project", "path": "group2/guillaume-testing",
+        "source_criticality": "unknown", "monitoring_status": "active", "deleted_at":
+        null}], "custom_tags": [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count":
+        0, "score": 55, "displayed_occurrence": {"id": 261408101, "issue": 30544091,
+        "account": 8, "kind": "RLTM", "element": "5e35304d12f5207f72dc3da8e7033494e3d49a90",
+        "element_type": "GIT_COMMIT", "author_name": "Alina Tuholukova", "author_info":
+        "user-1ee838f7@example.com", "value": null, "value_hash": "dmdGBLQCcXWDEKckkQGMvXTikhk7Qkpaml86yoY9X4Xmx+Oc7u2brhHr47K73UWF",
         "published_at": "2026-04-21T13:50:33Z", "date": "2026-04-21T13:50:33Z", "detected_at":
         "2026-04-21T13:51:50.123829Z", "is_vcs_type": true, "last_detected_at": "2026-04-21T13:50:33Z",
-        "last_seen_at": "2026-04-21T13:50:33Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/group2/guillaume-testing/commit/5e35304d12f5207f72dc3da8e7033494e3d49a90#1a1b9769344cb239f2e540e1e6ee1efa2d3034ea_0_8",
-        "source": {"id": 24066096, "url": "https://gitlab-01.aws-qa-gitguardian.com/group2/guillaume-testing",
+        "last_seen_at": "2026-04-21T13:50:33Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-8c87b477/ns-711f682e/commit/5e35304d12f5207f72dc3da8e7033494e3d49a90#1a1b9769344cb239f2e540e1e6ee1efa2d3034ea_0_8",
+        "source": {"id": 24066096, "url": "https://host-a31e7ce0.example.com/ns-8c87b477/ns-711f682e",
         "type": "gl_project", "display_name": "group3 / Guillaume testing", "visibility":
         "private", "monitored": true, "source_criticality": "unknown", "deleted_at":
         null, "default_branch": "main", "monitoring_status": "active"}, "regression":

--- a/tests/cassettes/tools/vcr/test_list_incidents_coerce_single_status.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incidents_coerce_single_status.yaml
@@ -34,15 +34,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274792885, "issue": 34205503, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
         "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
@@ -50,20 +50,19 @@ interactions:
         "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
         "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
-        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
-        34186239, "account": 8, "criterion": "Generic Password", "date": "2026-06-22T15:14:57Z",
-        "last_trigger_published_at": "2026-06-22T15:14:57Z", "last_triggered_at":
-        "2026-06-22T15:16:49.799821Z", "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z",
-        "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-23T11:13:31.325324Z", "last_presence_check_at": "2026-06-23T11:13:31.325324Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}, {"id": 34186239, "account": 8, "criterion":
+        "Generic Password", "date": "2026-06-22T15:14:57Z", "last_trigger_published_at":
+        "2026-06-22T15:14:57Z", "last_triggered_at": "2026-06-22T15:16:49.799821Z",
+        "last_trigger_detected_at": "2026-06-22T15:16:49.799821Z", "hash": "l20PufsE4GDTHxA+dQvcCRYgs5n0Jvz4ekZkuygCenyvIwxefma8ieOEhD7igl+v",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -71,21 +70,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 20,
-        "score": 53, "displayed_occurrence": {"id": 274668904, "issue": 34186239,
-        "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 20, "score": 53, "displayed_occurrence": {"id":
+        274668904, "issue": 34186239, "account": 8, "kind": "RLTM", "element": "66a360da7770977c2b7146563965cc3b8f9bef14",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "qqQJUpRklXj/KcBjoHQUnrWhkWLSAzSR9We18pNwPA0YKdPADPOCUzfoeV0RPL4H",
         "published_at": "2026-06-22T15:14:57Z", "date": "2026-06-22T15:14:57Z", "detected_at":
         "2026-06-22T15:16:47.285045Z", "is_vcs_type": true, "last_detected_at": "2026-06-22T15:14:57Z",
-        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-22T15:14:57Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/66a360da7770977c2b7146563965cc3b8f9bef14#157ea6d1df25f65376ae6ed723abb24924786892_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 171323163,
@@ -110,21 +109,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "Generic Password", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": true, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 23485701, "name": "olaugier
-        / test", "type": "gl_project", "path": "olaugier/test", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 6,
-        "score": 63, "displayed_occurrence": {"id": 274099881, "issue": 34122510,
-        "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 23485701, "name": "olaugier / test", "type": "gl_project", "path":
+        "olaugier/test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 6, "score": 63, "displayed_occurrence": {"id":
+        274099881, "issue": 34122510, "account": 8, "kind": "RLTM", "element": "d991029e4f16242f69a123e6569f01a4ac353751",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "ziZG+4sRyEs9M1tKKvLjAoozkz2gjPS5hWTz9PpkSBIlHCLdWt2C2oWuiBSDKfgX",
         "published_at": "2026-06-19T13:41:03Z", "date": "2026-06-19T13:41:03Z", "detected_at":
         "2026-06-19T13:43:02.430249Z", "is_vcs_type": true, "last_detected_at": "2026-06-19T13:41:03Z",
-        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
-        "source": {"id": 23485701, "url": "https://gitlab-01.aws-qa-gitguardian.com/olaugier/test",
+        "last_seen_at": "2026-06-19T13:41:03Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081/commit/d991029e4f16242f69a123e6569f01a4ac353751#d258e1e638ae25e4c740fb3d15c74cd7c66d9c77_0_2",
+        "source": {"id": 23485701, "url": "https://host-a31e7ce0.example.com/ns-b228ad4d/ns-9f86d081",
         "type": "gl_project", "display_name": "olaugier / test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 170735860,
@@ -150,15 +149,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 273386288, "issue": 34038186, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
         "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
@@ -166,20 +165,19 @@ interactions:
         "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
         "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
-        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
-        33905111, "account": 8, "criterion": "GitLab Deploy Token", "date": "2026-06-11T12:29:43Z",
-        "last_trigger_published_at": "2026-06-11T12:29:43Z", "last_triggered_at":
-        "2026-06-11T12:30:11.342010Z", "last_trigger_detected_at": "2026-06-11T12:30:11.342010Z",
-        "hash": "G0fVu31BJOKtUHJsvHbpcGhXGXhyr2/bQf6zzlhNv+czrK+KrGdxdFLGuJmYhmlq",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-16T18:55:43.166667Z", "last_presence_check_at": "2026-06-16T18:55:43.166667Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}, {"id": 33905111, "account": 8, "criterion":
+        "GitLab Deploy Token", "date": "2026-06-11T12:29:43Z", "last_trigger_published_at":
+        "2026-06-11T12:29:43Z", "last_triggered_at": "2026-06-11T12:30:11.342010Z",
+        "last_trigger_detected_at": "2026-06-11T12:30:11.342010Z", "hash": "G0fVu31BJOKtUHJsvHbpcGhXGXhyr2/bQf6zzlhNv+czrK+KrGdxdFLGuJmYhmlq",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -187,21 +185,21 @@ interactions:
         "none", "manual_severity_setter_type": "none", "status": "TRIGGERED", "issue_name":
         "GitLab Deploy Token", "severity_rule_config": null, "declarative_secret_status":
         null, "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com", "name": "dev"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
-        1, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 1, "sources": [{"id": 28664611, "name": "dev / plal_test",
-        "type": "gl_project", "path": "dev/plal_test", "source_criticality": "unknown",
-        "monitoring_status": "active", "deleted_at": null}], "custom_tags": [], "vault_metadata":
-        null, "is_vaulted": false, "similar_issue_count": 0, "score": 85, "displayed_occurrence":
-        {"id": 272645187, "issue": 33905111, "account": 8, "kind": "HIST", "element":
-        "0102329ae146f51358cff771dbdf860acbc78ef6", "element_type": "GIT_COMMIT",
-        "author_name": "dev", "author_info": "gim+dev@gitguardian.com", "value": null,
-        "value_hash": "vKgkDXA4NszdEvKqefnQ7tPG4AsADP5uV3carLt96S2ZoMa7KySfdZ9m9HlrAElh",
+        "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com", "name":
+        "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
+        0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
+        [{"id": 28664611, "name": "dev / plal_test", "type": "gl_project", "path":
+        "dev/plal_test", "source_criticality": "unknown", "monitoring_status": "active",
+        "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
+        false, "similar_issue_count": 0, "score": 85, "displayed_occurrence": {"id":
+        272645187, "issue": 33905111, "account": 8, "kind": "HIST", "element": "0102329ae146f51358cff771dbdf860acbc78ef6",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
+        "value": null, "value_hash": "vKgkDXA4NszdEvKqefnQ7tPG4AsADP5uV3carLt96S2ZoMa7KySfdZ9m9HlrAElh",
         "published_at": "2026-06-11T12:29:43Z", "date": "2026-06-11T12:29:43Z", "detected_at":
         "2026-06-11T12:30:10.472937Z", "is_vcs_type": true, "last_detected_at": "2026-06-11T12:37:30.541974Z",
-        "last_seen_at": "2026-06-11T12:37:30.541974Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/dev/plal_test/commit/0102329ae146f51358cff771dbdf860acbc78ef6#5a06a4630a05426a25bc162c233d6cf8ed2462a0_None_5",
-        "source": {"id": 28664611, "url": "https://gitlab-01.aws-qa-gitguardian.com/dev/plal_test",
+        "last_seen_at": "2026-06-11T12:37:30.541974Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-ef260e9a/ns-c602f9c5/commit/0102329ae146f51358cff771dbdf860acbc78ef6#5a06a4630a05426a25bc162c233d6cf8ed2462a0_None_5",
+        "source": {"id": 28664611, "url": "https://host-a31e7ce0.example.com/ns-ef260e9a/ns-c602f9c5",
         "type": "gl_project", "display_name": "dev / plal_test", "visibility": "private",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 168574637,

--- a/tests/cassettes/tools/vcr/test_list_incidents_coerce_single_validity.yaml
+++ b/tests/cassettes/tools/vcr/test_list_incidents_coerce_single_validity.yaml
@@ -34,15 +34,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        true, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": true, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 274792885, "issue": 34205503,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 274792885, "issue": 34205503, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-dedup/secrets.jsonl.169",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "1TXwqQngy2cxRxis2dLzOshet5LX0P4n6uJ9tbzrAYI/0Tf5WGr+ma7NdWCAggYy",
         "published_at": "2026-06-23T11:13:31.325324Z", "date": "2026-06-23T11:13:31.325324Z",
@@ -50,38 +50,37 @@ interactions:
         "2026-06-23T11:13:31.325324Z", "last_seen_at": "2026-06-23T11:13:31.325324Z",
         "data": {"line": 2, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-23T11:13:31.325324Z", "last_presence_check_at":
-        "2026-06-23T11:13:31.325324Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
-        34181686, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
-        "date": "2026-06-22T11:25:45.739149Z", "last_trigger_published_at": "2026-06-22T11:25:45.739149Z",
-        "last_triggered_at": "2026-06-22T11:25:45.762592Z", "last_trigger_detected_at":
-        "2026-06-22T11:25:45.762592Z", "hash": "gVrL/pjjFLo7sSikPS1pWtPJbr+oWSSVz8IB6+2ViJDSJKiK25LITKmJimoqGr3z",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-23T11:13:31.325324Z", "last_presence_check_at": "2026-06-23T11:13:31.325324Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}, {"id": 34181686, "account": 8, "criterion":
+        "microsoft_azure_storage_connection_string", "date": "2026-06-22T11:25:45.739149Z",
+        "last_trigger_published_at": "2026-06-22T11:25:45.739149Z", "last_triggered_at":
+        "2026-06-22T11:25:45.762592Z", "last_trigger_detected_at": "2026-06-22T11:25:45.762592Z",
+        "hash": "gVrL/pjjFLo7sSikPS1pWtPJbr+oWSSVz8IB6+2ViJDSJKiK25LITKmJimoqGr3z",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": true, "resolved_at": "2026-06-22T11:26:52.971214Z", "resolver":
         1751937, "regression": false, "manual_severity_setter": null, "ignorer_display_name":
-        "none", "ignorer_type": "none", "resolver_display_name": "candidate.playground+eu@gitguardian.com",
+        "none", "ignorer_type": "none", "resolver_display_name": "user-1ffcf115@example.com",
         "resolver_type": "user", "manual_severity_setter_display_name": "none", "manual_severity_setter_type":
         "none", "status": "RESOLVED", "issue_name": "Microsoft Azure Storage Connection
         String", "severity_rule_config": null, "declarative_secret_status": "revoked",
         "assignee": null, "last_presence_check_at": null, "secret": "[REDACTED]",
-        "severity": 100, "authors": [{"info": "", "name": "Kashyapa P.A. Jayasekera"}],
-        "user_permission": 7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
+        "severity": 100, "authors": [{"info": "", "name": "User 801c5600"}], "user_permission":
+        7, "is_publicly_shared": false, "feedbacks_count": 0, "occurrences_presence_seen_count":
         6, "occurrences_presence_deleted_count": 0, "occurrences_presence_should_be_checked":
-        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "GGFRLTA127
-        \u2014 kashyapap.jayasekera", "type": "endpoints", "path": "GGFRLTA127 \u2014
-        kashyapap.jayasekera", "source_criticality": "unknown", "monitoring_status":
-        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
-        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        null, "locations_count": 6, "sources": [{"id": 28462334, "name": "endpoint-86a2394f",
+        "type": "endpoints", "path": "endpoint-86a2394f", "source_criticality": "unknown",
+        "monitoring_status": "active", "deleted_at": null}], "custom_tags": [], "vault_metadata":
+        null, "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
         {"id": 274639444, "issue": 34181686, "account": 8, "kind": "RLTM", "element":
-        "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.159-bm/secrets/secrets.jsonl.5",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "AAr6ayAj6Hs2pOICdVUlEyuXlsQ78K3HFGOJgWA/yAiQrRuQH9Kv1GxUH36IT99d",
         "published_at": "2026-06-22T11:25:45.739149Z", "date": "2026-06-22T11:25:45.739149Z",
@@ -89,20 +88,20 @@ interactions:
         "2026-06-22T11:25:45.739149Z", "last_seen_at": "2026-06-22T11:25:45.739149Z",
         "data": {"line": 20, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-22T11:25:45.739149Z", "last_presence_check_at":
-        "2026-06-22T11:25:45.739149Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 6}, {"id":
-        34038186, "account": 8, "criterion": "microsoft_azure_storage_connection_string",
-        "date": "2026-06-16T18:55:43.166667Z", "last_trigger_published_at": "2026-06-16T18:55:43.166667Z",
-        "last_triggered_at": "2026-06-16T18:55:43.185061Z", "last_trigger_detected_at":
-        "2026-06-16T18:55:43.185061Z", "hash": "JFTpQX+4P/dEcXJJ2iw+u54JYDsJnqLtrdws1wjFQ8t9LtHh25LITKmJimoqGr3z",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-22T11:25:45.739149Z", "last_presence_check_at": "2026-06-22T11:25:45.739149Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 6}, {"id": 34038186, "account": 8, "criterion":
+        "microsoft_azure_storage_connection_string", "date": "2026-06-16T18:55:43.166667Z",
+        "last_trigger_published_at": "2026-06-16T18:55:43.166667Z", "last_triggered_at":
+        "2026-06-16T18:55:43.185061Z", "last_trigger_detected_at": "2026-06-16T18:55:43.185061Z",
+        "hash": "JFTpQX+4P/dEcXJJ2iw+u54JYDsJnqLtrdws1wjFQ8t9LtHh25LITKmJimoqGr3z",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -111,15 +110,15 @@ interactions:
         "Microsoft Azure Storage Connection String", "severity_rule_config": null,
         "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "", "name":
-        "Kashyapa P.A. Jayasekera"}], "user_permission": 7, "is_publicly_shared":
-        false, "feedbacks_count": 0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
+        "User 801c5600"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
+        0, "occurrences_presence_seen_count": 16, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 16,
-        "sources": [{"id": 28462334, "name": "GGFRLTA127 \u2014 kashyapap.jayasekera",
-        "type": "endpoints", "path": "GGFRLTA127 \u2014 kashyapap.jayasekera", "source_criticality":
-        "unknown", "monitoring_status": "active", "deleted_at": null}], "custom_tags":
-        [], "vault_metadata": null, "is_vaulted": false, "similar_issue_count": 0,
-        "score": 97, "displayed_occurrence": {"id": 273386288, "issue": 34038186,
-        "account": 8, "kind": "RLTM", "element": "/Users/kashyapap.jayasekera/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
+        "sources": [{"id": 28462334, "name": "endpoint-86a2394f", "type": "endpoints",
+        "path": "endpoint-86a2394f", "source_criticality": "unknown", "monitoring_status":
+        "active", "deleted_at": null}], "custom_tags": [], "vault_metadata": null,
+        "is_vaulted": false, "similar_issue_count": 0, "score": 97, "displayed_occurrence":
+        {"id": 273386288, "issue": 34038186, "account": 8, "kind": "RLTM", "element":
+        "/Users/user-eb6cfa60/leak-digger/leakdigger/scripts/secrets2db/benchmark-investigation/2.158/secrets/secrets.jsonl.54",
         "element_type": "ENDPOINT_FILE", "author_name": "Kashyapa P.A. Jayasekera",
         "author_info": "", "value": null, "value_hash": "/a+pc4LjKNLVtU/mRpEwYgEVVkXAgC4N/eP1ViVyLummI09iOJjROwJtISDlDj7d",
         "published_at": "2026-06-16T18:55:43.166667Z", "date": "2026-06-16T18:55:43.166667Z",
@@ -127,20 +126,19 @@ interactions:
         "2026-06-16T18:55:43.166667Z", "last_seen_at": "2026-06-16T18:55:43.166667Z",
         "data": {"line": 5, "matched_lines": []}, "url": "", "source": {"id": 28462334,
         "url": "/workspace/8/endpoints/users/217", "type": "endpoints", "display_name":
-        "GGFRLTA127 \u2014 kashyapap.jayasekera", "visibility": "private", "monitored":
-        true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
-        null, "monitoring_status": "active"}, "regression": false, "content": 168376390,
-        "secrets_engine_version": "2.165.0", "matches": [], "most_sensitive_match_name":
-        null, "insights": [], "filepath": null, "filename": null, "presence": "visible",
-        "last_presence_seen_at": "2026-06-16T18:55:43.166667Z", "last_presence_check_at":
-        "2026-06-16T18:55:43.166667Z", "first_presence_deleted_at": null, "seen_in_default_branch":
-        null, "change_type": null, "full_tags": []}, "has_dropped_occurrences": false,
-        "tags": [], "public_exposure": {"source_publicly_visible": false, "public_incident_linked":
-        false, "leaked_outside_perimeter": false}, "occurrences_count": 16}, {"id":
-        32985083, "account": 8, "criterion": "Google API Key", "date": "2026-05-19T09:33:23Z",
-        "last_trigger_published_at": "2026-05-19T09:33:23Z", "last_triggered_at":
-        "2026-05-19T09:36:55.570755Z", "last_trigger_detected_at": "2026-05-19T09:36:55.570755Z",
-        "hash": "pHE0O7zGgt2lhT0TLQzB2cwgMuZgrhqH4vSIGV5fw5ao1EL3iwQ5Z8PP16EaJtIX",
+        "endpoint-86a2394f", "visibility": "private", "monitored": true, "source_criticality":
+        "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":
+        "active"}, "regression": false, "content": 168376390, "secrets_engine_version":
+        "2.165.0", "matches": [], "most_sensitive_match_name": null, "insights": [],
+        "filepath": null, "filename": null, "presence": "visible", "last_presence_seen_at":
+        "2026-06-16T18:55:43.166667Z", "last_presence_check_at": "2026-06-16T18:55:43.166667Z",
+        "first_presence_deleted_at": null, "seen_in_default_branch": null, "change_type":
+        null, "full_tags": []}, "has_dropped_occurrences": false, "tags": [], "public_exposure":
+        {"source_publicly_visible": false, "public_incident_linked": false, "leaked_outside_perimeter":
+        false}, "occurrences_count": 16}, {"id": 32985083, "account": 8, "criterion":
+        "Google API Key", "date": "2026-05-19T09:33:23Z", "last_trigger_published_at":
+        "2026-05-19T09:33:23Z", "last_triggered_at": "2026-05-19T09:36:55.570755Z",
+        "last_trigger_detected_at": "2026-05-19T09:36:55.570755Z", "hash": "pHE0O7zGgt2lhT0TLQzB2cwgMuZgrhqH4vSIGV5fw5ao1EL3iwQ5Z8PP16EaJtIX",
         "ignored": false, "ignored_at": null, "ignore_reason": null, "ignorer": null,
         "resolved": false, "resolved_at": null, "resolver": null, "regression": false,
         "manual_severity_setter": null, "ignorer_display_name": "none", "ignorer_type":
@@ -156,21 +154,21 @@ interactions:
         "EQ", "arg1": {"path": "issue.secret.validity_status", "default": null}, "arg2":
         {"value": "invalid"}}}]}, "is_global": false, "scope": "private", "author":
         520858}}, "declarative_secret_status": "active", "assignee": null, "last_presence_check_at":
-        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "gim+dev@gitguardian.com",
-        "name": "dev"}], "user_permission": 7, "is_publicly_shared": false, "feedbacks_count":
-        0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
+        null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "user-1ca9c7a6@example.com",
+        "name": "User ef260e9a"}], "user_permission": 7, "is_publicly_shared": false,
+        "feedbacks_count": 0, "occurrences_presence_seen_count": 2, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 1, "sources":
         [{"id": 16218896, "name": "qa / test-nriv", "type": "gl_project", "path":
         "qa1/test-nriv", "source_criticality": "unknown", "monitoring_status": "active",
         "deleted_at": null}], "custom_tags": [], "vault_metadata": null, "is_vaulted":
         false, "similar_issue_count": 0, "score": 64, "displayed_occurrence": {"id":
         268288466, "issue": 32985083, "account": 8, "kind": "RLTM", "element": "9181621d49e910c3d2393f2373e52c04b26c7adb",
-        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "gim+dev@gitguardian.com",
+        "element_type": "GIT_COMMIT", "author_name": "dev", "author_info": "user-1ca9c7a6@example.com",
         "value": null, "value_hash": "y0o7bgCt8InKo3/G0QE6WaG+gU32WlUdYH0N4oUFXredK2KoKwrhfI+hoCMCs6v6",
         "published_at": "2026-05-19T09:33:23Z", "date": "2026-05-19T09:33:23Z", "detected_at":
         "2026-05-19T09:36:53.339083Z", "is_vcs_type": true, "last_detected_at": "2026-05-19T09:33:23Z",
-        "last_seen_at": "2026-05-19T09:33:23Z", "data": {}, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa1/test-nriv/commit/9181621d49e910c3d2393f2373e52c04b26c7adb#a290632bbcae192e53c54337b3238d835c97e8a9_5_4",
-        "source": {"id": 16218896, "url": "https://gitlab-01.aws-qa-gitguardian.com/qa1/test-nriv",
+        "last_seen_at": "2026-05-19T09:33:23Z", "data": {}, "url": "https://host-a31e7ce0.example.com/ns-e5a6b85b/ns-9acfb06d/commit/9181621d49e910c3d2393f2373e52c04b26c7adb#a290632bbcae192e53c54337b3238d835c97e8a9_5_4",
+        "source": {"id": 16218896, "url": "https://host-a31e7ce0.example.com/ns-e5a6b85b/ns-9acfb06d",
         "type": "gl_project", "display_name": "qa / test-nriv", "visibility": "internal",
         "monitored": true, "source_criticality": "unknown", "deleted_at": null, "default_branch":
         "main", "monitoring_status": "active"}, "regression": false, "content": 162813398,
@@ -202,7 +200,7 @@ interactions:
         {"value": "valid"}}, "is_global": true, "scope": "private", "author": null}},
         "declarative_secret_status": null, "assignee": null, "last_presence_check_at":
         null, "secret": "[REDACTED]", "severity": 100, "authors": [{"info": "<unknown>",
-        "name": "Guy Le Gardien"}], "user_permission": 7, "is_publicly_shared": false,
+        "name": "User f043662d"}], "user_permission": 7, "is_publicly_shared": false,
         "feedbacks_count": 0, "occurrences_presence_seen_count": 1, "occurrences_presence_deleted_count":
         0, "occurrences_presence_should_be_checked": null, "locations_count": 0, "sources":
         [{"id": 26936741, "name": "gitguardian-team-vxrpkdpl / Philippe Gablain",
@@ -216,8 +214,8 @@ interactions:
         "published_at": "2026-05-18T16:46:02.652000Z", "date": "2026-05-18T16:46:02.652000Z",
         "detected_at": "2026-05-18T21:53:58.368709Z", "is_vcs_type": false, "last_detected_at":
         "2026-05-18T16:46:02.652000Z", "last_seen_at": "2026-05-18T16:46:02.652000Z",
-        "data": {}, "url": "https://gitguardian-team-vxrpkdpl.atlassian.net/wiki/spaces/~62a76a05979e6e00690427b5/pages/14057485/test+gg+token",
-        "source": {"id": 26936741, "url": "https://gitguardian-team-vxrpkdpl.atlassian.net/wiki/spaces/~62a76a05979e6e00690427b5",
+        "data": {}, "url": "https://tenant-187af6b6.atlassian.net/wiki/spaces/~62a76a05979e6e00690427b5/pages/14057485/test+gg+token",
+        "source": {"id": 26936741, "url": "https://tenant-187af6b6.atlassian.net/wiki/spaces/~62a76a05979e6e00690427b5",
         "type": "confluence_cloud_space", "display_name": "gitguardian-team-vxrpkdpl
         / Philippe Gablain", "visibility": "private", "monitored": true, "source_criticality":
         "unknown", "deleted_at": null, "default_branch": null, "monitoring_status":

--- a/tests/cassettes/tools/vcr/test_list_members.yaml
+++ b/tests/cassettes/tools/vcr/test_list_members.yaml
@@ -21,20 +21,20 @@ interactions:
   response:
     body:
       string: '[{"id": 10, "role": "manager", "access_level": "manager", "email":
-        "bruce-wayne-gg@protonmail.com", "name": "Bruce Wayne", "created_at": "2020-01-15T15:07:36.510559Z",
+        "user-324427de@example.com", "name": "User 2b03ad68", "created_at": "2020-01-15T15:07:36.510559Z",
         "last_login": "2020-09-30T12:21:19.319487Z", "active": true}, {"id": 13, "role":
-        "manager", "access_level": "manager", "email": "aymeric.sicard@gitguardian.com",
-        "name": "Aymeric SICARD", "created_at": "2020-01-21T09:35:47.907207Z", "last_login":
+        "manager", "access_level": "manager", "email": "user-71ab73d0@example.com",
+        "name": "User d0d18d7e", "created_at": "2020-01-21T09:35:47.907207Z", "last_login":
         "2026-06-22T14:20:46.680540Z", "active": true}, {"id": 2508, "role": "manager",
-        "access_level": "manager", "email": "guillaume.charpiat@gitguardian.com",
-        "name": "Guillaume CHARPIAT", "created_at": "2020-03-23T17:53:57.158457Z",
-        "last_login": "2026-06-10T11:29:54.420261Z", "active": true}, {"id": 37699,
-        "role": "manager", "access_level": "manager", "email": "alexis.larnaud@gitguardian.com",
-        "name": "Alexis LARNAUD", "created_at": "2020-09-03T11:16:05.980606Z", "last_login":
-        "2026-06-22T09:33:43.124144Z", "active": true}, {"id": 63809, "role": "manager",
-        "access_level": "manager", "email": "orian.roturier@gitguardian.com", "name":
-        "Orian ROTURIER", "created_at": "2020-11-25T14:01:01.749542Z", "last_login":
-        "2025-08-05T08:47:38.723615Z", "active": true}]'
+        "access_level": "manager", "email": "user-d9f863cd@example.com", "name": "User
+        793501dc", "created_at": "2020-03-23T17:53:57.158457Z", "last_login": "2026-06-10T11:29:54.420261Z",
+        "active": true}, {"id": 37699, "role": "manager", "access_level": "manager",
+        "email": "user-d3774a22@example.com", "name": "User 40f52996", "created_at":
+        "2020-09-03T11:16:05.980606Z", "last_login": "2026-06-22T09:33:43.124144Z",
+        "active": true}, {"id": 63809, "role": "manager", "access_level": "manager",
+        "email": "user-0222ba7e@example.com", "name": "User 97a9750c", "created_at":
+        "2020-11-25T14:01:01.749542Z", "last_login": "2025-08-05T08:47:38.723615Z",
+        "active": true}]'
     headers:
       CF-RAY:
       - a10398c8de77e8c9-CDG

--- a/tests/cassettes/tools/vcr/test_list_public_occurrences_basic.yaml
+++ b/tests/cassettes/tools/vcr/test_list_public_occurrences_basic.yaml
@@ -112,50 +112,47 @@ interactions:
         "apikey", "indice_start": 23, "indice_end": 55, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 1, "post_line_end": 1}], "tags": ["FROM_HISTORICAL_SCAN",
         "INTERNALLY_LEAKED"], "sha": "2b9ef5781791f7f4a54af30a254bab215cf97e51", "url":
-        "https://github.com/ssokgg/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
-        "source": {"id": 11, "type": "github", "name": "ssokgg/tetris1", "url": "https://github.com/ssokgg/tetris1"},
-        "actor": {"id": 85, "type": "github_user", "name": "ssokgg", "email": "sandra.sok@gitguardian.com",
-        "url": "https://github.com/ssokgg"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
-        3, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url":
-        "https://github.com/guillaume-malle/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 1, "incident_id": 1, "date": "2022-09-21T12:48:20Z", "filepath": "hello.py",
-        "kind": "historical", "presence": "present", "matches": [{"name": "apikey",
-        "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
-        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
-        3, "post_line_start": null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url":
-        "https://github.com/guillaume-malle/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290", "url":
-        "https://github.com/guillaume-malle/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+        "https://github.com/ns-e843d958/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
+        "source": {"id": 11, "type": "github", "name": "ns-e843d958/tetris1", "url":
+        "https://github.com/ns-e843d958/tetris1"}, "actor": {"id": 85, "type": "github_user",
+        "name": "User e843d958", "email": "user-f709bf8d@example.com", "url": "https://github.com/ns-e843d958"},
+        "attachment_reasons": ["by_dev_from_perimeter"]}, {"id": 2718, "incident_id":
+        1, "date": "2022-10-06T13:57:38Z", "filepath": "hello.py", "kind": "historical",
+        "presence": "present", "matches": [{"name": "apikey", "indice_start": 50,
+        "indice_end": 82, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
+        3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"],
+        "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url": "https://github.com/ns-255bd396/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 1, "incident_id": 1, "date": "2022-09-21T12:48:20Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 52, "indice_end": 84, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 3}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2",
+        "url": "https://github.com/ns-255bd396/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start":
+        3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97",
+        "url": "https://github.com/ns-255bd396/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 3}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290",
+        "url": "https://github.com/ns-255bd396/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
       - a10397d4be8c0d9a-CDG

--- a/tests/cassettes/tools/vcr/test_list_public_occurrences_with_date_range.yaml
+++ b/tests/cassettes/tools/vcr/test_list_public_occurrences_with_date_range.yaml
@@ -112,50 +112,47 @@ interactions:
         "apikey", "indice_start": 23, "indice_end": 55, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 1, "post_line_end": 1}], "tags": ["FROM_HISTORICAL_SCAN",
         "INTERNALLY_LEAKED"], "sha": "2b9ef5781791f7f4a54af30a254bab215cf97e51", "url":
-        "https://github.com/ssokgg/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
-        "source": {"id": 11, "type": "github", "name": "ssokgg/tetris1", "url": "https://github.com/ssokgg/tetris1"},
-        "actor": {"id": 85, "type": "github_user", "name": "ssokgg", "email": "sandra.sok@gitguardian.com",
-        "url": "https://github.com/ssokgg"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
-        3, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url":
-        "https://github.com/guillaume-malle/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 1, "incident_id": 1, "date": "2022-09-21T12:48:20Z", "filepath": "hello.py",
-        "kind": "historical", "presence": "present", "matches": [{"name": "apikey",
-        "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
-        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
-        3, "post_line_start": null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url":
-        "https://github.com/guillaume-malle/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290", "url":
-        "https://github.com/guillaume-malle/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+        "https://github.com/ns-e843d958/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
+        "source": {"id": 11, "type": "github", "name": "ns-e843d958/tetris1", "url":
+        "https://github.com/ns-e843d958/tetris1"}, "actor": {"id": 85, "type": "github_user",
+        "name": "User e843d958", "email": "user-f709bf8d@example.com", "url": "https://github.com/ns-e843d958"},
+        "attachment_reasons": ["by_dev_from_perimeter"]}, {"id": 2718, "incident_id":
+        1, "date": "2022-10-06T13:57:38Z", "filepath": "hello.py", "kind": "historical",
+        "presence": "present", "matches": [{"name": "apikey", "indice_start": 50,
+        "indice_end": 82, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
+        3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"],
+        "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url": "https://github.com/ns-255bd396/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 1, "incident_id": 1, "date": "2022-09-21T12:48:20Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 52, "indice_end": 84, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 3}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2",
+        "url": "https://github.com/ns-255bd396/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start":
+        3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97",
+        "url": "https://github.com/ns-255bd396/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 3}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290",
+        "url": "https://github.com/ns-255bd396/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
       - a10397dc4d59d11b-CDG

--- a/tests/cassettes/tools/vcr/test_list_public_occurrences_with_multi_value_filters.yaml
+++ b/tests/cassettes/tools/vcr/test_list_public_occurrences_with_multi_value_filters.yaml
@@ -112,50 +112,47 @@ interactions:
         "apikey", "indice_start": 23, "indice_end": 55, "pre_line_start": null, "pre_line_end":
         null, "post_line_start": 1, "post_line_end": 1}], "tags": ["FROM_HISTORICAL_SCAN",
         "INTERNALLY_LEAKED"], "sha": "2b9ef5781791f7f4a54af30a254bab215cf97e51", "url":
-        "https://github.com/ssokgg/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
-        "source": {"id": 11, "type": "github", "name": "ssokgg/tetris1", "url": "https://github.com/ssokgg/tetris1"},
-        "actor": {"id": 85, "type": "github_user", "name": "ssokgg", "email": "sandra.sok@gitguardian.com",
-        "url": "https://github.com/ssokgg"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 2718, "incident_id": 1, "date": "2022-10-06T13:57:38Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
-        3, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url":
-        "https://github.com/guillaume-malle/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 1, "incident_id": 1, "date": "2022-09-21T12:48:20Z", "filepath": "hello.py",
-        "kind": "historical", "presence": "present", "matches": [{"name": "apikey",
-        "indice_start": 52, "indice_end": 84, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2", "url":
-        "https://github.com/guillaume-malle/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": 3, "pre_line_end":
-        3, "post_line_start": null, "post_line_end": null}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97", "url":
-        "https://github.com/guillaume-malle/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]},
-        {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z", "filepath":
-        "hello.py", "kind": "historical", "presence": "present", "matches": [{"name":
-        "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start": null, "pre_line_end":
-        null, "post_line_start": 3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN",
-        "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290", "url":
-        "https://github.com/guillaume-malle/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
-        "source": {"id": 1, "type": "github", "name": "guillaume-malle/test", "url":
-        "https://github.com/guillaume-malle/test"}, "actor": {"id": 1, "type": "github_user",
-        "name": "guillaume-malle", "email": "110610637+guillaume-malle@users.noreply.github.com",
-        "url": "https://github.com/guillaume-malle"}, "attachment_reasons": ["by_dev_from_perimeter"]}]'
+        "https://github.com/ns-e843d958/tetris1/commit/2b9ef5781791f7f4a54af30a254bab215cf97e51#diff-706a1ecbc3c67f839c5b9103d4f96e3da1c61e28591053d120c97292b1492b7bR1",
+        "source": {"id": 11, "type": "github", "name": "ns-e843d958/tetris1", "url":
+        "https://github.com/ns-e843d958/tetris1"}, "actor": {"id": 85, "type": "github_user",
+        "name": "User e843d958", "email": "user-f709bf8d@example.com", "url": "https://github.com/ns-e843d958"},
+        "attachment_reasons": ["by_dev_from_perimeter"]}, {"id": 2718, "incident_id":
+        1, "date": "2022-10-06T13:57:38Z", "filepath": "hello.py", "kind": "historical",
+        "presence": "present", "matches": [{"name": "apikey", "indice_start": 50,
+        "indice_end": 82, "pre_line_start": 3, "pre_line_end": 3, "post_line_start":
+        3, "post_line_end": 3}], "tags": ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"],
+        "sha": "e1c2d9ef179795f195e89ed6a0bf21831fdca527", "url": "https://github.com/ns-255bd396/test/commit/e1c2d9ef179795f195e89ed6a0bf21831fdca527#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 1, "incident_id": 1, "date": "2022-09-21T12:48:20Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 52, "indice_end": 84, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 3}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "7474a92c9f1f5da3a71fcf4a6a395118ad780fe2",
+        "url": "https://github.com/ns-255bd396/test/commit/7474a92c9f1f5da3a71fcf4a6a395118ad780fe2#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 4691, "incident_id": 1, "date": "2022-09-21T12:45:39Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start":
+        3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "768e248cc3cc3022226de014e9051689b9c7be97",
+        "url": "https://github.com/ns-255bd396/test/commit/768e248cc3cc3022226de014e9051689b9c7be97#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103L3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}, {"id": 212, "incident_id": 1, "date": "2022-08-09T08:29:08Z",
+        "filepath": "hello.py", "kind": "historical", "presence": "present", "matches":
+        [{"name": "apikey", "indice_start": 50, "indice_end": 82, "pre_line_start":
+        null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 3}], "tags":
+        ["FROM_HISTORICAL_SCAN", "INTERNALLY_LEAKED"], "sha": "b45f9204145211197fb32f0e10fec4f115f7b290",
+        "url": "https://github.com/ns-255bd396/test/commit/b45f9204145211197fb32f0e10fec4f115f7b290#diff-d9972c0502bd2119acc4368f9d34b3310c6841190ded5fcece8aa9b66b845103R3",
+        "source": {"id": 1, "type": "github", "name": "ns-255bd396/test", "url": "https://github.com/ns-255bd396/test"},
+        "actor": {"id": 1, "type": "github_user", "name": "User 255bd396", "email":
+        "user-c3a01e84@example.com", "url": "https://github.com/ns-255bd396"}, "attachment_reasons":
+        ["by_dev_from_perimeter"]}]'
     headers:
       CF-RAY:
       - a10397d8aebe463a-CDG

--- a/tests/cassettes/tools/vcr/test_list_repo_occurrences_with_mine_true.yaml
+++ b/tests/cassettes/tools/vcr/test_list_repo_occurrences_with_mine_true.yaml
@@ -102,73 +102,73 @@ interactions:
         "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
         [{"name": "apikey", "indice_start": 48, "indice_end": 726, "pre_line_start":
         3, "pre_line_end": 14, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "333db3e12b3f863ebb02cac6f232fc44e4f46533", "change_type": "deletion",
-        "source_id": 12320}, {"id": 78200, "incident_id": 21461, "date": "2020-10-29T09:19:54.249454Z",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/ns-80126292/private-gg-bis-2020-09/commit/333db3e12b3f863ebb02cac6f232fc44e4f46533#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "333db3e12b3f863ebb02cac6f232fc44e4f46533", "change_type": "deletion", "source_id":
+        12320}, {"id": 78200, "incident_id": 21461, "date": "2020-10-29T09:19:54.249454Z",
         "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
         [{"name": "apikey", "indice_start": 91, "indice_end": 769, "pre_line_start":
         null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 14}], "tags":
-        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "76dd4f31a31c78a151723031bfebff4d076751b2", "change_type": "addition",
-        "source_id": 12320}, {"id": 78203, "incident_id": 21463, "date": "2020-10-29T06:20:19.846592Z",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/ns-80126292/private-gg-bis-2020-09/commit/76dd4f31a31c78a151723031bfebff4d076751b2#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "76dd4f31a31c78a151723031bfebff4d076751b2", "change_type": "addition", "source_id":
+        12320}, {"id": 78203, "incident_id": 21463, "date": "2020-10-29T06:20:19.846592Z",
         "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
         [{"name": "apikey", "indice_start": 48, "indice_end": 1842, "pre_line_start":
         3, "pre_line_end": 32, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-10/commit/65563d9586ec109e098c952559204dbb54e88d6f#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "65563d9586ec109e098c952559204dbb54e88d6f", "change_type": "deletion",
-        "source_id": 12308}, {"id": 78204, "incident_id": 21463, "date": "2020-10-29T06:20:15.521071Z",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/ns-80126292/private-gg-2020-10/commit/65563d9586ec109e098c952559204dbb54e88d6f#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "65563d9586ec109e098c952559204dbb54e88d6f", "change_type": "deletion", "source_id":
+        12308}, {"id": 78204, "incident_id": 21463, "date": "2020-10-29T06:20:15.521071Z",
         "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
         [{"name": "apikey", "indice_start": 91, "indice_end": 1885, "pre_line_start":
         null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 32}], "tags":
-        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-10/commit/35a6a3b548c4bf220b347f2bcb0be46f3692d35d#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "35a6a3b548c4bf220b347f2bcb0be46f3692d35d", "change_type": "addition",
-        "source_id": 12308}, {"id": 78210, "incident_id": 21467, "date": "2020-10-26T16:19:44.303499Z",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/ns-80126292/private-gg-2020-10/commit/35a6a3b548c4bf220b347f2bcb0be46f3692d35d#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "35a6a3b548c4bf220b347f2bcb0be46f3692d35d", "change_type": "addition", "source_id":
+        12308}, {"id": 78210, "incident_id": 21467, "date": "2020-10-26T16:19:44.303499Z",
         "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
         [{"name": "apikey", "indice_start": 46, "indice_end": 86, "pre_line_start":
         3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-10/commit/a18096b36e00c74db6878ad3acb9221e27539b14#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "a18096b36e00c74db6878ad3acb9221e27539b14", "change_type": "deletion",
-        "source_id": 12350}, {"id": 78212, "incident_id": 21467, "date": "2020-10-26T14:19:40.469654Z",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/ns-80126292/public-app-gg-2020-10/commit/a18096b36e00c74db6878ad3acb9221e27539b14#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "a18096b36e00c74db6878ad3acb9221e27539b14", "change_type": "deletion", "source_id":
+        12350}, {"id": 78212, "incident_id": 21467, "date": "2020-10-26T14:19:40.469654Z",
         "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
         [{"name": "apikey", "indice_start": 89, "indice_end": 129, "pre_line_start":
         null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 3}], "tags":
-        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-10/commit/a37529b48365f196ed92632301558cbb675a5e1c#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "a37529b48365f196ed92632301558cbb675a5e1c", "change_type": "addition",
-        "source_id": 12350}, {"id": 78215, "incident_id": 21469, "date": "2020-10-26T00:19:46.194077Z",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/ns-80126292/public-app-gg-2020-10/commit/a37529b48365f196ed92632301558cbb675a5e1c#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "a37529b48365f196ed92632301558cbb675a5e1c", "change_type": "addition", "source_id":
+        12350}, {"id": 78215, "incident_id": 21469, "date": "2020-10-26T00:19:46.194077Z",
         "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
         [{"name": "apikey", "indice_start": 48, "indice_end": 498, "pre_line_start":
         3, "pre_line_end": 10, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-09/commit/2c9fe6c6aff44b05bc748ec9f86447c99f5286fb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "2c9fe6c6aff44b05bc748ec9f86447c99f5286fb", "change_type": "deletion",
-        "source_id": 12314}, {"id": 78216, "incident_id": 21469, "date": "2020-10-25T23:19:57.381648Z",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/ns-80126292/private-gg-2020-09/commit/2c9fe6c6aff44b05bc748ec9f86447c99f5286fb#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "2c9fe6c6aff44b05bc748ec9f86447c99f5286fb", "change_type": "deletion", "source_id":
+        12314}, {"id": 78216, "incident_id": 21469, "date": "2020-10-25T23:19:57.381648Z",
         "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
         [{"name": "apikey", "indice_start": 91, "indice_end": 541, "pre_line_start":
         null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 10}], "tags":
-        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-09/commit/5f4022de142ac57f9e2d4667c950268a3073afe3#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "5f4022de142ac57f9e2d4667c950268a3073afe3", "change_type": "addition",
-        "source_id": 12314}, {"id": 78217, "incident_id": 21470, "date": "2020-10-25T07:19:36.511158Z",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/ns-80126292/private-gg-2020-09/commit/5f4022de142ac57f9e2d4667c950268a3073afe3#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "5f4022de142ac57f9e2d4667c950268a3073afe3", "change_type": "addition", "source_id":
+        12314}, {"id": 78217, "incident_id": 21470, "date": "2020-10-25T07:19:36.511158Z",
         "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
         [{"name": "apikey", "indice_start": 46, "indice_end": 83, "pre_line_start":
         3, "pre_line_end": 3, "post_line_start": null, "post_line_end": null}], "tags":
-        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2020-09/commit/4103f583616340e3ba72614410e5e001bbe8455f#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "4103f583616340e3ba72614410e5e001bbe8455f", "change_type": "deletion",
-        "source_id": 12367}, {"id": 78218, "incident_id": 21470, "date": "2020-10-25T05:20:21.486451Z",
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/ns-80126292/private-app-gg-2020-09/commit/4103f583616340e3ba72614410e5e001bbe8455f#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "4103f583616340e3ba72614410e5e001bbe8455f", "change_type": "deletion", "source_id":
+        12367}, {"id": 78218, "incident_id": 21470, "date": "2020-10-25T05:20:21.486451Z",
         "filepath": "app.py", "kind": "realtime", "presence": "removed", "matches":
         [{"name": "apikey", "indice_start": 89, "indice_end": 126, "pre_line_start":
         null, "pre_line_end": null, "post_line_start": 3, "post_line_end": 3}], "tags":
-        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2020-09/commit/addd9179363127bce3e861fead4b74134600da0e#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
-        "author_info": "lucius-fox-gg@protonmail.com", "author_name": "Lucius Fox",
-        "sha": "addd9179363127bce3e861fead4b74134600da0e", "change_type": "addition",
-        "source_id": 12367}]'
+        ["PUBLIC", "PUBLICLY_EXPOSED"], "url": "https://github.com/ns-80126292/private-app-gg-2020-09/commit/addd9179363127bce3e861fead4b74134600da0e#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R3",
+        "author_info": "user-4176d3f1@example.com", "author_name": "Lucius Fox", "sha":
+        "addd9179363127bce3e861fead4b74134600da0e", "change_type": "addition", "source_id":
+        12367}]'
     headers:
       CF-RAY:
       - a10397dffc66c8ed-CDG

--- a/tests/cassettes/tools/vcr/test_list_sources_basic.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_basic.yaml
@@ -20,45 +20,46 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?per_page=5
   response:
     body:
-      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
-        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
-        "type": "github", "full_name": "lonely/hunter", "health": "unknown", "source_criticality":
-        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
-        "deleted_on_remote", "visibility": "public", "external_id": "22", "secret_incidents_breakdown":
+      string: '[{"id": 12259, "type": "github", "full_name": "ns-1cb0f5a9/cowboy",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "23", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/hunter",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-6d1173c4",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
+        "type": "github", "full_name": "ns-1cb0f5a9/hunter", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "22", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-e9a63a4e",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12261,
-        "type": "github", "full_name": "lonely/time", "health": "unknown", "source_criticality":
+        "type": "github", "full_name": "ns-1cb0f5a9/time", "health": "unknown", "source_criticality":
         "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
         0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
         "deleted_on_remote", "visibility": "public", "external_id": "25", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/time",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-33607480",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12262,
-        "type": "github", "full_name": "lonely/tower", "health": "unknown", "source_criticality":
+        "type": "github", "full_name": "ns-1cb0f5a9/tower", "health": "unknown", "source_criticality":
         "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
         0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
         "deleted_on_remote", "visibility": "public", "external_id": "24", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/tower",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-ad201526",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12263,
-        "type": "github", "full_name": "my-testing-org/christian_dior", "health":
-        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        "type": "github", "full_name": "ns-242f04fd/christian_dior", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:39.211442Z", "status": "finished", "failing_reason":
         "", "commits_scanned": 1, "duration": "1.218169", "branches_scanned": 1, "progress":
@@ -67,7 +68,7 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-eb7dee60",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/tools/vcr/test_list_sources_get_all.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_get_all.yaml
@@ -20,45 +20,46 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?per_page=20
   response:
     body:
-      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
-        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
-        "type": "github", "full_name": "lonely/hunter", "health": "unknown", "source_criticality":
-        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
-        "deleted_on_remote", "visibility": "public", "external_id": "22", "secret_incidents_breakdown":
+      string: '[{"id": 12259, "type": "github", "full_name": "ns-1cb0f5a9/cowboy",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "23", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/hunter",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-6d1173c4",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
+        "type": "github", "full_name": "ns-1cb0f5a9/hunter", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "22", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-e9a63a4e",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12261,
-        "type": "github", "full_name": "lonely/time", "health": "unknown", "source_criticality":
+        "type": "github", "full_name": "ns-1cb0f5a9/time", "health": "unknown", "source_criticality":
         "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
         0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
         "deleted_on_remote", "visibility": "public", "external_id": "25", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/time",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-33607480",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12262,
-        "type": "github", "full_name": "lonely/tower", "health": "unknown", "source_criticality":
+        "type": "github", "full_name": "ns-1cb0f5a9/tower", "health": "unknown", "source_criticality":
         "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
         0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
         "deleted_on_remote", "visibility": "public", "external_id": "24", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/tower",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-ad201526",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12263,
-        "type": "github", "full_name": "my-testing-org/christian_dior", "health":
-        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        "type": "github", "full_name": "ns-242f04fd/christian_dior", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:39.211442Z", "status": "finished", "failing_reason":
         "", "commits_scanned": 1, "duration": "1.218169", "branches_scanned": 1, "progress":
@@ -67,9 +68,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-eb7dee60",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12264,
-        "type": "github", "full_name": "my-testing-org/armani_code", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/armani_code", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 1, "last_scan":
         {"date": "2020-06-04T09:06:33.833273Z", "status": "finished", "failing_reason":
@@ -79,9 +80,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 1}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/armani_code",
+        "info": 0, "unknown": 1}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-12b26c3e",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12265,
-        "type": "github", "full_name": "my-testing-org/louis_vuitton", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/louis_vuitton", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:32.770273Z", "status": "finished", "failing_reason":
@@ -91,9 +92,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/louis_vuitton",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-f6c46dcc",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12266,
-        "type": "github", "full_name": "my-testing-org/lagarfeld", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/lagarfeld", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:33.598712Z", "status": "finished", "failing_reason":
@@ -103,9 +104,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/lagarfeld",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-f7e0173c",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12267,
-        "type": "github", "full_name": "my-testing-org/saint_laurent", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/saint_laurent", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-10-09T12:55:14.542227Z", "status": "canceled", "failing_reason":
@@ -115,139 +116,139 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/saint_laurent",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-29961463",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12268,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2021-04",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
-        3, "last_scan": {"date": "2021-05-12T13:40:00.812612Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 686, "duration": "2.80448", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-gg-2021-04", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 2, "closed_incidents_count": 3, "last_scan":
+        {"date": "2021-05-12T13:40:00.812612Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 686, "duration": "2.80448", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "353525015", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         1, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 3, "severity_breakdown": {"critical": 0, "high": 3, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2021-04",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-2021-04",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12269,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2021-02",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
-        9, "last_scan": {"date": "2021-05-12T13:40:00.842952Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1474, "duration": "4.569221", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-gg-bis-2021-02", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 3, "closed_incidents_count": 9, "last_scan":
+        {"date": "2021-05-12T13:40:00.842952Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1474, "duration": "4.569221", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "339243552", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
         2, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2021-02",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2021-02",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12270,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2021-04",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
-        4, "last_scan": {"date": "2021-05-12T13:40:00.804955Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 419, "duration": "2.634533", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-bis-2021-04", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 1, "closed_incidents_count": 4, "last_scan":
+        {"date": "2021-05-12T13:40:00.804955Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 419, "duration": "2.634533", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "358427683", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 1}}, "closed_secret_incidents":
         {"total": 4, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0,
-        "low": 0, "info": 1, "unknown": 2}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2021-04",
+        "low": 0, "info": 1, "unknown": 2}}}, "url": "https://github.com/ns-80126292/private-app-gg-bis-2021-04",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12271,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2021-03",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
-        7, "last_scan": {"date": "2021-05-12T13:40:00.809898Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1216, "duration": "8.598146", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-2021-03", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 2, "closed_incidents_count": 7, "last_scan":
+        {"date": "2021-05-12T13:40:00.809898Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1216, "duration": "8.598146", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "343245836", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 2}}, "closed_secret_incidents":
         {"total": 7, "severity_breakdown": {"critical": 0, "high": 2, "medium": 0,
-        "low": 0, "info": 4, "unknown": 1}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2021-03",
+        "low": 0, "info": 4, "unknown": 1}}}, "url": "https://github.com/ns-80126292/private-app-gg-2021-03",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12272,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2021-03",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
-        1, "last_scan": {"date": "2021-05-12T13:40:00.801498Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 940, "duration": "6.936519", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-bis-2021-03", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 1, "closed_incidents_count": 1, "last_scan":
+        {"date": "2021-05-12T13:40:00.801498Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 940, "duration": "6.936519", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "348161051", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 1}}, "closed_secret_incidents":
         {"total": 1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2021-03",
+        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://github.com/ns-80126292/private-app-gg-bis-2021-03",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12273,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2021-03",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
-        6, "last_scan": {"date": "2021-05-12T13:40:00.818740Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 990, "duration": "6.295876", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-gg-bis-2021-03", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 3, "closed_incidents_count": 6, "last_scan":
+        {"date": "2021-05-12T13:40:00.818740Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 990, "duration": "6.295876", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "348161060", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
         3, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 6, "severity_breakdown": {"critical": 0, "high": 6, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2021-03",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2021-03",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12274,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-07",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
-        6, "last_scan": {"date": "2020-09-24T09:06:39.253667Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1408, "duration": "4.083977", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-gg-2020-07", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 3, "closed_incidents_count": 6, "last_scan":
+        {"date": "2020-09-24T09:06:39.253667Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1408, "duration": "4.083977", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "276237250", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
         3, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 6, "severity_breakdown": {"critical": 0, "high": 6, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-07",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-2020-07",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12275,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-08",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
-        9, "last_scan": {"date": "2020-09-24T09:06:39.215897Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 656, "duration": "5.5968", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "public", "external_id": "287845935", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
-        1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-08",
+        "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-08", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 1, "closed_incidents_count": 9, "last_scan":
+        {"date": "2020-09-24T09:06:39.215897Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 656, "duration": "5.5968", "branches_scanned": 1, "progress":
+        100}, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "287845935", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 1, "severity_breakdown": {"critical": 1, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-08",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12276,
-        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-2020-12",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
-        6, "last_scan": {"date": "2021-02-01T15:38:48.535700Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1040, "duration": "2.651208", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/public-app-gg-2020-12", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 1, "closed_incidents_count": 6, "last_scan":
+        {"date": "2021-02-01T15:38:48.535700Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1040, "duration": "2.651208", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "317380020", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
         1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 6, "severity_breakdown": {"critical": 0, "high": 6, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-12",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-2020-12",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12277,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2020-08",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
-        4, "last_scan": {"date": "2020-09-24T09:06:39.225976Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 913, "duration": "2.608482", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-2020-08", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 1, "closed_incidents_count": 4, "last_scan":
+        {"date": "2020-09-24T09:06:39.225976Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 913, "duration": "2.608482", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "284154416", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
         1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 4, "severity_breakdown": {"critical": 0, "high": 4, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2020-08",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-app-gg-2020-08",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12278,
-        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-11",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
-        7, "last_scan": {"date": "2021-02-01T15:38:48.535276Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1282, "duration": "3.557603", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-11", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 3, "closed_incidents_count": 7, "last_scan":
+        {"date": "2021-02-01T15:38:48.535276Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1282, "duration": "3.557603", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "313150729", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
         3, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 7, "severity_breakdown": {"critical": 0, "high": 7, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-11",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-11",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:
@@ -321,7 +322,7 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?per_page=20&cursor=cD0xMjI3OA%3D%3D
   response:
     body:
-      string: '[{"id": 12279, "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-01",
+      string: '[{"id": 12279, "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-01",
         "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
         3, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
@@ -329,22 +330,22 @@ interactions:
         {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
         1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 3, "severity_breakdown": {"critical": 0, "high": 3, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-01",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-01",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12280,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2020-12",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
-        7, "last_scan": {"date": "2021-03-05T16:32:08.931273Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1343, "duration": "3.700622", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-bis-2020-12", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 1, "closed_incidents_count": 7, "last_scan":
+        {"date": "2021-03-05T16:32:08.931273Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1343, "duration": "3.700622", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "321822525", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
         1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 7, "severity_breakdown": {"critical": 0, "high": 7, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2020-12",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-app-gg-bis-2020-12",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12281,
-        "type": "github", "full_name": "wayne-enterprises-gg/empty-repo", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        "type": "github", "full_name": "ns-80126292/empty-repo", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-01-27T09:14:01.990109Z", "status": "failed", "failing_reason":
         "Unknown error", "commits_scanned": 0, "duration": "0.0", "branches_scanned":
@@ -353,195 +354,195 @@ interactions:
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/empty-repo",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/empty-repo",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12282,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-07",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
-        9, "last_scan": {"date": "2020-09-24T09:06:39.281285Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1146, "duration": "5.695658", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-07", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 2, "closed_incidents_count": 9, "last_scan":
+        {"date": "2020-09-24T09:06:39.281285Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1146, "duration": "5.695658", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "280012005", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-07",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-07",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12283,
-        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-2020-09",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
-        5, "last_scan": {"date": "2020-09-24T09:06:39.249695Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 405, "duration": "4.641103", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/public-app-gg-2020-09", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 2, "closed_incidents_count": 5, "last_scan":
+        {"date": "2020-09-24T09:06:39.249695Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 405, "duration": "4.641103", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "291853911", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 5, "severity_breakdown": {"critical": 0, "high": 5, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-09",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-2020-09",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12284,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2020-06",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
-        10, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "public", "external_id": "272571163", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
-        1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 10, "severity_breakdown": {"critical": 0, "high": 10, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2020-06",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-bis-2020-06", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 1, "closed_incidents_count": 10, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "272571163", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 1, "severity_breakdown": {"critical": 1, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        10, "severity_breakdown": {"critical": 0, "high": 10, "medium": 0, "low":
+        0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-app-gg-bis-2020-06",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12285,
-        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-04",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
-        5, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "public", "external_id": "256067455", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
-        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 5, "severity_breakdown": {"critical": 0, "high": 5, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-04",
+        "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-04", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 2, "closed_incidents_count": 5, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "256067455", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 2, "severity_breakdown": {"critical": 2, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        5, "severity_breakdown": {"critical": 0, "high": 5, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-04",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12286,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2020-11",
-        "health": "safe", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        11, "last_scan": {"date": "2021-01-26T16:46:38.539876Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1486, "duration": "2.780691", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-2020-11", "health":
+        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 11, "last_scan":
+        {"date": "2021-01-26T16:46:38.539876Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1486, "duration": "2.780691", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "308995512", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 11, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2020-11",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-app-gg-2020-11",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12287,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2020-04",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 6, "closed_incidents_count":
-        11, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "public", "external_id": "252029776", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 6, "severity_breakdown": {"critical":
-        6, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 11, "severity_breakdown": {"critical": 0, "high": 11, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2020-04",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-2020-04", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 6, "closed_incidents_count": 11, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "252029776", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 6, "severity_breakdown": {"critical": 6, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        11, "severity_breakdown": {"critical": 0, "high": 11, "medium": 0, "low":
+        0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-app-gg-2020-04",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12288,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-12",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
-        6, "last_scan": {"date": "2021-03-11T11:00:13.725202Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1429, "duration": "2.608724", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-12", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 3, "closed_incidents_count": 6, "last_scan":
+        {"date": "2021-03-11T11:00:13.725202Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1429, "duration": "2.608724", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "321822539", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
         3, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 6, "severity_breakdown": {"critical": 0, "high": 6, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-12",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-12",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12289,
-        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-2020-02",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
-        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "public", "external_id": "237538596", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
-        1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-02",
+        "type": "github", "full_name": "ns-80126292/public-app-gg-2020-02", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 1, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "237538596", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 1, "severity_breakdown": {"critical": 1, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-2020-02",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12290,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2020-05",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
-        8, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "public", "external_id": "264326539", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
-        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 8, "severity_breakdown": {"critical": 0, "high": 8, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2020-05",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-bis-2020-05", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 2, "closed_incidents_count": 8, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "264326539", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 2, "severity_breakdown": {"critical": 2, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        8, "severity_breakdown": {"critical": 0, "high": 8, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-app-gg-bis-2020-05",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12291,
-        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-2020-07",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 6, "closed_incidents_count":
-        7, "last_scan": {"date": "2020-09-24T09:06:39.268982Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1442, "duration": "4.222266", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/public-app-gg-2020-07", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 6, "closed_incidents_count": 7, "last_scan":
+        {"date": "2020-09-24T09:06:39.268982Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1442, "duration": "4.222266", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "276237232", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 6, "severity_breakdown": {"critical":
         5, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 7, "severity_breakdown": {"critical": 0, "high": 7, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-07",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-2020-07",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12292,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2020-08",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 4, "closed_incidents_count":
-        13, "last_scan": {"date": "2020-11-04T14:06:32.755685Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1450, "duration": "2.440167", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-bis-2020-08", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 4, "closed_incidents_count": 13, "last_scan":
+        {"date": "2020-11-04T14:06:32.755685Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1450, "duration": "2.440167", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "287845929", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 4, "severity_breakdown": {"critical":
         4, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 13, "severity_breakdown": {"critical": 0, "high": 13, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2020-08",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-app-gg-bis-2020-08",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12293,
-        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-2020-03",
-        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        8, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "public", "external_id": "244061781", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 8, "severity_breakdown": {"critical": 0, "high": 8, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2020-03",
+        "type": "github", "full_name": "ns-80126292/public-app-gg-2020-03", "health":
+        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 8, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "244061781", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        8, "severity_breakdown": {"critical": 0, "high": 8, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-2020-03",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12294,
-        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-2021-03",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 5, "closed_incidents_count":
-        7, "last_scan": {"date": "2021-05-12T13:40:00.845299Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1247, "duration": "5.565196", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/public-app-gg-2021-03", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 5, "closed_incidents_count": 7, "last_scan":
+        {"date": "2021-05-12T13:40:00.845299Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1247, "duration": "5.565196", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "343245830", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 5, "severity_breakdown": {"critical":
         4, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 7, "severity_breakdown": {"critical": 0, "high": 7, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-2021-03",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-2021-03",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12295,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-02",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
-        1, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "public", "external_id": "240807321", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
-        3, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 1, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-02",
+        "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-02", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 3, "closed_incidents_count": 1, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "240807321", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 3, "severity_breakdown": {"critical": 3, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        1, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-02",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12296,
-        "type": "github", "full_name": "wayne-enterprises-gg/public-app-gg-bis-2020-08",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
-        6, "last_scan": {"date": "2020-11-02T19:32:24.488911Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1414, "duration": "4.213635", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/public-app-gg-bis-2020-08", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 3, "closed_incidents_count": 6, "last_scan":
+        {"date": "2020-11-02T19:32:24.488911Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1414, "duration": "4.213635", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "287845921", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
         3, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 6, "severity_breakdown": {"critical": 0, "high": 6, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/public-app-gg-bis-2020-08",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/public-app-gg-bis-2020-08",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12297,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-08",
-        "health": "safe", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        11, "last_scan": {"date": "2020-09-24T09:06:39.261262Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 928, "duration": "3.06658", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-gg-2020-08", "health":
+        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 11, "last_scan":
+        {"date": "2020-09-24T09:06:39.261262Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 928, "duration": "3.06658", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "284154426", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 11, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-2020-08",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12298,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-bis-2020-05",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
-        8, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "public", "external_id": "264326547", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
-        3, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 8, "severity_breakdown": {"critical": 0, "high": 8, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-bis-2020-05",
+        "type": "github", "full_name": "ns-80126292/private-gg-bis-2020-05", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 3, "closed_incidents_count": 8, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "264326547", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 3, "severity_breakdown": {"critical": 3, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        8, "severity_breakdown": {"critical": 0, "high": 8, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-bis-2020-05",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/tools/vcr/test_list_sources_pagination.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_pagination.yaml
@@ -20,33 +20,34 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?per_page=3
   response:
     body:
-      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
-        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
-        "type": "github", "full_name": "lonely/hunter", "health": "unknown", "source_criticality":
-        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
-        "deleted_on_remote", "visibility": "public", "external_id": "22", "secret_incidents_breakdown":
+      string: '[{"id": 12259, "type": "github", "full_name": "ns-1cb0f5a9/cowboy",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "23", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/hunter",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-6d1173c4",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
+        "type": "github", "full_name": "ns-1cb0f5a9/hunter", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "22", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-e9a63a4e",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12261,
-        "type": "github", "full_name": "lonely/time", "health": "unknown", "source_criticality":
+        "type": "github", "full_name": "ns-1cb0f5a9/time", "health": "unknown", "source_criticality":
         "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
         0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
         "deleted_on_remote", "visibility": "public", "external_id": "25", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/time",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-33607480",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/tools/vcr/test_list_sources_with_health_filter.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_with_health_filter.yaml
@@ -20,7 +20,7 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?health=safe&per_page=10
   response:
     body:
-      string: '[{"id": 12263, "type": "github", "full_name": "my-testing-org/christian_dior",
+      string: '[{"id": 12263, "type": "github", "full_name": "ns-242f04fd/christian_dior",
         "health": "safe", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         0, "last_scan": {"date": "2020-09-24T09:06:39.211442Z", "status": "finished",
@@ -30,9 +30,9 @@ interactions:
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-eb7dee60",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12264,
-        "type": "github", "full_name": "my-testing-org/armani_code", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/armani_code", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 1, "last_scan":
         {"date": "2020-06-04T09:06:33.833273Z", "status": "finished", "failing_reason":
@@ -42,9 +42,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 1}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/armani_code",
+        "info": 0, "unknown": 1}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-12b26c3e",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12265,
-        "type": "github", "full_name": "my-testing-org/louis_vuitton", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/louis_vuitton", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:32.770273Z", "status": "finished", "failing_reason":
@@ -54,9 +54,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/louis_vuitton",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-f6c46dcc",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12266,
-        "type": "github", "full_name": "my-testing-org/lagarfeld", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/lagarfeld", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:33.598712Z", "status": "finished", "failing_reason":
@@ -66,9 +66,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/lagarfeld",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-f7e0173c",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12267,
-        "type": "github", "full_name": "my-testing-org/saint_laurent", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/saint_laurent", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-10-09T12:55:14.542227Z", "status": "canceled", "failing_reason":
@@ -78,58 +78,58 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/saint_laurent",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-29961463",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12286,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2020-11",
-        "health": "safe", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        11, "last_scan": {"date": "2021-01-26T16:46:38.539876Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1486, "duration": "2.780691", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-2020-11", "health":
+        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 11, "last_scan":
+        {"date": "2021-01-26T16:46:38.539876Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1486, "duration": "2.780691", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "308995512", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 11, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2020-11",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-app-gg-2020-11",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12297,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-08",
-        "health": "safe", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        11, "last_scan": {"date": "2020-09-24T09:06:39.261262Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 928, "duration": "3.06658", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-gg-2020-08", "health":
+        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 11, "last_scan":
+        {"date": "2020-09-24T09:06:39.261262Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 928, "duration": "3.06658", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "284154426", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 11, "severity_breakdown": {"critical": 0, "high": 11, "medium":
-        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-08",
+        0, "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-2020-08",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12308,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2020-10",
-        "health": "safe", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        9, "last_scan": {"date": "2020-12-10T10:45:12.767631Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1251, "duration": "4.299251", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-gg-2020-10", "health":
+        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 9, "last_scan":
+        {"date": "2020-12-10T10:45:12.767631Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1251, "duration": "4.299251", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "300095842", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 9, "severity_breakdown": {"critical": 0, "high": 9, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2020-10",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-2020-10",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12312,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2021-04",
-        "health": "safe", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        2, "last_scan": {"date": "2021-05-12T13:40:00.816026Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 701, "duration": "3.011352", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-2021-04", "health":
+        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 2, "last_scan":
+        {"date": "2021-05-12T13:40:00.816026Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 701, "duration": "3.011352", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "353525012", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 2, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0,
-        "low": 0, "info": 1, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2021-04",
+        "low": 0, "info": 1, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-app-gg-2021-04",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12338,
-        "type": "github", "full_name": "wayne-enterprises-gg/shared-app", "health":
-        "safe", "source_criticality": "low", "default_branch": "master", "default_branch_head":
+        "type": "github", "full_name": "ns-80126292/shared-app", "health": "safe",
+        "source_criticality": "low", "default_branch": "master", "default_branch_head":
         "a219c18ff8e913427c38fc7d90756d6bb1bb5b43", "open_incidents_count": 0, "closed_incidents_count":
         0, "last_scan": {"date": "2026-02-02T10:49:30.905195Z", "status": "finished",
         "failing_reason": "", "commits_scanned": 544, "duration": "0.0", "branches_scanned":
@@ -138,7 +138,7 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/shared-app",
+        "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/shared-app",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/tools/vcr/test_list_sources_with_monitored_filter.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_with_monitored_filter.yaml
@@ -20,45 +20,46 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?monitored=true&per_page=10
   response:
     body:
-      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
-        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
-        "type": "github", "full_name": "lonely/hunter", "health": "unknown", "source_criticality":
-        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
-        "deleted_on_remote", "visibility": "public", "external_id": "22", "secret_incidents_breakdown":
+      string: '[{"id": 12259, "type": "github", "full_name": "ns-1cb0f5a9/cowboy",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "23", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/hunter",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-6d1173c4",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
+        "type": "github", "full_name": "ns-1cb0f5a9/hunter", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "22", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-e9a63a4e",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12261,
-        "type": "github", "full_name": "lonely/time", "health": "unknown", "source_criticality":
+        "type": "github", "full_name": "ns-1cb0f5a9/time", "health": "unknown", "source_criticality":
         "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
         0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
         "deleted_on_remote", "visibility": "public", "external_id": "25", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/time",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-33607480",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12262,
-        "type": "github", "full_name": "lonely/tower", "health": "unknown", "source_criticality":
+        "type": "github", "full_name": "ns-1cb0f5a9/tower", "health": "unknown", "source_criticality":
         "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
         0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
         "deleted_on_remote", "visibility": "public", "external_id": "24", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/tower",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-ad201526",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12263,
-        "type": "github", "full_name": "my-testing-org/christian_dior", "health":
-        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        "type": "github", "full_name": "ns-242f04fd/christian_dior", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:39.211442Z", "status": "finished", "failing_reason":
         "", "commits_scanned": 1, "duration": "1.218169", "branches_scanned": 1, "progress":
@@ -67,9 +68,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-eb7dee60",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12264,
-        "type": "github", "full_name": "my-testing-org/armani_code", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/armani_code", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 1, "last_scan":
         {"date": "2020-06-04T09:06:33.833273Z", "status": "finished", "failing_reason":
@@ -79,9 +80,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 1}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/armani_code",
+        "info": 0, "unknown": 1}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-12b26c3e",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12265,
-        "type": "github", "full_name": "my-testing-org/louis_vuitton", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/louis_vuitton", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:32.770273Z", "status": "finished", "failing_reason":
@@ -91,9 +92,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/louis_vuitton",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-f6c46dcc",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12266,
-        "type": "github", "full_name": "my-testing-org/lagarfeld", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/lagarfeld", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:33.598712Z", "status": "finished", "failing_reason":
@@ -103,9 +104,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/lagarfeld",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-f7e0173c",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12267,
-        "type": "github", "full_name": "my-testing-org/saint_laurent", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/saint_laurent", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-10-09T12:55:14.542227Z", "status": "canceled", "failing_reason":
@@ -115,19 +116,19 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/saint_laurent",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-29961463",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12268,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2021-04",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
-        3, "last_scan": {"date": "2021-05-12T13:40:00.812612Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 686, "duration": "2.80448", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-gg-2021-04", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 2, "closed_incidents_count": 3, "last_scan":
+        {"date": "2021-05-12T13:40:00.812612Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 686, "duration": "2.80448", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "353525015", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         1, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 3, "severity_breakdown": {"critical": 0, "high": 3, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2021-04",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-2021-04",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/tools/vcr/test_list_sources_with_per_page.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_with_per_page.yaml
@@ -20,33 +20,34 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?per_page=3
   response:
     body:
-      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
-        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
-        "type": "github", "full_name": "lonely/hunter", "health": "unknown", "source_criticality":
-        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
-        "deleted_on_remote", "visibility": "public", "external_id": "22", "secret_incidents_breakdown":
+      string: '[{"id": 12259, "type": "github", "full_name": "ns-1cb0f5a9/cowboy",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "23", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/hunter",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-6d1173c4",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
+        "type": "github", "full_name": "ns-1cb0f5a9/hunter", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "22", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-e9a63a4e",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12261,
-        "type": "github", "full_name": "lonely/time", "health": "unknown", "source_criticality":
+        "type": "github", "full_name": "ns-1cb0f5a9/time", "health": "unknown", "source_criticality":
         "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
         0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
         "deleted_on_remote", "visibility": "public", "external_id": "25", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/time",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-33607480",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/tools/vcr/test_list_sources_with_search.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_with_search.yaml
@@ -20,7 +20,7 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?search=test&per_page=10
   response:
     body:
-      string: '[{"id": 12263, "type": "github", "full_name": "my-testing-org/christian_dior",
+      string: '[{"id": 12263, "type": "github", "full_name": "ns-242f04fd/christian_dior",
         "health": "safe", "source_criticality": "unknown", "default_branch": null,
         "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
         0, "last_scan": {"date": "2020-09-24T09:06:39.211442Z", "status": "finished",
@@ -30,9 +30,9 @@ interactions:
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-eb7dee60",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12264,
-        "type": "github", "full_name": "my-testing-org/armani_code", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/armani_code", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 1, "last_scan":
         {"date": "2020-06-04T09:06:33.833273Z", "status": "finished", "failing_reason":
@@ -42,9 +42,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 1}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/armani_code",
+        "info": 0, "unknown": 1}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-12b26c3e",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12265,
-        "type": "github", "full_name": "my-testing-org/louis_vuitton", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/louis_vuitton", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:32.770273Z", "status": "finished", "failing_reason":
@@ -54,9 +54,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/louis_vuitton",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-f6c46dcc",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12266,
-        "type": "github", "full_name": "my-testing-org/lagarfeld", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/lagarfeld", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:33.598712Z", "status": "finished", "failing_reason":
@@ -66,9 +66,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/lagarfeld",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-f7e0173c",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12267,
-        "type": "github", "full_name": "my-testing-org/saint_laurent", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/saint_laurent", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-10-09T12:55:14.542227Z", "status": "canceled", "failing_reason":
@@ -78,57 +78,57 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/saint_laurent",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-29961463",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 3342391,
-        "type": "github", "full_name": "github-app-test-eugene/test", "health": "unknown",
-        "source_criticality": "unknown", "default_branch": "master", "default_branch_head":
-        "739d8fc531ae1130672b694ef20d445be095266c", "open_incidents_count": 0, "closed_incidents_count":
-        6, "last_scan": null, "monitored": false, "monitoring_status": "deleted_on_remote",
-        "visibility": "public", "external_id": "157555465", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
-        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 6, "severity_breakdown": {"critical": 0, "high": 6, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/github-app-test-eugene/test",
+        "type": "github", "full_name": "ns-e587ab62/test", "health": "unknown", "source_criticality":
+        "unknown", "default_branch": "master", "default_branch_head": "739d8fc531ae1130672b694ef20d445be095266c",
+        "open_incidents_count": 0, "closed_incidents_count": 6, "last_scan": null,
+        "monitored": false, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "157555465", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        6, "severity_breakdown": {"critical": 0, "high": 6, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-e587ab62/test",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 3342392,
-        "type": "github", "full_name": "github-app-test-eugene/test_preprod", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
+        "type": "github", "full_name": "ns-e587ab62/test_preprod", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
         "59ad17cf384bb8abdb3fd21bdc557382b8f85fbf", "open_incidents_count": 0, "closed_incidents_count":
         4, "last_scan": null, "monitored": false, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "327924619", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 4, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 4}}}, "url": "https://github.com/github-app-test-eugene/test_preprod",
+        "low": 0, "info": 0, "unknown": 4}}}, "url": "https://github.com/ns-e587ab62/test_preprod",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6088722,
-        "type": "github", "full_name": "github-app-test-eugene/test_local_1", "health":
-        "at_risk", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
+        "type": "github", "full_name": "ns-e587ab62/test_local_1", "health": "at_risk",
+        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
         "529672f724fe0cb58ec7db5753f1ba8c26e62b1f", "open_incidents_count": 13, "closed_incidents_count":
         8, "last_scan": null, "monitored": false, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "515202288", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 13, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 13}}, "closed_secret_incidents":
         {"total": 8, "severity_breakdown": {"critical": 0, "high": 4, "medium": 0,
-        "low": 0, "info": 0, "unknown": 4}}}, "url": "https://github.com/github-app-test-eugene/test_local_1",
+        "low": 0, "info": 0, "unknown": 4}}}, "url": "https://github.com/ns-e587ab62/test_local_1",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6088740,
-        "type": "github", "full_name": "github-app-test-eugene/test_local_2", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
+        "type": "github", "full_name": "ns-e587ab62/test_local_2", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
         "5f014343520d1baefd1dc34a9fca19ae210b052a", "open_incidents_count": 0, "closed_incidents_count":
         0, "last_scan": null, "monitored": false, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "515203110", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/github-app-test-eugene/test_local_2",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-e587ab62/test_local_2",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 6088766,
-        "type": "github", "full_name": "github-app-test-eugene/test_local_3", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
+        "type": "github", "full_name": "ns-e587ab62/test_local_3", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": "main", "default_branch_head":
         "587f67ce9635b955452eb56a69ddae46e8bcbae6", "open_incidents_count": 0, "closed_incidents_count":
         1, "last_scan": null, "monitored": false, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "515204240", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://github.com/github-app-test-eugene/test_local_3",
+        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://github.com/ns-e587ab62/test_local_3",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/tools/vcr/test_list_sources_with_source_criticality_filter.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_with_source_criticality_filter.yaml
@@ -20,45 +20,46 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?source_criticality=unknown&per_page=10
   response:
     body:
-      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
-        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
-        "type": "github", "full_name": "lonely/hunter", "health": "unknown", "source_criticality":
-        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
-        "deleted_on_remote", "visibility": "public", "external_id": "22", "secret_incidents_breakdown":
+      string: '[{"id": 12259, "type": "github", "full_name": "ns-1cb0f5a9/cowboy",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "23", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/hunter",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-6d1173c4",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
+        "type": "github", "full_name": "ns-1cb0f5a9/hunter", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "22", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-e9a63a4e",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12261,
-        "type": "github", "full_name": "lonely/time", "health": "unknown", "source_criticality":
+        "type": "github", "full_name": "ns-1cb0f5a9/time", "health": "unknown", "source_criticality":
         "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
         0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
         "deleted_on_remote", "visibility": "public", "external_id": "25", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/time",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-33607480",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12262,
-        "type": "github", "full_name": "lonely/tower", "health": "unknown", "source_criticality":
+        "type": "github", "full_name": "ns-1cb0f5a9/tower", "health": "unknown", "source_criticality":
         "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
         0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
         "deleted_on_remote", "visibility": "public", "external_id": "24", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/tower",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-ad201526",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12263,
-        "type": "github", "full_name": "my-testing-org/christian_dior", "health":
-        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        "type": "github", "full_name": "ns-242f04fd/christian_dior", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:39.211442Z", "status": "finished", "failing_reason":
         "", "commits_scanned": 1, "duration": "1.218169", "branches_scanned": 1, "progress":
@@ -67,9 +68,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-eb7dee60",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12264,
-        "type": "github", "full_name": "my-testing-org/armani_code", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/armani_code", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 1, "last_scan":
         {"date": "2020-06-04T09:06:33.833273Z", "status": "finished", "failing_reason":
@@ -79,9 +80,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 1}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/armani_code",
+        "info": 0, "unknown": 1}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-12b26c3e",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12265,
-        "type": "github", "full_name": "my-testing-org/louis_vuitton", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/louis_vuitton", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:32.770273Z", "status": "finished", "failing_reason":
@@ -91,9 +92,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/louis_vuitton",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-f6c46dcc",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12266,
-        "type": "github", "full_name": "my-testing-org/lagarfeld", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/lagarfeld", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:33.598712Z", "status": "finished", "failing_reason":
@@ -103,9 +104,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/lagarfeld",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-f7e0173c",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12267,
-        "type": "github", "full_name": "my-testing-org/saint_laurent", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/saint_laurent", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-10-09T12:55:14.542227Z", "status": "canceled", "failing_reason":
@@ -115,19 +116,19 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/saint_laurent",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-29961463",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12268,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2021-04",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
-        3, "last_scan": {"date": "2021-05-12T13:40:00.812612Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 686, "duration": "2.80448", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-gg-2021-04", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 2, "closed_incidents_count": 3, "last_scan":
+        {"date": "2021-05-12T13:40:00.812612Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 686, "duration": "2.80448", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "353525015", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         1, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 3, "severity_breakdown": {"critical": 0, "high": 3, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2021-04",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-2021-04",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/tools/vcr/test_list_sources_with_type_filter.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_with_type_filter.yaml
@@ -20,45 +20,46 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?type=github&per_page=10
   response:
     body:
-      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
-        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
-        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
-        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
-        "type": "github", "full_name": "lonely/hunter", "health": "unknown", "source_criticality":
-        "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
-        0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
-        "deleted_on_remote", "visibility": "public", "external_id": "22", "secret_incidents_breakdown":
+      string: '[{"id": 12259, "type": "github", "full_name": "ns-1cb0f5a9/cowboy",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "23", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/hunter",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-6d1173c4",
+        "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12260,
+        "type": "github", "full_name": "ns-1cb0f5a9/hunter", "health": "unknown",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "public", "external_id": "22", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-e9a63a4e",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12261,
-        "type": "github", "full_name": "lonely/time", "health": "unknown", "source_criticality":
+        "type": "github", "full_name": "ns-1cb0f5a9/time", "health": "unknown", "source_criticality":
         "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
         0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
         "deleted_on_remote", "visibility": "public", "external_id": "25", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/time",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-33607480",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12262,
-        "type": "github", "full_name": "lonely/tower", "health": "unknown", "source_criticality":
+        "type": "github", "full_name": "ns-1cb0f5a9/tower", "health": "unknown", "source_criticality":
         "unknown", "default_branch": null, "default_branch_head": null, "open_incidents_count":
         0, "closed_incidents_count": 0, "last_scan": null, "monitored": true, "monitoring_status":
         "deleted_on_remote", "visibility": "public", "external_id": "24", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/tower",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-ad201526",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12263,
-        "type": "github", "full_name": "my-testing-org/christian_dior", "health":
-        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        "type": "github", "full_name": "ns-242f04fd/christian_dior", "health": "safe",
+        "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:39.211442Z", "status": "finished", "failing_reason":
         "", "commits_scanned": 1, "duration": "1.218169", "branches_scanned": 1, "progress":
@@ -67,9 +68,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/christian_dior",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-eb7dee60",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12264,
-        "type": "github", "full_name": "my-testing-org/armani_code", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/armani_code", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 1, "last_scan":
         {"date": "2020-06-04T09:06:33.833273Z", "status": "finished", "failing_reason":
@@ -79,9 +80,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 1}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/armani_code",
+        "info": 0, "unknown": 1}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-12b26c3e",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12265,
-        "type": "github", "full_name": "my-testing-org/louis_vuitton", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/louis_vuitton", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:32.770273Z", "status": "finished", "failing_reason":
@@ -91,9 +92,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/louis_vuitton",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-f6c46dcc",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12266,
-        "type": "github", "full_name": "my-testing-org/lagarfeld", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/lagarfeld", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:33.598712Z", "status": "finished", "failing_reason":
@@ -103,9 +104,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/lagarfeld",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-f7e0173c",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12267,
-        "type": "github", "full_name": "my-testing-org/saint_laurent", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/saint_laurent", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-10-09T12:55:14.542227Z", "status": "canceled", "failing_reason":
@@ -115,19 +116,19 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/saint_laurent",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-29961463",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12268,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-gg-2021-04",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
-        3, "last_scan": {"date": "2021-05-12T13:40:00.812612Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 686, "duration": "2.80448", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-gg-2021-04", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 2, "closed_incidents_count": 3, "last_scan":
+        {"date": "2021-05-12T13:40:00.812612Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 686, "duration": "2.80448", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "public", "external_id": "353525015", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         1, "high": 1, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 3, "severity_breakdown": {"critical": 0, "high": 3, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-gg-2021-04",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-gg-2021-04",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/tools/vcr/test_list_sources_with_visibility_filter.yaml
+++ b/tests/cassettes/tools/vcr/test_list_sources_with_visibility_filter.yaml
@@ -20,17 +20,17 @@ interactions:
     uri: https://api.gitguardian.com/v1/sources?visibility=private&per_page=10
   response:
     body:
-      string: '[{"id": 12259, "type": "github", "full_name": "lonely/cowboy", "health":
-        "unknown", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
-        null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
-        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
-        "private", "external_id": "23", "secret_incidents_breakdown": {"open_secret_incidents":
+      string: '[{"id": 12259, "type": "github", "full_name": "ns-1cb0f5a9/cowboy",
+        "health": "unknown", "source_criticality": "unknown", "default_branch": null,
+        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
+        0, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "visibility": "private", "external_id": "23", "secret_incidents_breakdown":
+        {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
+        0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
-        0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/lonely/cowboy",
+        "low": 0, "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-1cb0f5a9/ns-6d1173c4",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12265,
-        "type": "github", "full_name": "my-testing-org/louis_vuitton", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/louis_vuitton", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:32.770273Z", "status": "finished", "failing_reason":
@@ -40,9 +40,9 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/louis_vuitton",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-f6c46dcc",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12266,
-        "type": "github", "full_name": "my-testing-org/lagarfeld", "health": "safe",
+        "type": "github", "full_name": "ns-242f04fd/lagarfeld", "health": "safe",
         "source_criticality": "unknown", "default_branch": null, "default_branch_head":
         null, "open_incidents_count": 0, "closed_incidents_count": 0, "last_scan":
         {"date": "2020-09-24T09:06:33.598712Z", "status": "finished", "failing_reason":
@@ -52,89 +52,89 @@ interactions:
         {"total": 0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
         "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
         0, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0,
-        "info": 0, "unknown": 0}}}, "url": "https://ghe.dev.gitguardian.com/my-testing-org/lagarfeld",
+        "info": 0, "unknown": 0}}}, "url": "https://host-3c66a8bc.example.com/ns-242f04fd/ns-f7e0173c",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12270,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2021-04",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
-        4, "last_scan": {"date": "2021-05-12T13:40:00.804955Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 419, "duration": "2.634533", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-bis-2021-04", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 1, "closed_incidents_count": 4, "last_scan":
+        {"date": "2021-05-12T13:40:00.804955Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 419, "duration": "2.634533", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "358427683", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 1}}, "closed_secret_incidents":
         {"total": 4, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0,
-        "low": 0, "info": 1, "unknown": 2}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2021-04",
+        "low": 0, "info": 1, "unknown": 2}}}, "url": "https://github.com/ns-80126292/private-app-gg-bis-2021-04",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12271,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2021-03",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
-        7, "last_scan": {"date": "2021-05-12T13:40:00.809898Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1216, "duration": "8.598146", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-2021-03", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 2, "closed_incidents_count": 7, "last_scan":
+        {"date": "2021-05-12T13:40:00.809898Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1216, "duration": "8.598146", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "343245836", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 2}}, "closed_secret_incidents":
         {"total": 7, "severity_breakdown": {"critical": 0, "high": 2, "medium": 0,
-        "low": 0, "info": 4, "unknown": 1}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2021-03",
+        "low": 0, "info": 4, "unknown": 1}}}, "url": "https://github.com/ns-80126292/private-app-gg-2021-03",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12272,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2021-03",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 1, "closed_incidents_count":
-        1, "last_scan": {"date": "2021-05-12T13:40:00.801498Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 940, "duration": "6.936519", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-bis-2021-03", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 1, "closed_incidents_count": 1, "last_scan":
+        {"date": "2021-05-12T13:40:00.801498Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 940, "duration": "6.936519", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "348161051", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 1, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 1}}, "closed_secret_incidents":
         {"total": 1, "severity_breakdown": {"critical": 0, "high": 0, "medium": 0,
-        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2021-03",
+        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://github.com/ns-80126292/private-app-gg-bis-2021-03",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12304,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-bis-2021-02",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
-        6, "last_scan": {"date": "2021-05-12T13:40:00.833901Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1425, "duration": "7.69941", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-bis-2021-02", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 2, "closed_incidents_count": 6, "last_scan":
+        {"date": "2021-05-12T13:40:00.833901Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1425, "duration": "7.69941", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "339243545", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
         1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 1}}, "closed_secret_incidents":
         {"total": 6, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0,
-        "low": 0, "info": 1, "unknown": 4}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-bis-2021-02",
+        "low": 0, "info": 1, "unknown": 4}}}, "url": "https://github.com/ns-80126292/private-app-gg-bis-2021-02",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12307,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2021-02",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 2, "closed_incidents_count":
-        2, "last_scan": null, "monitored": true, "monitoring_status": "deleted_on_remote",
-        "visibility": "private", "external_id": "334786496", "secret_incidents_breakdown":
-        {"open_secret_incidents": {"total": 2, "severity_breakdown": {"critical":
-        2, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
-        {"total": 2, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0,
-        "low": 0, "info": 0, "unknown": 1}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2021-02",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-2021-02", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 2, "closed_incidents_count": 2, "last_scan":
+        null, "monitored": true, "monitoring_status": "deleted_on_remote", "visibility":
+        "private", "external_id": "334786496", "secret_incidents_breakdown": {"open_secret_incidents":
+        {"total": 2, "severity_breakdown": {"critical": 2, "high": 0, "medium": 0,
+        "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents": {"total":
+        2, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0, "low": 0,
+        "info": 0, "unknown": 1}}}, "url": "https://github.com/ns-80126292/private-app-gg-2021-02",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12312,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2021-04",
-        "health": "safe", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 0, "closed_incidents_count":
-        2, "last_scan": {"date": "2021-05-12T13:40:00.816026Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 701, "duration": "3.011352", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-2021-04", "health":
+        "safe", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 0, "closed_incidents_count": 2, "last_scan":
+        {"date": "2021-05-12T13:40:00.816026Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 701, "duration": "3.011352", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "353525012", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 0, "severity_breakdown": {"critical":
         0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}}, "closed_secret_incidents":
         {"total": 2, "severity_breakdown": {"critical": 0, "high": 1, "medium": 0,
-        "low": 0, "info": 1, "unknown": 0}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2021-04",
+        "low": 0, "info": 1, "unknown": 0}}}, "url": "https://github.com/ns-80126292/private-app-gg-2021-04",
         "provider_metadata": {"archived": false}, "deleted": false}, {"id": 12316,
-        "type": "github", "full_name": "wayne-enterprises-gg/private-app-gg-2021-01",
-        "health": "at_risk", "source_criticality": "unknown", "default_branch": null,
-        "default_branch_head": null, "open_incidents_count": 3, "closed_incidents_count":
-        5, "last_scan": {"date": "2021-03-22T09:56:45.983204Z", "status": "finished",
-        "failing_reason": "", "commits_scanned": 1345, "duration": "2.752545", "branches_scanned":
-        1, "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
+        "type": "github", "full_name": "ns-80126292/private-app-gg-2021-01", "health":
+        "at_risk", "source_criticality": "unknown", "default_branch": null, "default_branch_head":
+        null, "open_incidents_count": 3, "closed_incidents_count": 5, "last_scan":
+        {"date": "2021-03-22T09:56:45.983204Z", "status": "finished", "failing_reason":
+        "", "commits_scanned": 1345, "duration": "2.752545", "branches_scanned": 1,
+        "progress": 100}, "monitored": true, "monitoring_status": "deleted_on_remote",
         "visibility": "private", "external_id": "325893139", "secret_incidents_breakdown":
         {"open_secret_incidents": {"total": 3, "severity_breakdown": {"critical":
         1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 2}}, "closed_secret_incidents":
         {"total": 5, "severity_breakdown": {"critical": 0, "high": 3, "medium": 0,
-        "low": 0, "info": 1, "unknown": 1}}}, "url": "https://github.com/wayne-enterprises-gg/private-app-gg-2021-01",
+        "low": 0, "info": 1, "unknown": 1}}}, "url": "https://github.com/ns-80126292/private-app-gg-2021-01",
         "provider_metadata": {"archived": false}, "deleted": false}]'
     headers:
       CF-RAY:

--- a/tests/cassettes/tools/vcr/test_list_users_with_access_level.yaml
+++ b/tests/cassettes/tools/vcr/test_list_users_with_access_level.yaml
@@ -21,35 +21,35 @@ interactions:
   response:
     body:
       string: '[{"id": 10, "role": "manager", "access_level": "manager", "email":
-        "bruce-wayne-gg@protonmail.com", "name": "Bruce Wayne", "created_at": "2020-01-15T15:07:36.510559Z",
+        "user-324427de@example.com", "name": "User 2b03ad68", "created_at": "2020-01-15T15:07:36.510559Z",
         "last_login": "2020-09-30T12:21:19.319487Z", "active": true}, {"id": 13, "role":
-        "manager", "access_level": "manager", "email": "aymeric.sicard@gitguardian.com",
-        "name": "Aymeric SICARD", "created_at": "2020-01-21T09:35:47.907207Z", "last_login":
+        "manager", "access_level": "manager", "email": "user-71ab73d0@example.com",
+        "name": "User d0d18d7e", "created_at": "2020-01-21T09:35:47.907207Z", "last_login":
         "2026-06-22T14:20:46.680540Z", "active": true}, {"id": 2508, "role": "manager",
-        "access_level": "manager", "email": "guillaume.charpiat@gitguardian.com",
-        "name": "Guillaume CHARPIAT", "created_at": "2020-03-23T17:53:57.158457Z",
-        "last_login": "2026-06-10T11:29:54.420261Z", "active": true}, {"id": 37699,
-        "role": "manager", "access_level": "manager", "email": "alexis.larnaud@gitguardian.com",
-        "name": "Alexis LARNAUD", "created_at": "2020-09-03T11:16:05.980606Z", "last_login":
-        "2026-06-22T09:33:43.124144Z", "active": true}, {"id": 63809, "role": "manager",
-        "access_level": "manager", "email": "orian.roturier@gitguardian.com", "name":
-        "Orian ROTURIER", "created_at": "2020-11-25T14:01:01.749542Z", "last_login":
-        "2025-08-05T08:47:38.723615Z", "active": true}, {"id": 104544, "role": "manager",
-        "access_level": "manager", "email": "pierre.lalanne@gitguardian.com", "name":
-        "Pierre LALANNE", "created_at": "2021-04-07T13:54:43.138909Z", "last_login":
-        "2026-06-22T08:37:50.823418Z", "active": true}, {"id": 104916, "role": "manager",
-        "access_level": "manager", "email": "wassim.hana@gitguardian.com", "name":
-        "Wassim HANA", "created_at": "2021-04-08T14:54:40.049555Z", "last_login":
-        "2026-06-22T07:42:16.988277Z", "active": true}, {"id": 136170, "role": "manager",
-        "access_level": "manager", "email": "eric.fourrier@gitguardian.com", "name":
-        "Eric FOURRIER", "created_at": "2021-07-13T07:29:59.706367Z", "last_login":
-        "2026-06-23T12:05:26.347426Z", "active": true}, {"id": 160089, "role": "manager",
-        "access_level": "manager", "email": "aurelien.gateau@gitguardian.com", "name":
-        "Aur\u00e9lien G\u00c2TEAU", "created_at": "2021-09-08T14:07:28.496410Z",
-        "last_login": "2026-06-22T12:34:48.437530Z", "active": true}, {"id": 166199,
-        "role": "manager", "access_level": "manager", "email": "stanislas.crepin@gitguardian.com",
-        "name": "Stanislas CR\u00c9PIN", "created_at": "2021-09-24T14:02:28.853139Z",
-        "last_login": "2026-06-22T12:24:56.053377Z", "active": true}]'
+        "access_level": "manager", "email": "user-d9f863cd@example.com", "name": "User
+        793501dc", "created_at": "2020-03-23T17:53:57.158457Z", "last_login": "2026-06-10T11:29:54.420261Z",
+        "active": true}, {"id": 37699, "role": "manager", "access_level": "manager",
+        "email": "user-d3774a22@example.com", "name": "User 40f52996", "created_at":
+        "2020-09-03T11:16:05.980606Z", "last_login": "2026-06-22T09:33:43.124144Z",
+        "active": true}, {"id": 63809, "role": "manager", "access_level": "manager",
+        "email": "user-0222ba7e@example.com", "name": "User 97a9750c", "created_at":
+        "2020-11-25T14:01:01.749542Z", "last_login": "2025-08-05T08:47:38.723615Z",
+        "active": true}, {"id": 104544, "role": "manager", "access_level": "manager",
+        "email": "user-aba104cf@example.com", "name": "User 9a67720c", "created_at":
+        "2021-04-07T13:54:43.138909Z", "last_login": "2026-06-22T08:37:50.823418Z",
+        "active": true}, {"id": 104916, "role": "manager", "access_level": "manager",
+        "email": "user-f548df99@example.com", "name": "User f4c96fee", "created_at":
+        "2021-04-08T14:54:40.049555Z", "last_login": "2026-06-22T07:42:16.988277Z",
+        "active": true}, {"id": 136170, "role": "manager", "access_level": "manager",
+        "email": "user-db85bcf2@example.com", "name": "User 795904a4", "created_at":
+        "2021-07-13T07:29:59.706367Z", "last_login": "2026-06-23T12:05:26.347426Z",
+        "active": true}, {"id": 160089, "role": "manager", "access_level": "manager",
+        "email": "user-90859989@example.com", "name": "User 595a74b4", "created_at":
+        "2021-09-08T14:07:28.496410Z", "last_login": "2026-06-22T12:34:48.437530Z",
+        "active": true}, {"id": 166199, "role": "manager", "access_level": "manager",
+        "email": "user-1a0bc62d@example.com", "name": "User fbc68cb1", "created_at":
+        "2021-09-24T14:02:28.853139Z", "last_login": "2026-06-22T12:24:56.053377Z",
+        "active": true}]'
     headers:
       CF-RAY:
       - a10398cc9c7b6ed2-CDG

--- a/tests/cassettes/tools/vcr/test_list_users_with_active_filter.yaml
+++ b/tests/cassettes/tools/vcr/test_list_users_with_active_filter.yaml
@@ -21,33 +21,33 @@ interactions:
   response:
     body:
       string: '[{"id": 10, "role": "manager", "access_level": "manager", "email":
-        "bruce-wayne-gg@protonmail.com", "name": "Bruce Wayne", "created_at": "2020-01-15T15:07:36.510559Z",
+        "user-324427de@example.com", "name": "User 2b03ad68", "created_at": "2020-01-15T15:07:36.510559Z",
         "last_login": "2020-09-30T12:21:19.319487Z", "active": true}, {"id": 13, "role":
-        "manager", "access_level": "manager", "email": "aymeric.sicard@gitguardian.com",
-        "name": "Aymeric SICARD", "created_at": "2020-01-21T09:35:47.907207Z", "last_login":
+        "manager", "access_level": "manager", "email": "user-71ab73d0@example.com",
+        "name": "User d0d18d7e", "created_at": "2020-01-21T09:35:47.907207Z", "last_login":
         "2026-06-22T14:20:46.680540Z", "active": true}, {"id": 2508, "role": "manager",
-        "access_level": "manager", "email": "guillaume.charpiat@gitguardian.com",
-        "name": "Guillaume CHARPIAT", "created_at": "2020-03-23T17:53:57.158457Z",
-        "last_login": "2026-06-10T11:29:54.420261Z", "active": true}, {"id": 37699,
-        "role": "manager", "access_level": "manager", "email": "alexis.larnaud@gitguardian.com",
-        "name": "Alexis LARNAUD", "created_at": "2020-09-03T11:16:05.980606Z", "last_login":
-        "2026-06-22T09:33:43.124144Z", "active": true}, {"id": 63809, "role": "manager",
-        "access_level": "manager", "email": "orian.roturier@gitguardian.com", "name":
-        "Orian ROTURIER", "created_at": "2020-11-25T14:01:01.749542Z", "last_login":
-        "2025-08-05T08:47:38.723615Z", "active": true}, {"id": 69474, "role": "member",
-        "access_level": "member", "email": "elacaille0@gmail.com", "name": "Eric",
-        "created_at": "2020-12-15T08:53:29.392054Z", "last_login": "2022-03-28T09:34:32.148429Z",
+        "access_level": "manager", "email": "user-d9f863cd@example.com", "name": "User
+        793501dc", "created_at": "2020-03-23T17:53:57.158457Z", "last_login": "2026-06-10T11:29:54.420261Z",
+        "active": true}, {"id": 37699, "role": "manager", "access_level": "manager",
+        "email": "user-d3774a22@example.com", "name": "User 40f52996", "created_at":
+        "2020-09-03T11:16:05.980606Z", "last_login": "2026-06-22T09:33:43.124144Z",
+        "active": true}, {"id": 63809, "role": "manager", "access_level": "manager",
+        "email": "user-0222ba7e@example.com", "name": "User 97a9750c", "created_at":
+        "2020-11-25T14:01:01.749542Z", "last_login": "2025-08-05T08:47:38.723615Z",
+        "active": true}, {"id": 69474, "role": "member", "access_level": "member",
+        "email": "user-5af3cff5@example.com", "name": "User 4cb39c1b", "created_at":
+        "2020-12-15T08:53:29.392054Z", "last_login": "2022-03-28T09:34:32.148429Z",
         "active": true}, {"id": 104544, "role": "manager", "access_level": "manager",
-        "email": "pierre.lalanne@gitguardian.com", "name": "Pierre LALANNE", "created_at":
+        "email": "user-aba104cf@example.com", "name": "User 9a67720c", "created_at":
         "2021-04-07T13:54:43.138909Z", "last_login": "2026-06-22T08:37:50.823418Z",
         "active": true}, {"id": 104916, "role": "manager", "access_level": "manager",
-        "email": "wassim.hana@gitguardian.com", "name": "Wassim HANA", "created_at":
+        "email": "user-f548df99@example.com", "name": "User f4c96fee", "created_at":
         "2021-04-08T14:54:40.049555Z", "last_login": "2026-06-22T07:42:16.988277Z",
         "active": true}, {"id": 113168, "role": "owner", "access_level": "owner",
-        "email": "henri.hubert@gitguardian.com", "name": "Henri HUBERT", "created_at":
+        "email": "user-c010b87e@example.com", "name": "User 00d1c796", "created_at":
         "2021-05-04T08:20:06.714793Z", "last_login": "2026-06-22T16:25:44.928986Z",
         "active": true}, {"id": 136170, "role": "manager", "access_level": "manager",
-        "email": "eric.fourrier@gitguardian.com", "name": "Eric FOURRIER", "created_at":
+        "email": "user-db85bcf2@example.com", "name": "User 795904a4", "created_at":
         "2021-07-13T07:29:59.706367Z", "last_login": "2026-06-23T12:05:26.347426Z",
         "active": true}]'
     headers:

--- a/tests/cassettes/tools/vcr/test_list_users_with_ordering.yaml
+++ b/tests/cassettes/tools/vcr/test_list_users_with_ordering.yaml
@@ -21,31 +21,31 @@ interactions:
   response:
     body:
       string: '[{"id": 1831560, "role": "member", "access_level": "member", "email":
-        "chris.heine@gitguardian.com", "name": "Chris HEINE", "created_at": "2026-06-22T09:31:09.529363Z",
+        "user-6cf4a340@example.com", "name": "User 075b2f33", "created_at": "2026-06-22T09:31:09.529363Z",
         "last_login": null, "active": true}, {"id": 1827687, "role": "member", "access_level":
-        "member", "email": "badr.bennasri@gitguardian.com", "name": "Badr BENNASRI",
-        "created_at": "2026-06-16T12:40:54.847312Z", "last_login": null, "active":
-        true}, {"id": 1827686, "role": "member", "access_level": "member", "email":
-        "kevin.duchier-ext@gitguardian.com", "name": "Kevin DUCHIER", "created_at":
-        "2026-06-16T12:40:53.811676Z", "last_login": null, "active": true}, {"id":
-        1826598, "role": "member", "access_level": "member", "email": "matthew.perry@gitguardian.com",
-        "name": "Matthew PERRY", "created_at": "2026-06-15T09:40:43.609269Z", "last_login":
-        null, "active": true}, {"id": 1823951, "role": "member", "access_level": "member",
-        "email": "colin.evans@gitguardian.com", "name": "Colin EVANS", "created_at":
-        "2026-06-11T19:46:03.577270Z", "last_login": null, "active": true}, {"id":
-        1821084, "role": "member", "access_level": "member", "email": "elias.zegouagh-new@gitguardian.com",
-        "name": "Elias ZEGOUAGH", "created_at": "2026-06-08T19:05:42.720751Z", "last_login":
-        null, "active": true}, {"id": 1815173, "role": "member", "access_level": "member",
-        "email": "zoraver.singh@gitguardian.com", "name": "Zoraver SINGH", "created_at":
-        "2026-06-03T15:36:30.208960Z", "last_login": null, "active": true}, {"id":
-        1810671, "role": "member", "access_level": "member", "email": "melanie.almeida-ext@gitguardian.com",
-        "name": "M\u00e9lanie ALMEIDA", "created_at": "2026-05-29T07:55:45.623834Z",
-        "last_login": null, "active": true}, {"id": 1810140, "role": "member", "access_level":
-        "member", "email": "lia.vector@gitguardian.com", "name": "Lia VECTOR", "created_at":
-        "2026-05-28T15:45:53.126488Z", "last_login": null, "active": true}, {"id":
-        1809695, "role": "member", "access_level": "member", "email": "patrycja.kucharska@gitguardian.com",
-        "name": "Patrycja KUCHARSKA", "created_at": "2026-05-28T07:06:18.936256Z",
-        "last_login": "2026-06-16T14:08:45.946144Z", "active": true}]'
+        "member", "email": "user-b9296f05@example.com", "name": "User dd80f6e6", "created_at":
+        "2026-06-16T12:40:54.847312Z", "last_login": null, "active": true}, {"id":
+        1827686, "role": "member", "access_level": "member", "email": "user-871fac1d@example.com",
+        "name": "User 7fb663b6", "created_at": "2026-06-16T12:40:53.811676Z", "last_login":
+        null, "active": true}, {"id": 1826598, "role": "member", "access_level": "member",
+        "email": "user-277e5301@example.com", "name": "User 8141b801", "created_at":
+        "2026-06-15T09:40:43.609269Z", "last_login": null, "active": true}, {"id":
+        1823951, "role": "member", "access_level": "member", "email": "user-a034d179@example.com",
+        "name": "User aaa0231d", "created_at": "2026-06-11T19:46:03.577270Z", "last_login":
+        null, "active": true}, {"id": 1821084, "role": "member", "access_level": "member",
+        "email": "user-07e415c4@example.com", "name": "User ae846c26", "created_at":
+        "2026-06-08T19:05:42.720751Z", "last_login": null, "active": true}, {"id":
+        1815173, "role": "member", "access_level": "member", "email": "user-145072dc@example.com",
+        "name": "User 4539c90b", "created_at": "2026-06-03T15:36:30.208960Z", "last_login":
+        null, "active": true}, {"id": 1810671, "role": "member", "access_level": "member",
+        "email": "user-33c25618@example.com", "name": "User 60ec4330", "created_at":
+        "2026-05-29T07:55:45.623834Z", "last_login": null, "active": true}, {"id":
+        1810140, "role": "member", "access_level": "member", "email": "user-9b584182@example.com",
+        "name": "User 68ee8fcc", "created_at": "2026-05-28T15:45:53.126488Z", "last_login":
+        null, "active": true}, {"id": 1809695, "role": "member", "access_level": "member",
+        "email": "user-38354293@example.com", "name": "User 6eabded6", "created_at":
+        "2026-05-28T07:06:18.936256Z", "last_login": "2026-06-16T14:08:45.946144Z",
+        "active": true}]'
     headers:
       CF-RAY:
       - a10398ce4b4ed785-CDG

--- a/tests/cassettes/tools/vcr/test_list_users_with_search.yaml
+++ b/tests/cassettes/tools/vcr/test_list_users_with_search.yaml
@@ -21,35 +21,34 @@ interactions:
   response:
     body:
       string: '[{"id": 13, "role": "manager", "access_level": "manager", "email":
-        "aymeric.sicard@gitguardian.com", "name": "Aymeric SICARD", "created_at":
-        "2020-01-21T09:35:47.907207Z", "last_login": "2026-06-22T14:20:46.680540Z",
-        "active": true}, {"id": 2508, "role": "manager", "access_level": "manager",
-        "email": "guillaume.charpiat@gitguardian.com", "name": "Guillaume CHARPIAT",
-        "created_at": "2020-03-23T17:53:57.158457Z", "last_login": "2026-06-10T11:29:54.420261Z",
-        "active": true}, {"id": 37699, "role": "manager", "access_level": "manager",
-        "email": "alexis.larnaud@gitguardian.com", "name": "Alexis LARNAUD", "created_at":
-        "2020-09-03T11:16:05.980606Z", "last_login": "2026-06-22T09:33:43.124144Z",
+        "user-71ab73d0@example.com", "name": "User d0d18d7e", "created_at": "2020-01-21T09:35:47.907207Z",
+        "last_login": "2026-06-22T14:20:46.680540Z", "active": true}, {"id": 2508,
+        "role": "manager", "access_level": "manager", "email": "user-d9f863cd@example.com",
+        "name": "User 793501dc", "created_at": "2020-03-23T17:53:57.158457Z", "last_login":
+        "2026-06-10T11:29:54.420261Z", "active": true}, {"id": 37699, "role": "manager",
+        "access_level": "manager", "email": "user-d3774a22@example.com", "name": "User
+        40f52996", "created_at": "2020-09-03T11:16:05.980606Z", "last_login": "2026-06-22T09:33:43.124144Z",
         "active": true}, {"id": 63809, "role": "manager", "access_level": "manager",
-        "email": "orian.roturier@gitguardian.com", "name": "Orian ROTURIER", "created_at":
+        "email": "user-0222ba7e@example.com", "name": "User 97a9750c", "created_at":
         "2020-11-25T14:01:01.749542Z", "last_login": "2025-08-05T08:47:38.723615Z",
         "active": true}, {"id": 104544, "role": "manager", "access_level": "manager",
-        "email": "pierre.lalanne@gitguardian.com", "name": "Pierre LALANNE", "created_at":
+        "email": "user-aba104cf@example.com", "name": "User 9a67720c", "created_at":
         "2021-04-07T13:54:43.138909Z", "last_login": "2026-06-22T08:37:50.823418Z",
         "active": true}, {"id": 104916, "role": "manager", "access_level": "manager",
-        "email": "wassim.hana@gitguardian.com", "name": "Wassim HANA", "created_at":
+        "email": "user-f548df99@example.com", "name": "User f4c96fee", "created_at":
         "2021-04-08T14:54:40.049555Z", "last_login": "2026-06-22T07:42:16.988277Z",
         "active": true}, {"id": 113168, "role": "owner", "access_level": "owner",
-        "email": "henri.hubert@gitguardian.com", "name": "Henri HUBERT", "created_at":
+        "email": "user-c010b87e@example.com", "name": "User 00d1c796", "created_at":
         "2021-05-04T08:20:06.714793Z", "last_login": "2026-06-22T16:25:44.928986Z",
         "active": true}, {"id": 136170, "role": "manager", "access_level": "manager",
-        "email": "eric.fourrier@gitguardian.com", "name": "Eric FOURRIER", "created_at":
+        "email": "user-db85bcf2@example.com", "name": "User 795904a4", "created_at":
         "2021-07-13T07:29:59.706367Z", "last_login": "2026-06-23T12:05:26.347426Z",
         "active": true}, {"id": 160089, "role": "manager", "access_level": "manager",
-        "email": "aurelien.gateau@gitguardian.com", "name": "Aur\u00e9lien G\u00c2TEAU",
-        "created_at": "2021-09-08T14:07:28.496410Z", "last_login": "2026-06-22T12:34:48.437530Z",
+        "email": "user-90859989@example.com", "name": "User 595a74b4", "created_at":
+        "2021-09-08T14:07:28.496410Z", "last_login": "2026-06-22T12:34:48.437530Z",
         "active": true}, {"id": 166199, "role": "manager", "access_level": "manager",
-        "email": "stanislas.crepin@gitguardian.com", "name": "Stanislas CR\u00c9PIN",
-        "created_at": "2021-09-24T14:02:28.853139Z", "last_login": "2026-06-22T12:24:56.053377Z",
+        "email": "user-1a0bc62d@example.com", "name": "User fbc68cb1", "created_at":
+        "2021-09-24T14:02:28.853139Z", "last_login": "2026-06-22T12:24:56.053377Z",
         "active": true}]'
     headers:
       CF-RAY:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,11 @@
+import hashlib
 import json
 import logging
 import os
 import re
 from os.path import dirname, join, realpath
 from unittest.mock import AsyncMock, MagicMock, patch
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, quote, unquote, urlparse
 
 import pytest
 import vcr
@@ -47,6 +48,127 @@ ALLOWED_HEADERS = {
 # Placeholder for redacted values
 REDACTED = "[REDACTED]"
 
+# GitGuardian product hostnames that may stay in cassettes as-is. Any other
+# hostname that references the recording workspace's perimeter is anonymized.
+PUBLIC_HOSTNAMES = {
+    "gitguardian.com",
+    "api.gitguardian.com",
+    "dashboard.gitguardian.com",
+    "docs.gitguardian.com",
+    "hook.gitguardian.com",
+    "www.gitguardian.com",
+}
+
+_EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+_HOSTNAME_RE = re.compile(r"\b[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+\b")
+# Tenant-scoped SaaS hosts: the tenant name identifies the recording workspace.
+_SAAS_TENANT_SUFFIXES = (".atlassian.net", ".jfrog.io", ".sharepoint.com")
+
+
+def _hash8(value: str) -> str:
+    """Stable 8-char token so the same input maps to the same fake everywhere."""
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:8]
+
+
+def _anonymize_email(match: re.Match) -> str:
+    email = match.group(0)
+    local, _, domain = email.partition("@")
+    # Keep already-fake addresses and ssh-style remotes (git@github.com).
+    if domain.lower().endswith("example.com") or local.lower() == "git":
+        return email
+    return f"user-{_hash8(email.lower())}@example.com"
+
+
+def _anonymize_hostname(match: re.Match) -> str:
+    host = match.group(0)
+    lowered = host.lower()
+    if lowered in PUBLIC_HOSTNAMES:
+        return host
+    for suffix in _SAAS_TENANT_SUFFIXES:
+        if lowered.endswith(suffix):
+            tenant = lowered[: -len(suffix)]
+            if _ANON_TENANT_RE.fullmatch(tenant):
+                return host
+            return f"tenant-{_hash8(lowered)}{suffix}"
+    if "gitguardian" in lowered or lowered.endswith(".ovh"):
+        return f"host-{_hash8(lowered)}.example.com"
+    return host
+
+
+# Every rule below must be idempotent: VCR runs before_record_request on
+# outgoing requests at replay time too, so a value already anonymized in a
+# cassette must survive a second pass unchanged or it stops matching.
+_ANON_SEGMENT_RE = re.compile(r"ns-[0-9a-f]{8}")
+_ANON_USER_RE = re.compile(r"user-[0-9a-f]{8}")
+_ANON_TENANT_RE = re.compile(r"tenant-[0-9a-f]{8}")
+
+
+def _anon_segment(segment: str) -> str:
+    return segment if _ANON_SEGMENT_RE.fullmatch(segment) else f"ns-{_hash8(segment)}"
+
+
+def _anon_user(name: str) -> str:
+    return name if _ANON_USER_RE.fullmatch(name) else f"user-{_hash8(name)}"
+
+
+_ANON_PERSON_RE = re.compile(r"User [0-9a-f]{8}")
+_ANON_ENDPOINT_RE = re.compile(r"endpoint-[0-9a-f]{8}")
+
+
+def _anon_person(name: str) -> str:
+    return name if _ANON_PERSON_RE.fullmatch(name) else f"User {_hash8(name)}"
+
+
+def _anon_endpoint(name: str) -> str:
+    return name if _ANON_ENDPOINT_RE.fullmatch(name) else f"endpoint-{_hash8(name)}"
+
+
+def _anonymize_namespace(value: str, keep_repo: bool) -> str:
+    """Anonymize a namespaced repository name. Public GitHub repo names keep
+    their repo segment (it is public data and search fixtures rely on it);
+    other SCM projects are fully anonymized."""
+    segments = [s.strip() for s in value.split("/")]
+    if keep_repo and len(segments) > 1:
+        return "/".join([_anon_segment(segments[0]), *segments[1:]])
+    return "/".join(_anon_segment(s) for s in segments)
+
+
+# github.com URL owners are user handles; keep the public GitGuardian org.
+_GITHUB_OWNER_RE = re.compile(r"(github\.com/)(?!GitGuardian/)([A-Za-z0-9_.-]+)(?=[/\"?#])")
+# Home directories in occurrence file paths are named after their user.
+_HOMEDIR_RE = re.compile(r"/(Users|home)/([A-Za-z0-9._%+-]+)")
+# The leading path segments on an anonymized host are a user/group namespace
+# and a project name.
+_ANON_HOST_NAMESPACE_RE = re.compile(r"(host-[0-9a-f]{8}\.example\.com)/([A-Za-z0-9._%+-]+)(/[A-Za-z0-9._%+-]+)?")
+# Sources are re-fetched by searching for names taken from earlier responses,
+# so search parameters must be anonymized the same way as the names they match.
+_SEARCH_PARAM_RE = re.compile(r"([?&]search=)([^&#]+)")
+
+
+def _anonymize_text(text: str) -> str:
+    """Anonymize emails, non-public hostnames, and user paths in a serialized body."""
+    text = _EMAIL_RE.sub(_anonymize_email, text)
+    text = _HOSTNAME_RE.sub(_anonymize_hostname, text)
+    text = _GITHUB_OWNER_RE.sub(lambda m: m.group(1) + _anon_segment(m.group(2)), text)
+    text = _HOMEDIR_RE.sub(lambda m: f"/{m.group(1)}/{_anon_user(m.group(2))}", text)
+    return _ANON_HOST_NAMESPACE_RE.sub(
+        lambda m: f"{m.group(1)}/{_anon_segment(m.group(2))}"
+        + (f"/{_anon_segment(m.group(3)[1:])}" if m.group(3) else ""),
+        text,
+    )
+
+
+def _anonymize_uri(uri: str) -> str:
+    """Anonymize a request URI: body-level rules plus search query values."""
+
+    def _sub(match: re.Match) -> str:
+        value = unquote(match.group(2))
+        if "/" not in value:
+            return match.group(0)
+        return match.group(1) + quote(_anonymize_namespace(value, keep_repo=True), safe="")
+
+    return _SEARCH_PARAM_RE.sub(_sub, _anonymize_text(uri))
+
 
 def _redact_sensitive_fields(obj):
     """
@@ -54,7 +176,32 @@ def _redact_sensitive_fields(obj):
     """
     if isinstance(obj, dict):
         redacted = {}
+        # Person names: members/assignees carry an email sibling, commit
+        # authors carry an info sibling. Emails themselves are anonymized by
+        # _anonymize_text; names need this structural pass.
+        person_key = "email" if "email" in obj else "info" if "info" in obj else None
+        # Endpoint-type sources are named after the machine they run on.
+        is_endpoint_source = obj.get("type") == "endpoints"
+        # Repository sources are namespaced under a user or org handle.
+        source_type = obj.get("type")
+        is_repo_source = isinstance(source_type, str) and source_type.startswith(
+            ("gh_", "github", "gitlab", "bitbucket", "azure")
+        )
         for key, value in obj.items():
+            if key == "name" and person_key and isinstance(value, str) and value:
+                redacted[key] = _anon_person(value)
+                continue
+            if key in ("name", "path", "display_name") and is_endpoint_source and isinstance(value, str):
+                redacted[key] = _anon_endpoint(value)
+                continue
+            if (
+                key in ("name", "path", "full_name", "display_name")
+                and is_repo_source
+                and isinstance(value, str)
+                and value
+            ):
+                redacted[key] = _anonymize_namespace(value, keep_repo=source_type.startswith(("gh_", "github")))
+                continue
             # Redact known sensitive field names
             if key in (
                 "secret_key",
@@ -146,6 +293,14 @@ def _filter_request_headers_and_store(request):
     for name in list(request.headers):
         if name.lower() not in ALLOWED_HEADERS:
             request.headers.pop(name)
+
+    request.uri = _anonymize_uri(request.uri)
+    if request.body:
+        body = request.body
+        if isinstance(body, bytes):
+            request.body = _anonymize_text(body.decode("utf-8", errors="replace")).encode("utf-8")
+        elif isinstance(body, str):
+            request.body = _anonymize_text(body)
     return request
 
 
@@ -173,7 +328,7 @@ def _before_record_response(response):
 
         data = json.loads(body_str)
         redacted_data = _redact_sensitive_fields(data)
-        redacted_body = json.dumps(redacted_data)
+        redacted_body = _anonymize_text(json.dumps(redacted_data))
 
         response["body"]["string"] = redacted_body.encode("utf-8")
     except (json.JSONDecodeError, UnicodeDecodeError):

--- a/tests/test_cassette_sanitization.py
+++ b/tests/test_cassette_sanitization.py
@@ -1,0 +1,93 @@
+"""Guards for the VCR fixture anonymization in conftest.
+
+Cassettes are recorded against a real workspace, so the anonymization hooks are
+what keep workspace-identifying data out of the repository. These tests fail if
+a re-recording reintroduces it, or if a transform stops being idempotent.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import (
+    CASSETTES_DIR,
+    PUBLIC_HOSTNAMES,
+    _anonymize_text,
+    _anonymize_uri,
+    _redact_sensitive_fields,
+)
+
+CASSETTES = sorted(Path(CASSETTES_DIR).rglob("*.yaml"))
+
+# Fake domains the anonymizers emit, plus opaque non-routable identifiers that
+# carry no workspace information (Teams conversation ids, git-over-ssh remotes).
+ALLOWED_EMAIL_DOMAINS = ("example.com", "thread.tacv", "users.noreply.github.com")
+
+_EMAIL = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+_COMPANY_HOST = re.compile(r"[A-Za-z0-9.-]*gitguardian[A-Za-z0-9.-]*\.[A-Za-z]{2,}")
+
+
+def test_cassettes_exist():
+    assert CASSETTES, "no cassettes found; the hygiene scan below would vacuously pass"
+
+
+@pytest.mark.parametrize("cassette", CASSETTES, ids=lambda p: p.name)
+def test_cassette_has_no_real_email_addresses(cassette):
+    """Only anonymized addresses may appear in a recorded fixture."""
+    leaked = {
+        email for email in _EMAIL.findall(cassette.read_text()) if not email.lower().endswith(ALLOWED_EMAIL_DOMAINS)
+    }
+    assert not leaked, f"{cassette.name} carries non-anonymized addresses: {sorted(leaked)}"
+
+
+@pytest.mark.parametrize("cassette", CASSETTES, ids=lambda p: p.name)
+def test_cassette_has_no_non_public_company_hostnames(cassette):
+    """Product hostnames are fine; anything else on the company domain is not."""
+    leaked = {host for host in _COMPANY_HOST.findall(cassette.read_text()) if host.lower() not in PUBLIC_HOSTNAMES}
+    assert not leaked, f"{cassette.name} carries non-public hostnames: {sorted(leaked)}"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "someone@corp.example.org",
+        "user-f548df99@example.com",
+        "internal-host.example.org",
+        "/Users/someone/project/file.py",
+        "/Users/user-eb6cfa60/project/file.py",
+        "https://github.com/some-owner/some-repo",
+        "https://github.com/ns-f0afee16/some-repo",
+    ],
+)
+def test_text_anonymization_is_idempotent(value):
+    """VCR filters outgoing requests at replay time as well as at record time,
+    so an already-anonymized value must survive a second pass unchanged."""
+    once = _anonymize_text(value)
+    assert _anonymize_text(once) == once
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "https://api.gitguardian.com/v1/sources?search=owner%2Frepo&per_page=50",
+        "https://api.gitguardian.com/v1/sources?search=ns-1cb0f5a9%2Frepo&per_page=50",
+    ],
+)
+def test_uri_anonymization_is_idempotent(uri):
+    once = _anonymize_uri(uri)
+    assert _anonymize_uri(once) == once
+
+
+def test_structural_redaction_is_idempotent():
+    """The name/endpoint/repository rules key off sibling fields, so they must
+    also recognize their own output."""
+    payload = {
+        "members": [{"name": "Some Person", "email": "some.person@corp.example.org"}],
+        "sources": [
+            {"type": "endpoints", "name": "LAPTOP01 - some.person", "path": "LAPTOP01 - some.person"},
+            {"type": "gh_repository", "name": "some-owner/some-repo", "path": "some-owner/some-repo"},
+        ],
+    }
+    once = _redact_sensitive_fields(payload)
+    assert _redact_sensitive_fields(once) == once


### PR DESCRIPTION
## Summary

Cassettes recorded against a real workspace carried identifying data: member emails and names, source and repository names, tenant hostnames, and local paths. This PR anonymizes all of it and wires the rules into the VCR `before_record` hooks so future recordings are sanitized automatically.

- Deterministic mapping (same input, same fake), so fixtures stay internally consistent and replay matching keeps working.
- Idempotent rules: VCR reapplies them at replay time, so each recognizes its own output.
- Public GitHub repo segments are kept; search fixtures rely on them.

most edits are just scrubing jump to  tests/conftest.py at the bottom 

All 693 tests pass on the rewritten cassettes with no test changes; a new test scans committed cassettes for leftover emails and hostnames.

Refs: SI-3953
