### PR TITLE
fix(tools): give params wrappers a default so all-optional tools accept {}

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/tools/count_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/count_incidents.py
@@ -367,7 +367,7 @@ def _build_filter_info(params: CountIncidentsParams) -> dict[str, Any]:
 
 
 async def count_incidents(
-    params: CountIncidentsParams,
+    params: CountIncidentsParams = CountIncidentsParams(),
 ) -> CountIncidentsResult | CountIncidentsError:
     """
     Count secret incidents matching the given filters.

--- a/packages/gg_api_core/src/gg_api_core/tools/list_detectors.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_detectors.py
@@ -46,7 +46,7 @@ class ListDetectorsResult(BaseModel):
     )
 
 
-async def list_detectors(params: ListDetectorsParams) -> ListDetectorsResult:
+async def list_detectors(params: ListDetectorsParams = ListDetectorsParams()) -> ListDetectorsResult:
     """
     List secret detectors from the GitGuardian detection engine.
 

--- a/packages/gg_api_core/src/gg_api_core/tools/list_honeytokens.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_honeytokens.py
@@ -54,7 +54,7 @@ class ListHoneytokensResult(BaseModel):
     )
 
 
-async def list_honeytokens(params: ListHoneytokensParams) -> ListHoneytokensResult:
+async def list_honeytokens(params: ListHoneytokensParams = ListHoneytokensParams()) -> ListHoneytokensResult:
     """
     List honeytokens from the GitGuardian dashboard with filtering options.
 

--- a/packages/gg_api_core/src/gg_api_core/tools/list_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_incidents.py
@@ -479,7 +479,7 @@ class ListIncidentsError(BaseModel):
 
 
 async def list_incidents(
-    params: ListIncidentsParams,
+    params: ListIncidentsParams = ListIncidentsParams(),
 ) -> ListIncidentsResult | ListIncidentsError:
     """
     List secret incidents with enhanced filtering using the MCP-optimized endpoint.

--- a/packages/gg_api_core/src/gg_api_core/tools/list_public_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_public_incidents.py
@@ -269,7 +269,7 @@ def _build_filter_info(params: ListPublicIncidentsParams) -> dict[str, Any]:
 
 
 async def list_public_incidents(
-    params: ListPublicIncidentsParams,
+    params: ListPublicIncidentsParams = ListPublicIncidentsParams(),
 ) -> ListPublicIncidentsResult | ListPublicIncidentsError:
     """List public secret incidents detected by GitGuardian on public sources (e.g. public GitHub).
 

--- a/packages/gg_api_core/src/gg_api_core/tools/list_repo_occurrences.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_repo_occurrences.py
@@ -182,7 +182,7 @@ def _build_suggestion(params: ListRepoOccurrencesParams, occurrences_count: int)
 
 
 async def list_repo_occurrences(
-    params: ListRepoOccurrencesParams,
+    params: ListRepoOccurrencesParams = ListRepoOccurrencesParams(),
 ) -> ListRepoOccurrencesResult | ListRepoOccurrencesError:
     """
     List secret occurrences for a specific repository using the GitGuardian v1/occurrences/secrets API.

--- a/packages/gg_api_core/src/gg_api_core/tools/list_sources.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_sources.py
@@ -119,7 +119,7 @@ class ListSourcesResult(BaseModel):
     )
 
 
-async def list_sources(params: ListSourcesParams) -> ListSourcesResult:
+async def list_sources(params: ListSourcesParams = ListSourcesParams()) -> ListSourcesResult:
     """
     List sources known by GitGuardian.
 

--- a/packages/gg_api_core/src/gg_api_core/tools/list_users.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_users.py
@@ -50,7 +50,7 @@ class ListUsersResult(BaseModel):
     )
 
 
-async def list_users(params: ListUsersParams) -> ListUsersResult:
+async def list_users(params: ListUsersParams = ListUsersParams()) -> ListUsersResult:
     """
     List members/users in the GitGuardian workspace.
 

--- a/packages/gg_api_core/src/gg_api_core/tools/remediate_secret_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/remediate_secret_incidents.py
@@ -92,7 +92,7 @@ class RemediateSecretIncidentsError(BaseModel):
 
 
 async def remediate_secret_incidents(
-    params: RemediateSecretIncidentsParams,
+    params: RemediateSecretIncidentsParams = RemediateSecretIncidentsParams(),
 ) -> RemediateSecretIncidentsResult | RemediateSecretIncidentsError:
     """
     Find and remediate secret incidents in the current repository.


### PR DESCRIPTION
## Problem

Nine all-optional tools (`list_incidents`, `list_detectors`, `count_incidents`, `list_honeytokens`, `list_public_incidents`, `list_repo_occurrences`, `list_sources`, `list_users`, `remediate_secret_incidents`) rejected the empty call. Both the schema clients see and the runtime validation are generated from the Python signature, so one missing default broke both at once.

**Before**

```python
async def list_detectors(params: ListDetectorsParams) -> ListDetectorsResult:
```

```json
{
  "type": "object",
  "properties": { "params": { "…all fields optional…" : "…" } },
  "required": ["params"]
}
```

Every field inside `params` has a default, but the wrapper itself is required. A client sending `"arguments": {}` (what an LLM does when everything looks optional) fails before the tool runs:

```
ValidationError: 1 validation error for call[list_detectors]
params
  Missing required argument [type=missing_argument, input_value={}, input_type=dict]
```

**After**

```python
async def list_detectors(params: ListDetectorsParams = ListDetectorsParams()) -> ListDetectorsResult:
```

```json
{
  "type": "object",
  "properties": { "params": { "…all fields optional…" : "…" } }
}
```

`"required"` is gone and `{}` validates to a default instance. Pydantic deep-copies the default per call, so the shared instance cannot leak state between requests (verified against our fastmcp version).

## Tests

A schema-level regression test (every all-optional tool must accept `{}`) lands in a follow-up PR.

## Follow-up

SI-3963 removes the `params` wrapper entirely (flat top-level parameters), which deletes this bug class and the flat-arguments failure mode (`{"per_page": 5}` sent without nesting) at the root.

Fixes SI-3911
