### PR TITLE
feat(distribution): publish to PyPI and MCP Registry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,15 @@
 # GitGuardian MCP Server Environment Variables
 
+# Authentication mode: oauth-proxy | header | env-pat | local-oauth.
+# The mode is the single source of truth for transport and tenancy:
+#   oauth-proxy  HTTP, multi-tenant (requires MCP_PORT; forbids a server-side PAT)
+#   header       HTTP, multi-tenant (requires MCP_PORT; forbids a server-side PAT)
+#   env-pat      stdio, single-tenant (requires GITGUARDIAN_PERSONAL_ACCESS_TOKEN)
+#   local-oauth  stdio, single-tenant (interactive browser flow)
+# When unset, the mode is inferred from the legacy selectors below for one
+# release cycle (deprecated).
+# MCP_AUTH_MODE=env-pat
+
 # OAuth Authentication
 GITGUARDIAN_CLIENT_ID=your_oauth_client_id_here
 # Optional: Comma-separated list of scopes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,28 @@ jobs:
           ENABLE_LOCAL_OAUTH: "false"
         run: make test-vcr
 
+  package-build:
+    runs-on: ubuntu-latest
+    name: Build and Smoke Test PyPI Package
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      # Install the wheel outside the source tree so editable project files
+      # cannot hide missing files or undeclared dependencies.
+      - name: Build and smoke-test distribution
+        run: make test-distribution
+
   docker-build:
     runs-on: ubuntu-latest
     name: Build Docker Image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,62 +13,101 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  MCP_PUBLISHER_VERSION: "1.8.1"
+  MCP_PUBLISHER_LINUX_AMD64_SHA256: "a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc"
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    name: Release Please
+    name: Release Please and Resolve Context
     # Maintains a rolling "chore(main): release X.Y.Z" PR from conventional commits
     # (version bumps in pyproject.toml + server.json + uv.lock, plus CHANGELOG.md;
     # see release-please-config.json). Merging it creates the vX.Y.Z tag and a draft
-    # release, and outputs the tag for the docker build below; the draft is published
-    # only after that build succeeds. Manual dispatch from main refreshes the PR.
-    if: |
-      github.ref == 'refs/heads/main' &&
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    # release. This job also resolves human-pushed escape-hatch tags so every
+    # distribution job consumes one validated release context.
     permissions:
       contents: write # create the release PR branch, the tag, and the release
       issues: write # apply release lifecycle labels (GitHub auto-creates missing ones)
       pull-requests: write # open/update the release PR
+    # Release invariant, computed once here as a single flag: nothing publishes
+    # unless there is a valid, uninterruptible release tag. Every distribution
+    # job below reads `publishable` rather than re-deriving is-release and
+    # rebuild-blocked itself, so the policy lives in one place. (build-and-push-docker
+    # keeps using rebuild-blocked directly because it also refreshes non-release
+    # `main`/branch images.)
     outputs:
-      tag: ${{ steps.release-tag.outputs.tag }}
+      generate-release-notes: ${{ steps.release-tag.outputs.generate-release-notes }}
+      publishable: ${{ steps.release-tag.outputs.publishable }}
       rebuild-blocked: ${{ steps.release-tag.outputs.rebuild-blocked }}
+      tag: ${{ steps.release-tag.outputs.tag }}
 
     steps:
       - name: Run release-please
+        if: |
+          github.ref == 'refs/heads/main' &&
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: googleapis/release-please-action@v4
 
       - name: Checkout release commit
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0 # all tags, for the lookups below
+          fetch-depth: 0 # all tags, for release policy checks below
 
-      # The version tag at this commit, empty on ordinary merges. Read from git
-      # rather than the action's outputs so that a rerun finds the tag its first
-      # attempt created (force-tag-creation makes it, since drafts do not).
-      - name: Resolve release tag
+      # Resolve the tag from either entry point. Git lookup makes reruns recover
+      # tags created by a previous release-please attempt, since GITHUB_TOKEN tags
+      # do not trigger a second workflow.
+      - name: Resolve release context
         id: release-tag
         run: |
+          set -euo pipefail
           semver_tags() { git tag --list 'v*.*.*' "$@" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true; }
 
-          mapfile -t tags < <(semver_tags --points-at "$GITHUB_SHA")
-          if [ "${#tags[@]}" -gt 1 ]; then
-            echo "::error::Multiple version tags point at $GITHUB_SHA: ${tags[*]}"
+          tag=""
+          generate_release_notes="false"
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF_TYPE" == "tag" ]]; then
+            tag="$GITHUB_REF_NAME"
+            generate_release_notes="true"
+          elif [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
+            mapfile -t tags < <(semver_tags --points-at "$GITHUB_SHA")
+            if [[ "${#tags[@]}" -gt 1 ]]; then
+              echo "::error::Multiple version tags point at $GITHUB_SHA: ${tags[*]}"
+              exit 1
+            fi
+            tag="${tags[0]:-}"
+          fi
+
+          if [[ -n "$tag" && ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid release tag: $tag"
             exit 1
           fi
-          tag="${tags[0]:-}"
 
-          # Only the newest release may be rebuilt: an older one would steal the
-          # mutable latest/X.Y tags and rewind `main` onto an old commit. Signalled
-          # as an output rather than an exit code, so that a broken release-please
-          # still refreshes `main`. nightly_docker_rebuild.yml's `gh release view`
-          # lookup skips drafts, so it is not usable here.
+          # Every release entry point shares this policy. Rebuilding an older
+          # version would steal mutable latest/X.Y Docker tags.
+          rebuild_blocked="false"
           newest=$(semver_tags | sort -V | tail -1)
-          if [ -n "$tag" ] && [ "$tag" != "$newest" ]; then
+          if [[ -n "$tag" && "$tag" != "$newest" ]]; then
             echo "::warning::Refusing to rebuild $tag: newer release $newest exists"
-            echo "rebuild-blocked=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            rebuild_blocked="true"
           fi
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+          is_release="false"
+          if [[ -n "$tag" ]]; then
+            is_release="true"
+          fi
+
+          # Single publishability flag: a valid tag that is not being superseded.
+          publishable="false"
+          if [[ "$is_release" == "true" && "$rebuild_blocked" != "true" ]]; then
+            publishable="true"
+          fi
+
+          {
+            echo "generate-release-notes=$generate_release_notes"
+            echo "publishable=$publishable"
+            echo "rebuild-blocked=$rebuild_blocked"
+            echo "tag=$tag"
+          } >> "$GITHUB_OUTPUT"
 
   build-and-push-docker:
     name: Build and Push Docker Image
@@ -93,29 +132,36 @@ jobs:
     uses: ./.github/workflows/build_docker.yml
     with:
       # Empty outside releases: build_docker.yml then falls back to `main` / branch-<branch>-<sha> tags.
-      ref: ${{ github.ref_type == 'tag' && github.ref_name || needs.release-please.outputs.tag }}
-      release-tag: ${{ github.ref_type == 'tag' && github.ref_name || needs.release-please.outputs.tag }}
+      ref: ${{ needs.release-please.outputs.tag }}
+      release-tag: ${{ needs.release-please.outputs.tag }}
       is-main: ${{ github.ref == 'refs/heads/main' }}
     secrets: inherit
 
   publish-to-pypi:
     runs-on: ubuntu-latest
     name: Publish to PyPI
-    if: false && github.event_name == 'push' && github.ref_type == 'tag'
-    timeout-minutes: 10
+    needs: [ release-please ]
+    # GITHUB_TOKEN-created tags do not trigger a second workflow, so the resolver
+    # also exposes tags created by release-please in this run.
+    if: |
+      always() &&
+      needs.release-please.outputs.publishable == 'true'
+    timeout-minutes: 15
     permissions:
-      id-token: write
+      id-token: write # PyPI trusted publishing
       contents: read
     environment:
       name: pypi
-      url: https://test.pypi.org/project/ggmcp/
+      url: https://pypi.org/project/gg-mcp-server/
     concurrency:
-      group: publish-pypi-${{ github.ref_name }}
+      group: publish-pypi-${{ needs.release-please.outputs.tag }}
       cancel-in-progress: false
 
     steps:
-      - name: Checkout code
+      - name: Checkout release tag
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.tag }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -127,111 +173,146 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Build package
+      - name: Verify release versions
+        env:
+          RELEASE_TAG: ${{ needs.release-please.outputs.tag }}
         run: |
-          echo "Building ggmcp package..."
-          uv build
-          echo "Build artifacts:"
-          ls -lh dist/
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          package_version=$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
+          registry_version=$(jq -r '.version' server.json)
+          registry_package_version=$(jq -r '.packages[0].version' server.json)
+          test "$package_version" = "$version"
+          test "$registry_version" = "$version"
+          test "$registry_package_version" = "$version"
+
+      - name: Build and smoke-test distribution
+        run: make test-distribution
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: https://test.pypi.org/legacy/
           packages-dir: dist/
           print-hash: true
+          skip-existing: true
 
       - name: Create summary
         run: |
-          echo "## ✅ PyPI Publication Successful" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Package published to: https://test.pypi.org/project/ggmcp/" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Install with:" >> $GITHUB_STEP_SUMMARY
-          echo '```bash' >> $GITHUB_STEP_SUMMARY
-          echo "pip install --index-url https://test.pypi.org/simple/ ggmcp" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## ✅ PyPI Publication Successful"
+            echo ""
+            echo "Package: https://pypi.org/project/gg-mcp-server/"
+            echo ""
+            echo "Run with \`uvx gg-mcp-server@latest\`."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   publish-to-mcp-registry:
     runs-on: ubuntu-latest
     name: Publish to MCP Registry
-    needs: [ publish-to-pypi ]
+    needs: [ release-please, publish-to-pypi ]
     if: |
-      false &&
       always() &&
-      github.event_name == 'push' &&
-      github.ref_type == 'tag' &&
-      (needs.publish-to-pypi.result == 'success' || needs.publish-to-pypi.result == 'skipped')
-    timeout-minutes: 10
+      needs.release-please.outputs.publishable == 'true' &&
+      needs.publish-to-pypi.result == 'success'
+    timeout-minutes: 15
     permissions:
+      id-token: write # MCP Registry GitHub OIDC authentication
       contents: read
 
     steps:
-      - name: Checkout code
+      - name: Checkout release tag
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.tag }}
 
