### PR TITLE
fix(auth): derive multi-tenancy from MCP_AUTH_MODE (SI-4057)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,15 @@
 # GitGuardian MCP Server Environment Variables
 
+# Authentication mode: oauth-proxy | header | env-pat | local-oauth.
+# The mode is the single source of truth for transport and tenancy:
+#   oauth-proxy  HTTP, multi-tenant (requires MCP_PORT; forbids a server-side PAT)
+#   header       HTTP, multi-tenant (requires MCP_PORT; forbids a server-side PAT)
+#   env-pat      stdio, single-tenant (requires GITGUARDIAN_PERSONAL_ACCESS_TOKEN)
+#   local-oauth  stdio, single-tenant (interactive browser flow)
+# When unset, the mode is inferred from the legacy selectors below for one
+# release cycle (deprecated).
+# MCP_AUTH_MODE=env-pat
+
 # OAuth Authentication
 GITGUARDIAN_CLIENT_ID=your_oauth_client_id_here
 # Optional: Comma-separated list of scopes

--- a/src/gg_api_core/client.py
+++ b/src/gg_api_core/client.py
@@ -13,7 +13,7 @@ import httpx
 from pydantic import TypeAdapter, ValidationError
 
 from gg_api_core.log_context import record_downstream_call, record_downstream_wait, record_truncation
-from gg_api_core.settings import get_settings
+from gg_api_core.settings import AuthMode, get_settings
 from gg_api_core.version import APP_VERSION
 
 # Setup logger
