### PR TITLE
fix(oauth): use explicit 20s timeout for token exchange and token-info calls

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/oauth.py
+++ b/packages/gg_api_core/src/gg_api_core/oauth.py
@@ -54,6 +54,12 @@ CALLBACK_PORT_RANGE = (29170, 29998)
 # Default token expiry in days (if not specified in token info)
 DEFAULT_TOKEN_EXPIRY_DAYS = 30
 
+# Network timeout (seconds) for the token exchange and token-info calls.
+# The project's API client uses a 20s timeout (DEFAULT_HTTP_TIMEOUT in client.py);
+# without an explicit value here httpx silently falls back to its 5s default, which
+# can reject slow-but-valid token endpoints and self-hosted API instances.
+OAUTH_HTTP_TIMEOUT = 20
+
 # Global counter for OAuth client instances (debugging)
 _oauth_client_counter = 0
 
@@ -702,7 +708,7 @@ class GitGuardianOAuthClient:
                 "User-Agent": f"GitGuardian-MCP-Server/{self.token_name}",  # Include in user agent
             }
 
-            async with httpx.AsyncClient(follow_redirects=True) as client:
+            async with httpx.AsyncClient(follow_redirects=True, timeout=OAUTH_HTTP_TIMEOUT) as client:
                 response = await client.post(token_url, data=token_params, headers=headers)
 
                 if response.status_code == 200:
@@ -775,7 +781,7 @@ class GitGuardianOAuthClient:
         try:
             import httpx  # Import here to avoid circular imports
 
-            async with httpx.AsyncClient(follow_redirects=True) as client:
+            async with httpx.AsyncClient(follow_redirects=True, timeout=OAUTH_HTTP_TIMEOUT) as client:
                 # Use the correct API endpoint with the full path
                 response = await client.get(
                     f"{self.api_url}/api_tokens/self",


### PR DESCRIPTION
## What

The OAuth flow in `oauth.py` makes two `httpx.AsyncClient` calls without an explicit timeout:

1. The token-exchange `POST` (`~line 705`)
2. The `GET /api_tokens/self` token-info verification call (`~line 778`)

Both use `httpx.AsyncClient(follow_redirects=True)` with no timeout argument, so `httpx` silently applies its 5-second default. Meanwhile the rest of the project's API client (`client.py`) consistently uses `DEFAULT_HTTP_TIMEOUT = 20`.

## Why it matters

The OAuth handshake talks to real token endpoints (GitGuardian Cloud or self-hosted instances). On slow-but-healthy connections, or deliberate response pacing, the 5s default is aggressive and can reject a valid token exchange that the project's own 20s convention would allow. For self-hosted deployments with appliance-level latency the discrepancy is magnified. The fix also makes the timeout behavior identical between the OAuth path and the normal API path.

## Changes

- Added a module-level `OAUTH_HTTP_TIMEOUT = 20` constant (matching `DEFAULT_HTTP_TIMEOUT` in `client.py`).
- Passed `timeout=OAUTH_HTTP_TIMEOUT` to both `httpx.AsyncClient(...)` calls in the OAuth flow.

This is a small, non-breaking change — no behavior difference on fast networks, robust on slow ones.