-      - name: Verify server.json
+      - name: Wait for package availability on PyPI
+        env:
+          RELEASE_TAG: ${{ needs.release-please.outputs.tag }}
         run: |
-          echo "Validating server.json..."
-          if [ ! -f "server.json" ]; then
-            echo "❌ Error: server.json not found"
-            exit 1
-          fi
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          for attempt in {1..12}; do
+            if curl --fail --silent --show-error \
+              "https://pypi.org/pypi/gg-mcp-server/$version/json" > /dev/null; then
+              exit 0
+            fi
+            echo "Waiting for gg-mcp-server $version to become available on PyPI ($attempt/12)"
+            sleep 10
+          done
+          echo "gg-mcp-server $version was not available on PyPI after two minutes" >&2
+          exit 1
 
-          if ! python3 -m json.tool server.json > /dev/null; then
-            echo "❌ Error: server.json is not valid JSON"
-            exit 1
-          fi
+      - name: Validate server.json
+        run: |
+          python3 -m json.tool server.json > /dev/null
+          test "$(jq -r '.packages[0].identifier' server.json)" = "gg-mcp-server"
+          grep -F '<!-- mcp-name: io.github.gitguardian/ggmcp -->' README.md
 
-          echo "✅ server.json is valid"
+      - name: Check for an existing registry version
+        id: registry-version
+        env:
+          RELEASE_TAG: ${{ needs.release-please.outputs.tag }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          registry_url="https://registry.modelcontextprotocol.io/v0/servers/io.github.gitguardian%2Fggmcp/versions/$version"
+          status=$(curl --path-as-is --silent --show-error --output /dev/null --write-out '%{http_code}' "$registry_url")
+
+          case "$status" in
+            200)
+              echo "Version $version is already in the MCP Registry; skipping the immutable publish"
+              echo "exists=true" >> "$GITHUB_OUTPUT"
+              ;;
+            404)
+              echo "exists=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unexpected MCP Registry response for $version: HTTP $status" >&2
+              exit 1
+              ;;
+          esac
 
       - name: Install mcp-publisher
+        if: steps.registry-version.outputs.exists != 'true'
         run: |
-          echo "Installing mcp-publisher..."
-          PUBLISHER_VERSION=$(curl -sL https://api.github.com/repos/modelcontextprotocol/mcp-publisher/releases/latest | jq -r '.tag_name' | sed 's/^v//')
-
-          if [ -z "$PUBLISHER_VERSION" ] || [ "$PUBLISHER_VERSION" = "null" ]; then
-            echo "❌ Error: Failed to fetch latest mcp-publisher version"
-            exit 1
-          fi
-
-          DOWNLOAD_URL="https://github.com/modelcontextprotocol/mcp-publisher/releases/download/v${PUBLISHER_VERSION}/mcp-publisher-linux-amd64"
-          if ! wget -q "$DOWNLOAD_URL" -O mcp-publisher; then
-            echo "❌ Error: Failed to download mcp-publisher"
-            exit 1
-          fi
-
-          chmod +x mcp-publisher
+          set -euo pipefail
+          archive="mcp-publisher_linux_amd64.tar.gz"
+          curl --fail --location --silent --show-error \
+            "https://github.com/modelcontextprotocol/registry/releases/download/v${MCP_PUBLISHER_VERSION}/${archive}" \
+            --output "$archive"
+          echo "${MCP_PUBLISHER_LINUX_AMD64_SHA256}  ${archive}" | sha256sum --check --strict
+          tar xzf "$archive" mcp-publisher
           ./mcp-publisher --version
-          echo "✅ Successfully installed mcp-publisher v${PUBLISHER_VERSION}"
+
+      - name: Authenticate to MCP Registry
+        if: steps.registry-version.outputs.exists != 'true'
+        run: ./mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Publishing to MCP Registry..."
-          ./mcp-publisher publish --non-interactive
-          echo "✅ Successfully published to MCP Registry"
+        if: steps.registry-version.outputs.exists != 'true'
+        run: ./mcp-publisher publish
 
       - name: Create summary
         run: |
-          echo "## ✅ MCP Registry Publication Successful" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Server registered in: https://github.com/modelcontextprotocol/registry" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## ✅ MCP Registry Publication Successful"
+            echo ""
+            echo "Server: io.github.gitguardian/ggmcp"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   create-github-release:
     runs-on: ubuntu-latest
     name: Publish GitHub Release
-    needs: [ release-please, build-and-push-docker ]
-    # Publish release-please's draft only once the image exists. On the escape-hatch
-    # path, create the release for the human-pushed tag after the same build.
+    needs: [ release-please, build-and-push-docker, publish-to-pypi, publish-to-mcp-registry ]
+    # Publish release-please's draft only once every distribution channel is
+    # available. On the escape-hatch path, create the release for the
+    # human-pushed tag after the same checks.
     if: |
       always() &&
-      (
-        (github.event_name == 'push' && github.ref_type == 'tag') ||
-        needs.release-please.outputs.tag != ''
-      ) &&
-      needs.build-and-push-docker.result == 'success'
+      needs.release-please.outputs.publishable == 'true' &&
+      needs.build-and-push-docker.result == 'success' &&
+      needs.publish-to-pypi.result == 'success' &&
+      needs.publish-to-mcp-registry.result == 'success'
     permissions:
       contents: write
 
@@ -240,9 +321,9 @@ jobs:
       - name: Publish Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_type == 'tag' && github.ref_name || needs.release-please.outputs.tag }}
+          tag_name: ${{ needs.release-please.outputs.tag }}
           draft: false
           # Keep release-please's changelog notes; generate them only for the
           # manual tag escape hatch.
-          generate_release_notes: ${{ github.ref_type == 'tag' }}
+          generate_release_notes: ${{ needs.release-please.outputs.generate-release-notes }}
           make_latest: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,7 @@ jobs:
       contents: read
     environment:
       name: pypi
-      url: https://pypi.org/project/gg-mcp-server/
+      url: https://pypi.org/project/ggmcp/
     concurrency:
       group: publish-pypi-${{ needs.release-please.outputs.tag }}
       cancel-in-progress: false
@@ -201,9 +201,9 @@ jobs:
           {
             echo "## ✅ PyPI Publication Successful"
             echo ""
-            echo "Package: https://pypi.org/project/gg-mcp-server/"
+            echo "Package: https://pypi.org/project/ggmcp/"
             echo ""
-            echo "Run with \`uvx gg-mcp-server@latest\`."
+            echo "Run with \`uvx ggmcp@latest\`."
           } >> "$GITHUB_STEP_SUMMARY"
 
   publish-to-mcp-registry:
@@ -233,19 +233,19 @@ jobs:
           version="${RELEASE_TAG#v}"
           for attempt in {1..12}; do
             if curl --fail --silent --show-error \
-              "https://pypi.org/pypi/gg-mcp-server/$version/json" > /dev/null; then
+              "https://pypi.org/pypi/ggmcp/$version/json" > /dev/null; then
               exit 0
             fi
-            echo "Waiting for gg-mcp-server $version to become available on PyPI ($attempt/12)"
+            echo "Waiting for ggmcp $version to become available on PyPI ($attempt/12)"
             sleep 10
           done
-          echo "gg-mcp-server $version was not available on PyPI after two minutes" >&2
+          echo "ggmcp $version was not available on PyPI after two minutes" >&2
           exit 1
 
       - name: Validate server.json
         run: |
           python3 -m json.tool server.json > /dev/null
-          test "$(jq -r '.packages[0].identifier' server.json)" = "gg-mcp-server"
+          test "$(jq -r '.packages[0].identifier' server.json)" = "ggmcp"
           grep -F '<!-- mcp-name: io.github.gitguardian/ggmcp -->' README.md
 
       - name: Check for an existing registry version

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-.PHONY: test test-vcr test-unit test-with-env test-vcr-with-env update-cassettes lint format typecheck
+.PHONY: test test-distribution test-vcr test-unit test-with-env test-vcr-with-env update-cassettes lint format typecheck
 
 # =============================================================================
 # CI commands (no .env sourcing)
@@ -26,6 +26,10 @@ test-vcr:
 # Run unit tests (tests NOT marked with @pytest.mark.vcr_test)
 test-unit:
 	ENABLE_LOCAL_OAUTH=false uv run pytest -m "not vcr_test"