@@ -291,7 +291,7 @@ async def acquire_single_tenant_token(
     Token sources (in order of precedence):
     1. GITGUARDIAN_PERSONAL_ACCESS_TOKEN env var
     2. Stored OAuth token from previous authentication flow
-    3. Interactive OAuth flow (if ENABLE_LOCAL_OAUTH=true)
+    3. Interactive OAuth flow (in local-oauth mode)
 
     Args:
         dashboard_url: Optional dashboard URL. If not provided, derived from env.
@@ -318,8 +318,8 @@ async def acquire_single_tenant_token(
         logger.info("Using stored OAuth token from previous authentication")
         return stored_token
 
-    # 3. Trigger OAuth flow if enabled
-    if get_settings().is_oauth_enabled:
+    # 3. Trigger OAuth flow in local-oauth mode
+    if get_settings().auth_mode is AuthMode.LOCAL_OAUTH:
         logger.info("No stored token, triggering OAuth flow")
         return await _run_oauth_flow(dashboard_url, public_api_url)
 
@@ -327,8 +327,8 @@ async def acquire_single_tenant_token(
     raise RuntimeError(
         "No API token available. Options: "
         "(1) Set GITGUARDIAN_PERSONAL_ACCESS_TOKEN env var, "
-        "(2) Set ENABLE_LOCAL_OAUTH=true to trigger interactive OAuth flow, "
-        "(3) For HTTP deployments, set MULTI_TENANCY_ENABLED=true and MCP_PORT."
+        "(2) Set MCP_AUTH_MODE=local-oauth to trigger interactive OAuth flow, "
+        "(3) For HTTP deployments, set MCP_AUTH_MODE=oauth-proxy or MCP_AUTH_MODE=header."
     )
 
 

--- a/src/gg_api_core/mcp_server.py
+++ b/src/gg_api_core/mcp_server.py
@@ -25,7 +25,7 @@ from gg_api_core.oauth_proxy_auth import (
     PassThroughTokenVerifier,
     create_oauth_proxy,
 )
-from gg_api_core.settings import get_settings
+from gg_api_core.settings import AuthMode, get_settings
 from gg_api_core.utils import get_client
 
 # Configure logger
@@ -361,12 +361,12 @@ def get_mcp_server(*args: Any, **kwargs: Any) -> AbstractGitGuardianFastMCP:
     kwargs.setdefault("icons", get_gitguardian_icons())
 
     settings = get_settings()
+    settings.validate_auth_mode()
+    mode = settings.auth_mode
 
-    if settings.is_oauth_proxy_enabled:
-        logger.info(
-            "Starting GitGuardian MCP server in %s mode",
-            GitGuardianOAuthProxyMCP.authentication_mode.value,
-        )
+    _log_startup(settings, mode)
+
+    if mode is AuthMode.OAUTH_PROXY:
         oauth_proxy = create_oauth_proxy(
             base_url=settings.mcp_base_url,
             gg_url=settings.gitguardian_url,
@@ -375,22 +375,31 @@ def get_mcp_server(*args: Any, **kwargs: Any) -> AbstractGitGuardianFastMCP:
         )
         return GitGuardianOAuthProxyMCP(*args, auth=oauth_proxy, **kwargs)
 
-    if settings.is_oauth_enabled:
-        logger.info(
-            "Starting GitGuardian MCP server in %s mode",
-            GitGuardianLocalOAuthMCP.authentication_mode.value,
-        )
+    if mode is AuthMode.LOCAL_OAUTH:
         return GitGuardianLocalOAuthMCP(*args, **kwargs)
 
-    if personal_access_token := settings.gitguardian_personal_access_token:
-        logger.info(
-            "Starting GitGuardian MCP server in %s mode",
-            GitGuardianPATEnvMCP.authentication_mode.value,
+    if mode is AuthMode.ENV_PAT:
+        return GitGuardianPATEnvMCP(
+            *args,
+            personal_access_token=settings.gitguardian_personal_access_token,
+            **kwargs,
         )
-        return GitGuardianPATEnvMCP(*args, personal_access_token=personal_access_token, **kwargs)
 
-    logger.info(
-        "Starting GitGuardian MCP server in %s mode",
-        GitGuardianAuthorizationHeaderMCP.authentication_mode.value,
-    )
     return GitGuardianAuthorizationHeaderMCP(*args, auth=PassThroughTokenVerifier(), **kwargs)
+
+
+def _log_startup(settings: Any, mode: AuthMode) -> None:
+    """Log the resolved mode, GG URL host, and tenancy as the first startup line.
+
+    A misconfiguration must be visible in the first second of any support
+    ticket, so this line is emitted before the server is constructed.
+    """
+    from urllib.parse import urlparse
+
+    host = urlparse(settings.gitguardian_url).netloc or settings.gitguardian_url
+    logger.info(
+        "Resolved auth mode=%s, gg_url_host=%s, tenancy=%s",
+        mode.value,
+        host,
+        "multi-tenant" if mode.is_multi_tenant else "single-tenant",
+    )

--- a/src/gg_api_core/settings.py
+++ b/src/gg_api_core/settings.py
@@ -12,6 +12,8 @@ test fixtures using ``patch.dict(os.environ, ...)`` or
 ``monkeypatch.setenv`` continue to work without cache invalidation.
 """
 
+import warnings
+from enum import Enum
 from typing import Literal
 
 from pydantic import Field
@@ -30,6 +32,60 @@ def string_env_to_bool(value: str | None) -> bool:
     if value is None:
         return False
     return value.lower() in TRUTHY_ENV_VALUES
+
+
+class AuthMode(str, Enum):
+    """Declared authentication mode for the MCP server.
+
+    The mode is the single source of truth for transport and tenancy:
+
+    - HTTP modes (``oauth-proxy``, ``header``) are multi-tenant by definition:
+      the credential arrives per request, so a process-level fallback token
+      would silently collapse every tenant onto one identity.
+    - stdio modes (``env-pat``, ``local-oauth``) are single-tenant: a single
+      process-level credential serves the whole server lifetime.
+
+    ``MULTI_TENANCY_ENABLED`` is no longer an input; tenancy is a consequence
+    of the mode (see :attr:`Settings.is_multi_tenant`).
+    """
+
+    OAUTH_PROXY = "oauth-proxy"
+    HEADER = "header"
+    ENV_PAT = "env-pat"
+    LOCAL_OAUTH = "local-oauth"
+
+    @property
+    def is_multi_tenant(self) -> bool:
+        """Whether this mode serves multiple identities per process."""
+        return self in (AuthMode.OAUTH_PROXY, AuthMode.HEADER)
+
+    @property
+    def transport(self) -> str:
+        """Transport implied by this mode: ``http`` or ``stdio``."""
+        return "http" if self.is_multi_tenant else "stdio"
+
+
+def _parse_auth_mode(value: str) -> AuthMode:
+    """Parse a raw ``MCP_AUTH_MODE`` value into an :class:`AuthMode`.
+
+    Accepts the canonical hyphenated spellings and their underscore variants
+    (``oauth_proxy`` → ``oauth-proxy``), case-insensitively.
+    """
+    normalized = value.strip().lower().replace("_", "-")
+    try:
+        return AuthMode(normalized)
+    except ValueError:
+        valid = ", ".join(mode.value for mode in AuthMode)
+        raise ValueError(f"Invalid MCP_AUTH_MODE={value!r}. Expected one of: {valid}") from None
+
+
+def _warn_deprecated(old: str, new: str) -> None:
+    """Emit a one-shot deprecation warning for a legacy selector var."""
+    warnings.warn(
+        f"{old} is deprecated; set {new} instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
 
 
 class Settings(BaseSettings):
@@ -61,6 +117,10 @@ class Settings(BaseSettings):
     # Kept as str|None so callers can distinguish "unset" (stdio mode) from "set".
     mcp_port: str | None = None
     mcp_host: str = "127.0.0.1"
+    # Declared authentication mode (oauth-proxy | header | env-pat | local-oauth).
+    # When unset, the mode is inferred from the legacy selectors below for one
+    # release cycle (see :attr:`auth_mode`).
+    mcp_auth_mode: str | None = None
     multi_tenancy_enabled: str = ""
     # None ⇒ unset (default: True). Empty/anything-but-"true" ⇒ False.
     enable_local_oauth: str | None = None
@@ -98,7 +158,114 @@ class Settings(BaseSettings):
 
     @property
     def is_multi_tenant(self) -> bool:
-        return string_env_to_bool(self.multi_tenancy_enabled)
+        """Whether the server serves multiple identities per process.
+
+        Derived from the resolved :attr:`auth_mode` rather than declared
+        separately: HTTP modes are multi-tenant, stdio modes are single-tenant.
+        """
+        return self.auth_mode.is_multi_tenant
+
+    @property
+    def auth_mode(self) -> AuthMode:
+        """Resolve the effective authentication mode.
+
+        ``MCP_AUTH_MODE`` wins when set. Otherwise the mode is inferred from
+        the legacy selectors (``MCP_OAUTH_PROXY_ENABLED``, ``ENABLE_LOCAL_OAUTH``,
+        ``GITGUARDIAN_PERSONAL_ACCESS_TOKEN``) with a deprecation warning, so
+        existing deployments keep working for one release cycle.
+
+        The inference also removes the old ladder surprise: a PAT alone now
+        selects ``env-pat`` without requiring ``ENABLE_LOCAL_OAUTH=false``.
+        """
+        if self.mcp_auth_mode:
+            return _parse_auth_mode(self.mcp_auth_mode)
+        return self._infer_auth_mode_from_legacy()
+
+    def _infer_auth_mode_from_legacy(self) -> AuthMode:
+        """Map the legacy selector vars onto an :class:`AuthMode`."""
+        if self.is_oauth_proxy_enabled:
+            _warn_deprecated("MCP_OAUTH_PROXY_ENABLED", "MCP_AUTH_MODE=oauth-proxy")
+            return AuthMode.OAUTH_PROXY
+
+        if self.enable_local_oauth is not None and not string_env_to_bool(self.enable_local_oauth):
+            # ENABLE_LOCAL_OAUTH explicitly false: PAT → env-pat, else header.
+            _warn_deprecated("ENABLE_LOCAL_OAUTH", "MCP_AUTH_MODE")
+            if self.gitguardian_personal_access_token:
+                return AuthMode.ENV_PAT
+            return AuthMode.HEADER
+
+        if self.enable_local_oauth is not None:
+            _warn_deprecated("ENABLE_LOCAL_OAUTH", "MCP_AUTH_MODE")
+
+        # Default: a PAT selects env-pat, otherwise local-oauth. This removes
+        # the ladder surprise where a PAT alone did not select PAT mode.
+        if self.gitguardian_personal_access_token:
+            return AuthMode.ENV_PAT
+        return AuthMode.LOCAL_OAUTH
+
+    def validate_auth_mode(self) -> None:
+        """Refuse to boot on a mode/var combination that cannot be safe.
+
+        Enforces each mode's required and forbidden variables and rejects a
+        ``MULTI_TENANCY_ENABLED`` value that contradicts the derived tenancy.
+        Called from :func:`gg_api_core.mcp_server.get_mcp_server` at startup.
+
+        Raises:
+            ValueError: if the resolved mode's configuration is invalid.
+        """
+        # HTTP transport (MCP_PORT set) without a declared mode is ambiguous:
+        # the legacy HTTP selectors still map onto HTTP modes, but a bare
+        # MCP_PORT with no mode and no legacy selector must be refused
+        # explicitly rather than silently inferring a stdio mode.
+        if (
+            not self.mcp_auth_mode
+            and self.mcp_port
+            and not self.is_oauth_proxy_enabled
+            and not (self.enable_local_oauth is not None and not string_env_to_bool(self.enable_local_oauth))
+        ):
+            raise ValueError(
+                "MCP_PORT is set but MCP_AUTH_MODE is not declared. "
+                "Declare MCP_AUTH_MODE=oauth-proxy or MCP_AUTH_MODE=header for HTTP transport."
+            )
+
+        mode = self.auth_mode
+
+        # MULTI_TENANCY_ENABLED (deprecated) must agree with the derived tenancy.
+        if self.multi_tenancy_enabled:
+            _warn_deprecated("MULTI_TENANCY_ENABLED", "MCP_AUTH_MODE")
+            declared = string_env_to_bool(self.multi_tenancy_enabled)
+            if declared != mode.is_multi_tenant:
+                raise ValueError(
+                    f"MULTI_TENANCY_ENABLED={self.multi_tenancy_enabled!r} contradicts "
+                    f"MCP_AUTH_MODE={mode.value} (tenancy is "
+                    f"{'multi' if mode.is_multi_tenant else 'single'}-tenant). "
+                    "Unset MULTI_TENANCY_ENABLED; tenancy is derived from the mode."
+                )
+
+        # Required variables.
+        if mode in (AuthMode.OAUTH_PROXY, AuthMode.HEADER):
+            if not self.mcp_port:
+                raise ValueError(f"MCP_AUTH_MODE={mode.value} requires MCP_PORT to be set (HTTP transport).")
+        elif mode is AuthMode.ENV_PAT:
+            if not self.gitguardian_personal_access_token:
+                raise ValueError("MCP_AUTH_MODE=env-pat requires GITGUARDIAN_PERSONAL_ACCESS_TOKEN to be set.")
+
+        # Forbidden variables: a server-side PAT in an HTTP mode would collapse
+        # every tenant onto one identity; MCP_PORT in a stdio mode is a stray
+        # credential waiting for a flag to drop.
+        if mode in (AuthMode.OAUTH_PROXY, AuthMode.HEADER):
+            if self.gitguardian_personal_access_token:
+                raise ValueError(
+                    f"MCP_AUTH_MODE={mode.value} is multi-tenant; a server-side "
+                    "GITGUARDIAN_PERSONAL_ACCESS_TOKEN would collapse every tenant onto "
+                    "one identity. Unset it or use a single-tenant mode (env-pat / local-oauth)."
+                )
+        elif mode in (AuthMode.ENV_PAT, AuthMode.LOCAL_OAUTH):
+            if self.mcp_port:
+                raise ValueError(
+                    f"MCP_AUTH_MODE={mode.value} is single-tenant (stdio); MCP_PORT must not be set. "
+                    "Use an HTTP mode (oauth-proxy / header) for HTTP transport."
+                )
 
     @property
     def use_dashboard_authenticated_page(self) -> bool:

--- a/src/gg_api_core/tools/find_current_source_id.py
+++ b/src/gg_api_core/tools/find_current_source_id.py
@@ -127,7 +127,7 @@ async def find_current_source_id(
             repository_name = parsed_url.split("/")[-1] if parsed_url else None
             detection_method = "provided remote URL"
             logger.debug(f"Using provided remote URL: {remote_url}, parsed repository name: {repository_name}")
-        elif get_settings().mcp_port:
+        elif get_settings().auth_mode.transport == "http":
             # Hosted (HTTP) transport: no access to the user's filesystem or git binary.
             # Ask the agent to resolve the remote URL locally and call again.
             logger.info("No remote_url provided on HTTP transport; returning suggestion to run git locally")

--- a/src/gg_api_core/utils.py
+++ b/src/gg_api_core/utils.py
@@ -24,23 +24,23 @@ _client_singleton: GitGuardianClient | None = None
 async def get_client(personal_access_token: str | None = None, user_agent: str | None = None) -> GitGuardianClient:
     """Get GitGuardian client for the current context.
 
-    **Single-tenant is the DEFAULT** (local stdio usage).
-    Multi-tenant requires explicit opt-in via MULTI_TENANCY_ENABLED=true.
+    Tenancy is derived from the resolved authentication mode
+    (:attr:`Settings.auth_mode`): HTTP modes (``oauth-proxy``, ``header``) are
+    multi-tenant, stdio modes (``env-pat``, ``local-oauth``) are single-tenant.
 
     Authentication modes (in order of precedence):
 
     1. **Explicit PAT provided** → Use it directly, no caching
        - For programmatic usage where caller manages the token
 
-    2. **Multi-tenant mode** (MULTI_TENANCY_ENABLED=true) → Per-request from headers
-       - Requires MCP_PORT to be set
+    2. **Multi-tenant mode** (HTTP) → Per-request from headers
        - Token MUST come from Authorization header
        - No caching (new client per request)
 
-    3. **Single-tenant mode** (DEFAULT) → Singleton pattern, token sources:
+    3. **Single-tenant mode** (stdio) → Singleton pattern, token sources:
        a. GITGUARDIAN_PERSONAL_ACCESS_TOKEN env var
        b. Stored OAuth token from previous authentication flow
-       c. ENABLE_LOCAL_OAUTH=true → trigger interactive OAuth flow
+       c. local-oauth mode → trigger interactive OAuth flow
        - Same identity for entire server lifetime
 
     Args:
@@ -53,7 +53,7 @@ async def get_client(personal_access_token: str | None = None, user_agent: str |
         GitGuardianClient: Client instance configured with appropriate authentication
 
     Raises:
-        ValidationError: In multi-tenant mode, if MCP_PORT not set or Authorization header missing
+        ValidationError: In multi-tenant mode, if the Authorization header is missing
         RuntimeError: In single-tenant mode, if no token source is available
     """
     # Build the User-Agent for outgoing API calls if not explicitly provided
@@ -65,19 +65,14 @@ async def get_client(personal_access_token: str | None = None, user_agent: str |
         logger.debug("Creating client with explicitly provided token")
         return GitGuardianClient(personal_access_token=personal_access_token, user_agent=user_agent)
 
-    # 2. Multi-tenant mode (explicit opt-in via MULTI_TENANCY_ENABLED=true) : no caching, no automatic refresh
+    # 2. Multi-tenant mode (HTTP): no caching, no automatic refresh
     settings = get_settings()
     if settings.is_multi_tenant:
-        if not settings.mcp_port:
-            raise ValidationError(
-                "MULTI_TENANCY_ENABLED=true requires MCP_PORT to be set. "
-                "Multi-tenant mode only works with HTTP transport."
-            )
         logger.debug("Multi-tenant mode: extracting token from request headers")
         token = _get_token_from_request_headers()
         return GitGuardianClient(personal_access_token=token, user_agent=user_agent)
 
-    # 3. Single-tenant mode (DEFAULT) - use singleton pattern to cache the PAT
+    # 3. Single-tenant mode (stdio) - use singleton pattern to cache the PAT
     global _client_singleton
     if _client_singleton is not None:
         return _client_singleton
@@ -120,7 +115,7 @@ def _build_user_agent() -> str:
         - stdio:  ``GitGuardian-MCP-Server/0.5.0 (transport=stdio)``
         - hosted: ``GitGuardian-MCP-Server/0.5.0 (transport=http; client=Claude-Code/1.2)``
     """
-    transport = "http" if get_settings().mcp_port else "stdio"
+    transport = get_settings().auth_mode.transport
     parts = [f"transport={transport}"]
     caller = _get_caller_user_agent()
     if caller:

--- a/src/ggmcp/run.py
+++ b/src/ggmcp/run.py
@@ -51,10 +51,11 @@ def run_http_with_uvicorn():
 def run_mcp_server():
     """Run the MCP server with transport auto-detection.
 
-    If MCP_PORT is set, uses StreamableHTTP transport.
-    Otherwise, uses stdio transport (default).
+    The transport is derived from the resolved authentication mode: HTTP modes
+    (oauth-proxy / header) use StreamableHTTP, stdio modes (env-pat /
+    local-oauth) use stdio.
     """
-    if get_settings().mcp_port:
+    if get_settings().auth_mode.transport == "http":
         run_http_with_uvicorn()
     else:
         run_stdio()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -36,15 +36,13 @@ def block_real_network(socket_disabled) -> None:
 @pytest.fixture
 def remote_env(monkeypatch):
     """Environment of the hosted multi-tenant deployment (OAuth proxy mode)."""
-    monkeypatch.setenv("MULTI_TENANCY_ENABLED", "true")
-    # The presence of MCP_PORT marks the server as HTTP-transport: it gates
-    # multi-tenant token extraction and the hosted-server behavior of tools
-    # like find_current_source_id.
+    # The auth mode is the single source of truth: oauth-proxy implies HTTP
+    # transport and multi-tenancy, which gates token extraction and the
+    # hosted-server behavior of tools like find_current_source_id.
+    monkeypatch.setenv("MCP_AUTH_MODE", "oauth-proxy")
     monkeypatch.setenv("MCP_PORT", "8000")
-    monkeypatch.setenv("MCP_OAUTH_PROXY_ENABLED", "true")
     monkeypatch.setenv("MCP_BASE_URL", MCP_BASE_URL)
     monkeypatch.setenv("GITGUARDIAN_URL", "https://dashboard.gitguardian.com")
-    monkeypatch.setenv("ENABLE_LOCAL_OAUTH", "false")
     monkeypatch.delenv("GITGUARDIAN_API_URL", raising=False)
     monkeypatch.delenv("GITGUARDIAN_PERSONAL_ACCESS_TOKEN", raising=False)
     monkeypatch.delenv("GITGUARDIAN_API_KEY", raising=False)

--- a/tests/e2e/test_stdio_server.py
+++ b/tests/e2e/test_stdio_server.py
@@ -50,10 +50,11 @@ def stdio_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.delenv("MCP_PORT", raising=False)
     monkeypatch.delenv("MULTI_TENANCY_ENABLED", raising=False)
     monkeypatch.delenv("MCP_OAUTH_PROXY_ENABLED", raising=False)
+    monkeypatch.delenv("ENABLE_LOCAL_OAUTH", raising=False)
     monkeypatch.delenv("GITGUARDIAN_API_URL", raising=False)
     monkeypatch.setenv("GITGUARDIAN_URL", "https://dashboard.gitguardian.com")
     monkeypatch.setenv("GITGUARDIAN_PERSONAL_ACCESS_TOKEN", STDIO_PAT)
-    monkeypatch.setenv("ENABLE_LOCAL_OAUTH", "false")
+    monkeypatch.setenv("MCP_AUTH_MODE", "env-pat")
 
 
 @pytest.fixture(autouse=True)
@@ -102,7 +103,7 @@ class TestPatEnvAuthentication:
         assert_authenticated_request(route, STDIO_PAT)
         assert "(transport=stdio)" in route.calls.last.request.headers["User-Agent"]
 
-    async def test_default_oauth_mode_still_uses_the_env_token_without_a_browser_flow(
+    async def test_pat_alone_selects_env_pat_mode_without_a_browser_flow(
         self,
         stdio_env: None,
         monkeypatch: pytest.MonkeyPatch,
@@ -110,21 +111,21 @@ class TestPatEnvAuthentication:
         mock_token_scopes: Any,
     ) -> None:
         """
-        GIVEN the default local setup (ENABLE_LOCAL_OAUTH unset) with a PAT env var
+        GIVEN a PAT env var with no MCP_AUTH_MODE and no ENABLE_LOCAL_OAUTH
         WHEN a tool is called
-        THEN the server runs in LOCAL_OAUTH_FLOW mode but the client picks the
-             env token, so no interactive flow is ever needed
+        THEN the server runs in PERSONAL_ACCESS_TOKEN_ENV_VAR mode (the old
+             ladder surprise where a PAT alone did not select PAT mode is gone)
         """
 
         async def unexpected_oauth_flow(*_args: Any, **_kwargs: Any) -> None:
             raise AssertionError("interactive OAuth must not start while an env PAT exists")
 
-        monkeypatch.delenv("ENABLE_LOCAL_OAUTH")
+        monkeypatch.delenv("MCP_AUTH_MODE")
         monkeypatch.setattr(client_module, "_run_oauth_flow", unexpected_oauth_flow)
         route = gg_api.get("/incidents/secrets/77").respond(200, json=INCIDENT)
 
         server = build_server()
-        assert server.authentication_mode.value == "LOCAL_OAUTH_FLOW"
+        assert server.authentication_mode.value == "PERSONAL_ACCESS_TOKEN_ENV_VAR"
         async with Client(server) as client:
             result = await client.call_tool("get_incident", {"params": {"incident_id": 77}})
 
@@ -166,7 +167,7 @@ class TestPatEnvAuthentication:
         """
         stored_pat = "stdio-stored-oauth-pat"
         monkeypatch.delenv("GITGUARDIAN_PERSONAL_ACCESS_TOKEN")
-        monkeypatch.delenv("ENABLE_LOCAL_OAUTH")
+        monkeypatch.delenv("MCP_AUTH_MODE")
         oauth.FileTokenStorage().save_token(
             "https://dashboard.gitguardian.com",
             {"access_token": stored_pat},

--- a/tests/test_auth_mode.py
+++ b/tests/test_auth_mode.py
@@ -1,0 +1,218 @@
+"""Tests for the MCP_AUTH_MODE resolution and boot-time validation.
+
+The auth mode is the single source of truth for transport and tenancy. These
+tests pin the explicit-mode parsing, the legacy back-compat inference (with
+deprecation warnings), and the boot asserts that refuse unsafe combinations.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from gg_api_core.settings import AuthMode, get_settings
+
+
+def _settings(env: dict[str, str]) -> object:
+    with patch.dict(os.environ, env, clear=True):
+        return get_settings()
+
+
+class TestAuthModeEnum:
+    """The enum's derived tenancy and transport."""
+
+    @pytest.mark.parametrize(
+        ("mode", "multi_tenant", "transport"),
+        [
+            (AuthMode.OAUTH_PROXY, True, "http"),
+            (AuthMode.HEADER, True, "http"),
+            (AuthMode.ENV_PAT, False, "stdio"),
+            (AuthMode.LOCAL_OAUTH, False, "stdio"),
+        ],
+    )
+    def test_derived_tenancy_and_transport(self, mode, multi_tenant, transport):
+        """
+        GIVEN an AuthMode
+        WHEN its is_multi_tenant and transport are read
+        THEN HTTP modes are multi-tenant, stdio modes are single-tenant
+        """
+        assert mode.is_multi_tenant is multi_tenant
+        assert mode.transport == transport
+
+
+class TestExplicitModeResolution:
+    """MCP_AUTH_MODE wins and is parsed leniently."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("oauth-proxy", AuthMode.OAUTH_PROXY),
+            ("header", AuthMode.HEADER),
+            ("env-pat", AuthMode.ENV_PAT),
+            ("local-oauth", AuthMode.LOCAL_OAUTH),
+            # underscore and case variants are accepted
+            ("oauth_proxy", AuthMode.OAUTH_PROXY),
+            ("ENV_PAT", AuthMode.ENV_PAT),
+            ("Local-OAuth", AuthMode.LOCAL_OAUTH),
+        ],
+    )
+    def test_explicit_mode_parses(self, raw, expected):
+        """
+        GIVEN MCP_AUTH_MODE set to a valid (possibly variant) spelling
+        WHEN auth_mode is read
+        THEN it resolves to the matching AuthMode
+        """
+        assert _settings({"MCP_AUTH_MODE": raw}).auth_mode is expected
+
+    def test_invalid_mode_raises(self):
+        """
+        GIVEN MCP_AUTH_MODE set to an unknown value
+        WHEN auth_mode is read
+        THEN it raises ValueError listing the valid modes
+        """
+        with pytest.raises(ValueError, match="Invalid MCP_AUTH_MODE"):
+            _settings({"MCP_AUTH_MODE": "bogus"}).auth_mode
+
+
+class TestLegacyInference:
+    """Back-compat mapping of the deprecated selector vars."""
+
+    def test_oauth_proxy_enabled_maps_to_oauth_proxy(self):
+        """
+        GIVEN MCP_OAUTH_PROXY_ENABLED=true and no MCP_AUTH_MODE
+        WHEN auth_mode is read
+        THEN it resolves to oauth-proxy with a deprecation warning
+        """
+        with pytest.warns(DeprecationWarning, match="MCP_OAUTH_PROXY_ENABLED"):
+            assert _settings({"MCP_OAUTH_PROXY_ENABLED": "true"}).auth_mode is AuthMode.OAUTH_PROXY
+
+    def test_enable_local_oauth_false_with_pat_maps_to_env_pat(self):
+        """
+        GIVEN ENABLE_LOCAL_OAUTH=false and a PAT, no MCP_AUTH_MODE
+        WHEN auth_mode is read
+        THEN it resolves to env-pat
+        """
+        with pytest.warns(DeprecationWarning, match="ENABLE_LOCAL_OAUTH"):
+            assert (
+                _settings({"ENABLE_LOCAL_OAUTH": "false", "GITGUARDIAN_PERSONAL_ACCESS_TOKEN": "x"}).auth_mode
+                is AuthMode.ENV_PAT
+            )
+
+    def test_enable_local_oauth_false_without_pat_maps_to_header(self):
+        """
+        GIVEN ENABLE_LOCAL_OAUTH=false and no PAT, no MCP_AUTH_MODE
+        WHEN auth_mode is read
+        THEN it resolves to header (HTTP, multi-tenant)
+        """
+        with pytest.warns(DeprecationWarning, match="ENABLE_LOCAL_OAUTH"):
+            assert _settings({"ENABLE_LOCAL_OAUTH": "false"}).auth_mode is AuthMode.HEADER
+
+    def test_pat_alone_maps_to_env_pat(self):
+        """
+        GIVEN a PAT with no MCP_AUTH_MODE and no ENABLE_LOCAL_OAUTH
+        WHEN auth_mode is read
+        THEN it resolves to env-pat (the old ladder surprise is gone)
+        """
+        assert _settings({"GITGUARDIAN_PERSONAL_ACCESS_TOKEN": "x"}).auth_mode is AuthMode.ENV_PAT
+
+    def test_nothing_set_maps_to_local_oauth(self):
+        """
+        GIVEN no auth-related env vars at all
+        WHEN auth_mode is read
+        THEN it resolves to local-oauth (single-tenant default)
+        """
+        assert _settings({}).auth_mode is AuthMode.LOCAL_OAUTH
+
+
+class TestValidateAuthMode:
+    """Boot asserts refuse unsafe mode/var combinations."""
+
+    def test_header_requires_mcp_port(self):
+        """
+        GIVEN MCP_AUTH_MODE=header without MCP_PORT
+        WHEN validate_auth_mode is called
+        THEN it raises ValueError
+        """
+        with pytest.raises(ValueError, match="MCP_PORT"):
+            _settings({"MCP_AUTH_MODE": "header"}).validate_auth_mode()
+
+    def test_oauth_proxy_requires_mcp_port(self):
+        """
+        GIVEN MCP_AUTH_MODE=oauth-proxy without MCP_PORT
+        WHEN validate_auth_mode is called
+        THEN it raises ValueError
+        """
+        with pytest.raises(ValueError, match="MCP_PORT"):
+            _settings({"MCP_AUTH_MODE": "oauth-proxy"}).validate_auth_mode()
+
+    def test_env_pat_requires_pat(self):
+        """
+        GIVEN MCP_AUTH_MODE=env-pat without a PAT
+        WHEN validate_auth_mode is called
+        THEN it raises ValueError
+        """
+        with pytest.raises(ValueError, match="GITGUARDIAN_PERSONAL_ACCESS_TOKEN"):
+            _settings({"MCP_AUTH_MODE": "env-pat"}).validate_auth_mode()
+
+    def test_http_mode_forbids_server_side_pat(self):
+        """
+        GIVEN MCP_AUTH_MODE=header with a server-side PAT
+        WHEN validate_auth_mode is called
+        THEN it raises ValueError (the PAT would collapse every tenant)
+        """
+        with pytest.raises(ValueError, match="collapse every tenant"):
+            _settings(
+                {"MCP_AUTH_MODE": "header", "MCP_PORT": "8000", "GITGUARDIAN_PERSONAL_ACCESS_TOKEN": "x"}
+            ).validate_auth_mode()
+
+    def test_stdio_mode_forbids_mcp_port(self):
+        """
+        GIVEN MCP_AUTH_MODE=env-pat with MCP_PORT set
+        WHEN validate_auth_mode is called
+        THEN it raises ValueError
+        """
+        with pytest.raises(ValueError, match="MCP_PORT"):
+            _settings(
+                {"MCP_AUTH_MODE": "env-pat", "GITGUARDIAN_PERSONAL_ACCESS_TOKEN": "x", "MCP_PORT": "8000"}
+            ).validate_auth_mode()
+
+    def test_multi_tenancy_enabled_contradiction_raises(self):
+        """
+        GIVEN MCP_AUTH_MODE=env-pat but MULTI_TENANCY_ENABLED=true
+        WHEN validate_auth_mode is called
+        THEN it raises ValueError (tenancy is derived, not declared)
+        """
+        with pytest.raises(ValueError, match="contradicts"):
+            _settings(
+                {
+                    "MCP_AUTH_MODE": "env-pat",
+                    "GITGUARDIAN_PERSONAL_ACCESS_TOKEN": "x",
+                    "MULTI_TENANCY_ENABLED": "true",
+                }
+            ).validate_auth_mode()
+
+    def test_http_transport_without_declared_mode_raises(self):
+        """
+        GIVEN MCP_PORT set but no MCP_AUTH_MODE and no legacy HTTP selector
+        WHEN validate_auth_mode is called
+        THEN it raises ValueError asking for a declared HTTP mode
+        """
+        with pytest.raises(ValueError, match="MCP_AUTH_MODE is not declared"):
+            _settings({"MCP_PORT": "8000"}).validate_auth_mode()
+
+    @pytest.mark.parametrize(
+        "env",
+        [
+            {"MCP_AUTH_MODE": "oauth-proxy", "MCP_PORT": "8000"},
+            {"MCP_AUTH_MODE": "header", "MCP_PORT": "8000"},
+            {"MCP_AUTH_MODE": "env-pat", "GITGUARDIAN_PERSONAL_ACCESS_TOKEN": "x"},
+            {"MCP_AUTH_MODE": "local-oauth"},
+        ],
+    )
+    def test_valid_configurations_pass(self, env):
+        """
+        GIVEN a valid mode/var combination
+        WHEN validate_auth_mode is called
+        THEN it does not raise
+        """
+        _settings(env).validate_auth_mode()

--- a/tests/test_get_client_safeguards.py
+++ b/tests/test_get_client_safeguards.py
@@ -50,29 +50,33 @@ class TestIsMultiTenant:
 
     def test_returns_true_when_enabled(self):
         """
-        GIVEN MULTI_TENANCY_ENABLED=true
+        GIVEN MCP_AUTH_MODE=header
         WHEN get_settings().is_multi_tenant is read
         THEN it returns True
         """
-        with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "true"}, clear=True):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "header"}, clear=True):
             assert get_settings().is_multi_tenant is True
 
     def test_returns_false_when_disabled(self):
         """
-        GIVEN MULTI_TENANCY_ENABLED=false
+        GIVEN MCP_AUTH_MODE=env-pat (single-tenant)
         WHEN get_settings().is_multi_tenant is read
         THEN it returns False
         """
-        with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "false"}, clear=True):
+        with patch.dict(
+            os.environ,
+            {"MCP_AUTH_MODE": "env-pat", "GITGUARDIAN_PERSONAL_ACCESS_TOKEN": "x"},
+            clear=True,
+        ):
             assert get_settings().is_multi_tenant is False
 
     def test_case_insensitive(self):
         """
-        GIVEN MULTI_TENANCY_ENABLED=TRUE (uppercase)
+        GIVEN MCP_AUTH_MODE=HEADER (uppercase)
         WHEN get_settings().is_multi_tenant is read
         THEN it returns True
         """
-        with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "TRUE"}, clear=True):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "HEADER"}, clear=True):
             assert get_settings().is_multi_tenant is True
 
 
@@ -109,7 +113,7 @@ class TestGetClientExplicitPAT:
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
 
-        with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "true", "MCP_PORT": "8080"}, clear=True):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "header", "MCP_PORT": "8080"}, clear=True):
             result = await get_client(personal_access_token="explicit-token")
 
         # MCP_PORT is set, so the transport marker is http (no caller header here)
@@ -121,26 +125,13 @@ class TestGetClientExplicitPAT:
 
 
 class TestGetClientMultiTenantMode:
-    """Tests for get_client() in multi-tenant mode (explicit opt-in)."""
-
-    async def test_multi_tenant_requires_mcp_port(self):
-        """
-        GIVEN MULTI_TENANCY_ENABLED=true but MCP_PORT is not set
-        WHEN get_client is called
-        THEN it raises ValidationError
-        """
-        with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "true"}, clear=True):
-            with pytest.raises(ValidationError) as exc_info:
-                await get_client()
-
-        assert "MCP_PORT" in str(exc_info.value)
-        assert "MULTI_TENANCY_ENABLED" in str(exc_info.value)
+    """Tests for get_client() in multi-tenant mode (HTTP auth modes)."""
 
     @patch("gg_api_core.utils.get_http_headers")
     @patch("gg_api_core.utils.GitGuardianClient")
     async def test_multi_tenant_extracts_token_from_headers(self, mock_client_class, mock_get_headers):
         """
-        GIVEN MULTI_TENANCY_ENABLED=true and MCP_PORT is set
+        GIVEN MCP_AUTH_MODE=header and MCP_PORT is set
         AND Authorization header is present
         WHEN get_client is called
         THEN it extracts token and user-agent from headers and creates new client
@@ -149,7 +140,7 @@ class TestGetClientMultiTenantMode:
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
 
-        with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "true", "MCP_PORT": "8080"}, clear=True):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "header", "MCP_PORT": "8080"}, clear=True):
             result = await get_client()
 
         # No user-agent header on the request, so only the transport marker is added
@@ -163,7 +154,7 @@ class TestGetClientMultiTenantMode:
     @patch("gg_api_core.utils.GitGuardianClient")
     async def test_multi_tenant_forwards_caller_user_agent(self, mock_client_class, mock_get_headers):
         """
-        GIVEN MULTI_TENANCY_ENABLED=true and MCP_PORT is set
+        GIVEN MCP_AUTH_MODE=header and MCP_PORT is set
         AND request has both Authorization and User-Agent headers
         WHEN get_client is called
         THEN the caller's User-Agent is preserved as client=... in the UA string
@@ -175,7 +166,7 @@ class TestGetClientMultiTenantMode:
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
 
-        with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "true", "MCP_PORT": "8080"}, clear=True):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "header", "MCP_PORT": "8080"}, clear=True):
             result = await get_client()
 
         mock_client_class.assert_called_once_with(
@@ -204,7 +195,7 @@ class TestGetClientMultiTenantMode:
         mock_client2 = MagicMock()
         mock_client_class.side_effect = [mock_client1, mock_client2]
 
-        with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "true", "MCP_PORT": "8080"}, clear=True):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "header", "MCP_PORT": "8080"}, clear=True):
             result1 = await get_client()
             result2 = await get_client()
 
@@ -222,7 +213,7 @@ class TestGetClientMultiTenantMode:
         """
         mock_get_headers.return_value = {"content-type": "application/json"}
 
-        with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "true", "MCP_PORT": "8080"}, clear=True):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "header", "MCP_PORT": "8080"}, clear=True):
             with pytest.raises(ValidationError) as exc_info:
                 await get_client()
 
