### PR TITLE
fix(tools): construct optional params per call

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/tools/count_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/count_incidents.py
@@ -367,7 +367,7 @@ def _build_filter_info(params: CountIncidentsParams) -> dict[str, Any]:
 
 
 async def count_incidents(
-    params: CountIncidentsParams = CountIncidentsParams(),
+    params: CountIncidentsParams | None = None,
 ) -> CountIncidentsResult | CountIncidentsError:
     """
     Count secret incidents matching the given filters.
@@ -389,6 +389,9 @@ async def count_incidents(
 
         CountIncidentsError: Pydantic model with error message if the operation fails
     """
+    if params is None:
+        params = CountIncidentsParams()
+
     client = await get_client()
 
     try:

--- a/packages/gg_api_core/src/gg_api_core/tools/list_detectors.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_detectors.py
@@ -46,7 +46,7 @@ class ListDetectorsResult(BaseModel):
     )
 
 
-async def list_detectors(params: ListDetectorsParams = ListDetectorsParams()) -> ListDetectorsResult:
+async def list_detectors(params: ListDetectorsParams | None = None) -> ListDetectorsResult:
     """
     List secret detectors from the GitGuardian detection engine.
 
@@ -65,6 +65,9 @@ async def list_detectors(params: ListDetectorsParams = ListDetectorsParams()) ->
     Raises:
         ToolError: If the listing operation fails
     """
+    if params is None:
+        params = ListDetectorsParams()
+
     client = await get_client()
     logger.debug("Listing secret detectors")
 

--- a/packages/gg_api_core/src/gg_api_core/tools/list_honeytokens.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_honeytokens.py
@@ -54,7 +54,7 @@ class ListHoneytokensResult(BaseModel):
     )
 
 
-async def list_honeytokens(params: ListHoneytokensParams = ListHoneytokensParams()) -> ListHoneytokensResult:
+async def list_honeytokens(params: ListHoneytokensParams | None = None) -> ListHoneytokensResult:
     """
     List honeytokens from the GitGuardian dashboard with filtering options.
 
@@ -72,6 +72,9 @@ async def list_honeytokens(params: ListHoneytokensParams = ListHoneytokensParams
     Raises:
         ToolError: If the listing operation fails
     """
+    if params is None:
+        params = ListHoneytokensParams()
+
     client = await get_client()
     logger.debug("Listing honeytokens with filters")
 

--- a/packages/gg_api_core/src/gg_api_core/tools/list_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_incidents.py
@@ -479,7 +479,7 @@ class ListIncidentsError(BaseModel):
 
 
 async def list_incidents(
-    params: ListIncidentsParams = ListIncidentsParams(),
+    params: ListIncidentsParams | None = None,
 ) -> ListIncidentsResult | ListIncidentsError:
     """
     List secret incidents with enhanced filtering using the MCP-optimized endpoint.
@@ -508,6 +508,9 @@ async def list_incidents(
 
         ListIncidentsError: Pydantic model with error message if the operation fails
     """
+    if params is None:
+        params = ListIncidentsParams()
+
     client = await get_client()
 
     try:

--- a/packages/gg_api_core/src/gg_api_core/tools/list_public_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_public_incidents.py
@@ -269,7 +269,7 @@ def _build_filter_info(params: ListPublicIncidentsParams) -> dict[str, Any]:
 
 
 async def list_public_incidents(
-    params: ListPublicIncidentsParams = ListPublicIncidentsParams(),
+    params: ListPublicIncidentsParams | None = None,
 ) -> ListPublicIncidentsResult | ListPublicIncidentsError:
     """List public secret incidents detected by GitGuardian on public sources (e.g. public GitHub).
 
@@ -286,6 +286,9 @@ async def list_public_incidents(
         ListPublicIncidentsResult with the public incidents page, or
         ListPublicIncidentsError on failure.
     """
+    if params is None:
+        params = ListPublicIncidentsParams()
+
     client = await get_client()
 
     try:

