### PR TITLE
fix(sentry): hide tool arguments from pydantic validation errors (SI-4068)

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/logging_config.py
+++ b/packages/gg_api_core/src/gg_api_core/logging_config.py
@@ -67,6 +67,12 @@ def _add_exception_cls(logger: WrappedLogger, method_name: str, event_dict: Even
 def configure_logging(
     *, log_level: str = "INFO", log_format: str | None = None, service: str = "gg-mcp-server"
 ) -> None:
+    # Log hardening: raise fastmcp's server logger to ERROR so its ``Invalid arguments for
+    # tool`` WARNING lines — which embed the raw submitted arguments via pydantic's ``input``
+    # field (see fastmcp server.py ``call_tool``, e.g. scan documents and file paths) — never
+    # reach the log. Real unexpected tool errors are logged by fastmcp at ERROR and kept.
+    logging.getLogger("fastmcp.server.server").setLevel(logging.ERROR)
+
     def _add_gg_fields(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
         event_dict["gg_service"] = service
         event_dict["gg_version"] = APP_VERSION or "unknown"

--- a/packages/gg_api_core/src/gg_api_core/sanitization.py
+++ b/packages/gg_api_core/src/gg_api_core/sanitization.py
@@ -46,6 +46,14 @@ _LEAF_TYPES: Final = (int, float, bool, date, datetime, type(None))
 _SENSITIVE_URL_PARAMS_RE = re.compile(rf"(({'|'.join(SENSITIVE_PARAMETER_NAMES)})=)([^&]+)(&|$)")
 _SENSITIVE_GIT_CLONE_RE = re.compile(r"(https?://)[^:@/\s]*:[^@/\s]*@")
 
+# Pydantic renders the rejected input into every ValidationError message as
+# ``input_value=<repr>, input_type=<type>]``. FastMCP validates tool calls
+# against a TypeAdapter built from the tool signature rather than against the
+# ``*Params`` model, so ``hide_input_in_errors`` on the model does not reach
+# this text and the raw arguments travel with the exception message.
+_PYDANTIC_INPUT_VALUE_RE = re.compile(r"input_value=[^\n]*")
+_PYDANTIC_INPUT_TYPE_MARKER: Final = ", input_type="
+
 
 def scrub_url_params(string: str) -> str:
     return _SENSITIVE_URL_PARAMS_RE.sub(rf"\1{SENSITIVE_DATA_PLACEHOLDER}\4", string)
@@ -58,11 +66,38 @@ def scrub_git_credentials(string: str) -> str:
     )
 
 
+def _redact_input_value(match: re.Match[str]) -> str:
+    """Replace one ``input_value=`` payload, keeping the diagnostic tail."""
+    rest = match.group(0)
+    marker = rest.rfind(_PYDANTIC_INPUT_TYPE_MARKER)
+    if marker != -1:
+        tail = rest[marker:]
+    elif rest.endswith("]"):
+        tail = "]"
+    else:
+        tail = ""
+    return f"input_value={SENSITIVE_DATA_PLACEHOLDER}{tail}"
+
+
+def scrub_pydantic_input_value(string: str) -> str:
+    """Redact the rejected input embedded in pydantic validation messages.
+
+    The value runs to the last ``, input_type=`` on its line, so a payload that
+    itself contains that marker is still redacted in full. ``input_type`` and
+    the error type are kept: they describe the failure without carrying the
+    submitted data.
+    """
+    if "input_value=" not in string:
+        return string
+    return _PYDANTIC_INPUT_VALUE_RE.sub(_redact_input_value, string)
+
+
 def scrub_by_value(value: Any) -> Any:
     if not isinstance(value, str):
         return value
     value = scrub_url_params(value)
     value = scrub_git_credentials(value)
+    value = scrub_pydantic_input_value(value)
     return value
 
 

--- a/packages/gg_api_core/src/gg_api_core/sanitization.py
+++ b/packages/gg_api_core/src/gg_api_core/sanitization.py
@@ -52,7 +52,6 @@ _SENSITIVE_GIT_CLONE_RE = re.compile(r"(https?://)[^:@/\s]*:[^@/\s]*@")
 # ``*Params`` model, so ``hide_input_in_errors`` on the model does not reach
 # this text and the raw arguments travel with the exception message.
 _PYDANTIC_INPUT_VALUE_RE = re.compile(r"input_value=[^\n]*")
-_PYDANTIC_INPUT_TYPE_MARKER: Final = ", input_type="
 
 
 def scrub_url_params(string: str) -> str:
@@ -67,28 +66,23 @@ def scrub_git_credentials(string: str) -> str:
 
 
 def _redact_input_value(match: re.Match[str]) -> str:
-    """Replace one ``input_value=`` payload, keeping the diagnostic tail."""
+    """Replace one ``input_value=`` payload, keeping the diagnostic tail.
+
+    Pydantic always renders ``input_type`` after ``input_value``, so the tail
+    starts at the last such marker on the line. Taking the last one keeps a
+    payload that embeds the marker itself fully redacted.
+    """
     rest = match.group(0)
-    marker = rest.rfind(_PYDANTIC_INPUT_TYPE_MARKER)
-    if marker != -1:
-        tail = rest[marker:]
-    elif rest.endswith("]"):
-        tail = "]"
-    else:
-        tail = ""
-    return f"input_value={SENSITIVE_DATA_PLACEHOLDER}{tail}"
+    marker = rest.rfind(", input_type=")
+    return f"input_value={SENSITIVE_DATA_PLACEHOLDER}{rest[marker:] if marker != -1 else ''}"
 
 
 def scrub_pydantic_input_value(string: str) -> str:
     """Redact the rejected input embedded in pydantic validation messages.
 
-    The value runs to the last ``, input_type=`` on its line, so a payload that
-    itself contains that marker is still redacted in full. ``input_type`` and
-    the error type are kept: they describe the failure without carrying the
-    submitted data.
+    ``input_type`` and the error type are kept: they describe the failure
+    without carrying the submitted data.
     """
-    if "input_value=" not in string:
-        return string
     return _PYDANTIC_INPUT_VALUE_RE.sub(_redact_input_value, string)
 
 

--- a/packages/gg_api_core/src/gg_api_core/tools/activity_logs.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/activity_logs.py
@@ -21,12 +21,13 @@ from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
 
 from gg_api_core.client import DEFAULT_PAGINATION_MAX_BYTES, ListResponse
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
 
 
-class ListActivityLogsParams(BaseModel):
+class ListActivityLogsParams(ToolParamsBase):
     """Parameters for listing the activity log of a secret incident."""
 
     incident_id: int = Field(description="ID of the secret incident whose activity log to list")

--- a/packages/gg_api_core/src/gg_api_core/tools/assign_incident.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/assign_incident.py
@@ -3,12 +3,13 @@ import logging
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field, model_validator
 
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
 
 
-class AssignIncidentParams(BaseModel):
+class AssignIncidentParams(ToolParamsBase):
     """Parameters for assigning an incident to a member."""
 
     incident_id: str | int = Field(description="ID of the secret incident to assign")

--- a/packages/gg_api_core/src/gg_api_core/tools/assign_public_incident.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/assign_public_incident.py
@@ -4,12 +4,13 @@ from typing import Any
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field, model_validator
 
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
 
 
-class AssignPublicIncidentParams(BaseModel):
+class AssignPublicIncidentParams(ToolParamsBase):
     """Parameters for assigning a public secret incident to a member."""
 
     incident_id: int = Field(description="ID of the public secret incident to assign")

--- a/packages/gg_api_core/src/gg_api_core/tools/count_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/count_incidents.py
@@ -10,12 +10,13 @@ from gg_api_core.tools.list_incidents import (
     DEFAULT_VALIDITIES,
     SEVERITY_NAME_TO_VALUE,
 )
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
 
 
-class CountIncidentsParams(BaseModel):
+class CountIncidentsParams(ToolParamsBase):
     """Parameters for counting incidents using the MCP-optimized count endpoint.
 
     Accepts the same filters as list_incidents but returns only a count.

--- a/packages/gg_api_core/src/gg_api_core/tools/create_code_fix_request.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/create_code_fix_request.py
@@ -3,6 +3,7 @@ import logging
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
 
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
@@ -15,7 +16,7 @@ class LocationToFix(BaseModel):
     location_ids: list[int] = Field(min_length=1, description="List of location IDs to fix for this issue")
 
 
-class CreateCodeFixRequestParams(BaseModel):
+class CreateCodeFixRequestParams(ToolParamsBase):
     """Parameters for creating code fix requests."""
 
     locations: list[LocationToFix] = Field(

--- a/packages/gg_api_core/src/gg_api_core/tools/generate_honey_token.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/generate_honey_token.py
@@ -5,6 +5,7 @@ import httpx
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
 
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
@@ -29,7 +30,7 @@ def _extract_api_detail(response: httpx.Response) -> str:
     return str(body)
 
 
-class GenerateHoneytokenParams(BaseModel):
+class GenerateHoneytokenParams(ToolParamsBase):
     """Parameters for generating a honeytoken."""
 
     name: str = Field(

--- a/packages/gg_api_core/src/gg_api_core/tools/get_incident.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/get_incident.py
@@ -4,12 +4,13 @@ from typing import Any
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
 
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
 
 
-class GetIncidentParams(BaseModel):
+class GetIncidentParams(ToolParamsBase):
     """Parameters for retrieving a specific incident."""
 
     incident_id: int = Field(description="The ID of the incident to retrieve")

--- a/packages/gg_api_core/src/gg_api_core/tools/get_member.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/get_member.py
@@ -4,12 +4,13 @@ from typing import Any
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
 
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
 
 
-class GetMemberParams(BaseModel):
+class GetMemberParams(ToolParamsBase):
     """Parameters for retrieving a specific member."""
 
     member_id: int = Field(description="The ID of the member to retrieve")

--- a/packages/gg_api_core/src/gg_api_core/tools/get_public_incident.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/get_public_incident.py
@@ -4,12 +4,13 @@ from typing import Any
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
 
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
 
 
-class GetPublicIncidentParams(BaseModel):
+class GetPublicIncidentParams(ToolParamsBase):
     """Parameters for retrieving a public secret incident."""
 
     incident_id: int = Field(description="The id of the public secret incident to retrieve")

--- a/packages/gg_api_core/src/gg_api_core/tools/incident_notes.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/incident_notes.py
@@ -15,6 +15,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field, StringConstraints, model_validator
 
 from gg_api_core.client import DEFAULT_PAGINATION_MAX_BYTES, ListResponse
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
@@ -24,7 +25,7 @@ logger = logging.getLogger(__name__)
 CommentStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=10_000)]
 
 
-class ListIncidentCommentsParams(BaseModel):
+class ListIncidentCommentsParams(ToolParamsBase):
     """Parameters for listing comments on a secret incident."""
 
     incident_id: int = Field(description="ID of the secret incident whose comments to list")
@@ -45,7 +46,7 @@ class ListCommentsResult(BaseModel):
     has_more: bool = Field(default=False, description="True if more results exist (use next_cursor to fetch)")
 
 
-class ManageIncidentCommentParams(BaseModel):
+class ManageIncidentCommentParams(ToolParamsBase):
     """Parameters for adding or editing a comment on a secret incident."""
 
     incident_id: int = Field(description="ID of the secret incident to comment on")

--- a/packages/gg_api_core/src/gg_api_core/tools/list_detectors.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_detectors.py
@@ -5,12 +5,13 @@ from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
 
 from gg_api_core.client import DEFAULT_PAGINATION_MAX_BYTES
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
 
 
-class ListDetectorsParams(BaseModel):
+class ListDetectorsParams(ToolParamsBase):
     """Parameters for listing secret detectors."""
 
     search: str | None = Field(

--- a/packages/gg_api_core/src/gg_api_core/tools/list_honeytokens.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_honeytokens.py
@@ -5,12 +5,13 @@ from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
 
 from gg_api_core.client import DEFAULT_PAGINATION_MAX_BYTES
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
 
 
-class ListHoneytokensParams(BaseModel):
+class ListHoneytokensParams(ToolParamsBase):
     """Parameters for listing honeytokens."""
 
     mine: bool = Field(

--- a/packages/gg_api_core/src/gg_api_core/tools/list_incident_members.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_incident_members.py
@@ -5,12 +5,13 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from gg_api_core.client import DEFAULT_PAGINATION_MAX_BYTES
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
 
 
-class ListIncidentMembersParams(BaseModel):
+class ListIncidentMembersParams(ToolParamsBase):
     """Parameters for listing members with access to a secret incident."""
 
     incident_id: int = Field(description="The ID of the secret incident to retrieve members for")

--- a/packages/gg_api_core/src/gg_api_core/tools/list_incident_teams.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_incident_teams.py
@@ -5,12 +5,13 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from gg_api_core.client import DEFAULT_PAGINATION_MAX_BYTES
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
 
 
-class ListIncidentTeamsParams(BaseModel):
+class ListIncidentTeamsParams(ToolParamsBase):
     """Parameters for listing teams with access to a secret incident."""
 
     incident_id: int = Field(description="The ID of the secret incident to retrieve teams for")

--- a/packages/gg_api_core/src/gg_api_core/tools/list_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_incidents.py
@@ -5,6 +5,7 @@ from typing import Any
 from pydantic import BaseModel, Field, field_validator
 
 from gg_api_core.client import DEFAULT_PAGINATION_MAX_BYTES, MAX_PAGINATION_PAGES
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
@@ -190,7 +191,7 @@ def _build_suggestion(params: "ListIncidentsParams", incidents_count: int) -> st
     return "\n".join(suggestions) if suggestions else ""
 
 
-class ListIncidentsParams(BaseModel):
+class ListIncidentsParams(ToolParamsBase):
     """Parameters for listing incidents using the MCP-optimized endpoint."""
 
     # Pagination

--- a/packages/gg_api_core/src/gg_api_core/tools/list_public_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_public_incidents.py
@@ -9,6 +9,7 @@ from gg_api_core.client import (
     IncidentStatus,
     IncidentValidity,
 )
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
@@ -36,7 +37,7 @@ DEFAULT_VALIDITIES: list[IncidentValidity] = [
 ]
 
 
-class ListPublicIncidentsParams(BaseModel):
+class ListPublicIncidentsParams(ToolParamsBase):
     """Parameters for listing public secret incidents.
 
     Public incidents are incidents detected by GitGuardian on public sources

--- a/packages/gg_api_core/src/gg_api_core/tools/list_public_occurrences.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_public_occurrences.py
@@ -4,12 +4,13 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from gg_api_core.client import DEFAULT_PAGINATION_MAX_BYTES
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
 
 
-class ListPublicOccurrencesParams(BaseModel):
+class ListPublicOccurrencesParams(ToolParamsBase):
     """Parameters for listing occurrences of a public secret incident."""
 
     incident_id: int = Field(

--- a/packages/gg_api_core/src/gg_api_core/tools/list_repo_occurrences.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_repo_occurrences.py
@@ -10,6 +10,7 @@ from gg_api_core.client import (
     IncidentValidity,
     TagNames,
 )
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
@@ -82,7 +83,7 @@ class ListRepoOccurrencesFilters(BaseModel):
         return self
 
 
-class ListRepoOccurrencesBaseParams(BaseModel):
+class ListRepoOccurrencesBaseParams(ToolParamsBase):
     """Parameters for listing repository occurrences."""
 
     source_id: str | int | None = Field(

--- a/packages/gg_api_core/src/gg_api_core/tools/list_sources.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_sources.py
@@ -5,12 +5,13 @@ from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
 
 from gg_api_core.client import DEFAULT_PAGINATION_MAX_BYTES
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
 
 
-class ListSourcesParams(BaseModel):
+class ListSourcesParams(ToolParamsBase):
     """Parameters for listing sources."""
 
     search: str | None = Field(

--- a/packages/gg_api_core/src/gg_api_core/tools/list_users.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_users.py
@@ -5,12 +5,13 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from gg_api_core.client import DEFAULT_PAGINATION_MAX_BYTES
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
 
 
-class ListUsersParams(BaseModel):
+class ListUsersParams(ToolParamsBase):
     """Parameters for listing workspace members/users."""
 
     cursor: str | None = Field(default=None, description="Pagination cursor for fetching next page of results")

--- a/packages/gg_api_core/src/gg_api_core/tools/manage_incident.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/manage_incident.py
@@ -2,14 +2,15 @@ import logging
 from typing import Any, Literal
 
 from fastmcp.exceptions import ToolError
-from pydantic import BaseModel, Field
+from pydantic import Field
 
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
 
 
-class ManageIncidentParams(BaseModel):
+class ManageIncidentParams(ToolParamsBase):
     """Parameters for managing an incident."""
 
     incident_id: str | int = Field(description="ID of the secret incident to manage")
@@ -99,7 +100,7 @@ async def manage_private_incident(params: ManageIncidentParams) -> dict[str, Any
         raise ToolError(f"Error: {str(e)}")
 
 
-class UpdateIncidentSeverityParams(BaseModel):
+class UpdateIncidentSeverityParams(ToolParamsBase):
     """Parameters for updating incident severity."""
 
     incident_id: str | int = Field(description="ID of the secret incident")

--- a/packages/gg_api_core/src/gg_api_core/tools/params.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/params.py
@@ -1,0 +1,31 @@
+"""Shared base model for MCP tool parameter schemas.
+
+Every tool in ``gg_api_core.tools`` accepts a single typed parameter model
+(``*Params``). Centralizing their pydantic model config here guarantees a
+consistent, security-hardened configuration across all of them.
+
+``hide_input_in_errors=True`` keeps pydantic from embedding the raw tool-call
+arguments in ``ValidationError`` messages. When a tool call fails validation
+(for example ``scan_secrets`` receiving documents that contain real secrets),
+pydantic normally writes the full input dict into the error text as
+``input_value={...}``. FastMCP re-raises that text as its own
+``ValidationError(str(e))``, and Sentry puts the message verbatim in the event
+title. Scrubbing that value after the fact is unreliable, so the sensitive
+input is omitted at the source instead.
+"""
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = ["ToolParamsBase"]
+
+
+class ToolParamsBase(BaseModel):
+    """Base class for all MCP tool parameter models.
+
+    ``hide_input_in_errors`` prevents pydantic from echoing the submitted arguments
+    into validation errors. Only that setting is centralized here: ``extra`` behavior
+    is left at pydantic's default (``ignore``) to preserve each model's existing
+    validation semantics.
+    """
+
+    model_config = ConfigDict(hide_input_in_errors=True)

--- a/packages/gg_api_core/src/gg_api_core/tools/read_custom_tags.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/read_custom_tags.py
@@ -2,14 +2,15 @@ import logging
 from typing import Literal
 
 from fastmcp.exceptions import ToolError
-from pydantic import BaseModel, Field
+from pydantic import Field
 
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
 
 
-class ReadCustomTagsParams(BaseModel):
+class ReadCustomTagsParams(ToolParamsBase):
     """Parameters for reading custom tags."""
 
     action: Literal["list_tags", "get_tag"] = Field(

--- a/packages/gg_api_core/src/gg_api_core/tools/remediate_secret_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/remediate_secret_incidents.py
@@ -6,6 +6,7 @@ from jinja2 import Template
 from pydantic import BaseModel, Field, model_validator
 
 from gg_api_core.client import TagNames
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 from .list_repo_occurrences import (
@@ -28,7 +29,7 @@ class ListRepoOccurrencesParamsForRemediate(ListRepoOccurrencesParams):
     )
 
 
-class RemediateSecretIncidentsParams(BaseModel):
+class RemediateSecretIncidentsParams(ToolParamsBase):
     """Parameters for remediating secret incidents."""
 
     source_id: str | int | None = Field(

--- a/packages/gg_api_core/src/gg_api_core/tools/revoke_secret.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/revoke_secret.py
@@ -3,12 +3,13 @@ import logging
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
 
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
 
 
-class RevokeSecretParams(BaseModel):
+class RevokeSecretParams(ToolParamsBase):
     """Parameters for revoking a secret."""
 
     secret_id: str | int = Field(description="ID of the secret to revoke")

--- a/packages/gg_api_core/src/gg_api_core/tools/scan_secret.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/scan_secret.py
@@ -3,12 +3,13 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
 
 
-class ScanSecretsParams(BaseModel):
+class ScanSecretsParams(ToolParamsBase):
     """Parameters for scanning secrets."""
 
     documents: list[dict[str, str]] = Field(

--- a/packages/gg_api_core/src/gg_api_core/tools/update_public_incident_status.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/update_public_incident_status.py
@@ -2,8 +2,9 @@ import logging
 from typing import Any, Literal
 
 from fastmcp.exceptions import ToolError
-from pydantic import BaseModel, Field
+from pydantic import Field
 
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
@@ -20,7 +21,7 @@ PublicIgnoreReason = Literal[
 ]
 
 
-class UpdatePublicIncidentStatusParams(BaseModel):
+class UpdatePublicIncidentStatusParams(ToolParamsBase):
     """Parameters for updating a public secret incident status."""
 
     incident_id: int = Field(description="ID of the public secret incident to update")

--- a/packages/gg_api_core/src/gg_api_core/tools/write_custom_tags.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/write_custom_tags.py
@@ -2,14 +2,15 @@ import logging
 from typing import Any, Literal
 
 from fastmcp.exceptions import ToolError
-from pydantic import BaseModel, Field
+from pydantic import Field
 
+from gg_api_core.tools.params import ToolParamsBase
 from gg_api_core.utils import get_client
 
 logger = logging.getLogger(__name__)
 
 
-class WriteCustomTagsParams(BaseModel):
+class WriteCustomTagsParams(ToolParamsBase):
     """Parameters for writing custom tags."""
 
     action: Literal["create_tag", "delete_tag"] = Field(
@@ -77,7 +78,7 @@ async def write_custom_tags(params: WriteCustomTagsParams):
         raise ToolError(f"Error: {str(e)}")
 
 
-class UpdateOrCreateIncidentCustomTagsParams(BaseModel):
+class UpdateOrCreateIncidentCustomTagsParams(ToolParamsBase):
     """Parameters for updating or creating incident custom tags."""
 
     incident_id: str | int = Field(description="ID of the secret incident")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -609,6 +609,10 @@ def restore_logging_configuration():
     saved_handlers = list(root.handlers)
     saved_root_level = root.level
     saved_levels = {name: logging.getLogger(name).level for name in _DEMOTED_LOGGERS}
+    # configure_logging raises this logger to ERROR to suppress fastmcp's raw-argument
+    # WARNING lines; restore it so tests that don't run configure_logging keep the default.
+    fastmcp_server_logger = logging.getLogger("fastmcp.server.server")
+    saved_fastmcp_level = fastmcp_server_logger.level
 
     yield
 
@@ -617,3 +621,4 @@ def restore_logging_configuration():
     root.setLevel(saved_root_level)
     for name, level in saved_levels.items():
         logging.getLogger(name).setLevel(level)
+    fastmcp_server_logger.setLevel(saved_fastmcp_level)

--- a/tests/test_sanitization.py
+++ b/tests/test_sanitization.py
@@ -4,6 +4,7 @@ from gg_api_core.sanitization import (
     scrub_by_name,
     scrub_by_value,
     scrub_git_credentials,
+    scrub_pydantic_input_value,
     scrub_url_params,
 )
 
@@ -78,3 +79,62 @@ class TestScrubByValue:
     )
     def test_scrub_by_value(self, value, expected):
         assert scrub_by_value(value) == expected
+
+
+class TestScrubPydanticInputValue:
+    """Pydantic embeds the rejected input in every ValidationError message.
+
+    FastMCP validates a tool call against a TypeAdapter built from the tool
+    signature, not against the ``*Params`` model, so ``hide_input_in_errors``
+    on the model never reaches this text. Scrubbing it here is what keeps
+    submitted arguments out of the Sentry exception value.
+    """
+
+    @pytest.mark.parametrize(
+        ("message", "expected"),
+        [
+            (
+                "Input should be a valid list [type=list_type, input_value='doc', input_type=str]",
+                f"Input should be a valid list [type=list_type, input_value={PLACEHOLDER}, input_type=str]",
+            ),
+            # The value runs to the LAST marker on the line, so a payload that
+            # embeds ", input_type=" is still redacted in full.
+            (
+                "[type=list_type, input_value='a, input_type=x b', input_type=str]",
+                f"[type=list_type, input_value={PLACEHOLDER}, input_type=str]",
+            ),
+            (
+                "[type=list_type, input_value='doc']",
+                f"[type=list_type, input_value={PLACEHOLDER}]",
+            ),
+            ("GET /v1/incidents?page=2 returned 200", "GET /v1/incidents?page=2 returned 200"),
+        ],
+    )
+    def test_redacts_input_value(self, message, expected):
+        assert scrub_pydantic_input_value(message) == expected
+
+    def test_redacts_every_error_in_a_multi_error_message(self):
+        message = (
+            "2 validation errors for call[scan_secrets]\n"
+            "documents\n  msg [type=list_type, input_value='SECRET_ONE', input_type=str]\n"
+            "filename\n  msg [type=int_type, input_value='SECRET_TWO', input_type=str]"
+        )
+
+        scrubbed = scrub_pydantic_input_value(message)
+
+        assert "SECRET_ONE" not in scrubbed
+        assert "SECRET_TWO" not in scrubbed
+        assert scrubbed.count(f"input_value={PLACEHOLDER}") == 2
+
+    def test_keeps_the_fields_that_explain_the_failure(self):
+        message = "documents\n  Input should be a valid list [type=list_type, input_value='doc', input_type=str]"
+
+        scrubbed = scrub_pydantic_input_value(message)
+
+        assert "documents" in scrubbed
+        assert "Input should be a valid list" in scrubbed
+        assert "type=list_type" in scrubbed
+        assert "input_type=str" in scrubbed
+
+    def test_reached_through_scrub_by_value(self):
+        assert scrub_by_value("[input_value='doc', input_type=str]") == (f"[input_value={PLACEHOLDER}, input_type=str]")

--- a/tests/test_sanitization.py
+++ b/tests/test_sanitization.py
@@ -103,15 +103,25 @@ class TestScrubPydanticInputValue:
                 "[type=list_type, input_value='a, input_type=x b', input_type=str]",
                 f"[type=list_type, input_value={PLACEHOLDER}, input_type=str]",
             ),
-            (
-                "[type=list_type, input_value='doc']",
-                f"[type=list_type, input_value={PLACEHOLDER}]",
-            ),
             ("GET /v1/incidents?page=2 returned 200", "GET /v1/incidents?page=2 returned 200"),
         ],
     )
     def test_redacts_input_value(self, message, expected):
         assert scrub_pydantic_input_value(message) == expected
+
+    def test_redacts_even_without_the_input_type_marker(self):
+        """
+        GIVEN a message carrying input_value with no trailing input_type marker
+        WHEN it is scrubbed
+        THEN the payload is still gone
+
+        Pydantic always renders input_type after input_value, so this shape is
+        defensive: redaction must not depend on the marker being present.
+        """
+        scrubbed = scrub_pydantic_input_value("[type=list_type, input_value='doc']")
+
+        assert "doc" not in scrubbed
+        assert PLACEHOLDER in scrubbed
 
     def test_redacts_every_error_in_a_multi_error_message(self):
         message = (

--- a/tests/test_sentry_integration.py
+++ b/tests/test_sentry_integration.py
@@ -1,5 +1,7 @@
+import importlib
 import json
 import os
+import pkgutil
 import subprocess
 import sys
 from pathlib import Path
@@ -7,7 +9,7 @@ from pathlib import Path
 from gg_api_core.sanitization import SENSITIVE_DATA_PLACEHOLDER
 from gg_api_core.sentry_integration import _before_send_event, _before_send_transaction
 from gg_api_core.tools.scan_secret import ScanSecretsParams
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from tests.helpers.sentry_mcp_transaction_probe import RAW_DOCUMENT
 
@@ -53,6 +55,38 @@ def test_tool_params_hide_input_in_errors_on_shared_base():
         assert "input_value=" not in str(exc)
         return
     raise AssertionError("expected a validation error")
+
+
+def _tool_params_models():
+    """Every ``*Params`` model reachable from ``gg_api_core.tools``."""
+    import gg_api_core.tools
+
+    for module_info in pkgutil.iter_modules(gg_api_core.tools.__path__):
+        module = importlib.import_module(f"gg_api_core.tools.{module_info.name}")
+        for attribute in vars(module).values():
+            if (
+                isinstance(attribute, type)
+                and issubclass(attribute, BaseModel)
+                and attribute.__name__.endswith("Params")
+            ):
+                yield attribute
+
+
+def test_every_tool_params_model_hides_input_in_errors():
+    """
+    GIVEN every tool parameter model exposed by gg_api_core.tools
+    WHEN their pydantic configuration is inspected
+    THEN each one hides submitted arguments from validation errors
+
+    Discovery keeps this exhaustive: a new tool, or a refactor that reparents an
+    existing ``*Params`` class onto a base other than ToolParamsBase, fails here
+    instead of silently reopening the argument leak.
+    """
+    models = sorted(set(_tool_params_models()), key=lambda model: model.__qualname__)
+
+    assert models, "no *Params models discovered"
+    unprotected = [model.__qualname__ for model in models if model.model_config.get("hide_input_in_errors") is not True]
+    assert not unprotected, f"tool params models missing hide_input_in_errors: {unprotected}"
 
 
 def test_error_event_scrubs_custom_data_without_damaging_stacktrace():

--- a/tests/test_sentry_integration.py
+++ b/tests/test_sentry_integration.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 from gg_api_core.sanitization import SENSITIVE_DATA_PLACEHOLDER
 from gg_api_core.sentry_integration import _before_send_event, _before_send_transaction
+from gg_api_core.tools.scan_secret import ScanSecretsParams
+from pydantic import ValidationError
 
 from tests.helpers.sentry_mcp_transaction_probe import RAW_DOCUMENT
 
@@ -36,6 +38,21 @@ class TestPrepareSentryEvent:
         THEN no request ID tag is added
         """
         assert _before_send_event({}, {}) == {}
+
+
+def test_tool_params_hide_input_in_errors_on_shared_base():
+    """
+    GIVEN a tool parameter model built on the shared ToolParamsBase
+    WHEN it fails pydantic validation
+    THEN the error message carries no input_value payload
+    """
+    assert ScanSecretsParams.model_config.get("hide_input_in_errors") is True
+    try:
+        ScanSecretsParams(documents="not-a-list")  # type: ignore[call-arg]
+    except ValidationError as exc:
+        assert "input_value=" not in str(exc)
+        return
+    raise AssertionError("expected a validation error")
 
 
 def test_error_event_scrubs_custom_data_without_damaging_stacktrace():

--- a/tests/test_sentry_integration.py
+++ b/tests/test_sentry_integration.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 import json
 import os
@@ -6,9 +7,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+from fastmcp.tools import Tool
 from gg_api_core.sanitization import SENSITIVE_DATA_PLACEHOLDER
 from gg_api_core.sentry_integration import _before_send_event, _before_send_transaction
-from gg_api_core.tools.scan_secret import ScanSecretsParams
+from gg_api_core.tools.scan_secret import ScanSecretsParams, scan_secrets
 from pydantic import BaseModel, ValidationError
 
 from tests.helpers.sentry_mcp_transaction_probe import RAW_DOCUMENT
@@ -87,6 +89,48 @@ def test_every_tool_params_model_hides_input_in_errors():
     assert models, "no *Params models discovered"
     unprotected = [model.__qualname__ for model in models if model.model_config.get("hide_input_in_errors") is not True]
     assert not unprotected, f"tool params models missing hide_input_in_errors: {unprotected}"
+
+
+def test_validation_error_reaching_sentry_carries_no_tool_arguments():
+    """
+    GIVEN a tool call rejected by FastMCP's argument validation
+    WHEN the resulting exception is prepared for Sentry
+    THEN the submitted document is gone and the diagnostic fields remain
+
+    FastMCP validates against a TypeAdapter built from the tool signature, not
+    against ScanSecretsParams, so `hide_input_in_errors` on the model does not
+    apply to this message. This covers the path it cannot reach.
+    """
+    canary = "AKIA-CANARY-DOCUMENT-BODY"
+    try:
+        asyncio.run(Tool.from_function(scan_secrets).run({"params": {"documents": canary}}))
+    except Exception as exc:  # noqa: BLE001 - the ValidationError is the fixture
+        raised = exc
+    else:
+        raise AssertionError("expected a validation error")
+
+    event = _before_send_event(
+        {
+            "exception": {
+                "values": [
+                    {
+                        "type": type(raised).__name__,
+                        "value": str(raised),
+                        "stacktrace": {"frames": [{"filename": "fastmcp/tools/function_tool.py"}]},
+                    }
+                ]
+            }
+        },
+        {},
+    )
+
+    shipped = event["exception"]["values"][0]["value"]
+    assert canary not in shipped
+    assert f"input_value={SENSITIVE_DATA_PLACEHOLDER}" in shipped
+    # The parts that make the event debuggable survive.
+    assert "documents" in shipped
+    assert "input_type=str" in shipped
+    assert event["exception"]["values"][0]["stacktrace"]["frames"][0]["filename"] == ("fastmcp/tools/function_tool.py")
 
 
 def test_error_event_scrubs_custom_data_without_damaging_stacktrace():


### PR DESCRIPTION
## Merge order

Three open PRs touch the same tools. Land them in this order:

1. #227 (this PR) `SI-4068`. Sentry still ships tool arguments inside pydantic validation messages. Independent of the other two, and it gates the prod bump.
2. #207 `si-3940-...`. Generated filter vocabularies. Needs one small rebase once #227 lands: three import blocks where both sides are wanted.
3. #229 `SI-3963`. Flattens tool signatures to top-level parameters. Based on #207 and cannot land before it.

Only step 2 to step 3 is a hard dependency. Git merges #229's hand-copied signatures over #207's canonical types without a single conflict, and the result has three modules that fail to import plus a `list_incidents` that rejects its own default severity. #229 is based on #207 to force that order.

#227 collides with the other two on import lines only (21 of 27 shared files merge clean), so it stays on `main` rather than sitting at the bottom of a three-way stack, where every review comment on it would force a rebase of the other two.


### Known fixes needed at rebase time

Merging all three together and running the suite surfaces exactly two problems. Both are rebase work, not defects in any single PR, and #227's discovery test catches the first one rather than letting it through:

1. `IncidentFilterParams` in `gg_api_core/incident_filters.py` must inherit `ToolParamsBase` instead of `BaseModel`. #207 introduces that shared base and #227 introduces `ToolParamsBase`, so neither branch can do it alone. Without it `ListIncidentsParams` and `CountIncidentsParams` lose `hide_input_in_errors`, and git produces that state with a conflict only on the class line, where taking the refactor's side looks like the obvious resolution. Belongs in #207's rebase.
2. `test_validation_error_reaching_sentry_carries_no_tool_arguments` in `tests/test_sentry_integration.py` calls the nested `{"params": {...}}` shape. #229 flattens it away. Belongs in #229's rebase, alongside the 52 payloads it already unwrapped.

Verified union after both: 1384 passed, ruff and pyrefly clean, `generate_filter_vocabulary.py --check` exits 0, all 34 `*Params` models carry the config, and the scan_secrets canary stays out of the Sentry event on the flat call shape.

## What

Tool arguments leaked verbatim to Sentry/logs via pydantic `ValidationError` messages and FastMCP's WARNING logging (#215 missed exception content + the fastmcp log). Worst case: a failing `scan_secrets` shipped the scanned document. Live: GIM-MCP-SERVER-19.

## Fix

1. **`ToolParamsBase`** — `hide_input_in_errors=True` on every tool `*Params` (not enough alone: ignored by `errors()`/`json()`, which FastMCP uses).
2. **Log-level fix** — raise `fastmcp.server.server` to ERROR in `configure_logging`. FastMCP logs bad-arg failures at WARNING with raw args; this drops those two WARNING lines, keeps all ERROR telemetry (`Error calling tool`, resources, prompts). Replaces the fragile pydantic `errors()/json()` monkey-patch.

   ```python
   logging.getLogger("fastmcp.server.server").setLevel(logging.ERROR)
   ```

3. **`scrub_pydantic_input_value`** (the one that actually closes the Sentry path). `hide_input_in_errors` on the models does *not* reach a tool call: FastMCP validates against a `TypeAdapter` built from the tool signature, so the error is rendered by a synthesized `call[<tool>]` model with pydantic's default config. `scrub_by_value` now redacts the `input_value=` payload, which covers every string the Sentry boundary already walks (exception values, log entries, breadcrumbs, span data). Field path, error type and `input_type` are kept, so events stay debuggable.

   Configuring that `TypeAdapter` would mean patching `get_cached_typeadapter`, i.e. the fragile monkey-patching item 2 moved away from.

## Residual

The `ToolError` returned to the caller still contains `input_value=`. The caller supplied the data, so this is an echo rather than third-party egress, but on hosted clients it does put the payload into the model context. Separate concern, not this PR.

## What we lose

- The two `Invalid arguments for tool` WARNING lines — the leak itself; errors still reach the client.
- The rare mount-time `mask_error_details` mismatch WARNING (config-only, no payload).

Failed-call visibility stays via `tool_call_failed` ERROR in `ToolCallLoggingMiddleware`.

## Impact

Preprod exposed since #195. Prod not yet (0.7.0 is first release with #195) — must land before the prod bump.

## Tests

`uv run pytest tests -q` → 1242 passed, 3 skipped, 9 xfailed. New regressions in `test_logging_config.py`, `test_sanitization.py`, `test_sentry_integration.py`.

`test_every_tool_params_model_hides_input_in_errors` discovers every `*Params` class under `gg_api_core.tools` (34 today) and asserts `hide_input_in_errors` on each, so a new tool or a reparented `*Params` class fails the build rather than silently losing the setting.

Note that this asserts the model config only. It is not evidence the leak is closed, because FastMCP does not validate against these classes: that is what item 3 is for. `test_validation_error_reaching_sentry_carries_no_tool_arguments` covers the real path end to end, driving a rejected `scan_secrets` call through `Tool.run` and asserting the document is absent from the prepared Sentry event.

Follow-up to #215.

## Review follow-up

`scrub_pydantic_input_value` lost three pieces that were not earning their keep: a single-use module constant, a membership check duplicating what `re.sub` already does, and a branch for a message shape pydantic does not emit (`input_type` is always rendered after `input_value`). Redaction stays unconditional, so an unmarked shape is still scrubbed, now with its own test.

Considered and rejected: replacing the `fastmcp.server.server` log-level override with a filter that redacts the payload and keeps the WARNING line. The `fastmcp` logger sets `propagate=False` and owns its handlers, so a filter only lands if those handlers exist when `configure_logging` runs, and the order-independent version means clearing library-owned handlers and reformatting every fastmcp line from inside a security fix. The override is the direct mechanism, and `tool_call_failed` already carries failed-call visibility.
