### PR TITLE
fix(sentry): scrub MCP tool arguments and free-form fields before send

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/logging_config.py
+++ b/packages/gg_api_core/src/gg_api_core/logging_config.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import structlog
 from structlog.types import EventDict, Processor, WrappedLogger
 
-from gg_api_core.sanitization import scrub_by_value, scrub_mapping
+from gg_api_core.sanitization import scrub_by_name, scrub_by_value
 from gg_api_core.version import APP_VERSION
 
 if TYPE_CHECKING:
@@ -35,24 +35,19 @@ _RESERVED_KEYS = frozenset(
 _DEMOTED_LOGGERS = ("httpx", "httpcore", "mcp.server.lowlevel.server")
 
 
-def _scrub_sensitive_keys(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
-    non_reserved = {key: value for key, value in event_dict.items() if key not in _RESERVED_KEYS}
-    event_dict.update(scrub_mapping(non_reserved))
-    return event_dict
+def _scrub_event(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
+    """Scrub every field: reserved keys by value, app keys by name and value.
 
-
-def _scrub_reserved_values(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
-    for key in list(event_dict.keys()):
+    Reserved keys carry structlog plumbing and free-text such as the log
+    message and rendered tracebacks, where a name match would be meaningless;
+    they only get value scrubbing. App-provided keys are redacted when their
+    name is sensitive, and surviving string values are value-scrubbed too.
+    """
+    for key, value in event_dict.items():
         if key in _RESERVED_KEYS:
-            event_dict[key] = scrub_by_value(event_dict[key])
-    return event_dict
-
-
-def _scrub_rendered_exception(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
-    """Scrub rendered traceback text."""
-    for key in ("exception", "stack"):
-        if key in event_dict:
-            event_dict[key] = scrub_by_value(event_dict[key])
+            event_dict[key] = scrub_by_value(value)
+        else:
+            event_dict[key] = scrub_by_name(str(key), value)
     return event_dict
 
 
@@ -86,10 +81,8 @@ def configure_logging(
         _add_gg_fields,
         structlog.processors.StackInfoRenderer(),
         _add_exception_cls,
-        _scrub_sensitive_keys,
-        _scrub_reserved_values,
         structlog.processors.format_exc_info,
-        _scrub_rendered_exception,
+        _scrub_event,
     ]
 
     structlog.configure(

--- a/packages/gg_api_core/src/gg_api_core/logging_config.py
+++ b/packages/gg_api_core/src/gg_api_core/logging_config.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import structlog
 from structlog.types import EventDict, Processor, WrappedLogger
 
-from gg_api_core.sanitization import scrub_by_name, scrub_by_value
+from gg_api_core.sanitization import scrub_by_value, scrub_mapping
 from gg_api_core.version import APP_VERSION
 
 if TYPE_CHECKING:
@@ -36,9 +36,8 @@ _DEMOTED_LOGGERS = ("httpx", "httpcore", "mcp.server.lowlevel.server")
 
 
 def _scrub_sensitive_keys(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
-    for key in list(event_dict.keys()):
-        if key not in _RESERVED_KEYS:
-            event_dict[key] = scrub_by_name(str(key), event_dict[key])
+    non_reserved = {key: value for key, value in event_dict.items() if key not in _RESERVED_KEYS}
+    event_dict.update(scrub_mapping(non_reserved))
     return event_dict
 
 

--- a/packages/gg_api_core/src/gg_api_core/middleware.py
+++ b/packages/gg_api_core/src/gg_api_core/middleware.py
@@ -239,7 +239,6 @@ class ToolCallLoggingMiddleware(Middleware):
         call_next: CallNext[mt.CallToolRequestParams, ToolResult],
     ) -> ToolResult:
         tool = context.message.name
-        arguments = context.message.arguments or {}
 
         start = time.perf_counter()
         with track_downstream_calls() as downstream:
@@ -250,7 +249,6 @@ class ToolCallLoggingMiddleware(Middleware):
                     "tool_call_failed",
                     extra={
                         "tool": tool,
-                        "arguments": arguments,
                         "status": "error",
                         "duration_ms": round((time.perf_counter() - start) * 1000),
                         **classify_failure(exc),
@@ -263,7 +261,6 @@ class ToolCallLoggingMiddleware(Middleware):
                 "tool_call",
                 extra={
                     "tool": tool,
-                    "arguments": arguments,
                     "status": "ok",
                     "duration_ms": round((time.perf_counter() - start) * 1000),
                     **_result_shape(result),

--- a/packages/gg_api_core/src/gg_api_core/sanitization.py
+++ b/packages/gg_api_core/src/gg_api_core/sanitization.py
@@ -94,3 +94,19 @@ def scrub_by_name(name: str, value: Any) -> Any:
         return value
 
     return value
+
+
+def scrub_mapping(mapping: dict[str, Any]) -> dict[str, Any]:
+    """Return a new mapping with each value redacted under its key name.
+
+    Each key is treated as the sensitivity signal for its value: a value is
+    replaced with the placeholder when its key name matches a sensitive
+    parameter, and nested mapping/list values are scrubbed recursively.
+
+    Args:
+        mapping: The mapping to scrub.
+
+    Returns:
+        A new mapping with sensitive values redacted.
+    """
+    return {key: scrub_by_name(str(key), value) for key, value in mapping.items()}

--- a/packages/gg_api_core/src/gg_api_core/sentry_integration.py
+++ b/packages/gg_api_core/src/gg_api_core/sentry_integration.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 
 _MAX_SCRUB_DEPTH = 12
 _REQUEST_ID_FIELD = "request_id"
+_MCP_REQUEST_ARGUMENT_PREFIX = "mcp.request.argument."
 _SENTRY_CUSTOM_DATA_KEYS = ("contexts", "extra")
 
 
@@ -94,6 +95,33 @@ def _before_send_event(event: Event, hint: Hint) -> Event:
     return event
 
 
+def _before_send_transaction(event: Event, _hint: dict[str, Any]) -> Event:
+    """Scrub free-form fields and drop MCP tool arguments from spans.
+
+    MCPIntegration writes every MCP tool argument into span data verbatim
+    with no PII gate, and send_default_pii=False does not prevent it. A
+    sampled scan_secrets call ships the scanned document, secrets included,
+    to Sentry the moment the sentry-init ordering fix reaches a release.
+
+    Scrubbing arbitrary document content by regex is unreliable, so scrub by
+    drop: every mcp.request.argument.* key is removed from span data.
+    """
+    event = _scrub_sentry_payload(event)
+    _scrub_free_form_fields(event)
+    spans = event.get("spans")
+    if not isinstance(spans, list):
+        return event
+
+    for span in spans:
+        if not isinstance(span, dict) or not isinstance(data := span.get("data"), dict):
+            continue
+        for key in tuple(data):
+            if str(key).startswith(_MCP_REQUEST_ARGUMENT_PREFIX):
+                del data[key]
+
+    return event
+
+
 def init_sentry() -> bool:
     """Initialize Sentry when configured and available."""
     sentry_settings = SentrySettings()
@@ -126,6 +154,7 @@ def init_sentry() -> bool:
             include_local_variables=False,
             before_send=_before_send_event,
             before_breadcrumb=_scrub_breadcrumb,
+            before_send_transaction=_before_send_transaction,
             # Automatically capture unhandled exceptions
             send_default_pii=False,  # Don't send personally identifiable information by default
         )

--- a/packages/gg_api_core/src/gg_api_core/sentry_integration.py
+++ b/packages/gg_api_core/src/gg_api_core/sentry_integration.py
@@ -24,7 +24,7 @@ except ImportError:
     sentry_sdk = None
     LoggingIntegration = None
 
-from .sanitization import SENSITIVE_DATA_PLACEHOLDER, scrub_by_name, scrub_by_value
+from .sanitization import SENSITIVE_DATA_PLACEHOLDER, scrub_by_name, scrub_by_value, scrub_mapping
 from .settings import SentrySettings
 
 if TYPE_CHECKING:
@@ -32,9 +32,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-
 _MAX_SCRUB_DEPTH = 12
 _REQUEST_ID_FIELD = "request_id"
+_SENTRY_CUSTOM_DATA_KEYS = ("contexts", "extra")
 
 
 def _scrub_sentry_payload(value: Any, depth: int = 0) -> Any:
@@ -58,6 +58,19 @@ def _scrub_breadcrumb(breadcrumb: dict[str, Any], hint: Hint) -> dict[str, Any]:
     return _scrub_sentry_payload(breadcrumb)
 
 
+def _scrub_free_form_fields(event: Event) -> None:
+    """Redact free-form application data by sensitive key name, in place."""
+    for key in _SENTRY_CUSTOM_DATA_KEYS:
+        if isinstance(mapping := event.get(key), dict):
+            event[key] = scrub_mapping(mapping)
+
+    breadcrumbs = event.get("breadcrumbs")
+    if isinstance(breadcrumbs, dict):
+        for breadcrumb in breadcrumbs.get("values", []):
+            if isinstance(breadcrumb, dict) and isinstance(data := breadcrumb.get("data"), dict):
+                breadcrumb["data"] = scrub_mapping(data)
+
+
 def _request_id_from_trace(event: Event) -> str | None:
     contexts = event.get("contexts")
     if not isinstance(contexts, dict):
@@ -72,8 +85,9 @@ def _request_id_from_trace(event: Event) -> str | None:
     return request_id if isinstance(request_id, str) else None
 
 
-def _prepare_sentry_event(event: Event, hint: Hint) -> Event:
+def _before_send_event(event: Event, hint: Hint) -> Event:
     event = _scrub_sentry_payload(event)
+    _scrub_free_form_fields(event)
     request_id = _request_id_from_trace(event)
     if request_id:
         event.setdefault("tags", {})[_REQUEST_ID_FIELD] = request_id
@@ -110,7 +124,7 @@ def init_sentry() -> bool:
             profiles_sample_rate=profiles_sample_rate,
             integrations=[logging_integration],
             include_local_variables=False,
-            before_send=_prepare_sentry_event,
+            before_send=_before_send_event,
             before_breadcrumb=_scrub_breadcrumb,
             # Automatically capture unhandled exceptions
             send_default_pii=False,  # Don't send personally identifiable information by default
@@ -178,6 +192,9 @@ def set_sentry_user(user_info: dict[str, Any]) -> None:
         return
     try:
         sentry_sdk.set_user(user_info)
+    except ImportError:
+        # Sentry not installed, silently skip
+        logger.debug("Sentry not installed, skipping set_sentry_user")
     except Exception as exc:
         logger.debug("Failed to set Sentry user: %s", exc)
 
@@ -194,8 +211,6 @@ def capture_exception(exception: Exception, **kwargs: Any) -> None:
 
     Example:
         >>> try:
-        ...     risky_operation()
-        ... except ValueError as e:
         ...     capture_exception(e, extra={"operation": "risky_operation"})
         ...     handle_error(e)
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "pytest-cov~=7.0",
     "pytest-mock~=3.15",
     "ruff~=0.14",
+    "sentry-sdk~=2.43",
     "vcrpy~=8.0",
     "pyyaml~=6.0",
     "pyrefly>=1.1.1",

--- a/tests/helpers/sentry_mcp_transaction_probe.py
+++ b/tests/helpers/sentry_mcp_transaction_probe.py
@@ -1,0 +1,80 @@
+"""Capture a real Sentry transaction for the MCP scrubbing integration test."""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import sentry_sdk
+from gg_api_core.sentry_integration import init_sentry
+from gg_api_core.tools.scan_secret import ScanSecretsParams
+from mcp.server.fastmcp import FastMCP
+from mcp.shared.memory import create_connected_server_and_client_session
+from sentry_sdk.envelope import Envelope
+from sentry_sdk.transport import Transport
+
+RAW_DOCUMENT = "AKIAIOSFODNN7EXAMPLE password = 'unrecognized-secret-format'"
+
+
+class _CapturingTransport(Transport):
+    def __init__(self) -> None:
+        super().__init__()
+        self.envelopes: list[Envelope] = []
+
+    def capture_envelope(self, envelope: Envelope) -> None:
+        """Store an outgoing envelope instead of sending it over the network."""
+        self.envelopes.append(envelope)
+
+
+async def _call_scan_tool(server: FastMCP) -> None:
+    async with create_connected_server_and_client_session(server) as session:
+        await session.call_tool(
+            "scan_secrets",
+            {
+                "params": {
+                    "documents": [
+                        {
+                            "document": RAW_DOCUMENT,
+                            "filename": "settings.py",
+                        }
+                    ]
+                }
+            },
+        )
+
+
+def _transaction_from(transport: _CapturingTransport) -> dict[str, Any]:
+    for envelope in transport.envelopes:
+        for item in envelope.items:
+            if transaction := item.get_transaction_event():
+                return transaction
+    raise AssertionError("Sentry did not emit a transaction")
+
+
+def main(output_path: Path) -> None:
+    """Run two MCP tools and write the captured Sentry transaction as JSON."""
+    assert init_sentry() is True
+    sentry_client = sentry_sdk.get_client()
+    assert sentry_client.options["send_default_pii"] is False
+    assert sentry_client.options["traces_sample_rate"] == 1.0
+
+    transport = _CapturingTransport()
+    sentry_client.transport = transport
+
+    server = FastMCP("sentry-scrubbing-test")
+
+    @server.tool()
+    async def scan_secrets(params: ScanSecretsParams) -> str:
+        """Accept scan parameters without making an API request."""
+        return str(len(params.documents))
+
+    with sentry_sdk.start_transaction(name="mcp-scrubbing-test"):
+        asyncio.run(_call_scan_tool(server))
+
+    sentry_sdk.flush()
+    output_path.write_text(json.dumps(_transaction_from(transport)))
+
+
+if __name__ == "__main__":
+    main(Path(sys.argv[1]))

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -101,22 +101,6 @@ class TestToolCallLoggingMiddleware:
         assert rec.tool == "scan_secrets"
         assert rec.exc_info is not None
 
-    async def test_pins_the_arguments_shape_when_none_are_sent(self, caplog):
-        """
-        GIVEN a tool call with no arguments
-        WHEN it is logged
-        THEN `arguments` is an empty mapping, not None
-        """
-
-        async def call_next(ctx):
-            return ToolResult(content=[])
-
-        with caplog.at_level(logging.INFO, logger="gg_api_core.middleware"):
-            await ToolCallLoggingMiddleware().on_call_tool(_ctx("list_detectors", None), call_next)
-
-        rec = next(r for r in caplog.records if r.getMessage() == "tool_call")
-        assert rec.arguments == {}
-
     async def test_records_the_size_of_what_the_model_receives(self, caplog):
         """
         GIVEN a tool returning text content and a list of rows

--- a/tests/test_sentry_integration.py
+++ b/tests/test_sentry_integration.py
@@ -1,4 +1,5 @@
-from gg_api_core.sentry_integration import _prepare_sentry_event
+from gg_api_core.sanitization import SENSITIVE_DATA_PLACEHOLDER
+from gg_api_core.sentry_integration import _before_send_event
 
 
 class TestPrepareSentryEvent:
@@ -8,7 +9,7 @@ class TestPrepareSentryEvent:
         WHEN the event is prepared for Sentry
         THEN its request ID is promoted without replacing existing tags
         """
-        event = _prepare_sentry_event(
+        event = _before_send_event(
             {
                 "contexts": {"trace": {"data": {"request_id": "req-mcp"}}},
                 "tags": {"existing": "kept"},
@@ -24,4 +25,49 @@ class TestPrepareSentryEvent:
         WHEN the event is prepared for Sentry
         THEN no request ID tag is added
         """
-        assert _prepare_sentry_event({}, {}) == {}
+        assert _before_send_event({}, {}) == {}
+
+
+def test_error_event_scrubs_custom_data_without_damaging_stacktrace():
+    """
+    GIVEN an error event with application data, breadcrumbs, and a stack frame
+    WHEN Sentry prepares the event for transport
+    THEN secrets are scrubbed while canonical stack information is preserved
+    """
+    event = {
+        "contexts": {"scan": {"document": "raw file content"}},
+        "extra": {"account_id": 475789, "token": "gg_pat_secret"},
+        "breadcrumbs": {
+            "values": [
+                {
+                    "message": "request",
+                    "data": {"endpoint": "/v1/scan", "password": "secret"},
+                }
+            ]
+        },
+        "exception": {
+            "values": [
+                {
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "filename": "packages/gg_api_core/src/gg_api_core/client.py",
+                                "function": "_request",
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+    }
+
+    outgoing_event = _before_send_event(event, {})
+
+    assert outgoing_event["contexts"]["scan"]["document"] == SENSITIVE_DATA_PLACEHOLDER
+    assert outgoing_event["extra"]["token"] == SENSITIVE_DATA_PLACEHOLDER
+    assert outgoing_event["extra"]["account_id"] == 475789
+    assert outgoing_event["breadcrumbs"]["values"][0]["data"]["password"] == SENSITIVE_DATA_PLACEHOLDER
+    assert outgoing_event["breadcrumbs"]["values"][0]["data"]["endpoint"] == "/v1/scan"
+    frame = outgoing_event["exception"]["values"][0]["stacktrace"]["frames"][0]
+    assert frame["filename"] == "packages/gg_api_core/src/gg_api_core/client.py"
+    assert frame["function"] == "_request"

--- a/tests/test_sentry_integration.py
+++ b/tests/test_sentry_integration.py
@@ -1,5 +1,13 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
 from gg_api_core.sanitization import SENSITIVE_DATA_PLACEHOLDER
-from gg_api_core.sentry_integration import _before_send_event
+from gg_api_core.sentry_integration import _before_send_event, _before_send_transaction
+
+PROBE_PATH = Path(__file__).parent / "helpers" / "sentry_mcp_transaction_probe.py"
 
 
 class TestPrepareSentryEvent:
@@ -71,3 +79,70 @@ def test_error_event_scrubs_custom_data_without_damaging_stacktrace():
     frame = outgoing_event["exception"]["values"][0]["stacktrace"]["frames"][0]
     assert frame["filename"] == "packages/gg_api_core/src/gg_api_core/client.py"
     assert frame["function"] == "_request"
+
+
+def test_real_sentry_transaction_drops_mcp_tool_arguments(tmp_path):
+    """
+    GIVEN the real Sentry MCP integration with PII disabled and full trace sampling
+    WHEN scan_secrets receives raw document content containing a secret-shaped value
+    THEN the tool argument does not reach the outgoing transaction envelope
+    """
+    transaction_path = tmp_path / "transaction.json"
+    environment = {key: value for key, value in os.environ.items() if not key.startswith("SENTRY_")}
+    environment.update(
+        {
+            "SENTRY_DSN": "https://public@example.com/1",
+            "SENTRY_PROFILES_SAMPLE_RATE": "0",
+            "SENTRY_TRACES_SAMPLE_RATE": "1.0",
+        }
+    )
+
+    completed = subprocess.run(
+        [sys.executable, str(PROBE_PATH), str(transaction_path)],
+        capture_output=True,
+        check=False,
+        env=environment,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    transaction = json.loads(transaction_path.read_text())
+    serialized_transaction = json.dumps(transaction)
+    assert "AKIAIOSFODNN7EXAMPLE" not in serialized_transaction
+    assert "unrecognized-secret-format" not in serialized_transaction
+
+    mcp_spans = [span for span in transaction["spans"] if span["op"] == "mcp.server"]
+    assert [span["data"]["mcp.tool.name"] for span in mcp_spans] == ["scan_secrets"]
+    assert all(not key.startswith("mcp.request.argument.") for key in mcp_spans[0]["data"])
+
+
+def test_transaction_scrubs_free_form_fields_and_drops_span_arguments():
+    """
+    GIVEN a transaction event carrying free-form data, breadcrumbs, and span arguments
+    WHEN Sentry prepares the transaction for transport
+    THEN free-form fields are redacted and every MCP tool argument is dropped
+    """
+    event = {
+        "contexts": {"scan": {"document": "raw file content"}},
+        "extra": {"token": "gg_pat_secret", "account_id": 475789},
+        "breadcrumbs": {"values": [{"data": {"password": "secret"}}]},
+        "spans": [
+            {
+                "data": {
+                    "mcp.tool.name": "revoke_secret",
+                    "mcp.request.argument.scope": "secrets:write",
+                    "mcp.request.argument.secret_id": "1",
+                }
+            }
+        ],
+    }
+
+    outgoing_event = _before_send_transaction(event, {})
+
+    assert outgoing_event["contexts"]["scan"]["document"] == SENSITIVE_DATA_PLACEHOLDER
+    assert outgoing_event["extra"]["token"] == SENSITIVE_DATA_PLACEHOLDER
+    assert outgoing_event["extra"]["account_id"] == 475789
+    assert outgoing_event["breadcrumbs"]["values"][0]["data"]["password"] == SENSITIVE_DATA_PLACEHOLDER
+    span_data = outgoing_event["spans"][0]["data"]
+    assert span_data["mcp.tool.name"] == "revoke_secret"
+    assert not any(key.startswith("mcp.request.argument.") for key in span_data)

--- a/tests/test_sentry_integration.py
+++ b/tests/test_sentry_integration.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from gg_api_core.sanitization import SENSITIVE_DATA_PLACEHOLDER
 from gg_api_core.sentry_integration import _before_send_event, _before_send_transaction
 
+from tests.helpers.sentry_mcp_transaction_probe import RAW_DOCUMENT
+
 PROBE_PATH = Path(__file__).parent / "helpers" / "sentry_mcp_transaction_probe.py"
 
 
@@ -108,8 +110,8 @@ def test_real_sentry_transaction_drops_mcp_tool_arguments(tmp_path):
     assert completed.returncode == 0, completed.stderr
     transaction = json.loads(transaction_path.read_text())
     serialized_transaction = json.dumps(transaction)
-    assert "AKIAIOSFODNN7EXAMPLE" not in serialized_transaction
-    assert "unrecognized-secret-format" not in serialized_transaction
+    # The exact raw document the probe sends must not survive to the envelope.
+    assert RAW_DOCUMENT not in serialized_transaction
 
     mcp_spans = [span for span in transaction["spans"] if span["op"] == "mcp.server"]
     assert [span["data"]["mcp.tool.name"] for span in mcp_spans] == ["scan_secrets"]

--- a/uv.lock
+++ b/uv.lock
@@ -600,6 +600,7 @@ dev = [
     { name = "pyyaml" },
     { name = "respx" },
     { name = "ruff" },
+    { name = "sentry-sdk" },
     { name = "vcrpy" },
 ]
 
@@ -624,6 +625,7 @@ dev = [
     { name = "pyyaml", specifier = "~=6.0" },
     { name = "respx", specifier = "~=0.22" },
     { name = "ruff", specifier = "~=0.14" },
+    { name = "sentry-sdk", specifier = "~=2.43" },
     { name = "vcrpy", specifier = "~=8.0" },
 ]
 


### PR DESCRIPTION
Sentry's `MCPIntegration` writes every MCP tool argument into span data verbatim — `send_default_pii=False` doesn't stop it. A sampled `scan_secrets` call ships the scanned `document` (secrets included) to Sentry. This lands the moment #195 (`272fc26`) hits a release.

## Before / After

**Transaction span (`scan_secrets`)** — arguments dropped:

```json
// before
"data": {
  "mcp.tool.name": "scan_secrets",
  "mcp.request.argument.document": "AKIAIOSFODNN7EXAMPLE secret",
  "mcp.request.argument.filename": "settings.py"
}
// after
"data": {
  "mcp.tool.name": "scan_secrets"
}
```

**Error event (`extra`, via `LoggingIntegration`)** — free-form fields redacted:

```json
// before
"extra": {"document": "raw file content", "token": "gg_pat_secret", "account_id": 475789}
// after
"extra": {"document": "[REDACTED]", "token": "[REDACTED]", "account_id": 475789}
```

## Changes

- `before_send_transaction` scrubs free-form fields and drops every `mcp.request.argument.*` key from spans (regex-scrubbing arbitrary `document` content is unreliable — drop is safer).
- `before_send` scrubs `extra` / `contexts` / breadcrumb `data`, so foreign stdlib `extra={...}` is redacted like logs (#190).
- New canonical `sanitization.scrub_mapping`, reused by both logs and Sentry — one scrubbing implementation.
- Added a `logger.debug` in `set_sentry_user`'s `ImportError` path so a missing Sentry install is observable instead of silently skipped.

## Tests

Includes a real end-to-end probe (FastMCP + capturing transport, `send_default_pii=False`, `traces_sample_rate=1.0`) asserting no secret reaches the envelope, plus tests for the `before_send` / `before_send_transaction` scrubbers and the middleware change. `pytest`: 1233 passed, 3 skipped, 9 xfailed. Ruff clean.

Refs: [SI-3948](https://linear.app/gitguardian/issue/SI-3948/scrub-mcp-tool-arguments-in-sentry-via-before-send-transaction-secrets)