@@ -310,7 +301,7 @@ class TestGetClientSingleTenantMode:
     @patch("gg_api_core.utils.GitGuardianClient")
     async def test_single_tenant_triggers_oauth_when_enabled(self, mock_client_class, mock_get_stored, mock_oauth):
         """
-        GIVEN no env PAT, no stored token, but ENABLE_LOCAL_OAUTH=true
+        GIVEN no env PAT, no stored token, but MCP_AUTH_MODE=local-oauth
         WHEN get_client is called
         THEN it triggers the OAuth flow and enables token refresh
         """
@@ -325,7 +316,7 @@ class TestGetClientSingleTenantMode:
 
         gg_api_core.utils._client_singleton = None
 
-        with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "true"}, clear=True):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "local-oauth"}, clear=True):
             result = await get_client()
 
         mock_oauth.assert_called_once()
@@ -338,7 +329,7 @@ class TestGetClientSingleTenantMode:
     @patch("gg_api_core.client._get_stored_oauth_token")
     async def test_single_tenant_raises_when_no_token_source(self, mock_get_stored):
         """
-        GIVEN no env PAT, no stored token, and OAuth disabled
+        GIVEN env-pat mode but no PAT and no stored token
         WHEN get_client is called
         THEN it raises RuntimeError with helpful message
         """
