### PR TITLE
chore(deps): resolve remaining lockfile source from PyPI

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1467,7 +1467,7 @@ wheels = [
 [[package]]
 name = "respx"
 version = "0.23.1"
-source = { registry = "https://gitlab.gitguardian.ovh/api/v4/projects/435/packages/pypi/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
 ]


### PR DESCRIPTION
## Summary

Resolve the remaining `respx` lockfile source from public PyPI instead of the private GitLab registry.

This finishes the cleanup from #201. A later dependency refresh in #199 updated `respx` while the private index was configured and reintroduced that single registry source.

## Audit

- all 96 registry-backed packages now use `https://pypi.org/simple`
- no project dependency or index configuration requires the GitGuardian package registry
- the only other tracked `index-url` reference is the intentional TestPyPI installation example in the release workflow

## Validation

- `uv lock --check`
- `uv sync --frozen`
- `pytest`: 1144 passed, 3 skipped, 9 xfailed
- `git diff --check`

Refs: SI-3953
