### PR TITLE
feat(client): identify MCP client, protocol, and tool on outgoing API calls

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -3,7 +3,7 @@ import json
 import logging
 import re
 import time
-from collections.abc import Awaitable, Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, Optional, TypedDict, cast
@@ -12,7 +12,11 @@ from urllib.parse import quote_plus, unquote, urlparse
 import httpx
 from pydantic import TypeAdapter, ValidationError
 
-from gg_api_core.log_context import record_downstream_call, record_downstream_wait, record_truncation
+from gg_api_core.log_context import (
+    record_downstream_call,
+    record_downstream_wait,
+    record_truncation,
+)
 from gg_api_core.settings import get_settings
 from gg_api_core.version import APP_VERSION
 
@@ -347,7 +351,7 @@ class GitGuardianClient:
         gitguardian_url: str | None = None,
         personal_access_token: str | None = None,
         allow_token_refresh: bool = False,
-        user_agent: str | None = None,
+        user_agent: Callable[[], str] | None = None,
     ):
         """Initialize the GitGuardian client.
 
@@ -360,15 +364,17 @@ class GitGuardianClient:
             allow_token_refresh: If True, the client can attempt to refresh the
                 token when a 401 error occurs (via env var or OAuth flow).
                 This enables self-healing when tokens expire or become invalid.
-            user_agent: Custom User-Agent string to identify the MCP client.
-                Defaults to DEFAULT_USER_AGENT if not provided.
+            user_agent: Zero-argument callable returning the User-Agent used to
+                identify the MCP client. Evaluated on every request so a
+                long-lived client reflects per-request context.
+                Defaults to a callable returning DEFAULT_USER_AGENT.
         """
         logger.debug("Initializing GitGuardian client")
 
         self._init_urls(gitguardian_url)
         self._oauth_token = personal_access_token
         self._allow_token_refresh = allow_token_refresh
-        self._user_agent = user_agent or self.DEFAULT_USER_AGENT
+        self._user_agent = user_agent or (lambda: self.DEFAULT_USER_AGENT)
         self._token_info: Any | None = None
 
     def _base_headers(self) -> dict[str, str]:
@@ -376,7 +382,7 @@ class GitGuardianClient:
         return {
             "Authorization": f"Token {self._oauth_token}",
             "Content-Type": "application/json",
-            "User-Agent": self._user_agent,
+            "User-Agent": self._user_agent(),
             "X-Privacy-Mode": "true",
         }
 

--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -371,6 +371,15 @@ class GitGuardianClient:
         self._user_agent = user_agent or self.DEFAULT_USER_AGENT
         self._token_info: Any | None = None
 
+    def _base_headers(self) -> dict[str, str]:
+        """Headers sent on every API request, before per-call overrides."""
+        return {
+            "Authorization": f"Token {self._oauth_token}",
+            "Content-Type": "application/json",
+            "User-Agent": self._user_agent,
+            "X-Privacy-Mode": "true",
+        }
+
     def _init_urls(self, gitguardian_url: str | None = None):
         from .urls import derive_public_api_url
 
@@ -529,12 +538,7 @@ class GitGuardianClient:
                     safe_json[key] = "[REDACTED]"
             logger.debug(f"Request body: {safe_json}")
 
-        headers = {
-            "Authorization": f"Token {self._oauth_token}",
-            "Content-Type": "application/json",
-            "User-Agent": self._user_agent,
-            "X-Privacy-Mode": "true",
-        }
+        headers = self._base_headers()
         logger.debug("Using token for authorization")
 
         headers.update(kwargs.pop("headers", {}))
@@ -795,12 +799,7 @@ class GitGuardianClient:
         url = f"{self.public_api_url}/{endpoint.lstrip('/')}"
         logger.debug(f"Making list request to {url}")
 
-        headers = {
-            "Authorization": f"Token {self._oauth_token}",
-            "Content-Type": "application/json",
-            "User-Agent": self._user_agent,
-            "X-Privacy-Mode": "true",
-        }
+        headers = self._base_headers()
         headers.update(kwargs.pop("headers", {}))
 
         async with httpx.AsyncClient(follow_redirects=True, timeout=DEFAULT_HTTP_TIMEOUT) as client:

--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -13,11 +13,11 @@ import httpx
 from pydantic import TypeAdapter, ValidationError
 
 from gg_api_core.log_context import (
-    current_tool_name,
     record_downstream_call,
     record_downstream_wait,
     record_truncation,
 )
+from gg_api_core.tool_context import current_tool_name
 from gg_api_core.settings import get_settings
 from gg_api_core.version import APP_VERSION
 
@@ -379,16 +379,12 @@ class GitGuardianClient:
         self._token_info: Any | None = None
 
     def _base_headers(self) -> dict[str, str]:
-        """Headers sent on every API request, before per-call overrides."""
         headers = {
             "Authorization": f"Token {self._oauth_token}",
             "Content-Type": "application/json",
             "User-Agent": self._user_agent(),
             "X-Privacy-Mode": "true",
         }
-        # Exposed so API-side analytics can attribute each endpoint call to the
-        # MCP tool that made it. Validated where it enters the process, so
-        # whatever is set here is already header-safe.
         tool_name = current_tool_name()
         if tool_name:
             headers["X-GG-MCP-Tool"] = tool_name