@@ -349,13 +340,13 @@ class TestGetClientSingleTenantMode:
 
         gg_api_core.utils._client_singleton = None
 
-        with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "false"}, clear=True):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "env-pat"}, clear=True):
             with pytest.raises(RuntimeError) as exc_info:
                 await get_client()
 
         assert "No API token available" in str(exc_info.value)
         assert "GITGUARDIAN_PERSONAL_ACCESS_TOKEN" in str(exc_info.value)
-        assert "ENABLE_LOCAL_OAUTH" in str(exc_info.value)
+        assert "MCP_AUTH_MODE" in str(exc_info.value)
 
 
 class TestAccountIsolation:
@@ -377,7 +368,7 @@ class TestAccountIsolation:
         mock_get_headers.return_value = {"authorization": "Bearer token"}
         mock_client_class.return_value = MagicMock()
 
-        with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "true", "MCP_PORT": "8080"}, clear=True):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "header", "MCP_PORT": "8080"}, clear=True):
             await get_client()
             await get_client()
             await get_client()
@@ -457,7 +448,7 @@ class TestCallerUserAgentExtraction:
         }
         mock_client_class.return_value = MagicMock()
 
-        with patch.dict(os.environ, {"MULTI_TENANCY_ENABLED": "true", "MCP_PORT": "8080"}, clear=True):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "header", "MCP_PORT": "8080"}, clear=True):
             await get_client()
 
         mock_client_class.assert_called_once_with(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -54,7 +54,7 @@ class TestGitGuardianFastMCP:
 
         # Use a SaaS URL instead of test/localhost URL
         with patch.dict(
-            os.environ, {"ENABLE_LOCAL_OAUTH": "true", "GITGUARDIAN_URL": "https://dashboard.gitguardian.com"}
+            os.environ, {"MCP_AUTH_MODE": "local-oauth", "GITGUARDIAN_URL": "https://dashboard.gitguardian.com"}
         ):
             mcp = get_mcp_server("TestMCP")
 
@@ -76,7 +76,7 @@ class TestGitGuardianFastMCP:
         from gg_api_core.mcp_server import CachedTokenInfoMixin, GitGuardianLocalOAuthMCP
 
         # Create OAuth MCP instance
-        with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "true"}):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "local-oauth"}):
             mcp = GitGuardianLocalOAuthMCP("test_server_lifespan")
 
             # Verify it has the CachedTokenInfoMixin