+
+# Build the public artifacts, install the wheel in isolation, and initialize MCP.
+test-distribution:
+	./scripts/test_distribution.sh
 
 # =============================================================================
 # Local dev commands (sources .env for API key)

--- a/README.md
+++ b/README.md
@@ -155,18 +155,16 @@ env vars.
 ## Local stdio mode (PAT-only)
 
 For CI/CD, airgapped environments, or older MCP clients, run the server
-locally over stdio with a PAT:
+locally over stdio with a PAT. You must explicitly set `ENABLE_LOCAL_OAUTH`
+to `false`; without it the server defaults to the (deprecated) browser-OAuth
+stdio flow rather than the PAT mode shown below:
 
 ```json
 {
   "mcpServers": {
     "GitGuardian": {
       "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/GitGuardian/ggmcp.git",
-        "ggmcp"
-      ],
+      "args": ["ggmcp@latest"],
       "env": {
         "ENABLE_LOCAL_OAUTH": "false",
         "GITGUARDIAN_PERSONAL_ACCESS_TOKEN": "your_pat_here",
@@ -179,6 +177,9 @@ locally over stdio with a PAT:
 
 Create a PAT in your GitGuardian dashboard under **API → Personal Access
 Tokens**. The set of tools the server exposes depends on the PAT's scopes.
+`@latest` checks for a newly published release when the client starts. For a
+reproducible installation, replace `latest` with an exact release number from
+the [`ggmcp` PyPI page](https://pypi.org/project/ggmcp/).
 
 
 For Claude Desktop on macOS, the `command` field needs the **absolute path**

--- a/scripts/smoke_test_wheel.py
+++ b/scripts/smoke_test_wheel.py
@@ -1,4 +1,4 @@
-"""Smoke-test an installed ``gg-mcp-server`` console script over MCP stdio."""
+"""Smoke-test an installed ``ggmcp`` console script over MCP stdio."""
 
 import argparse
 import asyncio
@@ -28,7 +28,7 @@ async def smoke_test_server(command: Path) -> None:
 def main() -> None:
     """Parse the installed executable path and run the smoke test."""
     parser = argparse.ArgumentParser()
-    parser.add_argument("command", type=Path, help="Path to the installed gg-mcp-server executable")
+    parser.add_argument("command", type=Path, help="Path to the installed ggmcp executable")
     arguments = parser.parse_args()
 
     asyncio.run(smoke_test_server(arguments.command))

--- a/scripts/smoke_test_wheel.py
+++ b/scripts/smoke_test_wheel.py
@@ -1,0 +1,38 @@
+"""Smoke-test an installed ``gg-mcp-server`` console script over MCP stdio."""
+
+import argparse
+import asyncio
+import os
+from pathlib import Path
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+async def smoke_test_server(command: Path) -> None:
+    """Initialize an installed server and verify its MCP identity."""
+    environment = {**os.environ, "ENABLE_LOCAL_OAUTH": "false"}
+    environment.pop("GITGUARDIAN_PERSONAL_ACCESS_TOKEN", None)
+
+    server_parameters = StdioServerParameters(command=str(command), env=environment)
+
+    async with asyncio.timeout(30):
+        async with stdio_client(server_parameters) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                initialization = await session.initialize()
+
+    if initialization.serverInfo.name != "GitGuardian":
+        raise RuntimeError(f"Unexpected MCP server name: {initialization.serverInfo.name}")
+
+
+def main() -> None:
+    """Parse the installed executable path and run the smoke test."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", type=Path, help="Path to the installed gg-mcp-server executable")
+    arguments = parser.parse_args()
+
+    asyncio.run(smoke_test_server(arguments.command))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_distribution.sh
+++ b/scripts/test_distribution.sh
@@ -23,4 +23,4 @@ uv pip install --python "$smoke_root/venv/bin/python" "${wheels[0]}"
 cd "$smoke_root"
 "$smoke_root/venv/bin/python" \
     "$repo_root/scripts/smoke_test_wheel.py" \
-    "$smoke_root/venv/bin/gg-mcp-server"
+    "$smoke_root/venv/bin/ggmcp"

--- a/scripts/test_distribution.sh
+++ b/scripts/test_distribution.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Exercise the exact artifact users receive, without imports from the source tree.
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+smoke_root=$(mktemp -d)
+trap 'rm -rf "$smoke_root"' EXIT
+
+rm -rf "$repo_root/dist"
+uv build --project "$repo_root" --out-dir "$repo_root/dist"
+
+shopt -s nullglob
+wheels=("$repo_root"/dist/*.whl)
+if [[ ${#wheels[@]} -ne 1 ]]; then
+    echo "Expected exactly one wheel in dist, found ${#wheels[@]}" >&2
+    exit 1
+fi
+
+uv venv --python 3.13 "$smoke_root/venv"
+uv pip install --python "$smoke_root/venv/bin/python" "${wheels[0]}"
+
+cd "$smoke_root"
+"$smoke_root/venv/bin/python" \
+    "$repo_root/scripts/smoke_test_wheel.py" \
+    "$smoke_root/venv/bin/gg-mcp-server"

--- a/server.json
+++ b/server.json
@@ -18,39 +18,26 @@
       },
       "environmentVariables": [
         {
+          "name": "ENABLE_LOCAL_OAUTH",
+          "description": "Deprecated browser-OAuth stdio flow, on by default. Set false and provide GITGUARDIAN_PERSONAL_ACCESS_TOKEN to run in the supported local PAT mode",
+          "format": "string",
+          "isRequired": false,
+          "isSecret": false,
+          "value": "true"
+        },
+        {
+          "name": "GITGUARDIAN_PERSONAL_ACCESS_TOKEN",
+          "description": "GitGuardian personal access token for the local PAT mode (used when ENABLE_LOCAL_OAUTH=false)",
+          "format": "string",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
+          "name": "GITGUARDIAN_URL",
           "description": "GitGuardian instance URL (defaults to https://dashboard.gitguardian.com for US SaaS)",
-          "isRequired": false,
           "format": "string",
-          "isSecret": false,
-          "name": "GITGUARDIAN_URL"
-        },
-        {
-          "description": "OAuth client ID for custom OAuth applications",
           "isRequired": false,
-          "format": "string",
-          "isSecret": false,
-          "name": "GITGUARDIAN_CLIENT_ID"
-        },
-        {
-          "description": "OAuth scopes to request (auto-detected by default)",
-          "isRequired": false,
-          "format": "string",
-          "isSecret": false,
-          "name": "GITGUARDIAN_SCOPES"
-        },
-        {
-          "description": "Name for the OAuth token",
-          "isRequired": false,
-          "format": "string",
-          "isSecret": false,
-          "name": "GITGUARDIAN_TOKEN_NAME"
-        },
-        {
-          "description": "Token lifetime in days (default: 30)",
-          "isRequired": false,
-          "format": "string",
-          "isSecret": false,
-          "name": "GITGUARDIAN_TOKEN_LIFETIME"
+          "isSecret": false
         }
       ]
     }

--- a/src/gg_api_core/client.py
+++ b/src/gg_api_core/client.py
@@ -13,7 +13,7 @@ import httpx
 from pydantic import TypeAdapter, ValidationError
 
 from gg_api_core.log_context import record_downstream_call, record_downstream_wait, record_truncation
-from gg_api_core.settings import get_settings
+from gg_api_core.settings import AuthMode, get_settings
 from gg_api_core.version import APP_VERSION
 
 # Setup logger
@@ -291,7 +291,7 @@ async def acquire_single_tenant_token(
     Token sources (in order of precedence):
     1. GITGUARDIAN_PERSONAL_ACCESS_TOKEN env var
     2. Stored OAuth token from previous authentication flow
-    3. Interactive OAuth flow (if ENABLE_LOCAL_OAUTH=true)
+    3. Interactive OAuth flow (in local-oauth mode)
 
     Args:
         dashboard_url: Optional dashboard URL. If not provided, derived from env.
@@ -318,8 +318,8 @@ async def acquire_single_tenant_token(
         logger.info("Using stored OAuth token from previous authentication")
         return stored_token
 
-    # 3. Trigger OAuth flow if enabled
-    if get_settings().is_oauth_enabled:
+    # 3. Trigger OAuth flow in local-oauth mode
+    if get_settings().auth_mode is AuthMode.LOCAL_OAUTH:
         logger.info("No stored token, triggering OAuth flow")
         return await _run_oauth_flow(dashboard_url, public_api_url)
 
@@ -327,8 +327,8 @@ async def acquire_single_tenant_token(
     raise RuntimeError(
         "No API token available. Options: "
         "(1) Set GITGUARDIAN_PERSONAL_ACCESS_TOKEN env var, "
-        "(2) Set ENABLE_LOCAL_OAUTH=true to trigger interactive OAuth flow, "
-        "(3) For HTTP deployments, set MULTI_TENANCY_ENABLED=true and MCP_PORT."
+        "(2) Set MCP_AUTH_MODE=local-oauth to trigger interactive OAuth flow, "
+        "(3) For HTTP deployments, set MCP_AUTH_MODE=oauth-proxy or MCP_AUTH_MODE=header."
     )
 
 

--- a/src/gg_api_core/mcp_server.py
+++ b/src/gg_api_core/mcp_server.py
@@ -25,7 +25,7 @@ from gg_api_core.oauth_proxy_auth import (
     PassThroughTokenVerifier,
     create_oauth_proxy,
 )
-from gg_api_core.settings import get_settings
+from gg_api_core.settings import AuthMode, get_settings
 from gg_api_core.utils import get_client
 
 # Configure logger
@@ -361,12 +361,12 @@ def get_mcp_server(*args: Any, **kwargs: Any) -> AbstractGitGuardianFastMCP:
     kwargs.setdefault("icons", get_gitguardian_icons())
 
     settings = get_settings()
+    settings.validate_auth_mode()
+    mode = settings.auth_mode
 
-    if settings.is_oauth_proxy_enabled:
-        logger.info(
-            "Starting GitGuardian MCP server in %s mode",
-            GitGuardianOAuthProxyMCP.authentication_mode.value,
-        )
+    _log_startup(settings, mode)
+
+    if mode is AuthMode.OAUTH_PROXY:
         oauth_proxy = create_oauth_proxy(
             base_url=settings.mcp_base_url,
             gg_url=settings.gitguardian_url,
@@ -375,22 +375,31 @@ def get_mcp_server(*args: Any, **kwargs: Any) -> AbstractGitGuardianFastMCP:
         )
         return GitGuardianOAuthProxyMCP(*args, auth=oauth_proxy, **kwargs)
 
-    if settings.is_oauth_enabled:
-        logger.info(
-            "Starting GitGuardian MCP server in %s mode",
-            GitGuardianLocalOAuthMCP.authentication_mode.value,
-        )
+    if mode is AuthMode.LOCAL_OAUTH:
         return GitGuardianLocalOAuthMCP(*args, **kwargs)
 
-    if personal_access_token := settings.gitguardian_personal_access_token:
-        logger.info(
-            "Starting GitGuardian MCP server in %s mode",
-            GitGuardianPATEnvMCP.authentication_mode.value,
+    if mode is AuthMode.ENV_PAT:
+        return GitGuardianPATEnvMCP(
+            *args,
+            personal_access_token=settings.gitguardian_personal_access_token,
+            **kwargs,
         )
-        return GitGuardianPATEnvMCP(*args, personal_access_token=personal_access_token, **kwargs)
 
-    logger.info(
-        "Starting GitGuardian MCP server in %s mode",
-        GitGuardianAuthorizationHeaderMCP.authentication_mode.value,
-    )
     return GitGuardianAuthorizationHeaderMCP(*args, auth=PassThroughTokenVerifier(), **kwargs)
+
+
+def _log_startup(settings: Any, mode: AuthMode) -> None:
+    """Log the resolved mode, GG URL host, and tenancy as the first startup line.
+
+    A misconfiguration must be visible in the first second of any support
+    ticket, so this line is emitted before the server is constructed.
+    """
+    from urllib.parse import urlparse
+
+    host = urlparse(settings.gitguardian_url).netloc or settings.gitguardian_url
+    logger.info(
+        "Resolved auth mode=%s, gg_url_host=%s, tenancy=%s",
+        mode.value,
+        host,
+        "multi-tenant" if mode.is_multi_tenant else "single-tenant",
+    )

--- a/src/gg_api_core/settings.py
+++ b/src/gg_api_core/settings.py
@@ -12,6 +12,8 @@ test fixtures using ``patch.dict(os.environ, ...)`` or
 ``monkeypatch.setenv`` continue to work without cache invalidation.
 """
 
+import warnings
+from enum import Enum
 from typing import Literal
 
 from pydantic import Field
@@ -30,6 +32,60 @@ def string_env_to_bool(value: str | None) -> bool:
     if value is None:
         return False
     return value.lower() in TRUTHY_ENV_VALUES
+
+
+class AuthMode(str, Enum):
+    """Declared authentication mode for the MCP server.
+
+    The mode is the single source of truth for transport and tenancy:
+
+    - HTTP modes (``oauth-proxy``, ``header``) are multi-tenant by definition:
+      the credential arrives per request, so a process-level fallback token
+      would silently collapse every tenant onto one identity.
+    - stdio modes (``env-pat``, ``local-oauth``) are single-tenant: a single
+      process-level credential serves the whole server lifetime.
+
+    ``MULTI_TENANCY_ENABLED`` is no longer an input; tenancy is a consequence
+    of the mode (see :attr:`Settings.is_multi_tenant`).
+    """
+
+    OAUTH_PROXY = "oauth-proxy"
+    HEADER = "header"
+    ENV_PAT = "env-pat"
+    LOCAL_OAUTH = "local-oauth"
+
+    @property
+    def is_multi_tenant(self) -> bool:
+        """Whether this mode serves multiple identities per process."""
+        return self in (AuthMode.OAUTH_PROXY, AuthMode.HEADER)
+
+    @property
+    def transport(self) -> str:
+        """Transport implied by this mode: ``http`` or ``stdio``."""
+        return "http" if self.is_multi_tenant else "stdio"
+
+
+def _parse_auth_mode(value: str) -> AuthMode:
+    """Parse a raw ``MCP_AUTH_MODE`` value into an :class:`AuthMode`.
+
+    Accepts the canonical hyphenated spellings and their underscore variants
+    (``oauth_proxy`` → ``oauth-proxy``), case-insensitively.
+    """
+    normalized = value.strip().lower().replace("_", "-")
+    try:
+        return AuthMode(normalized)
+    except ValueError:
+        valid = ", ".join(mode.value for mode in AuthMode)
+        raise ValueError(f"Invalid MCP_AUTH_MODE={value!r}. Expected one of: {valid}") from None
+
+
+def _warn_deprecated(old: str, new: str) -> None:
+    """Emit a one-shot deprecation warning for a legacy selector var."""
+    warnings.warn(
+        f"{old} is deprecated; set {new} instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
 
 
 class Settings(BaseSettings):
@@ -61,6 +117,10 @@ class Settings(BaseSettings):
     # Kept as str|None so callers can distinguish "unset" (stdio mode) from "set".
     mcp_port: str | None = None
     mcp_host: str = "127.0.0.1"
+    # Declared authentication mode (oauth-proxy | header | env-pat | local-oauth).
+    # When unset, the mode is inferred from the legacy selectors below for one
+    # release cycle (see :attr:`auth_mode`).
+    mcp_auth_mode: str | None = None
     multi_tenancy_enabled: str = ""
     # None ⇒ unset (default: True). Empty/anything-but-"true" ⇒ False.
     enable_local_oauth: str | None = None
@@ -98,7 +158,114 @@ class Settings(BaseSettings):
 
     @property
     def is_multi_tenant(self) -> bool:
-        return string_env_to_bool(self.multi_tenancy_enabled)
+        """Whether the server serves multiple identities per process.
+
+        Derived from the resolved :attr:`auth_mode` rather than declared
+        separately: HTTP modes are multi-tenant, stdio modes are single-tenant.
+        """
+        return self.auth_mode.is_multi_tenant
+
+    @property
+    def auth_mode(self) -> AuthMode:
+        """Resolve the effective authentication mode.
+
+        ``MCP_AUTH_MODE`` wins when set. Otherwise the mode is inferred from
+        the legacy selectors (``MCP_OAUTH_PROXY_ENABLED``, ``ENABLE_LOCAL_OAUTH``,
+        ``GITGUARDIAN_PERSONAL_ACCESS_TOKEN``) with a deprecation warning, so
+        existing deployments keep working for one release cycle.
+
+        The inference also removes the old ladder surprise: a PAT alone now
+        selects ``env-pat`` without requiring ``ENABLE_LOCAL_OAUTH=false``.
+        """
+        if self.mcp_auth_mode:
+            return _parse_auth_mode(self.mcp_auth_mode)
+        return self._infer_auth_mode_from_legacy()
+
+    def _infer_auth_mode_from_legacy(self) -> AuthMode:
+        """Map the legacy selector vars onto an :class:`AuthMode`."""
+        if self.is_oauth_proxy_enabled:
+            _warn_deprecated("MCP_OAUTH_PROXY_ENABLED", "MCP_AUTH_MODE=oauth-proxy")
+            return AuthMode.OAUTH_PROXY
+
+        if self.enable_local_oauth is not None and not string_env_to_bool(self.enable_local_oauth):
+            # ENABLE_LOCAL_OAUTH explicitly false: PAT → env-pat, else header.
+            _warn_deprecated("ENABLE_LOCAL_OAUTH", "MCP_AUTH_MODE")
+            if self.gitguardian_personal_access_token:
+                return AuthMode.ENV_PAT
+            return AuthMode.HEADER
+
+        if self.enable_local_oauth is not None:
+            _warn_deprecated("ENABLE_LOCAL_OAUTH", "MCP_AUTH_MODE")
+
+        # Default: a PAT selects env-pat, otherwise local-oauth. This removes
+        # the ladder surprise where a PAT alone did not select PAT mode.
+        if self.gitguardian_personal_access_token:
+            return AuthMode.ENV_PAT
+        return AuthMode.LOCAL_OAUTH
+
+    def validate_auth_mode(self) -> None:
+        """Refuse to boot on a mode/var combination that cannot be safe.
+
+        Enforces each mode's required and forbidden variables and rejects a
+        ``MULTI_TENANCY_ENABLED`` value that contradicts the derived tenancy.
+        Called from :func:`gg_api_core.mcp_server.get_mcp_server` at startup.
+
+        Raises:
+            ValueError: if the resolved mode's configuration is invalid.
+        """
+        # HTTP transport (MCP_PORT set) without a declared mode is ambiguous:
+        # the legacy HTTP selectors still map onto HTTP modes, but a bare
+        # MCP_PORT with no mode and no legacy selector must be refused
+        # explicitly rather than silently inferring a stdio mode.
+        if (
+            not self.mcp_auth_mode
+            and self.mcp_port
+            and not self.is_oauth_proxy_enabled
+            and not (self.enable_local_oauth is not None and not string_env_to_bool(self.enable_local_oauth))
+        ):
+            raise ValueError(
+                "MCP_PORT is set but MCP_AUTH_MODE is not declared. "
+                "Declare MCP_AUTH_MODE=oauth-proxy or MCP_AUTH_MODE=header for HTTP transport."
+            )
+
+        mode = self.auth_mode
+
+        # MULTI_TENANCY_ENABLED (deprecated) must agree with the derived tenancy.
+        if self.multi_tenancy_enabled:
+            _warn_deprecated("MULTI_TENANCY_ENABLED", "MCP_AUTH_MODE")
+            declared = string_env_to_bool(self.multi_tenancy_enabled)
+            if declared != mode.is_multi_tenant:
+                raise ValueError(
+                    f"MULTI_TENANCY_ENABLED={self.multi_tenancy_enabled!r} contradicts "
+                    f"MCP_AUTH_MODE={mode.value} (tenancy is "
+                    f"{'multi' if mode.is_multi_tenant else 'single'}-tenant). "
+                    "Unset MULTI_TENANCY_ENABLED; tenancy is derived from the mode."
+                )
+
+        # Required variables.
+        if mode in (AuthMode.OAUTH_PROXY, AuthMode.HEADER):
+            if not self.mcp_port:
+                raise ValueError(f"MCP_AUTH_MODE={mode.value} requires MCP_PORT to be set (HTTP transport).")
+        elif mode is AuthMode.ENV_PAT:
+            if not self.gitguardian_personal_access_token:
+                raise ValueError("MCP_AUTH_MODE=env-pat requires GITGUARDIAN_PERSONAL_ACCESS_TOKEN to be set.")
+
+        # Forbidden variables: a server-side PAT in an HTTP mode would collapse
+        # every tenant onto one identity; MCP_PORT in a stdio mode is a stray
+        # credential waiting for a flag to drop.
+        if mode in (AuthMode.OAUTH_PROXY, AuthMode.HEADER):
+            if self.gitguardian_personal_access_token:
+                raise ValueError(
+                    f"MCP_AUTH_MODE={mode.value} is multi-tenant; a server-side "
+                    "GITGUARDIAN_PERSONAL_ACCESS_TOKEN would collapse every tenant onto "
+                    "one identity. Unset it or use a single-tenant mode (env-pat / local-oauth)."
+                )
+        elif mode in (AuthMode.ENV_PAT, AuthMode.LOCAL_OAUTH):
+            if self.mcp_port:
+                raise ValueError(
+                    f"MCP_AUTH_MODE={mode.value} is single-tenant (stdio); MCP_PORT must not be set. "
+                    "Use an HTTP mode (oauth-proxy / header) for HTTP transport."
+                )
 
     @property
     def use_dashboard_authenticated_page(self) -> bool:

--- a/src/gg_api_core/tools/find_current_source_id.py
+++ b/src/gg_api_core/tools/find_current_source_id.py
@@ -127,7 +127,7 @@ async def find_current_source_id(
             repository_name = parsed_url.split("/")[-1] if parsed_url else None
             detection_method = "provided remote URL"
             logger.debug(f"Using provided remote URL: {remote_url}, parsed repository name: {repository_name}")
-        elif get_settings().mcp_port:
+        elif get_settings().auth_mode.transport == "http":
             # Hosted (HTTP) transport: no access to the user's filesystem or git binary.
             # Ask the agent to resolve the remote URL locally and call again.
             logger.info("No remote_url provided on HTTP transport; returning suggestion to run git locally")

--- a/src/gg_api_core/utils.py
+++ b/src/gg_api_core/utils.py
@@ -24,23 +24,23 @@ _client_singleton: GitGuardianClient | None = None
 async def get_client(personal_access_token: str | None = None, user_agent: str | None = None) -> GitGuardianClient:
     """Get GitGuardian client for the current context.
 
-    **Single-tenant is the DEFAULT** (local stdio usage).
-    Multi-tenant requires explicit opt-in via MULTI_TENANCY_ENABLED=true.
+    Tenancy is derived from the resolved authentication mode
+    (:attr:`Settings.auth_mode`): HTTP modes (``oauth-proxy``, ``header``) are
+    multi-tenant, stdio modes (``env-pat``, ``local-oauth``) are single-tenant.
 
     Authentication modes (in order of precedence):
 
     1. **Explicit PAT provided** → Use it directly, no caching
        - For programmatic usage where caller manages the token
 
-    2. **Multi-tenant mode** (MULTI_TENANCY_ENABLED=true) → Per-request from headers
-       - Requires MCP_PORT to be set
+    2. **Multi-tenant mode** (HTTP) → Per-request from headers
        - Token MUST come from Authorization header
        - No caching (new client per request)
 
-    3. **Single-tenant mode** (DEFAULT) → Singleton pattern, token sources:
+    3. **Single-tenant mode** (stdio) → Singleton pattern, token sources:
        a. GITGUARDIAN_PERSONAL_ACCESS_TOKEN env var
        b. Stored OAuth token from previous authentication flow
-       c. ENABLE_LOCAL_OAUTH=true → trigger interactive OAuth flow
+       c. local-oauth mode → trigger interactive OAuth flow
        - Same identity for entire server lifetime
 
     Args:
@@ -53,7 +53,7 @@ async def get_client(personal_access_token: str | None = None, user_agent: str |
         GitGuardianClient: Client instance configured with appropriate authentication
 
     Raises:
-        ValidationError: In multi-tenant mode, if MCP_PORT not set or Authorization header missing
+        ValidationError: In multi-tenant mode, if the Authorization header is missing
         RuntimeError: In single-tenant mode, if no token source is available
     """
     # Build the User-Agent for outgoing API calls if not explicitly provided
@@ -65,19 +65,14 @@ async def get_client(personal_access_token: str | None = None, user_agent: str |
         logger.debug("Creating client with explicitly provided token")
         return GitGuardianClient(personal_access_token=personal_access_token, user_agent=user_agent)
 
-    # 2. Multi-tenant mode (explicit opt-in via MULTI_TENANCY_ENABLED=true) : no caching, no automatic refresh
+    # 2. Multi-tenant mode (HTTP): no caching, no automatic refresh
     settings = get_settings()
     if settings.is_multi_tenant:
-        if not settings.mcp_port:
-            raise ValidationError(
-                "MULTI_TENANCY_ENABLED=true requires MCP_PORT to be set. "
-                "Multi-tenant mode only works with HTTP transport."
-            )
         logger.debug("Multi-tenant mode: extracting token from request headers")
         token = _get_token_from_request_headers()
         return GitGuardianClient(personal_access_token=token, user_agent=user_agent)
 
-    # 3. Single-tenant mode (DEFAULT) - use singleton pattern to cache the PAT
+    # 3. Single-tenant mode (stdio) - use singleton pattern to cache the PAT
     global _client_singleton
     if _client_singleton is not None:
         return _client_singleton
@@ -120,7 +115,7 @@ def _build_user_agent() -> str:
         - stdio:  ``GitGuardian-MCP-Server/0.5.0 (transport=stdio)``
         - hosted: ``GitGuardian-MCP-Server/0.5.0 (transport=http; client=Claude-Code/1.2)``
     """
-    transport = "http" if get_settings().mcp_port else "stdio"
+    transport = get_settings().auth_mode.transport
     parts = [f"transport={transport}"]
     caller = _get_caller_user_agent()
     if caller:

--- a/src/ggmcp/run.py
+++ b/src/ggmcp/run.py
@@ -51,10 +51,11 @@ def run_http_with_uvicorn():
 def run_mcp_server():
     """Run the MCP server with transport auto-detection.
 
-    If MCP_PORT is set, uses StreamableHTTP transport.
-    Otherwise, uses stdio transport (default).
+    The transport is derived from the resolved authentication mode: HTTP modes
+    (oauth-proxy / header) use StreamableHTTP, stdio modes (env-pat /
+    local-oauth) use stdio.
     """
-    if get_settings().mcp_port:
+    if get_settings().auth_mode.transport == "http":
         run_http_with_uvicorn()
     else:
         run_stdio()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -36,15 +36,13 @@ def block_real_network(socket_disabled) -> None:
 @pytest.fixture
 def remote_env(monkeypatch):
     """Environment of the hosted multi-tenant deployment (OAuth proxy mode)."""
-    monkeypatch.setenv("MULTI_TENANCY_ENABLED", "true")
-    # The presence of MCP_PORT marks the server as HTTP-transport: it gates
-    # multi-tenant token extraction and the hosted-server behavior of tools
-    # like find_current_source_id.
+    # The auth mode is the single source of truth: oauth-proxy implies HTTP
+    # transport and multi-tenancy, which gates token extraction and the
+    # hosted-server behavior of tools like find_current_source_id.
+    monkeypatch.setenv("MCP_AUTH_MODE", "oauth-proxy")
     monkeypatch.setenv("MCP_PORT", "8000")
-    monkeypatch.setenv("MCP_OAUTH_PROXY_ENABLED", "true")
     monkeypatch.setenv("MCP_BASE_URL", MCP_BASE_URL)
     monkeypatch.setenv("GITGUARDIAN_URL", "https://dashboard.gitguardian.com")
-    monkeypatch.setenv("ENABLE_LOCAL_OAUTH", "false")
     monkeypatch.delenv("GITGUARDIAN_API_URL", raising=False)
     monkeypatch.delenv("GITGUARDIAN_PERSONAL_ACCESS_TOKEN", raising=False)
     monkeypatch.delenv("GITGUARDIAN_API_KEY", raising=False)

--- a/tests/e2e/test_stdio_server.py
+++ b/tests/e2e/test_stdio_server.py
@@ -50,10 +50,11 @@ def stdio_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.delenv("MCP_PORT", raising=False)
     monkeypatch.delenv("MULTI_TENANCY_ENABLED", raising=False)
     monkeypatch.delenv("MCP_OAUTH_PROXY_ENABLED", raising=False)
+    monkeypatch.delenv("ENABLE_LOCAL_OAUTH", raising=False)
     monkeypatch.delenv("GITGUARDIAN_API_URL", raising=False)
     monkeypatch.setenv("GITGUARDIAN_URL", "https://dashboard.gitguardian.com")
     monkeypatch.setenv("GITGUARDIAN_PERSONAL_ACCESS_TOKEN", STDIO_PAT)
-    monkeypatch.setenv("ENABLE_LOCAL_OAUTH", "false")
+    monkeypatch.setenv("MCP_AUTH_MODE", "env-pat")
 
 
 @pytest.fixture(autouse=True)
@@ -102,7 +103,7 @@ class TestPatEnvAuthentication:
         assert_authenticated_request(route, STDIO_PAT)
         assert "(transport=stdio)" in route.calls.last.request.headers["User-Agent"]
 
-    async def test_default_oauth_mode_still_uses_the_env_token_without_a_browser_flow(
+    async def test_pat_alone_selects_env_pat_mode_without_a_browser_flow(
         self,
         stdio_env: None,
         monkeypatch: pytest.MonkeyPatch,
@@ -110,21 +111,21 @@ class TestPatEnvAuthentication:
         mock_token_scopes: Any,
     ) -> None:
         """
-        GIVEN the default local setup (ENABLE_LOCAL_OAUTH unset) with a PAT env var
+        GIVEN a PAT env var with no MCP_AUTH_MODE and no ENABLE_LOCAL_OAUTH
         WHEN a tool is called
-        THEN the server runs in LOCAL_OAUTH_FLOW mode but the client picks the
-             env token, so no interactive flow is ever needed
+        THEN the server runs in PERSONAL_ACCESS_TOKEN_ENV_VAR mode (the old
+             ladder surprise where a PAT alone did not select PAT mode is gone)
         """
 
         async def unexpected_oauth_flow(*_args: Any, **_kwargs: Any) -> None:
             raise AssertionError("interactive OAuth must not start while an env PAT exists")
 
-        monkeypatch.delenv("ENABLE_LOCAL_OAUTH")
+        monkeypatch.delenv("MCP_AUTH_MODE")
         monkeypatch.setattr(client_module, "_run_oauth_flow", unexpected_oauth_flow)
         route = gg_api.get("/incidents/secrets/77").respond(200, json=INCIDENT)
 
         server = build_server()
-        assert server.authentication_mode.value == "LOCAL_OAUTH_FLOW"
+        assert server.authentication_mode.value == "PERSONAL_ACCESS_TOKEN_ENV_VAR"
         async with Client(server) as client:
             result = await client.call_tool("get_incident", {"params": {"incident_id": 77}})
 
@@ -166,7 +167,7 @@ class TestPatEnvAuthentication:
         """
         stored_pat = "stdio-stored-oauth-pat"
         monkeypatch.delenv("GITGUARDIAN_PERSONAL_ACCESS_TOKEN")
-        monkeypatch.delenv("ENABLE_LOCAL_OAUTH")
+        monkeypatch.delenv("MCP_AUTH_MODE")
         oauth.FileTokenStorage().save_token(
             "https://dashboard.gitguardian.com",
             {"access_token": stored_pat},

--- a/tests/test_auth_mode.py
+++ b/tests/test_auth_mode.py
@@ -1,0 +1,218 @@
+"""Tests for the MCP_AUTH_MODE resolution and boot-time validation.
+
+The auth mode is the single source of truth for transport and tenancy. These
+tests pin the explicit-mode parsing, the legacy back-compat inference (with
+deprecation warnings), and the boot asserts that refuse unsafe combinations.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from gg_api_core.settings import AuthMode, get_settings
+
+
+def _settings(env: dict[str, str]) -> object:
+    with patch.dict(os.environ, env, clear=True):
+        return get_settings()
+
+
+class TestAuthModeEnum:
+    """The enum's derived tenancy and transport."""
+
+    @pytest.mark.parametrize(
+        ("mode", "multi_tenant", "transport"),
+        [
+            (AuthMode.OAUTH_PROXY, True, "http"),
+            (AuthMode.HEADER, True, "http"),
+            (AuthMode.ENV_PAT, False, "stdio"),
+            (AuthMode.LOCAL_OAUTH, False, "stdio"),
+        ],
+    )
+    def test_derived_tenancy_and_transport(self, mode, multi_tenant, transport):
+        """
+        GIVEN an AuthMode
+        WHEN its is_multi_tenant and transport are read
+        THEN HTTP modes are multi-tenant, stdio modes are single-tenant
+        """
+        assert mode.is_multi_tenant is multi_tenant
+        assert mode.transport == transport
+
+
+class TestExplicitModeResolution:
+    """MCP_AUTH_MODE wins and is parsed leniently."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("oauth-proxy", AuthMode.OAUTH_PROXY),
+            ("header", AuthMode.HEADER),
+            ("env-pat", AuthMode.ENV_PAT),
+            ("local-oauth", AuthMode.LOCAL_OAUTH),
+            # underscore and case variants are accepted
+            ("oauth_proxy", AuthMode.OAUTH_PROXY),
+            ("ENV_PAT", AuthMode.ENV_PAT),
+            ("Local-OAuth", AuthMode.LOCAL_OAUTH),
+        ],
+    )
+    def test_explicit_mode_parses(self, raw, expected):
+        """
+        GIVEN MCP_AUTH_MODE set to a valid (possibly variant) spelling
+        WHEN auth_mode is read
+        THEN it resolves to the matching AuthMode
+        """
+        assert _settings({"MCP_AUTH_MODE": raw}).auth_mode is expected
+
+    def test_invalid_mode_raises(self):
+        """
+        GIVEN MCP_AUTH_MODE set to an unknown value
+        WHEN auth_mode is read
+        THEN it raises ValueError listing the valid modes
+        """
+        with pytest.raises(ValueError, match="Invalid MCP_AUTH_MODE"):
+            _settings({"MCP_AUTH_MODE": "bogus"}).auth_mode
+
+
+class TestLegacyInference:
+    """Back-compat mapping of the deprecated selector vars."""
+
+    def test_oauth_proxy_enabled_maps_to_oauth_proxy(self):
+        """
+        GIVEN MCP_OAUTH_PROXY_ENABLED=true and no MCP_AUTH_MODE
+        WHEN auth_mode is read
+        THEN it resolves to oauth-proxy with a deprecation warning
+        """
+        with pytest.warns(DeprecationWarning, match="MCP_OAUTH_PROXY_ENABLED"):
+            assert _settings({"MCP_OAUTH_PROXY_ENABLED": "true"}).auth_mode is AuthMode.OAUTH_PROXY
+
+    def test_enable_local_oauth_false_with_pat_maps_to_env_pat(self):
+        """
+        GIVEN ENABLE_LOCAL_OAUTH=false and a PAT, no MCP_AUTH_MODE
+        WHEN auth_mode is read
+        THEN it resolves to env-pat
+        """
+        with pytest.warns(DeprecationWarning, match="ENABLE_LOCAL_OAUTH"):
+            assert (
+                _settings({"ENABLE_LOCAL_OAUTH": "false", "GITGUARDIAN_PERSONAL_ACCESS_TOKEN": "x"}).auth_mode
+                is AuthMode.ENV_PAT
+            )
+
+    def test_enable_local_oauth_false_without_pat_maps_to_header(self):
+        """
+        GIVEN ENABLE_LOCAL_OAUTH=false and no PAT, no MCP_AUTH_MODE
+        WHEN auth_mode is read
+        THEN it resolves to header (HTTP, multi-tenant)
+        """
+        with pytest.warns(DeprecationWarning, match="ENABLE_LOCAL_OAUTH"):
+            assert _settings({"ENABLE_LOCAL_OAUTH": "false"}).auth_mode is AuthMode.HEADER
+
+    def test_pat_alone_maps_to_env_pat(self):
+        """
+        GIVEN a PAT with no MCP_AUTH_MODE and no ENABLE_LOCAL_OAUTH
+        WHEN auth_mode is read
+        THEN it resolves to env-pat (the old ladder surprise is gone)
+        """
+        assert _settings({"GITGUARDIAN_PERSONAL_ACCESS_TOKEN": "x"}).auth_mode is AuthMode.ENV_PAT
+
+    def test_nothing_set_maps_to_local_oauth(self):
+        """
+        GIVEN no auth-related env vars at all
+        WHEN auth_mode is read
+        THEN it resolves to local-oauth (single-tenant default)
+        """
+        assert _settings({}).auth_mode is AuthMode.LOCAL_OAUTH
+
+
+class TestValidateAuthMode:
+    """Boot asserts refuse unsafe mode/var combinations."""
+
+    def test_header_requires_mcp_port(self):
+        """
+        GIVEN MCP_AUTH_MODE=header without MCP_PORT
+        WHEN validate_auth_mode is called
+        THEN it raises ValueError
+        """
+        with pytest.raises(ValueError, match="MCP_PORT"):
+            _settings({"MCP_AUTH_MODE": "header"}).validate_auth_mode()
+
+    def test_oauth_proxy_requires_mcp_port(self):
+        """
+        GIVEN MCP_AUTH_MODE=oauth-proxy without MCP_PORT
+        WHEN validate_auth_mode is called
+        THEN it raises ValueError
+        """
+        with pytest.raises(ValueError, match="MCP_PORT"):
+            _settings({"MCP_AUTH_MODE": "oauth-proxy"}).validate_auth_mode()
+
+    def test_env_pat_requires_pat(self):
+        """
+        GIVEN MCP_AUTH_MODE=env-pat without a PAT
+        WHEN validate_auth_mode is called
+        THEN it raises ValueError
+        """
+        with pytest.raises(ValueError, match="GITGUARDIAN_PERSONAL_ACCESS_TOKEN"):
+            _settings({"MCP_AUTH_MODE": "env-pat"}).validate_auth_mode()
+
+    def test_http_mode_forbids_server_side_pat(self):
+        """
+        GIVEN MCP_AUTH_MODE=header with a server-side PAT
+        WHEN validate_auth_mode is called
+        THEN it raises ValueError (the PAT would collapse every tenant)
+        """
+        with pytest.raises(ValueError, match="collapse every tenant"):
+            _settings(
+                {"MCP_AUTH_MODE": "header", "MCP_PORT": "8000", "GITGUARDIAN_PERSONAL_ACCESS_TOKEN": "x"}
+            ).validate_auth_mode()
+
+    def test_stdio_mode_forbids_mcp_port(self):
+        """
+        GIVEN MCP_AUTH_MODE=env-pat with MCP_PORT set
+        WHEN validate_auth_mode is called
+        THEN it raises ValueError
+        """
+        with pytest.raises(ValueError, match="MCP_PORT"):
+            _settings(
+                {"MCP_AUTH_MODE": "env-pat", "GITGUARDIAN_PERSONAL_ACCESS_TOKEN": "x", "MCP_PORT": "8000"}
+            ).validate_auth_mode()
+
+    def test_multi_tenancy_enabled_contradiction_raises(self):
+        """
+        GIVEN MCP_AUTH_MODE=env-pat but MULTI_TENANCY_ENABLED=true
+        WHEN validate_auth_mode is called
+        THEN it raises ValueError (tenancy is derived, not declared)
+        """
+        with pytest.raises(ValueError, match="contradicts"):
+            _settings(
+                {
+                    "MCP_AUTH_MODE": "env-pat",
+                    "GITGUARDIAN_PERSONAL_ACCESS_TOKEN": "x",
+                    "MULTI_TENANCY_ENABLED": "true",
+                }
+            ).validate_auth_mode()
+
+    def test_http_transport_without_declared_mode_raises(self):
+        """
+        GIVEN MCP_PORT set but no MCP_AUTH_MODE and no legacy HTTP selector
+        WHEN validate_auth_mode is called
+        THEN it raises ValueError asking for a declared HTTP mode
+        """
+        with pytest.raises(ValueError, match="MCP_AUTH_MODE is not declared"):
+            _settings({"MCP_PORT": "8000"}).validate_auth_mode()
+
+    @pytest.mark.parametrize(
+        "env",
+        [
+            {"MCP_AUTH_MODE": "oauth-proxy", "MCP_PORT": "8000"},
+            {"MCP_AUTH_MODE": "header", "MCP_PORT": "8000"},
+            {"MCP_AUTH_MODE": "env-pat", "GITGUARDIAN_PERSONAL_ACCESS_TOKEN": "x"},
+            {"MCP_AUTH_MODE": "local-oauth"},
+        ],
+    )
+    def test_valid_configurations_pass(self, env):
+        """
+        GIVEN a valid mode/var combination
+        WHEN validate_auth_mode is called
+        THEN it does not raise
+        """
+        _settings(env).validate_auth_mode()

--- a/tests/test_get_client_safeguards.py
+++ b/tests/test_get_client_safeguards.py
@@ -50,29 +50,33 @@ class TestIsMultiTenant:
 
     def test_returns_true_when_enabled(self):
         """
-        GIVEN MULTI_TENANCY_ENABLED=true
+        GIVEN MCP_AUTH_MODE=header
         WHEN get_settings().is_multi_tenant is read
         THEN it returns True
         """
-        with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "true"}, clear=True):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "header"}, clear=True):
             assert get_settings().is_multi_tenant is True
 
     def test_returns_false_when_disabled(self):
         """
-        GIVEN MULTI_TENANCY_ENABLED=false
+        GIVEN MCP_AUTH_MODE=env-pat (single-tenant)
         WHEN get_settings().is_multi_tenant is read
         THEN it returns False
         """
-        with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "false"}, clear=True):
+        with patch.dict(
+            os.environ,
+            {"MCP_AUTH_MODE": "env-pat", "GITGUARDIAN_PERSONAL_ACCESS_TOKEN": "x"},
+            clear=True,
+        ):
             assert get_settings().is_multi_tenant is False
 
     def test_case_insensitive(self):
         """
-        GIVEN MULTI_TENANCY_ENABLED=TRUE (uppercase)
+        GIVEN MCP_AUTH_MODE=HEADER (uppercase)
         WHEN get_settings().is_multi_tenant is read
         THEN it returns True
         """
-        with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "TRUE"}, clear=True):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "HEADER"}, clear=True):
             assert get_settings().is_multi_tenant is True
 
 
@@ -109,7 +113,7 @@ class TestGetClientExplicitPAT:
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
 
-        with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "true", "MCP_PORT": "8080"}, clear=True):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "header", "MCP_PORT": "8080"}, clear=True):
             result = await get_client(personal_access_token="explicit-token")
 
         # MCP_PORT is set, so the transport marker is http (no caller header here)
@@ -121,26 +125,13 @@ class TestGetClientExplicitPAT:
 
 
 class TestGetClientMultiTenantMode:
-    """Tests for get_client() in multi-tenant mode (explicit opt-in)."""
-
-    async def test_multi_tenant_requires_mcp_port(self):
-        """
-        GIVEN MULTI_TENANCY_ENABLED=true but MCP_PORT is not set
-        WHEN get_client is called
-        THEN it raises ValidationError
-        """
-        with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "true"}, clear=True):
-            with pytest.raises(ValidationError) as exc_info:
-                await get_client()
-
-        assert "MCP_PORT" in str(exc_info.value)
-        assert "MULTI_TENANCY_ENABLED" in str(exc_info.value)
+    """Tests for get_client() in multi-tenant mode (HTTP auth modes)."""
 
     @patch("gg_api_core.utils.get_http_headers")
     @patch("gg_api_core.utils.GitGuardianClient")
     async def test_multi_tenant_extracts_token_from_headers(self, mock_client_class, mock_get_headers):
         """
-        GIVEN MULTI_TENANCY_ENABLED=true and MCP_PORT is set
+        GIVEN MCP_AUTH_MODE=header and MCP_PORT is set
         AND Authorization header is present
         WHEN get_client is called
         THEN it extracts token and user-agent from headers and creates new client
@@ -149,7 +140,7 @@ class TestGetClientMultiTenantMode:
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
 
-        with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "true", "MCP_PORT": "8080"}, clear=True):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "header", "MCP_PORT": "8080"}, clear=True):
             result = await get_client()
 
         # No user-agent header on the request, so only the transport marker is added
@@ -163,7 +154,7 @@ class TestGetClientMultiTenantMode:
     @patch("gg_api_core.utils.GitGuardianClient")
     async def test_multi_tenant_forwards_caller_user_agent(self, mock_client_class, mock_get_headers):
         """
-        GIVEN MULTI_TENANCY_ENABLED=true and MCP_PORT is set
+        GIVEN MCP_AUTH_MODE=header and MCP_PORT is set
         AND request has both Authorization and User-Agent headers
         WHEN get_client is called
         THEN the caller's User-Agent is preserved as client=... in the UA string
@@ -175,7 +166,7 @@ class TestGetClientMultiTenantMode:
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
 
-        with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "true", "MCP_PORT": "8080"}, clear=True):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "header", "MCP_PORT": "8080"}, clear=True):
             result = await get_client()
 
         mock_client_class.assert_called_once_with(
@@ -204,7 +195,7 @@ class TestGetClientMultiTenantMode:
         mock_client2 = MagicMock()
         mock_client_class.side_effect = [mock_client1, mock_client2]
 
-        with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "true", "MCP_PORT": "8080"}, clear=True):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "header", "MCP_PORT": "8080"}, clear=True):
             result1 = await get_client()
             result2 = await get_client()
 
@@ -222,7 +213,7 @@ class TestGetClientMultiTenantMode:
         """
         mock_get_headers.return_value = {"content-type": "application/json"}
 
-        with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "true", "MCP_PORT": "8080"}, clear=True):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "header", "MCP_PORT": "8080"}, clear=True):
             with pytest.raises(ValidationError) as exc_info:
                 await get_client()
 
@@ -310,7 +301,7 @@ class TestGetClientSingleTenantMode:
     @patch("gg_api_core.utils.GitGuardianClient")
     async def test_single_tenant_triggers_oauth_when_enabled(self, mock_client_class, mock_get_stored, mock_oauth):
         """
-        GIVEN no env PAT, no stored token, but ENABLE_LOCAL_OAUTH=true
+        GIVEN no env PAT, no stored token, but MCP_AUTH_MODE=local-oauth
         WHEN get_client is called
         THEN it triggers the OAuth flow and enables token refresh
         """
@@ -325,7 +316,7 @@ class TestGetClientSingleTenantMode:
 
         gg_api_core.utils._client_singleton = None
 
-        with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "true"}, clear=True):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "local-oauth"}, clear=True):
             result = await get_client()
 
         mock_oauth.assert_called_once()
@@ -338,7 +329,7 @@ class TestGetClientSingleTenantMode:
     @patch("gg_api_core.client._get_stored_oauth_token")
     async def test_single_tenant_raises_when_no_token_source(self, mock_get_stored):
         """
-        GIVEN no env PAT, no stored token, and OAuth disabled
+        GIVEN env-pat mode but no PAT and no stored token
         WHEN get_client is called
         THEN it raises RuntimeError with helpful message
         """
@@ -349,13 +340,13 @@ class TestGetClientSingleTenantMode:
 
         gg_api_core.utils._client_singleton = None
 
-        with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "false"}, clear=True):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "env-pat"}, clear=True):
             with pytest.raises(RuntimeError) as exc_info:
                 await get_client()
 
         assert "No API token available" in str(exc_info.value)
         assert "GITGUARDIAN_PERSONAL_ACCESS_TOKEN" in str(exc_info.value)
-        assert "ENABLE_LOCAL_OAUTH" in str(exc_info.value)
+        assert "MCP_AUTH_MODE" in str(exc_info.value)
 
 
 class TestAccountIsolation:
@@ -377,7 +368,7 @@ class TestAccountIsolation:
         mock_get_headers.return_value = {"authorization": "Bearer token"}
         mock_client_class.return_value = MagicMock()
 
-        with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "true", "MCP_PORT": "8080"}, clear=True):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "header", "MCP_PORT": "8080"}, clear=True):
             await get_client()
             await get_client()
             await get_client()
@@ -457,7 +448,7 @@ class TestCallerUserAgentExtraction:
         }
         mock_client_class.return_value = MagicMock()
 
-        with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "true", "MCP_PORT": "8080"}, clear=True):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "header", "MCP_PORT": "8080"}, clear=True):
             await get_client()
 
         mock_client_class.assert_called_once_with(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -54,7 +54,7 @@ class TestGitGuardianFastMCP:
 
         # Use a SaaS URL instead of test/localhost URL
         with patch.dict(
-            os.environ, {"ENABLE_LOCAL_OAUTH": "true", "GITGUARDIAN_URL": "https://dashboard.gitguardian.com"}
+            os.environ, {"MCP_AUTH_MODE": "local-oauth", "GITGUARDIAN_URL": "https://dashboard.gitguardian.com"}
         ):
             mcp = get_mcp_server("TestMCP")
 
@@ -76,7 +76,7 @@ class TestGitGuardianFastMCP:
         from gg_api_core.mcp_server import CachedTokenInfoMixin, GitGuardianLocalOAuthMCP
 
         # Create OAuth MCP instance
-        with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "true"}):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "local-oauth"}):
             mcp = GitGuardianLocalOAuthMCP("test_server_lifespan")
 
             # Verify it has the CachedTokenInfoMixin
@@ -103,7 +103,7 @@ class TestGitGuardianFastMCP:
         from gg_api_core.mcp_server import GitGuardianAuthorizationHeaderMCP
 
         # Create MCP server using AuthorizationHeader mode (non-caching)
-        with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "false"}):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "header"}):
             mcp = GitGuardianAuthorizationHeaderMCP("test_server")
 
             # Verify it doesn't have the CachedTokenInfoMixin methods
@@ -135,7 +135,7 @@ class TestGitGuardianFastMCP:
         from unittest.mock import patch
 
         # Test in OAuth mode (cached scopes)
-        with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "true"}):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "local-oauth"}):
             # Set token scopes to include all required scopes
             self.mcp._token_scopes = {"scan", "incidents:read", "honeytokens:read"}
 
@@ -167,7 +167,7 @@ class TestGitGuardianFastMCP:
         from gg_api_core.mcp_server import GitGuardianLocalOAuthMCP
 
         # Test in OAuth mode (cached scopes) - create a new instance
-        with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "true"}):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "local-oauth"}):
             mcp = GitGuardianLocalOAuthMCP("test_server_scopes")
 
             # Set token scopes to include only some required scopes

--- a/tests/test_scope_filtering.py
+++ b/tests/test_scope_filtering.py
@@ -12,7 +12,7 @@ async def test_tools_filtered_by_scopes():
     """Test that tools are filtered based on user's available scopes."""
 
     # Test in OAuth mode (uses cached scopes)
-    with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "true"}):
+    with patch.dict(os.environ, {"MCP_AUTH_MODE": "local-oauth"}):
         # Create MCP instance
         mcp = get_mcp_server("Test Server")
 
@@ -70,7 +70,7 @@ async def test_tools_filtered_by_scopes():
 async def test_direct_call_tools_filtered_by_scopes():
     """Test that tools registered via direct call (mcp.tool(fn, ...)) are filtered by scopes."""
 
-    with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "true"}):
+    with patch.dict(os.environ, {"MCP_AUTH_MODE": "local-oauth"}):
         mcp = get_mcp_server("Test Direct Call")
         mcp._token_scopes = {"scan"}
 
@@ -100,7 +100,7 @@ async def test_direct_call_tools_filtered_by_scopes():
 async def test_direct_call_tools_with_custom_name_filtered_by_scopes():
     """Test that direct-call tools with explicit name= are filtered correctly."""
 
-    with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "true"}):
+    with patch.dict(os.environ, {"MCP_AUTH_MODE": "local-oauth"}):
         mcp = get_mcp_server("Test Custom Name")
         mcp._token_scopes = {"incidents:read"}
 
@@ -124,7 +124,7 @@ async def test_direct_call_tools_with_custom_name_filtered_by_scopes():
 async def test_scope_filtering_with_partially_satisfied_multiple_scopes():
     """Test that a tool requiring multiple scopes is hidden when only some are available."""
 
-    with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "true"}):
+    with patch.dict(os.environ, {"MCP_AUTH_MODE": "local-oauth"}):
         mcp = get_mcp_server("Test Partial Scopes")
         mcp._token_scopes = {"incidents:read"}
 

--- a/tests/test_server_profiles.py
+++ b/tests/test_server_profiles.py
@@ -12,7 +12,7 @@ import pytest
 @pytest.fixture
 def mock_env_no_http():
     """Mock env vars to keep imports in stdio/cached-scope mode."""
-    with patch.dict("os.environ", {"MCP_PORT": "", "ENABLE_LOCAL_OAUTH": "true"}, clear=False):
+    with patch.dict("os.environ", {"MCP_AUTH_MODE": "local-oauth"}, clear=False):
         yield
 
 

--- a/tests/tools/test_find_current_source_id.py
+++ b/tests/tools/test_find_current_source_id.py
@@ -444,7 +444,7 @@ class TestFindCurrentSourceId:
     @pytest.mark.asyncio
     async def test_find_current_source_id_http_transport_returns_suggestion(self, mock_gitguardian_client):
         """
-        GIVEN: The server runs over HTTP transport (mcp_port set) and no remote_url is provided
+        GIVEN: The server runs over HTTP transport (HTTP auth mode) and no remote_url is provided
         WHEN: Finding the source_id
         THEN: A suggestion is returned asking the agent to run git locally, without touching subprocess
         """
@@ -452,7 +452,7 @@ class TestFindCurrentSourceId:
             patch("gg_api_core.tools.find_current_source_id.get_settings") as mock_settings,
             patch("subprocess.run") as mock_run,
         ):
-            mock_settings.return_value = MagicMock(mcp_port="8000")
+            mock_settings.return_value = MagicMock(auth_mode=MagicMock(transport="http"))
 
             result = await find_current_source_id()
 


### PR DESCRIPTION
## Summary

Enable the distribution pipeline: publish the `ggmcp` package to PyPI and register it in the MCP Registry, so users can install via `uvx ggmcp@latest` instead of riding `git+main`.

## Changes

- Verify the built wheel in isolation (smoke test + distribution test script)
- Define the public local install contract (README + server.json metadata)
- Publish PyPI and MCP Registry artifacts (enable the previously-disabled release jobs)
- Align the publish pipeline with the `ggmcp` rename

## Stacked on

- #222 (si-4067-cleanup)

## Related

- SI-3952