--- a/packages/gg_api_core/src/gg_api_core/tools/list_repo_occurrences.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_repo_occurrences.py
@@ -182,7 +182,7 @@ def _build_suggestion(params: ListRepoOccurrencesParams, occurrences_count: int)
 
 
 async def list_repo_occurrences(
-    params: ListRepoOccurrencesParams = ListRepoOccurrencesParams(),
+    params: ListRepoOccurrencesParams | None = None,
 ) -> ListRepoOccurrencesResult | ListRepoOccurrencesError:
     """
     List secret occurrences for a specific repository using the GitGuardian v1/occurrences/secrets API.
@@ -220,6 +220,9 @@ async def list_repo_occurrences(
 
         ListRepoOccurrencesError: Pydantic model with error message if the operation fails
     """
+    if params is None:
+        params = ListRepoOccurrencesParams()
+
     client = await get_client()
     logger.debug(f"Listing occurrences with source_id={params.source_id}")
 

--- a/packages/gg_api_core/src/gg_api_core/tools/list_sources.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_sources.py
@@ -119,7 +119,7 @@ class ListSourcesResult(BaseModel):
     )
 
 
-async def list_sources(params: ListSourcesParams = ListSourcesParams()) -> ListSourcesResult:
+async def list_sources(params: ListSourcesParams | None = None) -> ListSourcesResult:
     """
     List sources known by GitGuardian.
 
@@ -138,6 +138,9 @@ async def list_sources(params: ListSourcesParams = ListSourcesParams()) -> ListS
     Raises:
         ToolError: If the listing operation fails
     """
+    if params is None:
+        params = ListSourcesParams()
+
     client = await get_client()
     logger.debug("Listing sources")
 

--- a/packages/gg_api_core/src/gg_api_core/tools/list_users.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_users.py
@@ -50,7 +50,7 @@ class ListUsersResult(BaseModel):
     )
 
 
-async def list_users(params: ListUsersParams = ListUsersParams()) -> ListUsersResult:
+async def list_users(params: ListUsersParams | None = None) -> ListUsersResult:
     """
     List members/users in the GitGuardian workspace.
 
@@ -69,6 +69,9 @@ async def list_users(params: ListUsersParams = ListUsersParams()) -> ListUsersRe
     Raises:
         ToolError: If the listing operation fails
     """
+    if params is None:
+        params = ListUsersParams()
+
     client = await get_client()
     logger.debug("Listing workspace members")
 

--- a/packages/gg_api_core/src/gg_api_core/tools/remediate_secret_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/remediate_secret_incidents.py
@@ -92,7 +92,7 @@ class RemediateSecretIncidentsError(BaseModel):
 
 
 async def remediate_secret_incidents(
-    params: RemediateSecretIncidentsParams = RemediateSecretIncidentsParams(),
+    params: RemediateSecretIncidentsParams | None = None,
 ) -> RemediateSecretIncidentsResult | RemediateSecretIncidentsError:
     """
     Find and remediate secret incidents in the current repository.
@@ -105,6 +105,9 @@ async def remediate_secret_incidents(
     Returns:
         RemediateSecretIncidentsResult or RemediateSecretIncidentsError
     """