@@ -103,7 +103,7 @@ class TestGitGuardianFastMCP:
         from gg_api_core.mcp_server import GitGuardianAuthorizationHeaderMCP
 
         # Create MCP server using AuthorizationHeader mode (non-caching)
-        with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "false"}):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "header"}):
             mcp = GitGuardianAuthorizationHeaderMCP("test_server")
 
             # Verify it doesn't have the CachedTokenInfoMixin methods
@@ -135,7 +135,7 @@ class TestGitGuardianFastMCP:
         from unittest.mock import patch
 
         # Test in OAuth mode (cached scopes)
-        with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "true"}):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "local-oauth"}):
             # Set token scopes to include all required scopes
             self.mcp._token_scopes = {"scan", "incidents:read", "honeytokens:read"}
 
@@ -167,7 +167,7 @@ class TestGitGuardianFastMCP:
         from gg_api_core.mcp_server import GitGuardianLocalOAuthMCP
 
         # Test in OAuth mode (cached scopes) - create a new instance
-        with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "true"}):
+        with patch.dict(os.environ, {"MCP_AUTH_MODE": "local-oauth"}):
             mcp = GitGuardianLocalOAuthMCP("test_server_scopes")
 
             # Set token scopes to include only some required scopes

--- a/tests/test_scope_filtering.py
+++ b/tests/test_scope_filtering.py
@@ -12,7 +12,7 @@ async def test_tools_filtered_by_scopes():
     """Test that tools are filtered based on user's available scopes."""
 
     # Test in OAuth mode (uses cached scopes)