--- a/packages/gg_api_core/src/gg_api_core/client.py
+++ b/packages/gg_api_core/src/gg_api_core/client.py
@@ -13,6 +13,7 @@ import httpx
 from pydantic import TypeAdapter, ValidationError
 
 from gg_api_core.log_context import (
+    current_tool_name,
     record_downstream_call,
     record_downstream_wait,
     record_truncation,
@@ -379,12 +380,19 @@ class GitGuardianClient:
 
     def _base_headers(self) -> dict[str, str]:
         """Headers sent on every API request, before per-call overrides."""
-        return {
+        headers = {
             "Authorization": f"Token {self._oauth_token}",
             "Content-Type": "application/json",
             "User-Agent": self._user_agent(),
             "X-Privacy-Mode": "true",
         }
+        # Exposed so API-side analytics can attribute each endpoint call to the
+        # MCP tool that made it. Validated where it enters the process, so
+        # whatever is set here is already header-safe.
+        tool_name = current_tool_name()
+        if tool_name:
+            headers["X-GG-MCP-Tool"] = tool_name
+        return headers
 
     def _init_urls(self, gitguardian_url: str | None = None):
         from .urls import derive_public_api_url

--- a/packages/gg_api_core/src/gg_api_core/client_identity.py
+++ b/packages/gg_api_core/src/gg_api_core/client_identity.py
@@ -1,0 +1,70 @@
+"""MCP client identity, captured once from the initialize handshake."""
+
+from __future__ import annotations
+
+import weakref
+from dataclasses import dataclass
+from typing import Any
+
+from fastmcp.server.dependencies import get_context
+from mcp.server.session import ServerSession
+from mcp.types import Implementation
+
+__all__ = [
+    "ClientIdentity",
+    "current_client_identity",
+    "set_client_identity",
+]
+
+
+@dataclass(frozen=True)
+class ClientIdentity:
+    name: str
+    version: str
+    protocol_version: str
+
+    @classmethod
+    def from_params(
+        cls,
+        client_info: Implementation,
+        protocol_version: str | int | None = None,
+    ) -> ClientIdentity:
+        return cls(
+            name=client_info.name,
+            version=client_info.version,
+            protocol_version=str(protocol_version) if protocol_version is not None else "",
+        )
+
+    @property
+    def label(self) -> str | None:
+        """``<name>/<version>``, or the bare name when no version was sent."""
+        if not self.name:
+            return None
+        return f"{self.name}/{self.version}" if self.version else self.name
+
+    def log_fields(self) -> dict[str, Any]:
+        """The subset present, under the field names logs use."""
+        fields = {
+            "client_name": self.name,
+            "client_version": self.version,
+            "protocol_version": self.protocol_version,
+        }
+        return {key: value for key, value in fields.items() if value}
+
+
+_identity_by_session: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+
+
+def set_client_identity(identity: ClientIdentity | None, session: ServerSession) -> None:
+    if identity is None:
+        _identity_by_session.pop(session, None)
+        return
+    _identity_by_session[session] = identity
+
+
+def current_client_identity() -> ClientIdentity | None:
+    try:
+        session = get_context().session
+    except RuntimeError:
+        return None
+    return _identity_by_session.get(session)

--- a/packages/gg_api_core/src/gg_api_core/log_context.py
+++ b/packages/gg_api_core/src/gg_api_core/log_context.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import re
 import time
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable, Iterable, Iterator
@@ -23,6 +24,7 @@ __all__ = [
     "clear_caller_identity_cache",
     "current_client_identity",
     "current_downstream_stats",
+    "current_tool_name",
     "derive_caller_identity",
     "derive_client_identity",
     "record_downstream_call",
@@ -30,6 +32,7 @@ __all__ = [
     "record_truncation",
     "resolve_caller_identity",
     "scopes_fingerprint",
+    "track_current_tool",
     "track_downstream_calls",
 ]
 
@@ -169,6 +172,33 @@ def track_downstream_calls() -> Iterator[DownstreamStats]:
 def current_downstream_stats() -> DownstreamStats | None:
     """The accumulator for the call in flight, if anything is tracking."""
     return _downstream_stats.get()
+
+
+_current_tool: ContextVar[str | None] = ContextVar("gg_current_tool", default=None)
+
+# The name arrives from the client's tools/call message, so it is untrusted
+# text until it has resolved to a registered tool. Registered names are plain
+# identifiers, so anything else is dropped here, at the point the value enters
+# the process, rather than at each place that later reads it.
+_TOOL_NAME = re.compile(r"[A-Za-z0-9_.-]{1,64}")
+
+
+@contextmanager
+def track_current_tool(tool_name: str) -> Iterator[None]:
+    """Expose the executing tool's name to downstream API calls."""
+    token = _current_tool.set(tool_name if _TOOL_NAME.fullmatch(tool_name) else None)
+    try:
+        yield
+    finally:
+        _current_tool.reset(token)
+
+
+def current_tool_name() -> str | None:
+    """The MCP tool the in-flight request is executing, if any.
+
+    Safe to put in an outgoing header: validated by :func:`track_current_tool`.
+    """
+    return _current_tool.get()
 
 
 def record_downstream_call(*, duration_ms: float, status: int | None = None, retried: bool = False) -> None:

--- a/packages/gg_api_core/src/gg_api_core/log_context.py
+++ b/packages/gg_api_core/src/gg_api_core/log_context.py
@@ -26,12 +26,12 @@ __all__ = [
     "current_downstream_stats",
     "current_tool_name",
     "derive_caller_identity",
-    "derive_client_identity",
     "record_downstream_call",
     "record_downstream_wait",
     "record_truncation",
     "resolve_caller_identity",
     "scopes_fingerprint",
+    "set_client_identity",
     "track_current_tool",
     "track_downstream_calls",
 ]
@@ -343,22 +343,33 @@ class ClientIdentity:
         return {key: value for key, value in fields.items() if value}
 
 
-def derive_client_identity(client_info: Any, protocol_version: Any = None) -> dict[str, Any]:
-    """Map optional MCP initialization metadata to log fields."""
-    return ClientIdentity.from_params(client_info, protocol_version).log_fields()
+# Where the identity negotiated at initialize is kept. It lives on the
+# session (which exists for the whole connection) because the tool call that
+# needs it runs long after the initialize message's context is gone.
+_CLIENT_IDENTITY_ATTR = "_gg_client_identity"
+
+
+def set_client_identity(identity: ClientIdentity | None, session: Any) -> None:
+    """Persist the negotiated client identity on the connection's session.
+
+    Called once, when the initialize handshake is processed, so downstream
+    reads never re-parse the handshake params. The session is a mutable fastmcp
+    object that already carries ad-hoc attributes (e.g. a state prefix), so
+    this fits the existing pattern.
+    """
+    setattr(session, _CLIENT_IDENTITY_ATTR, identity)
 
 
 def current_client_identity() -> ClientIdentity | None:
-    """Identity of the session in flight, or None outside an MCP request.
+    """The identity negotiated for this connection, or None outside an MCP request.
 
-    Read from the session rather than a contextvar: the handshake happens in an
-    earlier message, whose context is long gone by the time a tool runs, while
-    the session object lives for the whole connection.
+    Reads the identity stored by :func:`set_client_identity` rather than
+    re-deriving it from the handshake, so the per-request read is a single
+    attribute access. None when no session is active (e.g. before
+    initialization); ``get_context`` raises in that case.
     """
     try:
-        params = get_context().session.client_params
-    except Exception:
+        session = get_context().session
+    except RuntimeError:
         return None
-    if params is None:
-        return None
-    return ClientIdentity.from_params(params.clientInfo, params.protocolVersion)
+    return getattr(session, _CLIENT_IDENTITY_ATTR, None)

--- a/packages/gg_api_core/src/gg_api_core/log_context.py
+++ b/packages/gg_api_core/src/gg_api_core/log_context.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import logging
-import re
 import time
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable, Iterable, Iterator
@@ -15,24 +14,18 @@ from typing import Any
 from urllib.parse import urlparse
 
 import httpx
-from fastmcp.server.dependencies import get_context
 
 __all__ = [
-    "ClientIdentity",
     "DownstreamStats",
     "classify_failure",
     "clear_caller_identity_cache",
-    "current_client_identity",
     "current_downstream_stats",
-    "current_tool_name",
     "derive_caller_identity",
     "record_downstream_call",
     "record_downstream_wait",
     "record_truncation",
     "resolve_caller_identity",
     "scopes_fingerprint",
-    "set_client_identity",
-    "track_current_tool",
     "track_downstream_calls",
 ]
 
@@ -174,33 +167,6 @@ def current_downstream_stats() -> DownstreamStats | None:
     return _downstream_stats.get()
 
 
-_current_tool: ContextVar[str | None] = ContextVar("gg_current_tool", default=None)
-
-# The name arrives from the client's tools/call message, so it is untrusted
-# text until it has resolved to a registered tool. Registered names are plain
-# identifiers, so anything else is dropped here, at the point the value enters
-# the process, rather than at each place that later reads it.
-_TOOL_NAME = re.compile(r"[A-Za-z0-9_.-]{1,64}")
-
-
-@contextmanager
-def track_current_tool(tool_name: str) -> Iterator[None]:
-    """Expose the executing tool's name to downstream API calls."""
-    token = _current_tool.set(tool_name if _TOOL_NAME.fullmatch(tool_name) else None)
-    try:
-        yield
-    finally:
-        _current_tool.reset(token)
-
-
-def current_tool_name() -> str | None:
-    """The MCP tool the in-flight request is executing, if any.
-
-    Safe to put in an outgoing header: validated by :func:`track_current_tool`.
-    """
-    return _current_tool.get()
-
-
 def record_downstream_call(*, duration_ms: float, status: int | None = None, retried: bool = False) -> None:
     """Add an API call to the active accumulator, if any."""
     stats = _downstream_stats.get()
@@ -301,75 +267,3 @@ def classify_failure(exc: BaseException) -> dict[str, Any]:
         failure["gg_error_code"] = code
 
     return failure
-
-
-@dataclass(frozen=True)
-class ClientIdentity:
-    """Who is calling us, from the MCP initialize handshake.
-
-    One definition shared by the two consumers that need it: log fields, and
-    the ``client=``/``mcp=`` User-Agent fields on outgoing API calls. The
-    handshake is the only client hint that exists on every transport, so this
-    is what identifies a local stdio install.
-    """
-
-    name: str | None = None
-    version: str | None = None
-    protocol_version: str | None = None
-
-    @classmethod
-    def from_params(cls, client_info: Any, protocol_version: Any = None) -> ClientIdentity:
-        """Read identity off initialize params, tolerating partial ones."""
-        return cls(
-            name=getattr(client_info, "name", None) or None,
-            version=getattr(client_info, "version", None) or None,
-            protocol_version=str(protocol_version) if protocol_version else None,
-        )
-
-    @property
-    def label(self) -> str | None:
-        """``<name>/<version>``, or the bare name when no version was sent."""
-        if not self.name:
-            return None
-        return f"{self.name}/{self.version}" if self.version else self.name
-
-    def log_fields(self) -> dict[str, Any]:
-        """The subset present, under the field names logs use."""
-        fields = {
-            "client_name": self.name,
-            "client_version": self.version,
-            "protocol_version": self.protocol_version,
-        }
-        return {key: value for key, value in fields.items() if value}
-
-
-# Where the identity negotiated at initialize is kept. It lives on the
-# session (which exists for the whole connection) because the tool call that
-# needs it runs long after the initialize message's context is gone.
-_CLIENT_IDENTITY_ATTR = "_gg_client_identity"
-
-
-def set_client_identity(identity: ClientIdentity | None, session: Any) -> None:
-    """Persist the negotiated client identity on the connection's session.
-
-    Called once, when the initialize handshake is processed, so downstream
-    reads never re-parse the handshake params. The session is a mutable fastmcp
-    object that already carries ad-hoc attributes (e.g. a state prefix), so
-    this fits the existing pattern.
-    """
-    setattr(session, _CLIENT_IDENTITY_ATTR, identity)
-
-
-def current_client_identity() -> ClientIdentity | None:
-    """The identity negotiated for this connection, or None outside an MCP request.
-
-    Reads the identity stored by :func:`set_client_identity` rather than
-    re-deriving it from the handshake, so the per-request read is a single
-    attribute access. None when no session is active (e.g. before
-    initialization); ``get_context`` raises in that case.
-    """
-    try:
-        session = get_context().session
-    except RuntimeError:
-        return None
-    return getattr(session, _CLIENT_IDENTITY_ATTR, None)

--- a/packages/gg_api_core/src/gg_api_core/log_context.py
+++ b/packages/gg_api_core/src/gg_api_core/log_context.py
@@ -14,11 +14,14 @@ from typing import Any
 from urllib.parse import urlparse
 
 import httpx
+from fastmcp.server.dependencies import get_context
 
 __all__ = [
+    "ClientIdentity",
     "DownstreamStats",
     "classify_failure",
     "clear_caller_identity_cache",
+    "current_client_identity",
     "current_downstream_stats",
     "derive_caller_identity",
     "derive_client_identity",
@@ -270,17 +273,62 @@ def classify_failure(exc: BaseException) -> dict[str, Any]:
     return failure
 
 
+@dataclass(frozen=True)
+class ClientIdentity:
+    """Who is calling us, from the MCP initialize handshake.
+
+    One definition shared by the two consumers that need it: log fields, and
+    the ``client=``/``mcp=`` User-Agent fields on outgoing API calls. The
+    handshake is the only client hint that exists on every transport, so this
+    is what identifies a local stdio install.
+    """
+
+    name: str | None = None
+    version: str | None = None
+    protocol_version: str | None = None
+
+    @classmethod
+    def from_params(cls, client_info: Any, protocol_version: Any = None) -> ClientIdentity:
+        """Read identity off initialize params, tolerating partial ones."""
+        return cls(
+            name=getattr(client_info, "name", None) or None,
+            version=getattr(client_info, "version", None) or None,
+            protocol_version=str(protocol_version) if protocol_version else None,
+        )
+
+    @property
+    def label(self) -> str | None:
+        """``<name>/<version>``, or the bare name when no version was sent."""
+        if not self.name:
+            return None
+        return f"{self.name}/{self.version}" if self.version else self.name
+
+    def log_fields(self) -> dict[str, Any]:
+        """The subset present, under the field names logs use."""
+        fields = {
+            "client_name": self.name,
+            "client_version": self.version,
+            "protocol_version": self.protocol_version,
+        }
+        return {key: value for key, value in fields.items() if value}
+
+
 def derive_client_identity(client_info: Any, protocol_version: Any = None) -> dict[str, Any]:
     """Map optional MCP initialization metadata to log fields."""
-    identity: dict[str, Any] = {}
+    return ClientIdentity.from_params(client_info, protocol_version).log_fields()
 
-    name = getattr(client_info, "name", None)
-    if name:
-        identity["client_name"] = name
-    version = getattr(client_info, "version", None)
-    if version:
-        identity["client_version"] = version
-    if protocol_version:
-        identity["protocol_version"] = str(protocol_version)
 
-    return identity
+def current_client_identity() -> ClientIdentity | None:
+    """Identity of the session in flight, or None outside an MCP request.
+
+    Read from the session rather than a contextvar: the handshake happens in an
+    earlier message, whose context is long gone by the time a tool runs, while
+    the session object lives for the whole connection.
+    """
+    try:
+        params = get_context().session.client_params
+    except Exception:
+        return None
+    if params is None:
+        return None
+    return ClientIdentity.from_params(params.clientInfo, params.protocolVersion)

--- a/packages/gg_api_core/src/gg_api_core/middleware.py
+++ b/packages/gg_api_core/src/gg_api_core/middleware.py
@@ -15,17 +15,16 @@ from fastmcp.tools import Tool, ToolResult
 from typing_extensions import override
 
 from gg_api_core.client import DownstreamUnauthorizedError
+from gg_api_core.client_identity import ClientIdentity, set_client_identity
 from gg_api_core.log_context import (
-    ClientIdentity,
     classify_failure,
     resolve_caller_identity,
-    set_client_identity,
-    track_current_tool,
     track_downstream_calls,
 )
 from gg_api_core.oauth_proxy_auth import mark_downstream_unauthorized
 from gg_api_core.sentry_integration import set_sentry_request_id
 from gg_api_core.settings import get_settings
+from gg_api_core.tool_context import track_current_tool
 from gg_api_core.urls import derive_public_api_url
 
 if TYPE_CHECKING:
@@ -139,14 +138,9 @@ class RequestLoggingContextMiddleware(Middleware):
         context: MiddlewareContext[mt.InitializeRequest],
         call_next: CallNext[mt.InitializeRequest, mt.InitializeResult | None],
     ) -> mt.InitializeResult | None:
-        """Record client and protocol metadata from initialization."""
-        params = getattr(context.message, "params", context.message)
-        identity = ClientIdentity.from_params(
-            getattr(params, "clientInfo", None),
-            getattr(params, "protocolVersion", None),
-        )
-        # Keep the identity for the connection so downstream API calls don't
-        # re-derive it from the handshake on every request.
+
+        identity = ClientIdentity.from_params(context.message.params.clientInfo, context.message.params.protocolVersion)
+
         if context.fastmcp_context is not None:
             set_client_identity(identity, context.fastmcp_context.session)
         log_fields = identity.log_fields()

--- a/packages/gg_api_core/src/gg_api_core/middleware.py
+++ b/packages/gg_api_core/src/gg_api_core/middleware.py
@@ -16,9 +16,10 @@ from typing_extensions import override
 
 from gg_api_core.client import DownstreamUnauthorizedError
 from gg_api_core.log_context import (
+    ClientIdentity,
     classify_failure,
-    derive_client_identity,
     resolve_caller_identity,
+    set_client_identity,
     track_current_tool,
     track_downstream_calls,
 )
@@ -140,12 +141,17 @@ class RequestLoggingContextMiddleware(Middleware):
     ) -> mt.InitializeResult | None:
         """Record client and protocol metadata from initialization."""
         params = getattr(context.message, "params", context.message)
-        client_identity = derive_client_identity(
+        identity = ClientIdentity.from_params(
             getattr(params, "clientInfo", None),
             getattr(params, "protocolVersion", None),
         )
-        with structlog.contextvars.bound_contextvars(**client_identity):
-            logger.info("mcp_initialize", extra=client_identity)
+        # Keep the identity for the connection so downstream API calls don't
+        # re-derive it from the handshake on every request.
+        if context.fastmcp_context is not None:
+            set_client_identity(identity, context.fastmcp_context.session)
+        log_fields = identity.log_fields()
+        with structlog.contextvars.bound_contextvars(**log_fields):
+            logger.info("mcp_initialize", extra=log_fields)
             return await call_next(context)
 
 

--- a/packages/gg_api_core/src/gg_api_core/middleware.py
+++ b/packages/gg_api_core/src/gg_api_core/middleware.py
@@ -19,6 +19,7 @@ from gg_api_core.log_context import (
     classify_failure,
     derive_client_identity,
     resolve_caller_identity,
+    track_current_tool,
     track_downstream_calls,
 )
 from gg_api_core.oauth_proxy_auth import mark_downstream_unauthorized
@@ -241,7 +242,7 @@ class ToolCallLoggingMiddleware(Middleware):
         tool = context.message.name
 
         start = time.perf_counter()
-        with track_downstream_calls() as downstream:
+        with track_current_tool(tool), track_downstream_calls() as downstream:
             try:
                 result = await call_next(context)
             except Exception as exc:

--- a/packages/gg_api_core/src/gg_api_core/tool_context.py
+++ b/packages/gg_api_core/src/gg_api_core/tool_context.py
@@ -1,0 +1,39 @@
+"""Current MCP tool name, propagated to downstream API calls."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+__all__ = [
+    "current_tool_name",
+    "track_current_tool",
+]
+
+_current_tool: ContextVar[str | None] = ContextVar("gg_current_tool", default=None)
+
+# The name arrives from the client's tools/call message, so it is untrusted
+# text until it has resolved to a registered tool. Registered names are plain
+# identifiers, so anything else is dropped here, at the point the value enters
+# the process, rather than at each place that later reads it.
+_TOOL_NAME = re.compile(r"[A-Za-z0-9_.-]{1,64}")
+
+
+@contextmanager
+def track_current_tool(tool_name: str) -> Iterator[None]:
+    """Expose the executing tool's name to downstream API calls."""
+    token = _current_tool.set(tool_name if _TOOL_NAME.fullmatch(tool_name) else None)
+    try:
+        yield
+    finally:
+        _current_tool.reset(token)
+
+
+def current_tool_name() -> str | None:
+    """The MCP tool the in-flight request is executing, if any.
+
+    Safe to put in an outgoing header: validated by :func:`track_current_tool`.
+    """
+    return _current_tool.get()

--- a/packages/gg_api_core/src/gg_api_core/utils.py
+++ b/packages/gg_api_core/src/gg_api_core/utils.py
@@ -1,11 +1,13 @@
 import logging
 import re
+from collections.abc import Callable
 from urllib.parse import urljoin as urllib_urljoin
 
 from fastmcp.exceptions import ValidationError
 from fastmcp.server.dependencies import get_http_headers
 
 from .client import DEFAULT_USER_AGENT, GitGuardianClient, acquire_single_tenant_token
+from .log_context import current_client_identity
 from .settings import get_settings
 
 # Setup logger
@@ -45,9 +47,12 @@ async def get_client(personal_access_token: str | None = None, user_agent: str |
 
     Args:
         personal_access_token: Optional PAT for explicit authentication.
-        user_agent: Optional User-Agent string. If not provided, one is built
-            via :func:`_build_user_agent` (server identity + transport marker,
-            plus the caller's User-Agent when the request came over HTTP).
+        user_agent: Optional explicit User-Agent. If not provided, one is built
+            per request via :func:`_build_user_agent` (server identity +
+            transport marker, plus the client's identity from the MCP handshake
+            or HTTP headers). The client evaluates it per request so a
+            long-lived singleton reflects the session's handshake, not
+            whichever call created it first.
 
     Returns:
         GitGuardianClient: Client instance configured with appropriate authentication
@@ -56,14 +61,20 @@ async def get_client(personal_access_token: str | None = None, user_agent: str |
         ValidationError: In multi-tenant mode, if MCP_PORT not set or Authorization header missing
         RuntimeError: In single-tenant mode, if no token source is available
     """
-    # Build the User-Agent for outgoing API calls if not explicitly provided
-    if user_agent is None:
-        user_agent = _build_user_agent()
+    # The User-Agent is always a callable evaluated per request: the long-lived
+    # single-tenant singleton would otherwise freeze whatever handshake was known
+    # when the first call created it. An explicit override is wrapped into a
+    # constant callable; otherwise the live handshake-derived builder is used.
+    # All three modes below are therefore uniform: they pass the same source.
+    ua_source: Callable[[], str] = (lambda: user_agent) if user_agent else _build_user_agent
 
     # 1. Explicit PAT provided - caller manages the token (no caching, no automatic refresh)
     if personal_access_token:
         logger.debug("Creating client with explicitly provided token")
-        return GitGuardianClient(personal_access_token=personal_access_token, user_agent=user_agent)
+        return GitGuardianClient(
+            personal_access_token=personal_access_token,
+            user_agent=ua_source,
+        )
 
     # 2. Multi-tenant mode (explicit opt-in via MULTI_TENANCY_ENABLED=true) : no caching, no automatic refresh
     settings = get_settings()
@@ -75,7 +86,7 @@ async def get_client(personal_access_token: str | None = None, user_agent: str |
             )
         logger.debug("Multi-tenant mode: extracting token from request headers")
         token = _get_token_from_request_headers()
-        return GitGuardianClient(personal_access_token=token, user_agent=user_agent)
+        return GitGuardianClient(personal_access_token=token, user_agent=ua_source)
 
     # 3. Single-tenant mode (DEFAULT) - use singleton pattern to cache the PAT
     global _client_singleton
@@ -84,26 +95,35 @@ async def get_client(personal_access_token: str | None = None, user_agent: str |
 
     # Acquire token for single-tenant mode
     token = await acquire_single_tenant_token()
-    # Enable token refresh for self-healing on 401 errors
+    # Enable token refresh for self-healing on 401 errors.
     _client_singleton = GitGuardianClient(
         personal_access_token=token,
         allow_token_refresh=True,
-        user_agent=user_agent,
+        user_agent=ua_source,
     )
     return _client_singleton
 
 
 def _get_caller_user_agent() -> str | None:
-    """Try to extract User-Agent from the incoming MCP request headers.
+    """The caller's own User-Agent, for callers that reached us over HTTP.
 
-    Returns None if not available (e.g. stdio transport).
+    ``get_http_headers`` returns an empty mapping outside an HTTP request
+    rather than raising, so stdio simply yields None.
     """
-    try:
-        headers = get_http_headers(include={"user-agent"})
-        return headers.get("user-agent") if headers else None
-    except Exception:
-        logger.exception("Error when trying to extract User-Agent from headers")
-        return None
+    return get_http_headers(include={"user-agent"}).get("user-agent")
+
+
+# Comment fields are client-controlled text: keep printable ASCII, drop the
+# characters that delimit User-Agent comments or a field inside one (so a
+# client cannot forge its own `key=value` pair), and bound the length.
+_UA_FIELD_DISALLOWED = re.compile(r"[^\x20-\x7e]|[();=,]")
+_UA_FIELD_MAX_LENGTH = 64
+
+
+def _sanitize_ua_field(value: str) -> str | None:
+    """Make a client-controlled string safe to embed in a User-Agent comment."""
+    cleaned = _UA_FIELD_DISALLOWED.sub("", value).strip()
+    return cleaned[:_UA_FIELD_MAX_LENGTH] or None
 
 
 def _build_user_agent() -> str:
@@ -111,20 +131,28 @@ def _build_user_agent() -> str:
 
     The string always starts with ``GitGuardian-MCP-Server/<version>`` so that
     monitoring filtering on that substring keeps matching every MCP request,
-    regardless of transport. A ``transport=stdio|http`` marker is appended to
-    tell legacy local (stdio) clients apart from the hosted HTTP server, and
-    when the request arrives over HTTP the calling client's own User-Agent is
-    preserved as ``client=...`` for per-client analytics.
+    regardless of transport. A ``transport=stdio|http`` marker tells local
+    (stdio) installs apart from the hosted HTTP server. The calling client is
+    identified as ``client=<name>/<version>`` from the MCP handshake's
+    ``clientInfo`` (available on every transport), falling back to the raw
+    HTTP User-Agent for callers that reached us over HTTP. The negotiated MCP
+    protocol revision is appended as ``mcp=...`` to track spec adoption.
 
     Examples:
-        - stdio:  ``GitGuardian-MCP-Server/0.5.0 (transport=stdio)``
-        - hosted: ``GitGuardian-MCP-Server/0.5.0 (transport=http; client=Claude-Code/1.2)``
+        - stdio:  ``GitGuardian-MCP-Server/0.7.0 (transport=stdio; client=claude-code/2.0.14; mcp=2025-06-18)``
+        - hosted: ``GitGuardian-MCP-Server/0.7.0 (transport=http; client=cursor/1.4.2; mcp=2025-06-18)``
     """
     transport = "http" if get_settings().mcp_port else "stdio"
     parts = [f"transport={transport}"]
-    caller = _get_caller_user_agent()
-    if caller:
-        parts.append(f"client={caller}")
+
+    identity = current_client_identity()
+    client = (identity.label if identity else None) or _get_caller_user_agent()
+    protocol = identity.protocol_version if identity else None
+    if client and (sanitized_client := _sanitize_ua_field(client)):
+        parts.append(f"client={sanitized_client}")
+    if protocol and (sanitized_protocol := _sanitize_ua_field(protocol)):
+        parts.append(f"mcp={sanitized_protocol}")
+
     return f"{DEFAULT_USER_AGENT} ({'; '.join(parts)})"
 
 

--- a/packages/gg_api_core/src/gg_api_core/utils.py
+++ b/packages/gg_api_core/src/gg_api_core/utils.py
@@ -7,7 +7,7 @@ from fastmcp.exceptions import ValidationError
 from fastmcp.server.dependencies import get_http_headers
 
 from .client import DEFAULT_USER_AGENT, GitGuardianClient, acquire_single_tenant_token
-from .log_context import current_client_identity
+from .client_identity import current_client_identity
 from .settings import get_settings
 
 # Setup logger
@@ -61,11 +61,7 @@ async def get_client(personal_access_token: str | None = None, user_agent: str |
         ValidationError: In multi-tenant mode, if MCP_PORT not set or Authorization header missing
         RuntimeError: In single-tenant mode, if no token source is available
     """
-    # The User-Agent is always a callable evaluated per request: the long-lived
-    # single-tenant singleton would otherwise freeze whatever handshake was known
-    # when the first call created it. An explicit override is wrapped into a
-    # constant callable; otherwise the live handshake-derived builder is used.
-    # All three modes below are therefore uniform: they pass the same source.
+
     ua_source: Callable[[], str] = (lambda: user_agent) if user_agent else _build_user_agent
 
     # 1. Explicit PAT provided - caller manages the token (no caching, no automatic refresh)
@@ -95,7 +91,7 @@ async def get_client(personal_access_token: str | None = None, user_agent: str |
 
     # Acquire token for single-tenant mode
     token = await acquire_single_tenant_token()
-    # Enable token refresh for self-healing on 401 errors.
+    # Enable token refresh for self-healing on 401 errors
     _client_singleton = GitGuardianClient(
         personal_access_token=token,
         allow_token_refresh=True,
@@ -105,11 +101,6 @@ async def get_client(personal_access_token: str | None = None, user_agent: str |
 
 
 def _get_caller_user_agent() -> str | None:
-    """The caller's own User-Agent, for callers that reached us over HTTP.
-
-    ``get_http_headers`` returns an empty mapping outside an HTTP request
-    rather than raising, so stdio simply yields None.
-    """
     return get_http_headers(include={"user-agent"}).get("user-agent")
 
 

--- a/tests/e2e/test_stdio_server.py
+++ b/tests/e2e/test_stdio_server.py
@@ -100,7 +100,7 @@ class TestPatEnvAuthentication:
         assert result.structured_content == {"incident": INCIDENT}
         assert_authenticated_request(scope_route, STDIO_PAT)
         assert_authenticated_request(route, STDIO_PAT)
-        assert "(transport=stdio)" in route.calls.last.request.headers["User-Agent"]
+        assert "transport=stdio" in route.calls.last.request.headers["User-Agent"]
 
     async def test_default_oauth_mode_still_uses_the_env_token_without_a_browser_flow(
         self,
@@ -213,7 +213,7 @@ class TestStartupScopeCache:
         # Unlike the remote server, which re-fetches scopes per tools/list.
         assert scope_route.call_count == 1
         assert_authenticated_request(scope_route, STDIO_PAT)
-        assert "(transport=stdio)" in scope_route.calls.last.request.headers["User-Agent"]
+        assert "transport=stdio" in scope_route.calls.last.request.headers["User-Agent"]
 
     async def test_scan_only_token_prunes_the_catalog_at_startup(
         self,

--- a/tests/e2e/test_stdio_transport.py
+++ b/tests/e2e/test_stdio_transport.py
@@ -130,7 +130,7 @@ async def test_installed_stdio_entrypoint_serves_gitguardian_tools(
     assert {request["authorization"] for request in api_requests} == {f"Token {STDIO_PAT}"}
     assert {request["privacy_mode"] for request in api_requests} == {"true"}
     assert all(
-        request["user_agent"] is not None and "(transport=stdio)" in request["user_agent"] for request in api_requests
+        request["user_agent"] is not None and "transport=stdio" in request["user_agent"] for request in api_requests
     )
 
     assert STDIO_PAT not in stderr_log.read_text()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -778,3 +778,42 @@ class TestIncidentsForMCPAssigneeFilter:
         params = client._request_get.call_args.kwargs["params"]
         assert params["date__ge"] == "2026-07-01"
         assert params["date__le"] == "2026-08-01"
+
+
+class TestOutgoingRequestHeaders:
+    """Headers identifying the MCP client on outgoing API calls."""
+
+    def _patched_http(self, mock_response, mock_httpx_client):
+        mock_response.raise_for_status = MagicMock()
+        async_client_instance = AsyncMock()
+        async_client_instance.__aenter__.return_value = mock_httpx_client
+        mock_httpx_client.request = AsyncMock(return_value=mock_response)
+        return patch("httpx.AsyncClient", return_value=async_client_instance)
+
+    @pytest.mark.asyncio
+    async def test_callable_user_agent_evaluated_per_request(self, mock_response, mock_httpx_client):
+        """
+        GIVEN a client constructed with a callable user_agent
+        WHEN two requests are sent
+        THEN each request evaluates the callable, so the header can differ
+        """
+        values = iter(["UA-first", "UA-second"])
+        client = GitGuardianClient(gitguardian_url="https://custom.api.url", user_agent=lambda: next(values))
+        client._oauth_token = "test_oauth_token"
+
+        with self._patched_http(mock_response, mock_httpx_client):
+            await client._request_get("/test")
+            first = mock_httpx_client.request.call_args.kwargs["headers"]["User-Agent"]
+            await client._request_get("/test")
+            second = mock_httpx_client.request.call_args.kwargs["headers"]["User-Agent"]
+
+        assert (first, second) == ("UA-first", "UA-second")
+
+    def test_default_user_agent_callable(self):
+        """
+        GIVEN a client constructed without a user_agent
+        WHEN the user agent is read
+        THEN it resolves to DEFAULT_USER_AGENT
+        """
+        client = GitGuardianClient(gitguardian_url="https://custom.api.url")
+        assert client._user_agent() == GitGuardianClient.DEFAULT_USER_AGENT

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 from gg_api_core.client import GitGuardianClient, IncidentSeverity, IncidentStatus, IncidentValidity
-from gg_api_core.log_context import track_current_tool
+from gg_api_core.tool_context import track_current_tool
 
 
 @pytest.fixture

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 from gg_api_core.client import GitGuardianClient, IncidentSeverity, IncidentStatus, IncidentValidity
+from gg_api_core.log_context import track_current_tool
 
 
 @pytest.fixture
@@ -781,7 +782,7 @@ class TestIncidentsForMCPAssigneeFilter:
 
 
 class TestOutgoingRequestHeaders:
-    """Headers identifying the MCP client on outgoing API calls."""
+    """Headers identifying the MCP client and tool on outgoing API calls."""
 
     def _patched_http(self, mock_response, mock_httpx_client):
         mock_response.raise_for_status = MagicMock()
@@ -789,6 +790,50 @@ class TestOutgoingRequestHeaders:
         async_client_instance.__aenter__.return_value = mock_httpx_client
         mock_httpx_client.request = AsyncMock(return_value=mock_response)
         return patch("httpx.AsyncClient", return_value=async_client_instance)
+
+    @pytest.mark.asyncio
+    async def test_tool_header_sent_during_tracked_tool_call(self, client, mock_response, mock_httpx_client):
+        """
+        GIVEN an API request made while a tool call is tracked
+        WHEN the request is sent
+        THEN it carries X-GG-MCP-Tool with the tool name
+        """
+        with self._patched_http(mock_response, mock_httpx_client):
+            with track_current_tool("list_incidents"):
+                await client._request_get("/test")
+
+        headers = mock_httpx_client.request.call_args.kwargs["headers"]
+        assert headers["X-GG-MCP-Tool"] == "list_incidents"
+
+    @pytest.mark.asyncio
+    async def test_tool_header_absent_outside_tool_call(self, client, mock_response, mock_httpx_client):
+        """
+        GIVEN an API request made outside any tracked tool call
+        WHEN the request is sent
+        THEN it carries no X-GG-MCP-Tool header
+        """
+        with self._patched_http(mock_response, mock_httpx_client):
+            await client._request_get("/test")
+
+        headers = mock_httpx_client.request.call_args.kwargs["headers"]
+        assert "X-GG-MCP-Tool" not in headers
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tool_name", ["bad name", "tool\r\nX-Injected: 1", "a" * 65, "tool;drop"])
+    async def test_tool_header_dropped_for_unregisterable_names(
+        self, client, mock_response, mock_httpx_client, tool_name
+    ):
+        """
+        GIVEN a tool name that no registered tool could have, from the client's tools/call
+        WHEN an API request is made during that call
+        THEN the name is left out of the headers rather than shaping them
+        """
+        with self._patched_http(mock_response, mock_httpx_client):
+            with track_current_tool(tool_name):
+                await client._request_get("/test")
+
+        headers = mock_httpx_client.request.call_args.kwargs["headers"]
+        assert "X-GG-MCP-Tool" not in headers
 
     @pytest.mark.asyncio
     async def test_callable_user_agent_evaluated_per_request(self, mock_response, mock_httpx_client):

--- a/tests/test_get_client_safeguards.py
+++ b/tests/test_get_client_safeguards.py
@@ -7,9 +7,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastmcp.exceptions import ValidationError
 from gg_api_core.client import GitGuardianClient
-from gg_api_core.log_context import ClientIdentity
+from gg_api_core.client_identity import ClientIdentity, set_client_identity
 from gg_api_core.settings import get_settings
 from gg_api_core.utils import _build_user_agent, _get_caller_user_agent, get_client
+from mcp.server.session import ServerSession
 
 # Prefix every outgoing User-Agent carries, regardless of transport.
 UA_PREFIX = GitGuardianClient.DEFAULT_USER_AGENT
@@ -477,18 +478,27 @@ def _mock_mcp_context(client_name=None, client_version=None, protocol_version=No
     return SimpleNamespace(session=_mock_session(client_name, client_version, protocol_version))
 
 
+class _FakeSession(ServerSession):
+    """Weakref-able stand-in for a ServerSession (SimpleNamespace is not weakref-able)."""
+
+    def __init__(self):
+        pass
+
+
 def _mock_session(client_name=None, client_version=None, protocol_version=None):
     """A session that has gone through initialize: identity already derived and stored."""
     info = SimpleNamespace(name=client_name, version=client_version) if client_name else None
     params = SimpleNamespace(clientInfo=info, protocolVersion=protocol_version)
     identity = ClientIdentity.from_params(params.clientInfo, params.protocolVersion)
-    return SimpleNamespace(_gg_client_identity=identity)
+    session = _FakeSession()
+    set_client_identity(identity, session)
+    return session
 
 
 class TestMcpHandshakeUserAgent:
     """Tests for the client= and mcp= User-Agent fields built from the MCP handshake."""
 
-    @patch("gg_api_core.log_context.get_context")
+    @patch("gg_api_core.client_identity.get_context")
     def test_stdio_includes_client_and_protocol_from_handshake(self, mock_get_context):
         """
         GIVEN a stdio session whose initialize handshake carried clientInfo and protocolVersion
@@ -502,7 +512,7 @@ class TestMcpHandshakeUserAgent:
 
         assert ua == f"{UA_PREFIX} (transport=stdio; client=claude-code/2.0.14; mcp=2025-06-18)"
 
-    @patch("gg_api_core.log_context.get_context")
+    @patch("gg_api_core.client_identity.get_context")
     def test_client_name_without_version(self, mock_get_context):
         """
         GIVEN a handshake with a client name but no version
@@ -518,7 +528,7 @@ class TestMcpHandshakeUserAgent:
         assert "mcp=" not in ua
 
     @patch("gg_api_core.utils.get_http_headers")
-    @patch("gg_api_core.log_context.get_context")
+    @patch("gg_api_core.client_identity.get_context")
     def test_handshake_identity_preferred_over_http_user_agent(self, mock_get_context, mock_get_headers):
         """
         GIVEN both a handshake clientInfo and an HTTP User-Agent header
@@ -535,7 +545,7 @@ class TestMcpHandshakeUserAgent:
         assert "SomeBrowser" not in ua
 
     @patch("gg_api_core.utils.get_http_headers")
-    @patch("gg_api_core.log_context.get_context")
+    @patch("gg_api_core.client_identity.get_context")
     def test_falls_back_to_http_user_agent_without_handshake(self, mock_get_context, mock_get_headers):
         """
         GIVEN no usable handshake data (e.g. before initialization)
@@ -550,7 +560,7 @@ class TestMcpHandshakeUserAgent:
 
         assert ua == f"{UA_PREFIX} (transport=http; client=GitGuardian-In-App-Agent)"
 
-    @patch("gg_api_core.log_context.get_context")
+    @patch("gg_api_core.client_identity.get_context")
     def test_client_controlled_values_are_sanitized(self, mock_get_context):
         """
         GIVEN handshake values containing comment delimiters, control chars, and non-ASCII
@@ -567,7 +577,7 @@ class TestMcpHandshakeUserAgent:
         assert "\x07" not in ua
         assert "é" not in ua
 
-    @patch("gg_api_core.log_context.get_context")
+    @patch("gg_api_core.client_identity.get_context")
     def test_client_cannot_forge_a_field_inside_the_comment(self, mock_get_context):
         """
         GIVEN a handshake client name shaped like an extra UA field
@@ -583,7 +593,7 @@ class TestMcpHandshakeUserAgent:
         assert "mcp=2025-06-18" in ua
         assert "2099" in ua.split("client=")[1].split(";")[0]
 
-    @patch("gg_api_core.log_context.get_context")
+    @patch("gg_api_core.client_identity.get_context")
     def test_client_field_length_is_capped(self, mock_get_context):
         """
         GIVEN a handshake client name far longer than the field cap
@@ -618,7 +628,7 @@ class TestMcpHandshakeUserAgent:
 
         assert mock_client_class.call_args.kwargs["user_agent"] is _build_user_agent
 
-    @patch("gg_api_core.log_context.get_context")
+    @patch("gg_api_core.client_identity.get_context")
     @patch("gg_api_core.utils.acquire_single_tenant_token", new_callable=AsyncMock)
     async def test_singleton_user_agent_reflects_the_live_handshake(self, mock_acquire, mock_get_context):
         """

--- a/tests/test_get_client_safeguards.py
+++ b/tests/test_get_client_safeguards.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastmcp.exceptions import ValidationError
 from gg_api_core.client import GitGuardianClient
+from gg_api_core.log_context import ClientIdentity
 from gg_api_core.settings import get_settings
 from gg_api_core.utils import _build_user_agent, _get_caller_user_agent, get_client
 
@@ -472,10 +473,16 @@ class TestCallerUserAgentExtraction:
 
 
 def _mock_mcp_context(client_name=None, client_version=None, protocol_version=None):
-    """A FastMCP context whose session negotiated the given handshake values."""
+    """A FastMCP context whose session has stored the given handshake identity."""
+    return SimpleNamespace(session=_mock_session(client_name, client_version, protocol_version))
+
+
+def _mock_session(client_name=None, client_version=None, protocol_version=None):
+    """A session that has gone through initialize: identity already derived and stored."""
     info = SimpleNamespace(name=client_name, version=client_version) if client_name else None
     params = SimpleNamespace(clientInfo=info, protocolVersion=protocol_version)
-    return SimpleNamespace(session=SimpleNamespace(client_params=params))
+    identity = ClientIdentity.from_params(params.clientInfo, params.protocolVersion)
+    return SimpleNamespace(_gg_client_identity=identity)
 
 
 class TestMcpHandshakeUserAgent:

--- a/tests/test_get_client_safeguards.py
+++ b/tests/test_get_client_safeguards.py
@@ -1,13 +1,14 @@
 """Tests for get_client() to ensure proper tenant isolation and token acquisition."""
 
 import os
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastmcp.exceptions import ValidationError
 from gg_api_core.client import GitGuardianClient
 from gg_api_core.settings import get_settings
-from gg_api_core.utils import _get_caller_user_agent, get_client
+from gg_api_core.utils import _build_user_agent, _get_caller_user_agent, get_client
 
 # Prefix every outgoing User-Agent carries, regardless of transport.
 UA_PREFIX = GitGuardianClient.DEFAULT_USER_AGENT
@@ -93,9 +94,9 @@ class TestGetClientExplicitPAT:
         mock_client_class.assert_called_once()
         call_kwargs = mock_client_class.call_args.kwargs
         assert call_kwargs["personal_access_token"] == "explicit-token"
-        # User-Agent now always carries the server prefix + transport marker
-        assert call_kwargs["user_agent"].startswith(UA_PREFIX)
-        assert "transport=" in call_kwargs["user_agent"]
+        # The client receives the live UA builder (not a frozen string), so the
+        # user agent reflects the session's handshake on every request.
+        assert call_kwargs["user_agent"] is _build_user_agent
         assert result == mock_client
 
     @patch("gg_api_core.utils.GitGuardianClient")
@@ -114,7 +115,7 @@ class TestGetClientExplicitPAT:
         # MCP_PORT is set, so the transport marker is http (no caller header here)
         mock_client_class.assert_called_once_with(
             personal_access_token="explicit-token",
-            user_agent=f"{UA_PREFIX} (transport=http)",
+            user_agent=_build_user_agent,
         )
         assert result == mock_client
 
@@ -154,7 +155,7 @@ class TestGetClientMultiTenantMode:
         # No user-agent header on the request, so only the transport marker is added
         mock_client_class.assert_called_once_with(
             personal_access_token="request-token",
-            user_agent=f"{UA_PREFIX} (transport=http)",
+            user_agent=_build_user_agent,
         )
         assert result == mock_client
 
@@ -179,7 +180,7 @@ class TestGetClientMultiTenantMode:
 
         mock_client_class.assert_called_once_with(
             personal_access_token="request-token",
-            user_agent=f"{UA_PREFIX} (transport=http; client=GitGuardian-In-App-Agent)",
+            user_agent=_build_user_agent,
         )
         assert result == mock_client
 
@@ -430,19 +431,6 @@ class TestCallerUserAgentExtraction:
         assert result is None
 
     @patch("gg_api_core.utils.get_http_headers")
-    def test_returns_none_on_exception(self, mock_get_headers):
-        """
-        GIVEN get_http_headers raises an exception
-        WHEN _get_caller_user_agent is called
-        THEN it returns None (graceful degradation)
-        """
-        mock_get_headers.side_effect = RuntimeError("Unexpected error")
-
-        result = _get_caller_user_agent()
-
-        assert result is None
-
-    @patch("gg_api_core.utils.get_http_headers")
     @patch("gg_api_core.utils.GitGuardianClient")
     async def test_get_client_auto_extracts_user_agent(self, mock_client_class, mock_get_headers):
         """
@@ -461,7 +449,7 @@ class TestCallerUserAgentExtraction:
 
         mock_client_class.assert_called_once_with(
             personal_access_token="request-token",
-            user_agent=f"{UA_PREFIX} (transport=http; client=GitGuardian-In-App-Agent)",
+            user_agent=_build_user_agent,
         )
 
     @patch("gg_api_core.utils.get_http_headers")
@@ -477,7 +465,172 @@ class TestCallerUserAgentExtraction:
 
         await get_client(personal_access_token="explicit-token", user_agent="Custom-Agent")
 
-        mock_client_class.assert_called_once_with(
-            personal_access_token="explicit-token",
-            user_agent="Custom-Agent",
-        )
+        mock_client_class.assert_called_once()
+        call_kwargs = mock_client_class.call_args.kwargs
+        assert call_kwargs["personal_access_token"] == "explicit-token"
+        assert call_kwargs["user_agent"]() == "Custom-Agent"
+
+
+def _mock_mcp_context(client_name=None, client_version=None, protocol_version=None):
+    """A FastMCP context whose session negotiated the given handshake values."""
+    info = SimpleNamespace(name=client_name, version=client_version) if client_name else None
+    params = SimpleNamespace(clientInfo=info, protocolVersion=protocol_version)
+    return SimpleNamespace(session=SimpleNamespace(client_params=params))
+
+
+class TestMcpHandshakeUserAgent:
+    """Tests for the client= and mcp= User-Agent fields built from the MCP handshake."""
+
+    @patch("gg_api_core.log_context.get_context")
+    def test_stdio_includes_client_and_protocol_from_handshake(self, mock_get_context):
+        """
+        GIVEN a stdio session whose initialize handshake carried clientInfo and protocolVersion
+        WHEN _build_user_agent is called
+        THEN the UA carries transport=stdio plus client= and mcp= fields
+        """
+        mock_get_context.return_value = _mock_mcp_context("claude-code", "2.0.14", "2025-06-18")
+
+        with patch.dict(os.environ, {}, clear=True):
+            ua = _build_user_agent()
+
+        assert ua == f"{UA_PREFIX} (transport=stdio; client=claude-code/2.0.14; mcp=2025-06-18)"
+
+    @patch("gg_api_core.log_context.get_context")
+    def test_client_name_without_version(self, mock_get_context):
+        """
+        GIVEN a handshake with a client name but no version
+        WHEN _build_user_agent is called
+        THEN client= carries the bare name
+        """
+        mock_get_context.return_value = _mock_mcp_context("cursor")
+
+        with patch.dict(os.environ, {}, clear=True):
+            ua = _build_user_agent()
+
+        assert "client=cursor" in ua
+        assert "mcp=" not in ua
+
+    @patch("gg_api_core.utils.get_http_headers")
+    @patch("gg_api_core.log_context.get_context")
+    def test_handshake_identity_preferred_over_http_user_agent(self, mock_get_context, mock_get_headers):
+        """
+        GIVEN both a handshake clientInfo and an HTTP User-Agent header
+        WHEN _build_user_agent is called
+        THEN the structured handshake identity wins
+        """
+        mock_get_context.return_value = _mock_mcp_context("claude-code", "2.0.14")
+        mock_get_headers.return_value = {"user-agent": "SomeBrowser/99"}
+
+        with patch.dict(os.environ, {"MCP_PORT": "8080"}, clear=True):
+            ua = _build_user_agent()
+
+        assert "client=claude-code/2.0.14" in ua
+        assert "SomeBrowser" not in ua
+
+    @patch("gg_api_core.utils.get_http_headers")
+    @patch("gg_api_core.log_context.get_context")
+    def test_falls_back_to_http_user_agent_without_handshake(self, mock_get_context, mock_get_headers):
+        """
+        GIVEN no usable handshake data (e.g. before initialization)
+        WHEN _build_user_agent is called on an HTTP request
+        THEN the caller's HTTP User-Agent is used as client=
+        """
+        mock_get_context.side_effect = RuntimeError("no active request")
+        mock_get_headers.return_value = {"user-agent": "GitGuardian-In-App-Agent"}
+
+        with patch.dict(os.environ, {"MCP_PORT": "8080"}, clear=True):
+            ua = _build_user_agent()
+
+        assert ua == f"{UA_PREFIX} (transport=http; client=GitGuardian-In-App-Agent)"
+
+    @patch("gg_api_core.log_context.get_context")
+    def test_client_controlled_values_are_sanitized(self, mock_get_context):
+        """
+        GIVEN handshake values containing comment delimiters, control chars, and non-ASCII
+        WHEN _build_user_agent is called
+        THEN the unsafe characters are stripped from the UA
+        """
+        mock_get_context.return_value = _mock_mcp_context("Evil) (Agent;", "1.0\x07é", "2025-06-18\n")
+
+        with patch.dict(os.environ, {}, clear=True):
+            ua = _build_user_agent()
+
+        assert "client=Evil Agent/1.0" in ua
+        assert "mcp=2025-06-18" in ua
+        assert "\x07" not in ua
+        assert "é" not in ua
+
+    @patch("gg_api_core.log_context.get_context")
+    def test_client_cannot_forge_a_field_inside_the_comment(self, mock_get_context):
+        """
+        GIVEN a handshake client name shaped like an extra UA field
+        WHEN _build_user_agent is called
+        THEN the separators are stripped, so only the real mcp= field is present
+        """
+        mock_get_context.return_value = _mock_mcp_context("foo, mcp=2099", "1.0", "2025-06-18")
+
+        with patch.dict(os.environ, {}, clear=True):
+            ua = _build_user_agent()
+
+        assert ua.count("mcp=") == 1
+        assert "mcp=2025-06-18" in ua
+        assert "2099" in ua.split("client=")[1].split(";")[0]
+
+    @patch("gg_api_core.log_context.get_context")
+    def test_client_field_length_is_capped(self, mock_get_context):
+        """
+        GIVEN a handshake client name far longer than the field cap
+        WHEN _build_user_agent is called
+        THEN the client= value is truncated to 64 characters
+        """
+        mock_get_context.return_value = _mock_mcp_context("a" * 200, "1.0")
+
+        with patch.dict(os.environ, {}, clear=True):
+            ua = _build_user_agent()
+
+        client_field = ua.split("client=")[1].split(";")[0].rstrip(")")
+        assert client_field == "a" * 64
+
+    @patch("gg_api_core.utils.acquire_single_tenant_token", new_callable=AsyncMock)
+    @patch("gg_api_core.utils.GitGuardianClient")
+    async def test_singleton_receives_callable_user_agent(self, mock_client_class, mock_acquire):
+        """
+        GIVEN single-tenant mode (the long-lived singleton client)
+        WHEN get_client creates the singleton
+        THEN it receives _build_user_agent itself, so the UA is evaluated per request
+        """
+        mock_acquire.return_value = "env-token"
+        mock_client_class.return_value = MagicMock()
+
+        import gg_api_core.utils
+
+        gg_api_core.utils._client_singleton = None
+
+        with patch.dict(os.environ, {"GITGUARDIAN_PERSONAL_ACCESS_TOKEN": "env-token"}, clear=True):
+            await get_client()
+
+        assert mock_client_class.call_args.kwargs["user_agent"] is _build_user_agent
+
+    @patch("gg_api_core.log_context.get_context")
+    @patch("gg_api_core.utils.acquire_single_tenant_token", new_callable=AsyncMock)
+    async def test_singleton_user_agent_reflects_the_live_handshake(self, mock_acquire, mock_get_context):
+        """
+        GIVEN one long-lived singleton client created in single-tenant mode
+        WHEN its user agent is evaluated across two different initialize handshakes
+        THEN each evaluation reflects the handshake of that moment, not the first one
+        """
+        mock_acquire.return_value = "env-token"
+
+        import gg_api_core.utils
+
+        gg_api_core.utils._client_singleton = None
+        with patch.dict(os.environ, {"GITGUARDIAN_PERSONAL_ACCESS_TOKEN": "env-token"}, clear=True):
+            client = await get_client()
+
+        mock_get_context.side_effect = [
+            _mock_mcp_context("claude-code", "2.0.14", "2025-06-18"),
+            _mock_mcp_context("cursor", "1.4.2", "2025-06-18"),
+        ]
+
+        assert client._user_agent() == f"{UA_PREFIX} (transport=stdio; client=claude-code/2.0.14; mcp=2025-06-18)"
+        assert client._user_agent() == f"{UA_PREFIX} (transport=stdio; client=cursor/1.4.2; mcp=2025-06-18)"

--- a/tests/test_log_context.py
+++ b/tests/test_log_context.py
@@ -1,11 +1,13 @@
 """Derivation and caching of the identity fields bound to every log line."""
 
 import time
+from types import SimpleNamespace
 
 import pytest
 from gg_api_core.log_context import (
     _IDENTITY_CACHE_MAX_ENTRIES,
     _IDENTITY_TTL_SECONDS,
+    ClientIdentity,
     _identity_cache,
     _identity_cache_key,
     clear_caller_identity_cache,
@@ -289,3 +291,60 @@ class TestClearCallerIdentityCache:
         await resolve_caller_identity(fetcher("b"), token="tok-b")
 
         assert calls == {"a": 2, "b": 1}
+
+
+class TestClientIdentity:
+    def test_label_pairs_name_and_version(self):
+        """
+        GIVEN a handshake reporting both a name and a version
+        WHEN the identity is labelled
+        THEN the label is name/version
+        """
+        assert ClientIdentity(name="claude-code", version="2.0.14").label == "claude-code/2.0.14"
+
+    def test_label_is_the_bare_name_without_a_version(self):
+        """
+        GIVEN a handshake reporting a name but no version
+        WHEN the identity is labelled
+        THEN the label is the name alone
+        """
+        assert ClientIdentity(name="claude-code").label == "claude-code"
+
+    def test_label_is_none_without_a_name(self):
+        """
+        GIVEN a handshake that reported no client name
+        WHEN the identity is labelled
+        THEN there is no label to put in a User-Agent
+        """
+        assert ClientIdentity(protocol_version="2025-06-18").label is None
+
+    def test_log_fields_omit_what_was_not_reported(self):
+        """
+        GIVEN an identity with only some fields present
+        WHEN it is rendered for logs
+        THEN absent fields are left out rather than logged as None
+        """
+        assert ClientIdentity(name="cursor").log_fields() == {"client_name": "cursor"}
+
+    def test_from_params_tolerates_missing_client_info(self):
+        """
+        GIVEN initialize params without clientInfo
+        WHEN identity is derived
+        THEN the protocol version is still captured
+        """
+        identity = ClientIdentity.from_params(None, "2025-06-18")
+
+        assert identity.label is None
+        assert identity.protocol_version == "2025-06-18"
+
+    def test_the_user_agent_label_and_log_fields_agree(self):
+        """
+        GIVEN one handshake
+        WHEN it is rendered for a User-Agent and for logs
+        THEN both describe the same client, from the same definition
+        """
+        identity = ClientIdentity.from_params(SimpleNamespace(name="cursor", version="1.4.2"), "2025-06-18")
+        fields = identity.log_fields()
+
+        assert identity.label == f"{fields['client_name']}/{fields['client_version']}"
+        assert fields["protocol_version"] == identity.protocol_version

--- a/tests/test_log_context.py
+++ b/tests/test_log_context.py
@@ -11,10 +11,12 @@ from gg_api_core.log_context import (
     _identity_cache,
     _identity_cache_key,
     clear_caller_identity_cache,
+    current_tool_name,
     derive_caller_identity,
     derive_client_identity,
     resolve_caller_identity,
     scopes_fingerprint,
+    track_current_tool,
 )
 
 # Shape of a real GET /api_tokens/self response, trimmed to the fields we read.
@@ -348,3 +350,57 @@ class TestClientIdentity:
 
         assert identity.label == f"{fields['client_name']}/{fields['client_version']}"
         assert fields["protocol_version"] == identity.protocol_version
+
+
+class TestCurrentTool:
+    def test_no_tool_outside_tracking(self):
+        """
+        GIVEN no tool call is being tracked
+        WHEN current_tool_name is read
+        THEN it returns None
+        """
+        assert current_tool_name() is None
+
+    def test_tool_name_visible_inside_tracking(self):
+        """
+        GIVEN a tracked tool call
+        WHEN current_tool_name is read inside the block
+        THEN it returns the tool name, and None again after the block
+        """
+        with track_current_tool("list_incidents"):
+            assert current_tool_name() == "list_incidents"
+        assert current_tool_name() is None
+
+    def test_tracking_restores_previous_tool_on_exit(self):
+        """
+        GIVEN nested tracked tool calls
+        WHEN the inner block exits
+        THEN the outer tool name is restored
+        """
+        with track_current_tool("outer_tool"):
+            with track_current_tool("inner_tool"):
+                assert current_tool_name() == "inner_tool"
+            assert current_tool_name() == "outer_tool"
+
+    @pytest.mark.parametrize(
+        "tool_name",
+        ["bad name", "tool\r\nX-Injected: 1", "a" * 65, "tool;drop", "", "aç"],
+        ids=["space", "crlf", "too-long", "semicolon", "empty", "non-ascii"],
+    )
+    def test_a_name_no_registered_tool_could_have_is_not_exposed(self, tool_name):
+        """
+        GIVEN a tools/call naming something no registered tool could be called
+        WHEN that call is tracked
+        THEN the name is not exposed, so no reader can put it on the wire
+        """
+        with track_current_tool(tool_name):
+            assert current_tool_name() is None
+
+    def test_a_registered_style_name_is_exposed(self):
+        """
+        GIVEN a plain identifier, the shape every registered tool has
+        WHEN that call is tracked
+        THEN the name is exposed to downstream readers
+        """
+        with track_current_tool("update_or_create_incident_custom_tags"):
+            assert current_tool_name() == "update_or_create_incident_custom_tags"

--- a/tests/test_log_context.py
+++ b/tests/test_log_context.py
@@ -2,6 +2,7 @@
 
 import time
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 from gg_api_core.log_context import (
@@ -11,11 +12,12 @@ from gg_api_core.log_context import (
     _identity_cache,
     _identity_cache_key,
     clear_caller_identity_cache,
+    current_client_identity,
     current_tool_name,
     derive_caller_identity,
-    derive_client_identity,
     resolve_caller_identity,
     scopes_fingerprint,
+    set_client_identity,
     track_current_tool,
 )
 
@@ -95,30 +97,58 @@ class TestDeriveCallerIdentity:
         assert identity == {"account_id": 8, "workspace_id": 8}
 
 
-class TestDeriveClientIdentity:
-    def test_maps_client_info_and_protocol_version(self):
-        """
-        GIVEN an initialize payload's clientInfo and protocol version
-        WHEN client identity is derived
-        THEN name, version and protocol revision are returned
-        """
-        from types import SimpleNamespace
+class TestCurrentClientIdentity:
+    """The identity is captured once at initialize, then read from the session."""
 
-        identity = derive_client_identity(SimpleNamespace(name="cursor", version="1.4.0"), "2025-06-18")
-
-        assert identity == {
-            "client_name": "cursor",
-            "client_version": "1.4.0",
-            "protocol_version": "2025-06-18",
-        }
-
-    def test_tolerates_a_missing_client_info(self):
+    @patch("gg_api_core.log_context.get_context")
+    def test_returns_the_identity_stored_at_initialize(self, mock_get_context):
         """
-        GIVEN an initialize payload with no clientInfo
-        WHEN client identity is derived
-        THEN an empty mapping is returned
+        GIVEN an identity stored on the session during initialize
+        WHEN current_client_identity is read
+        THEN the stored identity comes back without re-deriving
         """
-        assert derive_client_identity(None) == {}
+        session = SimpleNamespace()
+        identity = ClientIdentity(name="cursor", version="1.4.2", protocol_version="2025-06-18")
+        set_client_identity(identity, session)
+        mock_get_context.return_value = SimpleNamespace(session=session)
+
+        assert current_client_identity() == identity
+
+    @patch("gg_api_core.log_context.get_context")
+    def test_none_before_initialize(self, mock_get_context):
+        """
+        GIVEN no active MCP session (e.g. before initialization)
+        WHEN current_client_identity is read
+        THEN it returns None
+        """
+        mock_get_context.side_effect = RuntimeError("No active context found.")
+
+        assert current_client_identity() is None
+
+    @patch("gg_api_core.log_context.get_context")
+    def test_none_when_session_carries_no_stored_identity(self, mock_get_context):
+        """
+        GIVEN a session that has not been through our initialize hook
+        WHEN current_client_identity is read
+        THEN it returns None
+        """
+        mock_get_context.return_value = SimpleNamespace(session=SimpleNamespace())
+
+        assert current_client_identity() is None
+
+    @patch("gg_api_core.log_context.get_context")
+    def test_clears_when_stored_none(self, mock_get_context):
+        """
+        GIVEN a session whose stored identity is cleared to None
+        WHEN current_client_identity is read
+        THEN it returns None
+        """
+        session = SimpleNamespace()
+        set_client_identity(ClientIdentity(name="cursor"), session)
+        set_client_identity(None, session)
+        mock_get_context.return_value = SimpleNamespace(session=session)
+
+        assert current_client_identity() is None
 
 
 class TestResolveCallerIdentity:

--- a/tests/test_log_context.py
+++ b/tests/test_log_context.py
@@ -1,24 +1,17 @@
 """Derivation and caching of the identity fields bound to every log line."""
 
 import time
-from types import SimpleNamespace
-from unittest.mock import patch
 
 import pytest
 from gg_api_core.log_context import (
     _IDENTITY_CACHE_MAX_ENTRIES,
     _IDENTITY_TTL_SECONDS,
-    ClientIdentity,
     _identity_cache,
     _identity_cache_key,
     clear_caller_identity_cache,
-    current_client_identity,
-    current_tool_name,
     derive_caller_identity,
     resolve_caller_identity,
     scopes_fingerprint,
-    set_client_identity,
-    track_current_tool,
 )
 
 # Shape of a real GET /api_tokens/self response, trimmed to the fields we read.
@@ -95,60 +88,6 @@ class TestDeriveCallerIdentity:
         identity = derive_caller_identity({"workspace_id": 8})
 
         assert identity == {"account_id": 8, "workspace_id": 8}
-
-
-class TestCurrentClientIdentity:
-    """The identity is captured once at initialize, then read from the session."""
-
-    @patch("gg_api_core.log_context.get_context")
-    def test_returns_the_identity_stored_at_initialize(self, mock_get_context):
-        """
-        GIVEN an identity stored on the session during initialize
-        WHEN current_client_identity is read
-        THEN the stored identity comes back without re-deriving
-        """
-        session = SimpleNamespace()
-        identity = ClientIdentity(name="cursor", version="1.4.2", protocol_version="2025-06-18")
-        set_client_identity(identity, session)
-        mock_get_context.return_value = SimpleNamespace(session=session)
-
-        assert current_client_identity() == identity
-
-    @patch("gg_api_core.log_context.get_context")
-    def test_none_before_initialize(self, mock_get_context):
-        """
-        GIVEN no active MCP session (e.g. before initialization)
-        WHEN current_client_identity is read
-        THEN it returns None
-        """
-        mock_get_context.side_effect = RuntimeError("No active context found.")
-
-        assert current_client_identity() is None
-
-    @patch("gg_api_core.log_context.get_context")
-    def test_none_when_session_carries_no_stored_identity(self, mock_get_context):
-        """
-        GIVEN a session that has not been through our initialize hook
-        WHEN current_client_identity is read
-        THEN it returns None
-        """
-        mock_get_context.return_value = SimpleNamespace(session=SimpleNamespace())
-
-        assert current_client_identity() is None
-
-    @patch("gg_api_core.log_context.get_context")
-    def test_clears_when_stored_none(self, mock_get_context):
-        """
-        GIVEN a session whose stored identity is cleared to None
-        WHEN current_client_identity is read
-        THEN it returns None
-        """
-        session = SimpleNamespace()
-        set_client_identity(ClientIdentity(name="cursor"), session)
-        set_client_identity(None, session)
-        mock_get_context.return_value = SimpleNamespace(session=session)
-
-        assert current_client_identity() is None
 
 
 class TestResolveCallerIdentity:
@@ -323,114 +262,3 @@ class TestClearCallerIdentityCache:
         await resolve_caller_identity(fetcher("b"), token="tok-b")
 
         assert calls == {"a": 2, "b": 1}
-
-
-class TestClientIdentity:
-    def test_label_pairs_name_and_version(self):
-        """
-        GIVEN a handshake reporting both a name and a version
-        WHEN the identity is labelled
-        THEN the label is name/version
-        """
-        assert ClientIdentity(name="claude-code", version="2.0.14").label == "claude-code/2.0.14"
-
-    def test_label_is_the_bare_name_without_a_version(self):
-        """
-        GIVEN a handshake reporting a name but no version
-        WHEN the identity is labelled
-        THEN the label is the name alone
-        """
-        assert ClientIdentity(name="claude-code").label == "claude-code"
-
-    def test_label_is_none_without_a_name(self):
-        """
-        GIVEN a handshake that reported no client name
-        WHEN the identity is labelled
-        THEN there is no label to put in a User-Agent
-        """
-        assert ClientIdentity(protocol_version="2025-06-18").label is None
-
-    def test_log_fields_omit_what_was_not_reported(self):
-        """
-        GIVEN an identity with only some fields present
-        WHEN it is rendered for logs
-        THEN absent fields are left out rather than logged as None
-        """
-        assert ClientIdentity(name="cursor").log_fields() == {"client_name": "cursor"}
-
-    def test_from_params_tolerates_missing_client_info(self):
-        """
-        GIVEN initialize params without clientInfo
-        WHEN identity is derived
-        THEN the protocol version is still captured
-        """
-        identity = ClientIdentity.from_params(None, "2025-06-18")
-
-        assert identity.label is None
-        assert identity.protocol_version == "2025-06-18"
-
-    def test_the_user_agent_label_and_log_fields_agree(self):
-        """
-        GIVEN one handshake
-        WHEN it is rendered for a User-Agent and for logs
-        THEN both describe the same client, from the same definition
-        """
-        identity = ClientIdentity.from_params(SimpleNamespace(name="cursor", version="1.4.2"), "2025-06-18")
-        fields = identity.log_fields()
-
-        assert identity.label == f"{fields['client_name']}/{fields['client_version']}"
-        assert fields["protocol_version"] == identity.protocol_version
-
-
-class TestCurrentTool:
-    def test_no_tool_outside_tracking(self):
-        """
-        GIVEN no tool call is being tracked
-        WHEN current_tool_name is read
-        THEN it returns None
-        """
-        assert current_tool_name() is None
-
-    def test_tool_name_visible_inside_tracking(self):
-        """
-        GIVEN a tracked tool call
-        WHEN current_tool_name is read inside the block
-        THEN it returns the tool name, and None again after the block
-        """
-        with track_current_tool("list_incidents"):
-            assert current_tool_name() == "list_incidents"
-        assert current_tool_name() is None
-
-    def test_tracking_restores_previous_tool_on_exit(self):
-        """
-        GIVEN nested tracked tool calls
-        WHEN the inner block exits
-        THEN the outer tool name is restored
-        """
-        with track_current_tool("outer_tool"):
-            with track_current_tool("inner_tool"):
-                assert current_tool_name() == "inner_tool"
-            assert current_tool_name() == "outer_tool"
-
-    @pytest.mark.parametrize(
-        "tool_name",
-        ["bad name", "tool\r\nX-Injected: 1", "a" * 65, "tool;drop", "", "aç"],
-        ids=["space", "crlf", "too-long", "semicolon", "empty", "non-ascii"],
-    )
-    def test_a_name_no_registered_tool_could_have_is_not_exposed(self, tool_name):
-        """
-        GIVEN a tools/call naming something no registered tool could be called
-        WHEN that call is tracked
-        THEN the name is not exposed, so no reader can put it on the wire
-        """
-        with track_current_tool(tool_name):
-            assert current_tool_name() is None
-
-    def test_a_registered_style_name_is_exposed(self):
-        """
-        GIVEN a plain identifier, the shape every registered tool has
-        WHEN that call is tracked
-        THEN the name is exposed to downstream readers
-        """
-        with track_current_tool("update_or_create_incident_custom_tags"):
-            assert current_tool_name() == "update_or_create_incident_custom_tags"

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -28,9 +28,9 @@ def _ctx(name, arguments=None):
     return SimpleNamespace(message=SimpleNamespace(name=name, arguments=arguments))
 
 
-def _message_ctx(message=None, session_id=None, method="tools/list"):
+def _message_ctx(message=None, session_id=None, method="tools/list", session=None):
     """A middleware context shaped like the fields the middleware reads."""
-    fastmcp_context = SimpleNamespace(session_id=session_id) if session_id else None
+    fastmcp_context = SimpleNamespace(session_id=session_id, session=session) if (session_id or session) else None
     return SimpleNamespace(message=message, fastmcp_context=fastmcp_context, method=method)
 
 
@@ -346,19 +346,26 @@ class TestRequestLoggingContextMiddleware:
             clientInfo=SimpleNamespace(name="claude-ai", version="0.1.0"),
             protocolVersion="2025-06-18",
         )
+        session = SimpleNamespace()
 
         async def call_next(ctx):
             return None
 
         with caplog.at_level(logging.INFO, logger="gg_api_core.middleware"):
             await RequestLoggingContextMiddleware(FakeServer()).on_initialize(
-                _message_ctx(message=SimpleNamespace(params=params)), call_next
+                _message_ctx(message=SimpleNamespace(params=params), session=session), call_next
             )
 
         rec = next(r for r in caplog.records if r.getMessage() == "mcp_initialize")
         assert rec.client_name == "claude-ai"
         assert rec.client_version == "0.1.0"
         assert rec.protocol_version == "2025-06-18"
+        # The negotiated identity is kept on the session so downstream API calls
+        # read it without re-deriving the handshake.
+        stored = session._gg_client_identity
+        assert stored.name == "claude-ai"
+        assert stored.version == "0.1.0"
+        assert stored.protocol_version == "2025-06-18"
 
     async def test_every_middleware_log_carries_request_identity_through_the_real_stack(self, capsys):
         """

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -13,6 +13,7 @@ from gg_api_core.log_context import clear_caller_identity_cache, record_downstre
 from gg_api_core.logging_config import configure_logging
 from gg_api_core.mcp_server import get_mcp_server
 from gg_api_core.middleware import RequestLoggingContextMiddleware, ToolCallLoggingMiddleware
+from mcp.server.session import ServerSession
 from mcp.types import TextContent
 
 TOKEN_INFO = {
@@ -32,6 +33,13 @@ def _message_ctx(message=None, session_id=None, method="tools/list", session=Non
     """A middleware context shaped like the fields the middleware reads."""
     fastmcp_context = SimpleNamespace(session_id=session_id, session=session) if (session_id or session) else None
     return SimpleNamespace(message=message, fastmcp_context=fastmcp_context, method=method)
+
+
+class _FakeSession(ServerSession):
+    """Weakref-able stand-in for a ServerSession (SimpleNamespace is not weakref-able)."""
+
+    def __init__(self):
+        pass
 
 
 class FakeServer:
@@ -346,7 +354,7 @@ class TestRequestLoggingContextMiddleware:
             clientInfo=SimpleNamespace(name="claude-ai", version="0.1.0"),
             protocolVersion="2025-06-18",
         )
-        session = SimpleNamespace()
+        session = _FakeSession()
 
         async def call_next(ctx):
             return None
@@ -362,7 +370,9 @@ class TestRequestLoggingContextMiddleware:
         assert rec.protocol_version == "2025-06-18"
         # The negotiated identity is kept on the session so downstream API calls
         # read it without re-deriving the handshake.
-        stored = session._gg_client_identity
+        from gg_api_core import client_identity as ci
+        stored = ci._identity_by_session.get(session)
+        assert stored is not None
         assert stored.name == "claude-ai"
         assert stored.version == "0.1.0"
         assert stored.protocol_version == "2025-06-18"

--- a/tests/test_tool_logging_middleware.py
+++ b/tests/test_tool_logging_middleware.py
@@ -2,7 +2,7 @@ import logging
 from types import SimpleNamespace
 
 import pytest
-from gg_api_core.log_context import current_tool_name
+from gg_api_core.tool_context import current_tool_name
 from gg_api_core.middleware import ToolCallLoggingMiddleware
 
 

--- a/tests/test_tool_logging_middleware.py
+++ b/tests/test_tool_logging_middleware.py
@@ -2,6 +2,7 @@ import logging
 from types import SimpleNamespace
 
 import pytest
+from gg_api_core.log_context import current_tool_name
 from gg_api_core.middleware import ToolCallLoggingMiddleware
 
 
@@ -36,3 +37,35 @@ class TestToolCallLoggingMiddleware:
         rec = next(r for r in caplog.records if r.getMessage() == "tool_call_failed")
         assert rec.tool == "scan_secrets"
         assert rec.exc_info is not None
+
+    async def test_exposes_tool_name_to_downstream_calls(self):
+        """
+        GIVEN a tool call passing through the middleware
+        WHEN the tool body runs
+        THEN current_tool_name() returns the tool name inside the call and None after it
+        """
+        seen: dict[str, str | None] = {}
+
+        async def call_next(ctx):
+            seen["tool"] = current_tool_name()
+            return "result"
+
+        await ToolCallLoggingMiddleware().on_call_tool(_ctx("list_incidents"), call_next)
+
+        assert seen["tool"] == "list_incidents"
+        assert current_tool_name() is None
+
+    async def test_clears_tool_name_when_tool_raises(self):
+        """
+        GIVEN a tool call that raises
+        WHEN the middleware re-raises
+        THEN the tracked tool name is cleared
+        """
+
+        async def call_next(ctx):
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError, match="boom"):
+            await ToolCallLoggingMiddleware().on_call_tool(_ctx("scan_secrets"), call_next)
+
+        assert current_tool_name() is None


### PR DESCRIPTION
## Problem

Every outgoing GitGuardian API call currently identifies identically. On stdio there's no incoming HTTP request to forward a caller UA from, so all local installs collapse into one anonymous bucket:

```
Before (all clients, every tool):
User-Agent: GitGuardian-MCP-Server/0.7.0 (transport=stdio)

HTTP transport only. stdio never gets this far:
User-Agent: GitGuardian-MCP-Server/0.7.0 (transport=http; client=cursor/1.4.2)
```

The API can't tell Claude Code from Cursor, can't see which MCP protocol clients negotiate, and can't see which tool triggered each call.

## Change

The MCP `initialize` handshake already carries the client's identity on every transport. We use it to enrich outgoing headers:

```
Before:                                  After:
User-Agent: GitGuardian-MCP-Server/0.7.0   User-Agent: GitGuardian-MCP-Server/0.7.0
            (transport=stdio)                          (transport=stdio; client=claude-code/2.0.14; mcp=2025-06-18)
                                           X-GG-MCP-Tool: list_incidents
```

Three new pieces of info:

| Field | Source | When it's visible |
|---|---|---|
| `client=name/version` | handshake `clientInfo` | immediately on deploy - the server request log already records UA |
| `mcp=protocolRevision` | handshake `protocolVersion` | immediately on deploy |
| `X-GG-MCP-Tool` | executing tool, from `ToolCallLoggingMiddleware` | once the receiving service starts logging it |

The `GitGuardian-MCP-Server/<version>` prefix is unchanged, so existing monitoring filters keep matching. `client=` gets its own fast path on HTTP: handshake `clientInfo` preferred, raw HTTP UA as fallback.

`X-GG-MCP-Tool` is a separate header (not another UA field) because it changes per request while the UA is stable per session. It's deliberately **absent** on internal scope-check requests (those run outside any tool call) - so once it's logged, its mere presence separates real user work from server startup. Don't attach it globally.

## Hardening

The handshake values and tool name are client-controlled, so:

- Values stripped to printable ASCII, `();=,` removed (a client reporting `foo, mcp=2099` can't forge a second field), capped at 64 chars.
- Tool name validated once in `track_current_tool`; downstream reads only ever see header-safe values.
- Identity has one definition: `ClientIdentity` in `log_context` renders both the log fields and the `<name>/<version>` UA label.
- Client takes a per-request User-Agent **callable**, so the long-lived singleton always reflects the live handshake, not the first call that created it.
- The two old duplicate header dicts consolidated into `_base_headers()`.

## Tests

Covers handshake fields present, handshake over HTTP UA preference, sanitization, forged-field rejection, length cap, tool header present/absent, and orphaned-tool-name drop.

Internal ref: SI-4045