+    if params is None:
+        params = RemediateSecretIncidentsParams()
+
     logger.debug(f"Using remediate_secret_incidents for source_id: {params.source_id}")
 
     try:

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -1,0 +1,181 @@
+"""Schema-level invariants that every registered tool must satisfy.
+
+These guard the contract clients see in ``tools/list``, independently of any
+individual tool's behaviour.
+"""
+
+import inspect
+from importlib import import_module
+from typing import get_args
+from unittest.mock import AsyncMock
+
+import pytest
+from fastmcp.tools import FunctionTool
+from gg_api_core.mcp_server import (
+    AbstractGitGuardianFastMCP,
+    get_mcp_server,
+    register_common_tools,
+)
+from gg_api_core.scopes import ALL_SCOPES
+from gg_mcp_server.register_tools import register_tools
+from pydantic import BaseModel
+
+EXPECTED_OPTIONAL_PARAMS_TOOLS = {
+    "count_incidents",
+    "list_detectors",
+    "list_honeytokens",
+    "list_incidents",
+    "list_public_incidents",
+    "list_repo_occurrences",
+    "list_sources",
+    "list_users",
+    "remediate_secret_incidents",
+}
+
+
+class _DownstreamBoundaryReached(BaseException):
+    """Stop a tool after params normalization without being caught by its error handling."""
+
+
+@pytest.fixture
+def unified_server() -> AbstractGitGuardianFastMCP:
+    """Build a server exposing every tool without fetching token scopes."""
+    server = get_mcp_server("tool-schema-contracts")
+    register_tools(server)
+    register_common_tools(server)
+    server._fetch_token_scopes_from_api = AsyncMock(return_value=set(ALL_SCOPES))
+    return server
+
+
+def _params_model(tool: FunctionTool) -> type[BaseModel] | None:
+    """Return the single Pydantic params model a tool accepts, if any."""
+    parameters = list(inspect.signature(tool.fn).parameters.values())
+    if len(parameters) != 1:
+        return None
+
+    annotation_candidates = (parameters[0].annotation, *get_args(parameters[0].annotation))
+    for annotation in annotation_candidates:
+        if inspect.isclass(annotation) and issubclass(annotation, BaseModel):
+            return annotation
+    return None
+
+
+async def _all_optional_params_tools(
+    unified_server: AbstractGitGuardianFastMCP,
+) -> dict[str, tuple[FunctionTool, type[BaseModel]]]:
+    """Return registered function tools whose params models have no required fields."""
+    tools: dict[str, tuple[FunctionTool, type[BaseModel]]] = {}
+    for tool in await unified_server.list_tools():
+        if not isinstance(tool, FunctionTool):
+            continue
+        model = _params_model(tool)
+        if model is None:
+            continue
+        if any(field.is_required() for field in model.model_fields.values()):
+            continue
+        tools[tool.name] = (tool, model)
+    return tools
+
+
+@pytest.mark.asyncio
+async def test_tools_with_all_optional_params_accept_empty_arguments(
+    unified_server: AbstractGitGuardianFastMCP,
+) -> None:
+    """
+    GIVEN a tool whose params model has a default for every field
+    WHEN a client calls it with no arguments at all
+    THEN the ``params`` wrapper must not be required
+
+    Regression test for GIM-MCP-SERVER-13: ``list_detectors`` (and eight
+    siblings) declared ``params`` without a default, so Pydantic marked the
+    wrapper required and ``{}`` failed validation before the tool ever ran,
+    even though every filter inside it was optional.
+    """
+    offenders: list[str] = []
+    optional_params_tools = await _all_optional_params_tools(unified_server)
+
+    for tool, _model in optional_params_tools.values():
+        if "params" in tool.parameters.get("required", []):
+            offenders.append(tool.name)
+
+    missing_tools = EXPECTED_OPTIONAL_PARAMS_TOOLS - optional_params_tools.keys()
+    assert not missing_tools, f"expected all-optional tools were not checked: {sorted(missing_tools)}"
+    assert not offenders, (
+        "these tools have all-optional params but still require the `params` wrapper, "
+        f"so calling them with {{}} raises ValidationError: {sorted(offenders)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_optional_params_wrappers_use_plain_none_defaults(
+    unified_server: AbstractGitGuardianFastMCP,
+) -> None:
+    """
+    GIVEN a tool whose params wrapper may be omitted
+    WHEN its Python signature and agent-facing JSON Schema are inspected
+    THEN it must use a plain None default without publishing a concrete model
+    """
+    python_default_offenders: list[str] = []
+    schema_default_offenders: list[str] = []
+    optional_params_tools = await _all_optional_params_tools(unified_server)
+
+    for tool, _model in optional_params_tools.values():
+        params_parameter = next(iter(inspect.signature(tool.fn).parameters.values()))
+        if params_parameter.default is not None:
+            python_default_offenders.append(tool.name)
+        params_schema = tool.parameters["properties"]["params"]
+        if isinstance(params_schema.get("default"), dict):
+            schema_default_offenders.append(tool.name)
+
+    missing_tools = EXPECTED_OPTIONAL_PARAMS_TOOLS - optional_params_tools.keys()
+    assert not missing_tools, f"expected all-optional tools were not checked: {sorted(missing_tools)}"
+    assert not python_default_offenders, (
+        "these tools do not use a plain None Python default, so direct calls may "
+        f"receive a shared model or framework metadata: {sorted(python_default_offenders)}"
+    )
+    assert not schema_default_offenders, (
+        "these tools publish a concrete params object as their schema default, "
+        f"duplicating defaults in the agent contract: {sorted(schema_default_offenders)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_omitted_params_work_through_python_and_fastmcp_calls(
+    unified_server: AbstractGitGuardianFastMCP,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    GIVEN each known tool whose params wrapper may be omitted
+    WHEN its Python function and FastMCP tool are each called twice without params
+    THEN every call must construct a distinct params model before downstream work
+    """
+    optional_params_tools = await _all_optional_params_tools(unified_server)
+    missing_tools = EXPECTED_OPTIONAL_PARAMS_TOOLS - optional_params_tools.keys()
+    assert not missing_tools, f"expected all-optional tools were not checked: {sorted(missing_tools)}"
+
+    for tool_name in sorted(EXPECTED_OPTIONAL_PARAMS_TOOLS):
+        tool, params_model = optional_params_tools[tool_name]
+        tool_module = import_module(tool.fn.__module__)
+        created_params: list[BaseModel] = []
+        downstream_boundary = AsyncMock(side_effect=_DownstreamBoundaryReached)
+        boundary_name = "list_repo_occurrences" if tool_name == "remediate_secret_incidents" else "get_client"
+
+        def create_params() -> BaseModel:
+            params = params_model()
+            created_params.append(params)
+            return params
+
+        with monkeypatch.context() as tool_monkeypatch:
+            tool_monkeypatch.setattr(tool_module, params_model.__name__, create_params)
+            tool_monkeypatch.setattr(tool_module, boundary_name, downstream_boundary)
+
+            for _ in range(2):
+                with pytest.raises(_DownstreamBoundaryReached):
+                    await tool.fn()
+            for _ in range(2):
+                with pytest.raises(_DownstreamBoundaryReached):
+                    await tool.run({})
+
+        assert downstream_boundary.await_count == 4, f"{tool_name} did not reach its downstream boundary every time"
+        assert len(created_params) == 4, f"{tool_name} did not construct params for every omitted-params call"
+        assert len({id(params) for params in created_params}) == 4, f"{tool_name} reused a params model across calls"


### PR DESCRIPTION
## Summary

- replace process-lifetime Pydantic params instances with explicit `Params | None = None` boundaries
- construct a fresh params model for every omitted-params invocation
- keep empty FastMCP calls working without binding function signatures to `FieldInfo`
- add self-contained schema and runtime contract tests for all nine affected tools

## Why

PR #206 made all-optional wrappers callable with `{}`, but concrete model defaults are shared by direct Python calls and are serialized into agent-facing JSON Schema defaults. This follow-up keeps the wrapper optional while avoiding shared instances and concrete schema defaults.

## Verification

- full suite: 698 passed, 3 skipped
- focused affected-tool suite: 118 passed
- Ruff lint: passed
- Ruff formatting: passed
- `pyrefly check tests/test_tool_schemas.py`: 0 errors
- repository-wide Pyrefly still reports the pre-existing `mcp_server.py:125` middleware self-type error; this PR does not touch that path
- thermonuclear review gate before isolation: 2/2 clean reviews

## Contract covered

The regression tests exercise both direct Python calls and actual `FunctionTool.run({})` calls, verify the expected nine tools, stop at the first downstream boundary, and assert that every invocation receives a distinct params model.