-    with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "true"}):
+    with patch.dict(os.environ, {"MCP_AUTH_MODE": "local-oauth"}):
         # Create MCP instance
         mcp = get_mcp_server("Test Server")
 
@@ -70,7 +70,7 @@ async def test_tools_filtered_by_scopes():
 async def test_direct_call_tools_filtered_by_scopes():
     """Test that tools registered via direct call (mcp.tool(fn, ...)) are filtered by scopes."""
 
-    with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "true"}):
+    with patch.dict(os.environ, {"MCP_AUTH_MODE": "local-oauth"}):
         mcp = get_mcp_server("Test Direct Call")
         mcp._token_scopes = {"scan"}
 
@@ -100,7 +100,7 @@ async def test_direct_call_tools_filtered_by_scopes():
 async def test_direct_call_tools_with_custom_name_filtered_by_scopes():
     """Test that direct-call tools with explicit name= are filtered correctly."""
 
-    with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "true"}):
+    with patch.dict(os.environ, {"MCP_AUTH_MODE": "local-oauth"}):
         mcp = get_mcp_server("Test Custom Name")
         mcp._token_scopes = {"incidents:read"}
 
@@ -124,7 +124,7 @@ async def test_direct_call_tools_with_custom_name_filtered_by_scopes():
 async def test_scope_filtering_with_partially_satisfied_multiple_scopes():
     """Test that a tool requiring multiple scopes is hidden when only some are available."""
 
-    with patch.dict(os.environ, {"ENABLE_LOCAL_OAUTH": "true"}):
+    with patch.dict(os.environ, {"MCP_AUTH_MODE": "local-oauth"}):
         mcp = get_mcp_server("Test Partial Scopes")
         mcp._token_scopes = {"incidents:read"}
 

--- a/tests/test_server_profiles.py
+++ b/tests/test_server_profiles.py
@@ -12,7 +12,7 @@ import pytest
 @pytest.fixture
 def mock_env_no_http():
     """Mock env vars to keep imports in stdio/cached-scope mode."""
-    with patch.dict("os.environ", {"MCP_PORT": "", "ENABLE_LOCAL_OAUTH": "true"}, clear=False):
+    with patch.dict("os.environ", {"MCP_AUTH_MODE": "local-oauth"}, clear=False):
         yield
 
 

--- a/tests/tools/test_find_current_source_id.py
+++ b/tests/tools/test_find_current_source_id.py
@@ -444,7 +444,7 @@ class TestFindCurrentSourceId:
     @pytest.mark.asyncio
     async def test_find_current_source_id_http_transport_returns_suggestion(self, mock_gitguardian_client):
         """
-        GIVEN: The server runs over HTTP transport (mcp_port set) and no remote_url is provided
+        GIVEN: The server runs over HTTP transport (HTTP auth mode) and no remote_url is provided
         WHEN: Finding the source_id
         THEN: A suggestion is returned asking the agent to run git locally, without touching subprocess
         """
@@ -452,7 +452,7 @@ class TestFindCurrentSourceId:
             patch("gg_api_core.tools.find_current_source_id.get_settings") as mock_settings,
             patch("subprocess.run") as mock_run,
         ):
-            mock_settings.return_value = MagicMock(mcp_port="8000")
+            mock_settings.return_value = MagicMock(auth_mode=MagicMock(transport="http"))
 
             result = await find_current_source_id()
 


### PR DESCRIPTION
## Summary

Closes SI-4057. Replaces the interacting auth selectors (`MCP_OAUTH_PROXY_ENABLED`, `ENABLE_LOCAL_OAUTH`, `MULTI_TENANCY_ENABLED`, plus the presence-based `GITGUARDIAN_PERSONAL_ACCESS_TOKEN` and `MCP_PORT`) with a single declared `MCP_AUTH_MODE` enum:

```
MCP_AUTH_MODE = oauth-proxy | header | env-pat | local-oauth
```

Tenancy is **derived** from the mode rather than declared separately, so the "HTTP deployment silently collapses onto one shared identity" state becomes unrepresentable instead of merely guarded.

## What changed

- **`AuthMode` enum** (`settings.py`) with `transport` and `is_multi_tenant` properties. HTTP modes (`oauth-proxy`, `header`) are multi-tenant; stdio modes (`env-pat`, `local-oauth`) are single-tenant.
- **Boot asserts** (`validate_auth_mode()`, called from `get_mcp_server()`): refuse unsafe combinations at startup —
  - server-side PAT (`GITGUARDIAN_PERSONAL_ACCESS_TOKEN`) in an HTTP mode,
  - `MCP_PORT` in a stdio mode,
  - `MULTI_TENANCY_ENABLED` contradicting the derived tenancy,
  - `MCP_PORT` set without a declared mode.
- **Startup log line**: first line prints resolved mode, GG URL host, and tenancy.
- **Back-compat mapping** of the legacy selectors with `DeprecationWarning` for one release cycle.
- **Ladder-surprise fix**: a PAT alone now selects `env-pat` (previously required `ENABLE_LOCAL_OAUTH=false`).

## Testing

- New `tests/test_auth_mode.py` (28 tests): enum derivation, explicit parsing, legacy inference, and all boot asserts.
- Updated existing tests to use `MCP_AUTH_MODE`.
- Full suite: 1256 passed, 3 skipped, 9 xfailed.

---

**Stacked on:** #222 (`si-4067-cleanup`)