### PR TITLE
fix(tools)!: flatten MCP tool signatures to top-level parameters (SI-3963)

### DIFF
--- a/packages/gg_api_core/src/gg_api_core/tools/activity_logs.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/activity_logs.py
@@ -15,7 +15,7 @@ elsewhere (e.g. ``assign_incident`` vs ``assign_public_incident``).
 """
 
 import logging
-from typing import Any
+from typing import Annotated, Any
 
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
@@ -80,7 +80,32 @@ def _build_list_result(result: ListResponse) -> ListActivityLogsResult:
     )
 
 
-async def list_incident_activity_logs(params: ListActivityLogsParams) -> ListActivityLogsResult:
+async def list_incident_activity_logs(
+    incident_id: Annotated[int, Field(description="ID of the secret incident whose activity log to list")],
+    content_key: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Filter to a single system-action type (e.g. 'TRIGGER', 'RESOLVE', 'ASSIGN', 'SET_SEVERITY'). Omit to return notes and every action type.",
+        ),
+    ] = None,
+    member_id: Annotated[
+        int | None,
+        Field(default=None, description="Filter to entries authored by a specific member (by member ID)"),
+    ] = None,
+    cursor: Annotated[str | None, Field(default=None, description="Pagination cursor for fetching the next page of results")] = None,
+    per_page: Annotated[
+        int,
+        Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)"),
+    ] = 20,
+    get_all: Annotated[
+        bool,
+        Field(
+            default=False,
+            description=f"If True, fetch all pages (capped at ~{DEFAULT_PAGINATION_MAX_BYTES / 1000}KB; check 'has_more' and use cursor to continue)",
+        ),
+    ] = False,
+) -> ListActivityLogsResult:
     """
     List the full activity log of an internal secret incident.
 
@@ -91,7 +116,12 @@ async def list_incident_activity_logs(params: ListActivityLogsParams) -> ListAct
     use `list_public_incident_activity_logs` instead.
 
     Args:
-        params: ListActivityLogsParams with the incident ID, optional filters and pagination options
+        incident_id: ID of the secret incident whose activity log to list
+        content_key: Filter to a single system-action type
+        member_id: Filter to entries authored by a specific member
+        cursor: Pagination cursor
+        per_page: Number of results per page (default: 20)
+        get_all: If True, fetch all pages
 
     Returns:
         ListActivityLogsResult with the entries, total_count, next_cursor, and has_more
@@ -99,6 +129,14 @@ async def list_incident_activity_logs(params: ListActivityLogsParams) -> ListAct
     Raises:
         ToolError: If the listing operation fails
     """
+    params = ListActivityLogsParams(
+        incident_id=incident_id,
+        content_key=content_key,
+        member_id=member_id,
+        cursor=cursor,
+        per_page=per_page,
+        get_all=get_all,
+    )
     client = await get_client()
     logger.debug(f"Listing activity logs for incident {params.incident_id}")
 
@@ -114,7 +152,32 @@ async def list_incident_activity_logs(params: ListActivityLogsParams) -> ListAct
         raise ToolError(f"Error: {str(e)}")
 
 
-async def list_public_incident_activity_logs(params: ListActivityLogsParams) -> ListActivityLogsResult:
+async def list_public_incident_activity_logs(
+    incident_id: Annotated[int, Field(description="ID of the public secret incident whose activity log to list")],
+    content_key: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Filter to a single system-action type (e.g. 'TRIGGER', 'RESOLVE', 'ASSIGN', 'SET_SEVERITY'). Omit to return notes and every action type.",
+        ),
+    ] = None,
+    member_id: Annotated[
+        int | None,
+        Field(default=None, description="Filter to entries authored by a specific member (by member ID)"),
+    ] = None,
+    cursor: Annotated[str | None, Field(default=None, description="Pagination cursor for fetching the next page of results")] = None,
+    per_page: Annotated[
+        int,
+        Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)"),
+    ] = 20,
+    get_all: Annotated[
+        bool,
+        Field(
+            default=False,
+            description=f"If True, fetch all pages (capped at ~{DEFAULT_PAGINATION_MAX_BYTES / 1000}KB; check 'has_more' and use cursor to continue)",
+        ),
+    ] = False,
+) -> ListActivityLogsResult:
     """
     List the full activity log of a public secret incident.
 
@@ -126,7 +189,12 @@ async def list_public_incident_activity_logs(params: ListActivityLogsParams) -> 
     NOT interchangeable with internal incident IDs.
 
     Args:
-        params: ListActivityLogsParams with the public incident ID, optional filters and pagination options
+        incident_id: ID of the public secret incident whose activity log to list
+        content_key: Filter to a single system-action type
+        member_id: Filter to entries authored by a specific member
+        cursor: Pagination cursor
+        per_page: Number of results per page (default: 20)
+        get_all: If True, fetch all pages
 
     Returns:
         ListActivityLogsResult with the entries, total_count, next_cursor, and has_more
@@ -134,6 +202,14 @@ async def list_public_incident_activity_logs(params: ListActivityLogsParams) -> 
     Raises:
         ToolError: If the listing operation fails
     """
+    params = ListActivityLogsParams(
+        incident_id=incident_id,
+        content_key=content_key,
+        member_id=member_id,
+        cursor=cursor,
+        per_page=per_page,
+        get_all=get_all,
+    )
     client = await get_client()
     logger.debug(f"Listing activity logs for public incident {params.incident_id}")
 

--- a/packages/gg_api_core/src/gg_api_core/tools/activity_logs.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/activity_logs.py
@@ -93,7 +93,9 @@ async def list_incident_activity_logs(
         int | None,
         Field(default=None, description="Filter to entries authored by a specific member (by member ID)"),
     ] = None,
-    cursor: Annotated[str | None, Field(default=None, description="Pagination cursor for fetching the next page of results")] = None,
+    cursor: Annotated[
+        str | None, Field(default=None, description="Pagination cursor for fetching the next page of results")
+    ] = None,
     per_page: Annotated[
         int,
         Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)"),
@@ -165,7 +167,9 @@ async def list_public_incident_activity_logs(
         int | None,
         Field(default=None, description="Filter to entries authored by a specific member (by member ID)"),
     ] = None,
-    cursor: Annotated[str | None, Field(default=None, description="Pagination cursor for fetching the next page of results")] = None,
+    cursor: Annotated[
+        str | None, Field(default=None, description="Pagination cursor for fetching the next page of results")
+    ] = None,
     per_page: Annotated[
         int,
         Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)"),

--- a/packages/gg_api_core/src/gg_api_core/tools/assign_incident.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/assign_incident.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Annotated
 
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field, model_validator
@@ -48,7 +49,30 @@ class AssignIncidentResult(BaseModel):
     success: bool = Field(default=True, description="Whether the assignment was successful")
 
 
-async def assign_incident(params: AssignIncidentParams) -> AssignIncidentResult:
+async def assign_incident(
+    incident_id: Annotated[str | int, Field(description="ID of the secret incident to assign")],
+    assignee_member_id: Annotated[
+        str | int | None,
+        Field(
+            default=None,
+            description="ID of the member to assign the incident to. One of assignee_member_id, email, or mine must be provided",
+        ),
+    ] = None,
+    email: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Email address of the member to assign the incident to. One of assignee_member_id, email, or mine must be provided",
+        ),
+    ] = None,
+    mine: Annotated[
+        bool,
+        Field(
+            default=False,
+            description="If True, assign the incident to the current user (will fetch current user's ID automatically). One of assignee_member_id, email, or mine must be provided",
+        ),
+    ] = False,
+) -> AssignIncidentResult:
     """
     Assign a secret incident to a specific member or to the current user.
 
@@ -60,11 +84,10 @@ async def assign_incident(params: AssignIncidentParams) -> AssignIncidentResult:
     Exactly one of these three options must be provided.
 
     Args:
-        params: AssignIncidentParams model containing:
-            - incident_id: ID of the incident to assign
-            - assignee_member_id: Optional ID of the member to assign to
-            - email: Optional email address of the member to assign to
-            - mine: If True, assigns to current user
+        incident_id: ID of the incident to assign
+        assignee_member_id: Optional ID of the member to assign to
+        email: Optional email address of the member to assign to
+        mine: If True, assigns to current user
 
     Returns:
         AssignIncidentResult: Pydantic model containing:
@@ -77,6 +100,12 @@ async def assign_incident(params: AssignIncidentParams) -> AssignIncidentResult:
         ToolError: If the assignment operation fails
         ValueError: If validation fails (none or multiple assignee options provided)
     """
+    params = AssignIncidentParams(
+        incident_id=incident_id,
+        assignee_member_id=assignee_member_id,
+        email=email,
+        mine=mine,
+    )
     client = await get_client()
 
     # Determine the assignee based on the provided option

--- a/packages/gg_api_core/src/gg_api_core/tools/assign_public_incident.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/assign_public_incident.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Annotated, Any
 
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field, model_validator
@@ -54,7 +54,37 @@ class AssignPublicIncidentResult(BaseModel):
     incident: dict[str, Any] | None = Field(default=None, description="Full updated public incident payload")
 
 
-async def assign_public_incident(params: AssignPublicIncidentParams) -> AssignPublicIncidentResult:
+async def assign_public_incident(
+    incident_id: Annotated[int, Field(description="ID of the public secret incident to assign")],
+    assignee_member_id: Annotated[
+        int | None,
+        Field(
+            default=None,
+            description="ID of the member to assign the incident to. One of assignee_member_id, email, or mine must be provided",
+        ),
+    ] = None,
+    email: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Email address of the member to assign the incident to. One of assignee_member_id, email, or mine must be provided",
+        ),
+    ] = None,
+    mine: Annotated[
+        bool,
+        Field(
+            default=False,
+            description="If True, assign the incident to the current user (will fetch current user's ID automatically). One of assignee_member_id, email, or mine must be provided",
+        ),
+    ] = False,
+    send_email: Annotated[
+        bool | None,
+        Field(
+            default=None,
+            description="If False, skip notifying the assignee. Defaults to the API default (True) when omitted.",
+        ),
+    ] = None,
+) -> AssignPublicIncidentResult:
     """
     Assign a public secret incident to a specific member or to the current user.
 
@@ -73,12 +103,11 @@ async def assign_public_incident(params: AssignPublicIncidentParams) -> AssignPu
     Wraps POST /v1/public-incidents/secrets/{incident_id}/assign.
 
     Args:
-        params: AssignPublicIncidentParams model containing:
-            - incident_id: ID of the public incident to assign
-            - assignee_member_id: Optional ID of the member to assign to
-            - email: Optional email address of the member to assign to
-            - mine: If True, assigns to current user
-            - send_email: If False, skip notifying the assignee
+        incident_id: ID of the public incident to assign
+        assignee_member_id: Optional ID of the member to assign to
+        email: Optional email address of the member to assign to
+        mine: If True, assigns to current user
+        send_email: If False, skip notifying the assignee
 
     Returns:
         AssignPublicIncidentResult: Pydantic model containing:
@@ -91,6 +120,13 @@ async def assign_public_incident(params: AssignPublicIncidentParams) -> AssignPu
         ToolError: If the assignment operation fails
         ValueError: If validation fails (none or multiple assignee options provided)
     """
+    params = AssignPublicIncidentParams(
+        incident_id=incident_id,
+        assignee_member_id=assignee_member_id,
+        email=email,
+        mine=mine,
+        send_email=send_email,
+    )
     client = await get_client()
 
     assignee_id: int | None = None

--- a/packages/gg_api_core/src/gg_api_core/tools/count_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/count_incidents.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Annotated, Any
 
 from pydantic import BaseModel, Field
 
@@ -34,28 +34,113 @@ class CountIncidentsError(BaseModel):
 
 
 async def count_incidents(
-    params: CountIncidentsParams = CountIncidentsParams(),
+    search: Annotated[str | None, Field(default=None, description='Search term to filter incidents by name or content')] = None,
+    status: Annotated[list[str] | str | None, Field(default=['TRIGGERED', 'ASSIGNED', 'RESOLVED'], description='Filter by status. Values: TRIGGERED (unassigned active), ASSIGNED (assigned active), RESOLVED, IGNORED. Default excludes IGNORED.')] = ['TRIGGERED', 'ASSIGNED', 'RESOLVED'],
+    mine: Annotated[bool, Field(default=False, description='If True, count only incidents assigned to the current user. Overrides assignee_id.')] = False,
+    assignee_id: Annotated[int | None, Field(default=None, description="Filter by assignee member ID. Use 0 for unassigned incidents. Cannot be used with 'mine'.")] = None,
+    severity: Annotated[list[str | int] | str | int | None, Field(default=[10, 20, 30, 100], description='Filter by severity levels. Values: critical (10), high (20), medium (30), low (40), info (50), unknown (100). Default excludes LOW and INFO.')] = [10, 20, 30, 100],
+    score_min: Annotated[int | None, Field(default=None, ge=0, le=100, description='Filter incidents with a score greater than or equal to this value (0-100).')] = None,
+    score_max: Annotated[int | None, Field(default=None, ge=0, le=100, description='Filter incidents with a score less than or equal to this value (0-100).')] = None,
+    validity: Annotated[list[str] | str | None, Field(default=['valid', 'failed_to_check', 'no_checker', 'not_checked'], description='Filter by validity status. Values: valid, invalid, failed_to_check, no_checker, not_checked. Default excludes INVALID.')] = ['valid', 'failed_to_check', 'no_checker', 'not_checked'],
+    detector_group_name: Annotated[list[str] | str | None, Field(default=None, description="Filter by detector group name (e.g., 'AWS Keys', 'GitHub Tokens')")] = None,
+    detector_type: Annotated[list[str] | str | None, Field(default=None, description='Filter by detector type/nature')] = None,
+    detector_category: Annotated[list[str] | str | None, Field(default=None, description='Filter by detector category')] = None,
+    issue_name: Annotated[list[str] | str | None, Field(default=None, description='Filter by issue/incident name')] = None,
+    secret_category: Annotated[list[str] | str | None, Field(default=None, description='Filter by secret category')] = None,
+    secret_family: Annotated[list[str] | str | None, Field(default=None, description='Filter by secret family')] = None,
+    secret_provider: Annotated[list[str] | str | None, Field(default=None, description="Filter by secret provider (e.g., 'aws', 'github', 'google')")] = None,
+    source_ids: Annotated[list[int] | int | None, Field(default=None, description='Filter by source ID(s). Can be obtained using list_source or find_current_source_id tools.')] = None,
+    source_type: Annotated[list[str] | str | None, Field(default=None, description="Filter by source type (e.g., 'github', 'gitlab', 'bitbucket')")] = None,
+    source_criticality: Annotated[list[str] | str | None, Field(default=None, description='Filter by source criticality. Values: critical, high, medium, low, unknown')] = None,
+    occurrence_count_min: Annotated[int | None, Field(default=None, description='Filter incidents with at least this many occurrences')] = None,
+    presence: Annotated[list[str] | str | None, Field(default=None, description='Filter by occurrence presence status. Values: present, removed')] = None,
+    opened_for_days: Annotated[int | None, Field(default=None, description='Filter incidents that have been open for at least this many days')] = None,
+    tags: Annotated[list[str] | str | None, Field(default=None, description="Filter by tag names (e.g., 'REGRESSION', 'PUBLICLY_EXPOSED', 'TEST_FILE')")] = None,
+    exclude_tags: Annotated[list[str] | str | None, Field(default=['TEST_FILE', 'FALSE_POSITIVE', 'CHECK_RUN_SKIP_FALSE_POSITIVE', 'CHECK_RUN_SKIP_LOW_RISK', 'CHECK_RUN_SKIP_TEST_CRED'], description='Exclude incidents with these tag names. Default excludes TEST_FILE, FALSE_POSITIVE, and CHECK_RUN_SKIP_* tags.')] = ['TEST_FILE', 'FALSE_POSITIVE', 'CHECK_RUN_SKIP_FALSE_POSITIVE', 'CHECK_RUN_SKIP_LOW_RISK', 'CHECK_RUN_SKIP_TEST_CRED'],
+    public_exposure: Annotated[list[str] | str | None, Field(default=None, description='Filter by public exposure. Values: source_publicly_visible, public_incident_linked, leaked_outside_perimeter')] = None,
+    integration: Annotated[list[str] | str | None, Field(default=None, description="Filter by integration type (e.g., 'github', 'gitlab', 'slack')")] = None,
+    issue_tracker: Annotated[list[str] | str | None, Field(default=None, description='Filter by issue tracker type. Values: jira_cloud_notifier, jira_data_center_notifier, servicenow')] = None,
+    has_related_issues: Annotated[bool | None, Field(default=None, description='Filter to incidents with (True) or without (False) related issues')] = None,
+    location: Annotated[bool | None, Field(default=None, description='Filter to incidents with (True) or without (False) location information')] = None,
+    feedback: Annotated[bool | None, Field(default=None, description='Filter to incidents with (True) or without (False) feedback')] = None,
+    publicly_shared: Annotated[bool | None, Field(default=None, description="Filter to incidents that are (True) or aren't (False) publicly shared")] = None,
+    secret_manager_type: Annotated[list[str] | str | None, Field(default=None, description='Filter by vault type. Values: hashicorpvault, awssecretsmanager, azurekeyvault, gcpsecretmanager, cyberarksaas, cyberarkselfhosted, akeyless, delineasecretserver')] = None,
+    secret_manager_instance: Annotated[list[int] | int | None, Field(default=None, description='Filter by vault instance ID(s)')] = None,
+    nhi_env: Annotated[list[str] | str | None, Field(default=None, description='Filter by NHI environment name(s)')] = None,
+    nhi_policy: Annotated[list[str] | str | None, Field(default=None, description='Filter by NHI policy breach name(s)')] = None,
+    teams: Annotated[list[int] | int | None, Field(default=None, description='Filter by team ID(s)')] = None,
+    similar_to: Annotated[int | None, Field(default=None, description='Filter incidents similar to the given incident ID')] = None,
+    date_before: Annotated[str | None, Field(default=None, description='Filter incidents detected before this date (YYYY-MM-DD format)')] = None,
+    date_after: Annotated[str | None, Field(default=None, description='Filter incidents detected after this date (YYYY-MM-DD format)')] = None,
+    secret_scope: Annotated[list[str] | str | None, Field(default=None, description='Filter by secret scope name(s)')] = None,
+    analyzer_status: Annotated[list[str] | str | None, Field(default=None, description='Filter by analyzer status. Values: no_checker, not_checked, checked, invalid, failed_to_check')] = None,
+    custom_tags: Annotated[list[int] | int | None, Field(default=None, description='Filter by custom tag ID(s)')] = None,
 ) -> CountIncidentsResult | CountIncidentsError:
     """
-    Count secret incidents matching the given filters.
+        Count secret incidents matching the given filters.
 
-    Returns the total number of matching incidents without fetching the full list.
-    This is useful to get an overview of incident volume, check filter results
-    before paginating, or build dashboards.
+        Returns the total number of matching incidents without fetching the full list.
+        This is useful to get an overview of incident volume, check filter results
+        before paginating, or build dashboards.
 
-    Accepts the same filters as list_incidents (status, severity, detector type,
-    source, tags, etc.) but returns only the count.
+        Accepts the same filters as list_incidents (status, severity, detector type,
+        source, tags, etc.) but returns only the count.
 
-    Args:
-        params: CountIncidentsParams model containing all filtering options.
+        Args:
+            params: CountIncidentsParams model containing all filtering options.
 
-    Returns:
-        CountIncidentsResult: Pydantic model containing:
-            - count: Total number of matching incidents
-            - applied_filters: Dictionary of filters that were applied
+        Returns:
+            CountIncidentsResult: Pydantic model containing:
+                - count: Total number of matching incidents
+                - applied_filters: Dictionary of filters that were applied
 
-        CountIncidentsError: Pydantic model with error message if the operation fails
+            CountIncidentsError: Pydantic model with error message if the operation fails
+
     """
+    params = CountIncidentsParams(
+        search=search,
+        status=status,
+        mine=mine,
+        assignee_id=assignee_id,
+        severity=severity,
+        score_min=score_min,
+        score_max=score_max,
+        validity=validity,
+        detector_group_name=detector_group_name,
+        detector_type=detector_type,
+        detector_category=detector_category,
+        issue_name=issue_name,
+        secret_category=secret_category,
+        secret_family=secret_family,
+        secret_provider=secret_provider,
+        source_ids=source_ids,
+        source_type=source_type,
+        source_criticality=source_criticality,
+        occurrence_count_min=occurrence_count_min,
+        presence=presence,
+        opened_for_days=opened_for_days,
+        tags=tags,
+        exclude_tags=exclude_tags,
+        public_exposure=public_exposure,
+        integration=integration,
+        issue_tracker=issue_tracker,
+        has_related_issues=has_related_issues,
+        location=location,
+        feedback=feedback,
+        publicly_shared=publicly_shared,
+        secret_manager_type=secret_manager_type,
+        secret_manager_instance=secret_manager_instance,
+        nhi_env=nhi_env,
+        nhi_policy=nhi_policy,
+        teams=teams,
+        similar_to=similar_to,
+        date_before=date_before,
+        date_after=date_after,
+        secret_scope=secret_scope,
+        analyzer_status=analyzer_status,
+        custom_tags=custom_tags,
+    )
+
     client = await get_client()
 
     try:

--- a/packages/gg_api_core/src/gg_api_core/tools/count_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/count_incidents.py
@@ -3,7 +3,19 @@ from typing import Annotated, Any
 
 from pydantic import BaseModel, Field
 
+from gg_api_core.generated_filter_vocabulary import (
+    IncidentSeverityFilter,
+    IncidentSourceTypeFilter,
+    IncidentStatusFilter,
+    IncidentValidityFilter,
+)
+from gg_api_core.incident_filter_adapters import (
+    IncidentIntegrationFilter,
+)
 from gg_api_core.incident_filters import (
+    DEFAULT_SEVERITIES,
+    DEFAULT_STATUSES,
+    DEFAULT_VALIDITIES,
     IncidentFilterParams,
     build_api_params,
     build_filter_info,
@@ -34,67 +46,229 @@ class CountIncidentsError(BaseModel):
 
 
 async def count_incidents(
-    search: Annotated[str | None, Field(default=None, description='Search term to filter incidents by name or content')] = None,
-    status: Annotated[list[str] | str | None, Field(default=['TRIGGERED', 'ASSIGNED', 'RESOLVED'], description='Filter by status. Values: TRIGGERED (unassigned active), ASSIGNED (assigned active), RESOLVED, IGNORED. Default excludes IGNORED.')] = ['TRIGGERED', 'ASSIGNED', 'RESOLVED'],
-    mine: Annotated[bool, Field(default=False, description='If True, count only incidents assigned to the current user. Overrides assignee_id.')] = False,
-    assignee_id: Annotated[int | None, Field(default=None, description="Filter by assignee member ID. Use 0 for unassigned incidents. Cannot be used with 'mine'.")] = None,
-    severity: Annotated[list[str | int] | str | int | None, Field(default=[10, 20, 30, 100], description='Filter by severity levels. Values: critical (10), high (20), medium (30), low (40), info (50), unknown (100). Default excludes LOW and INFO.')] = [10, 20, 30, 100],
-    score_min: Annotated[int | None, Field(default=None, ge=0, le=100, description='Filter incidents with a score greater than or equal to this value (0-100).')] = None,
-    score_max: Annotated[int | None, Field(default=None, ge=0, le=100, description='Filter incidents with a score less than or equal to this value (0-100).')] = None,
-    validity: Annotated[list[str] | str | None, Field(default=['valid', 'failed_to_check', 'no_checker', 'not_checked'], description='Filter by validity status. Values: valid, invalid, failed_to_check, no_checker, not_checked. Default excludes INVALID.')] = ['valid', 'failed_to_check', 'no_checker', 'not_checked'],
-    detector_group_name: Annotated[list[str] | str | None, Field(default=None, description="Filter by detector group name (e.g., 'AWS Keys', 'GitHub Tokens')")] = None,
-    detector_type: Annotated[list[str] | str | None, Field(default=None, description='Filter by detector type/nature')] = None,
-    detector_category: Annotated[list[str] | str | None, Field(default=None, description='Filter by detector category')] = None,
-    issue_name: Annotated[list[str] | str | None, Field(default=None, description='Filter by issue/incident name')] = None,
-    secret_category: Annotated[list[str] | str | None, Field(default=None, description='Filter by secret category')] = None,
-    secret_family: Annotated[list[str] | str | None, Field(default=None, description='Filter by secret family')] = None,
-    secret_provider: Annotated[list[str] | str | None, Field(default=None, description="Filter by secret provider (e.g., 'aws', 'github', 'google')")] = None,
-    source_ids: Annotated[list[int] | int | None, Field(default=None, description='Filter by source ID(s). Can be obtained using list_source or find_current_source_id tools.')] = None,
-    source_type: Annotated[list[str] | str | None, Field(default=None, description="Filter by source type (e.g., 'github', 'gitlab', 'bitbucket')")] = None,
-    source_criticality: Annotated[list[str] | str | None, Field(default=None, description='Filter by source criticality. Values: critical, high, medium, low, unknown')] = None,
-    occurrence_count_min: Annotated[int | None, Field(default=None, description='Filter incidents with at least this many occurrences')] = None,
-    presence: Annotated[list[str] | str | None, Field(default=None, description='Filter by occurrence presence status. Values: present, removed')] = None,
-    opened_for_days: Annotated[int | None, Field(default=None, description='Filter incidents that have been open for at least this many days')] = None,
-    tags: Annotated[list[str] | str | None, Field(default=None, description="Filter by tag names (e.g., 'REGRESSION', 'PUBLICLY_EXPOSED', 'TEST_FILE')")] = None,
-    exclude_tags: Annotated[list[str] | str | None, Field(default=['TEST_FILE', 'FALSE_POSITIVE', 'CHECK_RUN_SKIP_FALSE_POSITIVE', 'CHECK_RUN_SKIP_LOW_RISK', 'CHECK_RUN_SKIP_TEST_CRED'], description='Exclude incidents with these tag names. Default excludes TEST_FILE, FALSE_POSITIVE, and CHECK_RUN_SKIP_* tags.')] = ['TEST_FILE', 'FALSE_POSITIVE', 'CHECK_RUN_SKIP_FALSE_POSITIVE', 'CHECK_RUN_SKIP_LOW_RISK', 'CHECK_RUN_SKIP_TEST_CRED'],
-    public_exposure: Annotated[list[str] | str | None, Field(default=None, description='Filter by public exposure. Values: source_publicly_visible, public_incident_linked, leaked_outside_perimeter')] = None,
-    integration: Annotated[list[str] | str | None, Field(default=None, description="Filter by integration type (e.g., 'github', 'gitlab', 'slack')")] = None,
-    issue_tracker: Annotated[list[str] | str | None, Field(default=None, description='Filter by issue tracker type. Values: jira_cloud_notifier, jira_data_center_notifier, servicenow')] = None,
-    has_related_issues: Annotated[bool | None, Field(default=None, description='Filter to incidents with (True) or without (False) related issues')] = None,
-    location: Annotated[bool | None, Field(default=None, description='Filter to incidents with (True) or without (False) location information')] = None,
-    feedback: Annotated[bool | None, Field(default=None, description='Filter to incidents with (True) or without (False) feedback')] = None,
-    publicly_shared: Annotated[bool | None, Field(default=None, description="Filter to incidents that are (True) or aren't (False) publicly shared")] = None,
-    secret_manager_type: Annotated[list[str] | str | None, Field(default=None, description='Filter by vault type. Values: hashicorpvault, awssecretsmanager, azurekeyvault, gcpsecretmanager, cyberarksaas, cyberarkselfhosted, akeyless, delineasecretserver')] = None,
-    secret_manager_instance: Annotated[list[int] | int | None, Field(default=None, description='Filter by vault instance ID(s)')] = None,
-    nhi_env: Annotated[list[str] | str | None, Field(default=None, description='Filter by NHI environment name(s)')] = None,
-    nhi_policy: Annotated[list[str] | str | None, Field(default=None, description='Filter by NHI policy breach name(s)')] = None,
-    teams: Annotated[list[int] | int | None, Field(default=None, description='Filter by team ID(s)')] = None,
-    similar_to: Annotated[int | None, Field(default=None, description='Filter incidents similar to the given incident ID')] = None,
-    date_before: Annotated[str | None, Field(default=None, description='Filter incidents detected before this date (YYYY-MM-DD format)')] = None,
-    date_after: Annotated[str | None, Field(default=None, description='Filter incidents detected after this date (YYYY-MM-DD format)')] = None,
-    secret_scope: Annotated[list[str] | str | None, Field(default=None, description='Filter by secret scope name(s)')] = None,
-    analyzer_status: Annotated[list[str] | str | None, Field(default=None, description='Filter by analyzer status. Values: no_checker, not_checked, checked, invalid, failed_to_check')] = None,
-    custom_tags: Annotated[list[int] | int | None, Field(default=None, description='Filter by custom tag ID(s)')] = None,
+    search: Annotated[
+        str | None, Field(default=None, description="Search term to filter incidents by name or content")
+    ] = None,
+    status: Annotated[
+        list[IncidentStatusFilter] | IncidentStatusFilter | None,
+        Field(
+            default=DEFAULT_STATUSES,
+            description="Filter by status. Values: TRIGGERED, ASSIGNED, RESOLVED, IGNORED. Default excludes IGNORED.",
+        ),
+    ] = DEFAULT_STATUSES,
+    mine: Annotated[
+        bool,
+        Field(
+            default=False,
+            description="If True, count only incidents assigned to the current user. Overrides assignee_id.",
+        ),
+    ] = False,
+    assignee_id: Annotated[
+        int | None,
+        Field(
+            default=None,
+            description="Filter by assignee member ID. Use 0 for unassigned incidents. Cannot be used with 'mine'.",
+        ),
+    ] = None,
+    severity: Annotated[
+        list[IncidentSeverityFilter] | IncidentSeverityFilter | None,
+        Field(
+            default=DEFAULT_SEVERITIES,
+            description="Filter by severity levels. Values: critical (10), high (20), medium (30), low (40), info (50), unknown (100). Default excludes LOW and INFO.",
+        ),
+    ] = DEFAULT_SEVERITIES,
+    score_min: Annotated[
+        int | None,
+        Field(
+            default=None,
+            ge=0,
+            le=100,
+            description="Filter incidents with a score greater than or equal to this value (0-100).",
+        ),
+    ] = None,
+    score_max: Annotated[
+        int | None,
+        Field(
+            default=None,
+            ge=0,
+            le=100,
+            description="Filter incidents with a score less than or equal to this value (0-100).",
+        ),
+    ] = None,
+    validity: Annotated[
+        list[IncidentValidityFilter] | IncidentValidityFilter | None,
+        Field(
+            default=DEFAULT_VALIDITIES,
+            description="Filter by validity status. Values: valid, invalid, failed_to_check, no_checker, unknown. Default excludes INVALID.",
+        ),
+    ] = DEFAULT_VALIDITIES,
+    detector_group_name: Annotated[
+        list[str] | str | None,
+        Field(default=None, description="Filter by detector group name (e.g., 'AWS Keys', 'GitHub Tokens')"),
+    ] = None,
+    detector_type: Annotated[
+        list[str] | str | None, Field(default=None, description="Filter by detector type/nature")
+    ] = None,
+    detector_category: Annotated[
+        list[str] | str | None, Field(default=None, description="Filter by detector category")
+    ] = None,
+    issue_name: Annotated[
+        list[str] | str | None, Field(default=None, description="Filter by issue/incident name")
+    ] = None,
+    secret_category: Annotated[
+        list[str] | str | None, Field(default=None, description="Filter by secret category")
+    ] = None,
+    secret_family: Annotated[list[str] | str | None, Field(default=None, description="Filter by secret family")] = None,
+    secret_provider: Annotated[
+        list[str] | str | None,
+        Field(default=None, description="Filter by secret provider (e.g., 'aws', 'github', 'google')"),
+    ] = None,
+    source_ids: Annotated[
+        list[int] | int | None,
+        Field(
+            default=None,
+            description="Filter by source ID(s). Can be obtained using list_source or find_current_source_id tools.",
+        ),
+    ] = None,
+    source_type: Annotated[
+        list[IncidentSourceTypeFilter] | IncidentSourceTypeFilter | None,
+        Field(
+            default=None,
+            description="Filter by public API source type (for example: github, gitlab, bitbucket, azure_devops).",
+        ),
+    ] = None,
+    source_criticality: Annotated[
+        list[str] | str | None,
+        Field(default=None, description="Filter by source criticality. Values: critical, high, medium, low, unknown"),
+    ] = None,
+    occurrence_count_min: Annotated[
+        int | None, Field(default=None, description="Filter incidents with at least this many occurrences")
+    ] = None,
+    presence: Annotated[
+        list[str] | str | None,
+        Field(default=None, description="Filter by occurrence presence status. Values: present, removed"),
+    ] = None,
+    opened_for_days: Annotated[
+        int | None, Field(default=None, description="Filter incidents that have been open for at least this many days")
+    ] = None,
+    tags: Annotated[
+        list[str] | str | None,
+        Field(default=None, description="Filter by tag names (e.g., 'REGRESSION', 'PUBLICLY_EXPOSED', 'TEST_FILE')"),
+    ] = None,
+    exclude_tags: Annotated[
+        list[str] | str | None,
+        Field(
+            default=[
+                "TEST_FILE",
+                "FALSE_POSITIVE",
+                "CHECK_RUN_SKIP_FALSE_POSITIVE",
+                "CHECK_RUN_SKIP_LOW_RISK",
+                "CHECK_RUN_SKIP_TEST_CRED",
+            ],
+            description="Exclude incidents with these tag names. Default excludes TEST_FILE, FALSE_POSITIVE, and CHECK_RUN_SKIP_* tags.",
+        ),
+    ] = [
+        "TEST_FILE",
+        "FALSE_POSITIVE",
+        "CHECK_RUN_SKIP_FALSE_POSITIVE",
+        "CHECK_RUN_SKIP_LOW_RISK",
+        "CHECK_RUN_SKIP_TEST_CRED",
+    ],
+    public_exposure: Annotated[
+        list[str] | str | None,
+        Field(
+            default=None,
+            description="Filter by public exposure. Values: source_publicly_visible, public_incident_linked, leaked_outside_perimeter",
+        ),
+    ] = None,
+    integration: Annotated[
+        list[IncidentIntegrationFilter] | IncidentIntegrationFilter | None,
+        Field(
+            default=None,
+            description="Filter by audited integration name. Values: github, github_enterprise_server, gitlab",
+        ),
+    ] = None,
+    issue_tracker: Annotated[
+        list[str] | str | None,
+        Field(
+            default=None,
+            description="Filter by issue tracker type. Values: jira_cloud_notifier, jira_data_center_notifier, servicenow",
+        ),
+    ] = None,
+    has_related_issues: Annotated[
+        bool | None,
+        Field(default=None, description="Filter to incidents with (True) or without (False) related issues"),
+    ] = None,
+    location: Annotated[
+        bool | None,
+        Field(default=None, description="Filter to incidents with (True) or without (False) location information"),
+    ] = None,
+    feedback: Annotated[
+        bool | None, Field(default=None, description="Filter to incidents with (True) or without (False) feedback")
+    ] = None,
+    publicly_shared: Annotated[
+        bool | None,
+        Field(default=None, description="Filter to incidents that are (True) or aren't (False) publicly shared"),
+    ] = None,
+    secret_manager_type: Annotated[
+        list[str] | str | None,
+        Field(
+            default=None,
+            description="Filter by vault type. Values: hashicorpvault, awssecretsmanager, azurekeyvault, gcpsecretmanager, cyberarksaas, cyberarkselfhosted, akeyless, delineasecretserver",
+        ),
+    ] = None,
+    secret_manager_instance: Annotated[
+        list[int] | int | None, Field(default=None, description="Filter by vault instance ID(s)")
+    ] = None,
+    nhi_env: Annotated[
+        list[str] | str | None, Field(default=None, description="Filter by NHI environment name(s)")
+    ] = None,
+    nhi_policy: Annotated[
+        list[str] | str | None, Field(default=None, description="Filter by NHI policy breach name(s)")
+    ] = None,
+    teams: Annotated[list[int] | int | None, Field(default=None, description="Filter by team ID(s)")] = None,
+    similar_to: Annotated[
+        int | None, Field(default=None, description="Filter incidents similar to the given incident ID")
+    ] = None,
+    date_before: Annotated[
+        str | None, Field(default=None, description="Filter incidents detected before this date (YYYY-MM-DD format)")
+    ] = None,
+    date_after: Annotated[
+        str | None, Field(default=None, description="Filter incidents detected after this date (YYYY-MM-DD format)")
+    ] = None,
+    secret_scope: Annotated[
+        list[str] | str | None, Field(default=None, description="Filter by secret scope name(s)")
+    ] = None,
+    analyzer_status: Annotated[
+        list[str] | str | None,
+        Field(
+            default=None,
+            description="Filter by analyzer status. Values: no_checker, not_checked, checked, invalid, failed_to_check",
+        ),
+    ] = None,
+    custom_tags: Annotated[
+        list[int] | int | None, Field(default=None, description="Filter by custom tag ID(s)")
+    ] = None,
 ) -> CountIncidentsResult | CountIncidentsError:
     """
-        Count secret incidents matching the given filters.
+    Count secret incidents matching the given filters.
 
-        Returns the total number of matching incidents without fetching the full list.
-        This is useful to get an overview of incident volume, check filter results
-        before paginating, or build dashboards.
+    Returns the total number of matching incidents without fetching the full list.
+    This is useful to get an overview of incident volume, check filter results
+    before paginating, or build dashboards.
 
-        Accepts the same filters as list_incidents (status, severity, detector type,
-        source, tags, etc.) but returns only the count.
+    Accepts the same filters as list_incidents (status, severity, detector type,
+    source, tags, etc.) but returns only the count.
 
-        Args:
-            params: CountIncidentsParams model containing all filtering options.
+    Args:
+        params: CountIncidentsParams model containing all filtering options.
 
-        Returns:
-            CountIncidentsResult: Pydantic model containing:
-                - count: Total number of matching incidents
-                - applied_filters: Dictionary of filters that were applied
+    Returns:
+        CountIncidentsResult: Pydantic model containing:
+            - count: Total number of matching incidents
+            - applied_filters: Dictionary of filters that were applied
 
-            CountIncidentsError: Pydantic model with error message if the operation fails
+        CountIncidentsError: Pydantic model with error message if the operation fails
 
     """
     params = CountIncidentsParams(

--- a/packages/gg_api_core/src/gg_api_core/tools/create_code_fix_request.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/create_code_fix_request.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Annotated
 
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
@@ -33,7 +34,15 @@ class CreateCodeFixRequestResult(BaseModel):
     success: bool = Field(default=True, description="Whether the request was successful")
 
 
-async def create_code_fix_request(params: CreateCodeFixRequestParams) -> CreateCodeFixRequestResult:
+async def create_code_fix_request(
+    locations: Annotated[
+        list[LocationToFix],
+        Field(
+            min_length=1,
+            description="List of issues with their location IDs to fix. Each item must include an issue_id and a list of location_ids.",
+        ),
+    ],
+) -> CreateCodeFixRequestResult:
     """
     Create code fix requests for multiple secret incidents with their locations.
 
@@ -44,8 +53,8 @@ async def create_code_fix_request(params: CreateCodeFixRequestParams) -> CreateC
     The system will group locations by source repository and create one pull request per source.
 
     Args:
-        params: CreateCodeFixRequestParams model containing:
-            - locations: List of issues with their location IDs to fix
+        locations: List of issues with their location IDs to fix. Each item has an issue_id
+            and a list of location_ids.
 
     Returns:
         CreateCodeFixRequestResult: Pydantic model containing:
@@ -63,21 +72,18 @@ async def create_code_fix_request(params: CreateCodeFixRequestParams) -> CreateC
     Examples:
         Single issue with multiple locations:
         ```python
-        params = CreateCodeFixRequestParams(
-            locations=[LocationToFix(issue_id=12345, location_ids=[67890, 67891, 67892])]
-        )
+        locations=[LocationToFix(issue_id=12345, location_ids=[67890, 67891, 67892])]
         ```
 
         Multiple issues from different sources:
         ```python
-        params = CreateCodeFixRequestParams(
-            locations=[
-                LocationToFix(issue_id=12345, location_ids=[67890]),
-                LocationToFix(issue_id=12346, location_ids=[67893, 67894]),
-            ]
-        )
+        locations=[
+            LocationToFix(issue_id=12345, location_ids=[67890]),
+            LocationToFix(issue_id=12346, location_ids=[67893, 67894]),
+        ]
         ```
     """
+    params = CreateCodeFixRequestParams(locations=locations)
     client = await get_client()
 
     # Convert Pydantic models to dict format expected by API

--- a/packages/gg_api_core/src/gg_api_core/tools/create_code_fix_request.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/create_code_fix_request.py
@@ -72,12 +72,12 @@ async def create_code_fix_request(
     Examples:
         Single issue with multiple locations:
         ```python
-        locations=[LocationToFix(issue_id=12345, location_ids=[67890, 67891, 67892])]
+        locations = [LocationToFix(issue_id=12345, location_ids=[67890, 67891, 67892])]
         ```
 
         Multiple issues from different sources:
         ```python
-        locations=[
+        locations = [
             LocationToFix(issue_id=12345, location_ids=[67890]),
             LocationToFix(issue_id=12346, location_ids=[67893, 67894]),
         ]

--- a/packages/gg_api_core/src/gg_api_core/tools/generate_honey_token.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/generate_honey_token.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Annotated, Any
 
 import httpx
 from fastmcp.exceptions import ToolError
@@ -60,7 +60,28 @@ class GenerateHoneytokenResult(BaseModel):
     injection_recommendations: dict[str, Any] | None = Field(default=None, description="Injection recommendations")
 
 
-async def generate_honeytoken(params: GenerateHoneytokenParams) -> GenerateHoneytokenResult:
+async def generate_honeytoken(
+    name: Annotated[
+        str,
+        Field(
+            description="Name for the honeytoken. Must be UNIQUE among the workspace's active honeytokens — "
+            "reusing the name of an existing active token is rejected by the API. Pick a specific, descriptive "
+            "name (e.g. 'aws-prod-db-decoy-2026-07'), not a generic one."
+        ),
+    ],
+    description: Annotated[
+        str, Field(default="", description="Description of what the honeytoken is used for")
+    ] = "",
+    new_token: Annotated[
+        bool,
+        Field(
+            default=False,
+            description="If False (default), reuse your most recent active honeytoken instead of generating a new one; "
+            "the name is only used when no reusable token exists and one must be created. "
+            "If True, always create a new honeytoken — this fails if the name is already taken, so pass a fresh unique name.",
+        ),
+    ] = False,
+) -> GenerateHoneytokenResult:
     """
     Generate an AWS GitGuardian honeytoken and get injection recommendations.
 
@@ -68,7 +89,9 @@ async def generate_honeytoken(params: GenerateHoneytokenParams) -> GenerateHoney
     instead of generating a new one. If no existing token is found, a new one will be created.
 
     Args:
-        params: GenerateHoneytokenParams model containing honeytoken configuration
+        name: Name for the honeytoken (must be unique among active tokens)
+        description: Description of what the honeytoken is used for
+        new_token: If False (default), reuse most recent active honeytoken; if True, always create a new one
 
     Returns:
         GenerateHoneytokenResult: Pydantic model containing:
@@ -84,6 +107,7 @@ async def generate_honeytoken(params: GenerateHoneytokenParams) -> GenerateHoney
     Raises:
         ToolError: If the honeytoken generation or retrieval fails
     """
+    params = GenerateHoneytokenParams(name=name, description=description, new_token=new_token)
     client = await get_client()
     logger.debug(f"Processing honeytoken request with name: {params.name}, new_token: {params.new_token}")
 

--- a/packages/gg_api_core/src/gg_api_core/tools/generate_honey_token.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/generate_honey_token.py
@@ -69,9 +69,7 @@ async def generate_honeytoken(
             "name (e.g. 'aws-prod-db-decoy-2026-07'), not a generic one."
         ),
     ],
-    description: Annotated[
-        str, Field(default="", description="Description of what the honeytoken is used for")
-    ] = "",
+    description: Annotated[str, Field(default="", description="Description of what the honeytoken is used for")] = "",
     new_token: Annotated[
         bool,
         Field(

--- a/packages/gg_api_core/src/gg_api_core/tools/get_incident.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/get_incident.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Annotated, Any
 
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
@@ -27,7 +27,13 @@ class GetIncidentResult(BaseModel):
     incident: dict[str, Any] = Field(description="Detailed incident data including occurrences")
 
 
-async def get_incident(params: GetIncidentParams) -> GetIncidentResult:
+async def get_incident(
+    incident_id: Annotated[int, Field(description="The ID of the incident to retrieve")],
+    with_occurrences: Annotated[
+        int,
+        Field(ge=0, le=100, description="Number of occurrences to retrieve (0-100, default: 20)"),
+    ] = 20,
+) -> GetIncidentResult:
     """
     Retrieve a specific secret incident by its ID.
 
@@ -40,9 +46,8 @@ async def get_incident(params: GetIncidentParams) -> GetIncidentResult:
     - Occurrences (up to the specified limit)
 
     Args:
-        params: GetIncidentParams model containing:
-            - incident_id: The ID of the incident to retrieve
-            - with_occurrences: Number of occurrences to include (0-100)
+        incident_id: The ID of the incident to retrieve
+        with_occurrences: Number of occurrences to include (0-100)
 
     Returns:
         GetIncidentResult: Pydantic model containing:
@@ -51,6 +56,7 @@ async def get_incident(params: GetIncidentParams) -> GetIncidentResult:
     Raises:
         ToolError: If the retrieval operation fails
     """
+    params = GetIncidentParams(incident_id=incident_id, with_occurrences=with_occurrences)
     client = await get_client()
     logger.debug(f"Retrieving incident {params.incident_id}")
 

--- a/packages/gg_api_core/src/gg_api_core/tools/get_member.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/get_member.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Annotated, Any
 
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
@@ -21,7 +21,9 @@ class GetMemberResult(BaseModel):
     member: dict[str, Any] = Field(description="Member information")
 
 
-async def get_member(params: GetMemberParams) -> GetMemberResult:
+async def get_member(
+    member_id: Annotated[int, Field(description="The ID of the member to retrieve")],
+) -> GetMemberResult:
     """
     Retrieve a specific member by their ID.
 
@@ -36,8 +38,7 @@ async def get_member(params: GetMemberParams) -> GetMemberResult:
     - last_login: When the member last logged in
 
     Args:
-        params: GetMemberParams model containing:
-            - member_id: The ID of the member to retrieve
+        member_id: The ID of the member to retrieve
 
     Returns:
         GetMemberResult: Pydantic model containing:
@@ -46,6 +47,7 @@ async def get_member(params: GetMemberParams) -> GetMemberResult:
     Raises:
         ToolError: If the retrieval operation fails
     """
+    params = GetMemberParams(member_id=member_id)
     client = await get_client()
     logger.debug(f"Retrieving member {params.member_id}")
 

--- a/packages/gg_api_core/src/gg_api_core/tools/get_public_incident.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/get_public_incident.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Annotated, Any
 
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
@@ -21,7 +21,9 @@ class GetPublicIncidentResult(BaseModel):
     incident: dict[str, Any] = Field(description="Detailed public incident data")
 
 
-async def get_public_incident(params: GetPublicIncidentParams) -> GetPublicIncidentResult:
+async def get_public_incident(
+    incident_id: Annotated[int, Field(description="The id of the public secret incident to retrieve")],
+) -> GetPublicIncidentResult:
     """Retrieve a single public secret incident detected by GitGuardian Public Monitoring.
 
     Public incidents live on public sources (public GitHub repos/gists, Docker Hub, etc.) and
@@ -32,7 +34,7 @@ async def get_public_incident(params: GetPublicIncidentParams) -> GetPublicIncid
     Wraps GET /v1/public-incidents/secrets/{incident_id}.
 
     Args:
-        params: GetPublicIncidentParams model containing the incident_id.
+        incident_id: The id of the public secret incident to retrieve.
 
     Returns:
         GetPublicIncidentResult: Pydantic model containing:
@@ -42,6 +44,7 @@ async def get_public_incident(params: GetPublicIncidentParams) -> GetPublicIncid
     Raises:
         ToolError: If the retrieval operation fails (e.g. unknown id, API error).
     """
+    params = GetPublicIncidentParams(incident_id=incident_id)
     client = await get_client()
     logger.debug(f"Retrieving public incident {params.incident_id}")
 

--- a/packages/gg_api_core/src/gg_api_core/tools/incident_notes.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/incident_notes.py
@@ -82,7 +82,21 @@ def _build_list_result(result: ListResponse) -> ListCommentsResult:
     )
 
 
-async def list_incident_comments(params: ListIncidentCommentsParams) -> ListCommentsResult:
+async def list_incident_comments(
+    incident_id: Annotated[int, Field(description="ID of the secret incident whose comments to list")],
+    cursor: Annotated[str | None, Field(default=None, description="Pagination cursor for fetching the next page of results")] = None,
+    per_page: Annotated[
+        int,
+        Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)"),
+    ] = 20,
+    get_all: Annotated[
+        bool,
+        Field(
+            default=False,
+            description=f"If True, fetch all pages (capped at ~{DEFAULT_PAGINATION_MAX_BYTES / 1000}KB; check 'has_more' and use cursor to continue)",
+        ),
+    ] = False,
+) -> ListCommentsResult:
     """
     List the comments (notes) left on an internal secret incident.
 
@@ -91,7 +105,10 @@ async def list_incident_comments(params: ListIncidentCommentsParams) -> ListComm
     For Public Monitoring incidents use `list_public_incident_comments` instead.
 
     Args:
-        params: ListIncidentCommentsParams with the incident ID and pagination options
+        incident_id: ID of the secret incident whose comments to list
+        cursor: Pagination cursor
+        per_page: Number of results per page (default: 20)
+        get_all: If True, fetch all pages
 
     Returns:
         ListCommentsResult with the comments, total_count, next_cursor, and has_more
@@ -99,6 +116,12 @@ async def list_incident_comments(params: ListIncidentCommentsParams) -> ListComm
     Raises:
         ToolError: If the listing operation fails
     """
+    params = ListIncidentCommentsParams(
+        incident_id=incident_id,
+        cursor=cursor,
+        per_page=per_page,
+        get_all=get_all,
+    )
     client = await get_client()
     logger.debug(f"Listing comments for incident {params.incident_id}")
 
@@ -118,7 +141,28 @@ async def list_incident_comments(params: ListIncidentCommentsParams) -> ListComm
         raise ToolError(f"Error: {str(e)}")
 
 
-async def manage_incident_comment(params: ManageIncidentCommentParams) -> dict[str, Any]:
+async def manage_incident_comment(
+    incident_id: Annotated[int, Field(description="ID of the secret incident to comment on")],
+    action: Annotated[
+        Literal["add", "edit"],
+        Field(
+            description="Action to perform: 'add' creates a new comment, 'edit' replaces the body of an existing comment (requires comment_id)"
+        ),
+    ],
+    comment: Annotated[
+        CommentStr,
+        Field(
+            description="Body of the comment (1-10000 characters). For 'add' this is the new comment; for 'edit' this is the replacement text."
+        ),
+    ],
+    comment_id: Annotated[
+        int | None,
+        Field(
+            default=None,
+            description="ID of the comment to edit. Required when action is 'edit'. Use the listing tool to find it.",
+        ),
+    ] = None,
+) -> dict[str, Any]:
     """
     Add a new comment to an internal secret incident, or edit an existing one.
 
@@ -130,8 +174,10 @@ async def manage_incident_comment(params: ManageIncidentCommentParams) -> dict[s
     note ids are not interchangeable between the two perimeters.
 
     Args:
-        params: ManageIncidentCommentParams with the incident ID, action, comment
-            body, and comment_id (for edits)
+        incident_id: ID of the secret incident to comment on
+        action: Whether to add or edit a comment
+        comment: Body of the comment (1-10000 characters)
+        comment_id: ID of the comment to edit (required when action is 'edit')
 
     Returns:
         Dictionary containing the created or updated comment data from the API
@@ -139,6 +185,12 @@ async def manage_incident_comment(params: ManageIncidentCommentParams) -> dict[s
     Raises:
         ToolError: If the operation fails
     """
+    params = ManageIncidentCommentParams(
+        incident_id=incident_id,
+        action=action,
+        comment=comment,
+        comment_id=comment_id,
+    )
     client = await get_client()
     logger.debug(f"Managing comment on incident {params.incident_id} with action: {params.action}")
 
@@ -158,7 +210,21 @@ async def manage_incident_comment(params: ManageIncidentCommentParams) -> dict[s
         raise ToolError(f"Error: {str(e)}")
 
 
-async def list_public_incident_comments(params: ListIncidentCommentsParams) -> ListCommentsResult:
+async def list_public_incident_comments(
+    incident_id: Annotated[int, Field(description="ID of the public secret incident whose comments to list")],
+    cursor: Annotated[str | None, Field(default=None, description="Pagination cursor for fetching the next page of results")] = None,
+    per_page: Annotated[
+        int,
+        Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)"),
+    ] = 20,
+    get_all: Annotated[
+        bool,
+        Field(
+            default=False,
+            description=f"If True, fetch all pages (capped at ~{DEFAULT_PAGINATION_MAX_BYTES / 1000}KB; check 'has_more' and use cursor to continue)",
+        ),
+    ] = False,
+) -> ListCommentsResult:
     """
     List the comments (notes) left on a public secret incident.
 
@@ -169,7 +235,10 @@ async def list_public_incident_comments(params: ListIncidentCommentsParams) -> L
     `list_incident_comments` instead.
 
     Args:
-        params: ListIncidentCommentsParams with the public incident ID and pagination options
+        incident_id: ID of the public secret incident whose comments to list
+        cursor: Pagination cursor
+        per_page: Number of results per page (default: 20)
+        get_all: If True, fetch all pages
 
     Returns:
         ListCommentsResult with the comments, total_count, next_cursor, and has_more
@@ -177,6 +246,12 @@ async def list_public_incident_comments(params: ListIncidentCommentsParams) -> L
     Raises:
         ToolError: If the listing operation fails
     """
+    params = ListIncidentCommentsParams(
+        incident_id=incident_id,
+        cursor=cursor,
+        per_page=per_page,
+        get_all=get_all,
+    )
     client = await get_client()
     logger.debug(f"Listing comments for public incident {params.incident_id}")
 
@@ -196,7 +271,28 @@ async def list_public_incident_comments(params: ListIncidentCommentsParams) -> L
         raise ToolError(f"Error: {str(e)}")
 
 
-async def manage_public_incident_comment(params: ManageIncidentCommentParams) -> dict[str, Any]:
+async def manage_public_incident_comment(
+    incident_id: Annotated[int, Field(description="ID of the public secret incident to comment on")],
+    action: Annotated[
+        Literal["add", "edit"],
+        Field(
+            description="Action to perform: 'add' creates a new comment, 'edit' replaces the body of an existing comment (requires comment_id)"
+        ),
+    ],
+    comment: Annotated[
+        CommentStr,
+        Field(
+            description="Body of the comment (1-10000 characters). For 'add' this is the new comment; for 'edit' this is the replacement text."
+        ),
+    ],
+    comment_id: Annotated[
+        int | None,
+        Field(
+            default=None,
+            description="ID of the comment to edit. Required when action is 'edit'. Use the listing tool to find it.",
+        ),
+    ] = None,
+) -> dict[str, Any]:
     """
     Add a new comment to a public secret incident, or edit an existing one.
 
@@ -210,8 +306,10 @@ async def manage_public_incident_comment(params: ManageIncidentCommentParams) ->
     For internal incidents use `manage_incident_comment` instead.
 
     Args:
-        params: ManageIncidentCommentParams with the public incident ID, action,
-            comment body, and comment_id (for edits)
+        incident_id: ID of the public secret incident to comment on
+        action: Whether to add or edit a comment
+        comment: Body of the comment (1-10000 characters)
+        comment_id: ID of the comment to edit (required when action is 'edit')
 
     Returns:
         Dictionary containing the created or updated comment data from the API
@@ -219,6 +317,12 @@ async def manage_public_incident_comment(params: ManageIncidentCommentParams) ->
     Raises:
         ToolError: If the operation fails
     """
+    params = ManageIncidentCommentParams(
+        incident_id=incident_id,
+        action=action,
+        comment=comment,
+        comment_id=comment_id,
+    )
     client = await get_client()
     logger.debug(f"Managing comment on public incident {params.incident_id} with action: {params.action}")
 

--- a/packages/gg_api_core/src/gg_api_core/tools/incident_notes.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/incident_notes.py
@@ -84,7 +84,9 @@ def _build_list_result(result: ListResponse) -> ListCommentsResult:
 
 async def list_incident_comments(
     incident_id: Annotated[int, Field(description="ID of the secret incident whose comments to list")],
-    cursor: Annotated[str | None, Field(default=None, description="Pagination cursor for fetching the next page of results")] = None,
+    cursor: Annotated[
+        str | None, Field(default=None, description="Pagination cursor for fetching the next page of results")
+    ] = None,
     per_page: Annotated[
         int,
         Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)"),
@@ -212,7 +214,9 @@ async def manage_incident_comment(
 
 async def list_public_incident_comments(
     incident_id: Annotated[int, Field(description="ID of the public secret incident whose comments to list")],
-    cursor: Annotated[str | None, Field(default=None, description="Pagination cursor for fetching the next page of results")] = None,
+    cursor: Annotated[
+        str | None, Field(default=None, description="Pagination cursor for fetching the next page of results")
+    ] = None,
     per_page: Annotated[
         int,
         Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)"),

--- a/packages/gg_api_core/src/gg_api_core/tools/list_detectors.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_detectors.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Annotated, Any
 
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
@@ -46,7 +46,25 @@ class ListDetectorsResult(BaseModel):
     )
 
 
-async def list_detectors(params: ListDetectorsParams = ListDetectorsParams()) -> ListDetectorsResult:
+async def list_detectors(
+    search: Annotated[str | None, Field(default=None, description="Search string to filter detectors by name")] = None,
+    type: Annotated[
+        str | None,
+        Field(default=None, description="Filter by detector type: 'specific', 'generic', or 'custom'"),
+    ] = None,
+    per_page: Annotated[
+        int,
+        Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)"),
+    ] = 20,
+    cursor: Annotated[str | None, Field(default=None, description="Pagination cursor from a previous response")] = None,
+    get_all: Annotated[
+        bool,
+        Field(
+            default=False,
+            description=f"If True, fetch all pages (capped at ~{DEFAULT_PAGINATION_MAX_BYTES / 1000}KB; check 'has_more' and use cursor to continue)",
+        ),
+    ] = False,
+) -> ListDetectorsResult:
     """
     List secret detectors from the GitGuardian detection engine.
 
@@ -54,7 +72,11 @@ async def list_detectors(params: ListDetectorsParams = ListDetectorsParams()) ->
     identifying secrets in source code and other content.
 
     Args:
-        params: ListDetectorsParams model containing all filtering options
+        search: Search string to filter detectors by name
+        type: Optional detector type filter
+        per_page: Number of results per page (default: 20, min: 1, max: 100)
+        cursor: Pagination cursor from a previous response
+        get_all: If True, fetch all pages
 
     Returns:
         ListDetectorsResult: Pydantic model containing:
@@ -65,6 +87,7 @@ async def list_detectors(params: ListDetectorsParams = ListDetectorsParams()) ->
     Raises:
         ToolError: If the listing operation fails
     """
+    params = ListDetectorsParams(search=search, type=type, per_page=per_page, cursor=cursor, get_all=get_all)
     client = await get_client()
     logger.debug("Listing secret detectors")
 

--- a/packages/gg_api_core/src/gg_api_core/tools/list_honeytokens.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_honeytokens.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Annotated, Any
 
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
@@ -54,7 +54,40 @@ class ListHoneytokensResult(BaseModel):
     )
 
 
-async def list_honeytokens(params: ListHoneytokensParams = ListHoneytokensParams()) -> ListHoneytokensResult:
+async def list_honeytokens(
+    mine: Annotated[
+        bool,
+        Field(
+            default=False,
+            description="If True, fetch honeytokens created by the current user. Set to False to get all honeytokens in the workspace.",
+        ),
+    ] = False,
+    status: Annotated[str | None, Field(default=None, description="Filter by status (active, triggered, or revoked)")] = None,
+    search: Annotated[str | None, Field(default=None, description="Search string to filter results by name or description")] = None,
+    ordering: Annotated[
+        str | None,
+        Field(default=None, description="Sort field (e.g., 'name', '-name', 'created_at', '-created_at')"),
+    ] = None,
+    show_token: Annotated[
+        bool, Field(default=False, description="Whether to include token details in the response")
+    ] = False,
+    creator_id: Annotated[str | int | None, Field(default=None, description="Filter by creator ID")] = None,
+    creator_api_token_id: Annotated[
+        str | int | None, Field(default=None, description="Filter by creator API token ID")
+    ] = None,
+    per_page: Annotated[
+        int,
+        Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)"),
+    ] = 20,
+    cursor: Annotated[str | None, Field(default=None, description="Pagination cursor from a previous response")] = None,
+    get_all: Annotated[
+        bool,
+        Field(
+            default=False,
+            description=f"If True, fetch all pages (capped at ~{DEFAULT_PAGINATION_MAX_BYTES / 1000}KB; check 'has_more' and use cursor to continue)",
+        ),
+    ] = False,
+) -> ListHoneytokensResult:
     """
     List honeytokens from the GitGuardian dashboard with filtering options.
 
@@ -63,7 +96,16 @@ async def list_honeytokens(params: ListHoneytokensParams = ListHoneytokensParams
     to filter to only the current user's honeytokens.
 
     Args:
-        params: ListHoneytokensParams model containing all filtering options
+        mine: If True, fetch only the current user's honeytokens
+        status: Optional status filter
+        search: Optional search string
+        ordering: Optional sort field
+        show_token: Whether to include token details
+        creator_id: Optional creator ID filter
+        creator_api_token_id: Optional creator API token ID filter
+        per_page: Number of results per page (default: 20)
+        cursor: Pagination cursor
+        get_all: If True, fetch all pages
 
     Returns:
         ListHoneytokensResult: Pydantic model containing:
@@ -72,6 +114,18 @@ async def list_honeytokens(params: ListHoneytokensParams = ListHoneytokensParams
     Raises:
         ToolError: If the listing operation fails
     """
+    params = ListHoneytokensParams(
+        mine=mine,
+        status=status,
+        search=search,
+        ordering=ordering,
+        show_token=show_token,
+        creator_id=creator_id,
+        creator_api_token_id=creator_api_token_id,
+        per_page=per_page,
+        cursor=cursor,
+        get_all=get_all,
+    )
     client = await get_client()
     logger.debug("Listing honeytokens with filters")
 

--- a/packages/gg_api_core/src/gg_api_core/tools/list_honeytokens.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_honeytokens.py
@@ -62,8 +62,12 @@ async def list_honeytokens(
             description="If True, fetch honeytokens created by the current user. Set to False to get all honeytokens in the workspace.",
         ),
     ] = False,
-    status: Annotated[str | None, Field(default=None, description="Filter by status (active, triggered, or revoked)")] = None,
-    search: Annotated[str | None, Field(default=None, description="Search string to filter results by name or description")] = None,
+    status: Annotated[
+        str | None, Field(default=None, description="Filter by status (active, triggered, or revoked)")
+    ] = None,
+    search: Annotated[
+        str | None, Field(default=None, description="Search string to filter results by name or description")
+    ] = None,
     ordering: Annotated[
         str | None,
         Field(default=None, description="Sort field (e.g., 'name', '-name', 'created_at', '-created_at')"),

--- a/packages/gg_api_core/src/gg_api_core/tools/list_incident_members.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_incident_members.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any
+from typing import Annotated, Any
 
 from pydantic import BaseModel, Field
 
@@ -50,7 +50,40 @@ class ListIncidentMembersResult(BaseModel):
     )
 
 
-async def list_incident_members(params: ListIncidentMembersParams) -> ListIncidentMembersResult:
+async def list_incident_members(
+    incident_id: Annotated[int, Field(description="The ID of the secret incident to retrieve members for")],
+    cursor: Annotated[str | None, Field(default=None, description="Pagination cursor for fetching next page of results")] = None,
+    per_page: Annotated[
+        int,
+        Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)"),
+    ] = 20,
+    access_level: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Filter members based on their access level (owner, manager, member, restricted)",
+        ),
+    ] = None,
+    search: Annotated[str | None, Field(default=None, description="Search members based on their name or email")] = None,
+    ordering: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Sort results by field (created_at, -created_at, last_login, -last_login). Use '-' prefix for descending order",
+        ),
+    ] = None,
+    direct_access: Annotated[
+        bool | None,
+        Field(default=None, description="Filter on direct or indirect accesses"),
+    ] = None,
+    get_all: Annotated[
+        bool,
+        Field(
+            default=False,
+            description=f"If True, fetch all pages (capped at ~{DEFAULT_PAGINATION_MAX_BYTES / 1000}KB; check 'has_more' and use cursor to continue)",
+        ),
+    ] = False,
+) -> ListIncidentMembersResult:
     """
     List members with access to a secret incident.
 
@@ -59,7 +92,14 @@ async def list_incident_members(params: ListIncidentMembersParams) -> ListIncide
     and last login.
 
     Args:
-        params: ListIncidentMembersParams model containing incident ID and filtering/pagination options
+        incident_id: The ID of the secret incident to retrieve members for
+        cursor: Pagination cursor
+        per_page: Number of results per page (default: 20)
+        access_level: Filter by access level
+        search: Search members by name/email
+        ordering: Sort field
+        direct_access: Filter on direct or indirect accesses
+        get_all: If True, fetch all pages
 
     Returns:
         ListIncidentMembersResult: Pydantic model containing:
@@ -71,6 +111,16 @@ async def list_incident_members(params: ListIncidentMembersParams) -> ListIncide
     Raises:
         ToolError: If the listing operation fails
     """
+    params = ListIncidentMembersParams(
+        incident_id=incident_id,
+        cursor=cursor,
+        per_page=per_page,
+        access_level=access_level,
+        search=search,
+        ordering=ordering,
+        direct_access=direct_access,
+        get_all=get_all,
+    )
     client = await get_client()
     logger.debug(f"Listing members with access to incident {params.incident_id}")
 

--- a/packages/gg_api_core/src/gg_api_core/tools/list_incident_members.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_incident_members.py
@@ -52,7 +52,9 @@ class ListIncidentMembersResult(BaseModel):
 
 async def list_incident_members(
     incident_id: Annotated[int, Field(description="The ID of the secret incident to retrieve members for")],
-    cursor: Annotated[str | None, Field(default=None, description="Pagination cursor for fetching next page of results")] = None,
+    cursor: Annotated[
+        str | None, Field(default=None, description="Pagination cursor for fetching next page of results")
+    ] = None,
     per_page: Annotated[
         int,
         Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)"),
@@ -64,7 +66,9 @@ async def list_incident_members(
             description="Filter members based on their access level (owner, manager, member, restricted)",
         ),
     ] = None,
-    search: Annotated[str | None, Field(default=None, description="Search members based on their name or email")] = None,
+    search: Annotated[
+        str | None, Field(default=None, description="Search members based on their name or email")
+    ] = None,
     ordering: Annotated[
         str | None,
         Field(

--- a/packages/gg_api_core/src/gg_api_core/tools/list_incident_teams.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_incident_teams.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any
+from typing import Annotated, Any
 
 from pydantic import BaseModel, Field
 
@@ -42,7 +42,29 @@ class ListIncidentTeamsResult(BaseModel):
     )
 
 
-async def list_incident_teams(params: ListIncidentTeamsParams) -> ListIncidentTeamsResult:
+async def list_incident_teams(
+    incident_id: Annotated[int, Field(description="The ID of the secret incident to retrieve teams for")],
+    cursor: Annotated[str | None, Field(default=None, description="Pagination cursor for fetching next page of results")] = None,
+    per_page: Annotated[
+        int,
+        Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)"),
+    ] = 20,
+    search: Annotated[
+        str | None,
+        Field(default=None, description="Search teams based on their name and/or description"),
+    ] = None,
+    direct_access: Annotated[
+        bool | None,
+        Field(default=None, description="Filter on direct or indirect accesses"),
+    ] = None,
+    get_all: Annotated[
+        bool,
+        Field(
+            default=False,
+            description=f"If True, fetch all pages (capped at ~{DEFAULT_PAGINATION_MAX_BYTES / 1000}KB; check 'has_more' and use cursor to continue)",
+        ),
+    ] = False,
+) -> ListIncidentTeamsResult:
     """
     List teams with access to a secret incident.
 
@@ -50,7 +72,12 @@ async def list_incident_teams(params: ListIncidentTeamsParams) -> ListIncidentTe
     including their ID, name, description, global status, GitGuardian URL, and external provider ID.
 
     Args:
-        params: ListIncidentTeamsParams model containing incident ID and filtering/pagination options
+        incident_id: The ID of the secret incident to retrieve teams for
+        cursor: Pagination cursor
+        per_page: Number of results per page (default: 20)
+        search: Search teams by name/description
+        direct_access: Filter on direct or indirect accesses
+        get_all: If True, fetch all pages
 
     Returns:
         ListIncidentTeamsResult: Pydantic model containing:
@@ -62,6 +89,14 @@ async def list_incident_teams(params: ListIncidentTeamsParams) -> ListIncidentTe
     Raises:
         ToolError: If the listing operation fails
     """
+    params = ListIncidentTeamsParams(
+        incident_id=incident_id,
+        cursor=cursor,
+        per_page=per_page,
+        search=search,
+        direct_access=direct_access,
+        get_all=get_all,
+    )
     client = await get_client()
     logger.debug(f"Listing teams with access to incident {params.incident_id}")
 

--- a/packages/gg_api_core/src/gg_api_core/tools/list_incident_teams.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_incident_teams.py
@@ -44,7 +44,9 @@ class ListIncidentTeamsResult(BaseModel):
 
 async def list_incident_teams(
     incident_id: Annotated[int, Field(description="The ID of the secret incident to retrieve teams for")],
-    cursor: Annotated[str | None, Field(default=None, description="Pagination cursor for fetching next page of results")] = None,
+    cursor: Annotated[
+        str | None, Field(default=None, description="Pagination cursor for fetching next page of results")
+    ] = None,
     per_page: Annotated[
         int,
         Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)"),

--- a/packages/gg_api_core/src/gg_api_core/tools/list_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_incidents.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any
+from typing import Annotated, Any
 
 from pydantic import BaseModel, Field
 
@@ -108,34 +108,127 @@ class ListIncidentsError(BaseModel):
 
 
 async def list_incidents(
-    params: ListIncidentsParams = ListIncidentsParams(),
+    page: Annotated[int, Field(default=1, ge=1, description='Page number (1-indexed)')] = 1,
+    page_size: Annotated[int, Field(default=20, ge=1, le=100, description='Number of results per page (default: 20, max: 100)')] = 20,
+    get_all: Annotated[bool, Field(default=False, description="If True, fetch all pages (capped at ~20.0KB; check 'has_more' to see if results were truncated)")] = False,
+    ordering: Annotated[str | None, Field(default='-date', description="Sort field with optional '-' prefix for descending. Options: score, -score, date, -date, severity, -severity, status, -status")] = '-date',
+    search: Annotated[str | None, Field(default=None, description='Search term to filter incidents by name or content')] = None,
+    status: Annotated[list[str] | str | None, Field(default=['TRIGGERED', 'ASSIGNED', 'RESOLVED'], description="Filter by status. Values: TRIGGERED (unassigned active), ASSIGNED (assigned active), RESOLVED, IGNORED. Default excludes IGNORED. Note that OPENED is not a valid status but means 'TRIGGERED OR ASSIGNED'.")] = ['TRIGGERED', 'ASSIGNED', 'RESOLVED'],
+    mine: Annotated[bool, Field(default=False, description='If True, fetch only incidents assigned to the current user. Overrides assignee_id.')] = False,
+    assignee_id: Annotated[int | None, Field(default=None, description="Filter by assignee member ID. Use 0 for unassigned incidents. Cannot be used with 'mine'.")] = None,
+    severity: Annotated[list[str | int] | str | int | None, Field(default=[10, 20, 30, 100], description='Filter by severity levels. Values: critical (10), high (20), medium (30), low (40), info (50), unknown (100). Default excludes LOW and INFO.')] = [10, 20, 30, 100],
+    score_min: Annotated[int | None, Field(default=None, ge=0, le=100, description='Filter incidents with a score greater than or equal to this value (0-100). Higher scores indicate higher priority incidents.')] = None,
+    score_max: Annotated[int | None, Field(default=None, ge=0, le=100, description='Filter incidents with a score less than or equal to this value (0-100).')] = None,
+    validity: Annotated[list[str] | str | None, Field(default=['valid', 'failed_to_check', 'no_checker', 'not_checked'], description='Filter by validity status. Values: valid, invalid, failed_to_check, no_checker, not_checked. Default excludes INVALID.')] = ['valid', 'failed_to_check', 'no_checker', 'not_checked'],
+    detector_group_name: Annotated[list[str] | str | None, Field(default=None, description="Filter by detector group name (e.g., 'AWS Keys', 'GitHub Tokens')")] = None,
+    detector_type: Annotated[list[str] | str | None, Field(default=None, description='Filter by detector type/nature')] = None,
+    detector_category: Annotated[list[str] | str | None, Field(default=None, description='Filter by detector category')] = None,
+    issue_name: Annotated[list[str] | str | None, Field(default=None, description='Filter by issue/incident name')] = None,
+    secret_category: Annotated[list[str] | str | None, Field(default=None, description='Filter by secret category')] = None,
+    secret_family: Annotated[list[str] | str | None, Field(default=None, description='Filter by secret family')] = None,
+    secret_provider: Annotated[list[str] | str | None, Field(default=None, description="Filter by secret provider (e.g., 'aws', 'github', 'google')")] = None,
+    source_ids: Annotated[list[int] | int | None, Field(default=None, description='Filter by source ID(s). Can be obtained using list_source or find_current_source_id tools.')] = None,
+    source_type: Annotated[list[str] | str | None, Field(default=None, description="Filter by source type (e.g., 'github', 'gitlab', 'bitbucket')")] = None,
+    source_criticality: Annotated[list[str] | str | None, Field(default=None, description='Filter by source criticality. Values: critical, high, medium, low, unknown')] = None,
+    occurrence_count_min: Annotated[int | None, Field(default=None, description='Filter incidents with at least this many occurrences')] = None,
+    presence: Annotated[list[str] | str | None, Field(default=None, description='Filter by occurrence presence status. Values: present, removed')] = None,
+    opened_for_days: Annotated[int | None, Field(default=None, description='Filter incidents that have been open for at least this many days')] = None,
+    tags: Annotated[list[str] | str | None, Field(default=None, description="Filter by tag names (e.g., 'REGRESSION', 'PUBLICLY_EXPOSED', 'TEST_FILE')")] = None,
+    exclude_tags: Annotated[list[str] | str | None, Field(default=['TEST_FILE', 'FALSE_POSITIVE', 'CHECK_RUN_SKIP_FALSE_POSITIVE', 'CHECK_RUN_SKIP_LOW_RISK', 'CHECK_RUN_SKIP_TEST_CRED'], description='Exclude incidents with these tag names. Default excludes TEST_FILE, FALSE_POSITIVE, and CHECK_RUN_SKIP_* tags.')] = ['TEST_FILE', 'FALSE_POSITIVE', 'CHECK_RUN_SKIP_FALSE_POSITIVE', 'CHECK_RUN_SKIP_LOW_RISK', 'CHECK_RUN_SKIP_TEST_CRED'],
+    public_exposure: Annotated[list[str] | str | None, Field(default=None, description='Filter by public exposure. Values: source_publicly_visible, public_incident_linked, leaked_outside_perimeter')] = None,
+    integration: Annotated[list[str] | str | None, Field(default=None, description="Filter by integration type (e.g., 'github', 'gitlab', 'slack')")] = None,
+    issue_tracker: Annotated[list[str] | str | None, Field(default=None, description='Filter by issue tracker type. Values: jira_cloud_notifier, jira_data_center_notifier, servicenow')] = None,
+    has_related_issues: Annotated[bool | None, Field(default=None, description='Filter to incidents with (True) or without (False) related issues')] = None,
+    location: Annotated[bool | None, Field(default=None, description='Filter to incidents with (True) or without (False) location information')] = None,
+    feedback: Annotated[bool | None, Field(default=None, description='Filter to incidents with (True) or without (False) feedback')] = None,
+    publicly_shared: Annotated[bool | None, Field(default=None, description="Filter to incidents that are (True) or aren't (False) publicly shared")] = None,
+    secret_manager_type: Annotated[list[str] | str | None, Field(default=None, description='Filter by vault type. Values: hashicorpvault, awssecretsmanager, azurekeyvault, gcpsecretmanager, cyberarksaas, cyberarkselfhosted, akeyless, delineasecretserver')] = None,
+    secret_manager_instance: Annotated[list[int] | int | None, Field(default=None, description='Filter by vault instance ID(s)')] = None,
+    nhi_env: Annotated[list[str] | str | None, Field(default=None, description='Filter by NHI environment name(s)')] = None,
+    nhi_policy: Annotated[list[str] | str | None, Field(default=None, description='Filter by NHI policy breach name(s)')] = None,
+    teams: Annotated[list[int] | int | None, Field(default=None, description='Filter by team ID(s)')] = None,
+    similar_to: Annotated[int | None, Field(default=None, description='Filter incidents similar to the given incident ID')] = None,
+    date_before: Annotated[str | None, Field(default=None, description='Filter incidents detected before this date (YYYY-MM-DD format)')] = None,
+    date_after: Annotated[str | None, Field(default=None, description='Filter incidents detected after this date (YYYY-MM-DD format)')] = None,
+    secret_scope: Annotated[list[str] | str | None, Field(default=None, description='Filter by secret scope name(s)')] = None,
+    analyzer_status: Annotated[list[str] | str | None, Field(default=None, description='Filter by analyzer status. Values: no_checker, not_checked, checked, invalid, failed_to_check')] = None,
+    custom_tags: Annotated[list[int] | int | None, Field(default=None, description='Filter by custom tag ID(s)')] = None,
 ) -> ListIncidentsResult | ListIncidentsError:
     """
-    List secret incidents with enhanced filtering using the MCP-optimized endpoint.
+        List secret incidents with enhanced filtering using the MCP-optimized endpoint.
 
-    This endpoint provides filtering options including detector type, secret category,
-    source criticality, public exposure, and more. It uses page-based pagination.
+        This endpoint provides filtering options including detector type, secret category,
+        source criticality, public exposure, and more. It uses page-based pagination.
 
-    Features:
-    - Page-based pagination
-    - Status values: TRIGGERED, ASSIGNED, RESOLVED, IGNORED
-    - Rich filtering options for detector types, secret categories, and public exposure
-    - Returns detailed incident data including custom tags, vault metadata, and similar issue counts
+        Features:
+        - Page-based pagination
+        - Status values: TRIGGERED, ASSIGNED, RESOLVED, IGNORED
+        - Rich filtering options for detector types, secret categories, and public exposure
+        - Returns detailed incident data including custom tags, vault metadata, and similar issue counts
 
-    Args:
-        params: ListIncidentsParams model containing all filtering options.
+        Args:
+            params: ListIncidentsParams model containing all filtering options.
 
-    Returns:
-        ListIncidentsResult: Pydantic model containing:
-            - incidents: List of incident objects with detailed information
-            - page: Current page number
-            - page_size: Results per page
-            - has_next/has_previous: Pagination indicators
-            - applied_filters: Dictionary of filters that were applied
-            - suggestion: Suggestions for interpreting or modifying the results
+        Returns:
+            ListIncidentsResult: Pydantic model containing:
+                - incidents: List of incident objects with detailed information
+                - page: Current page number
+                - page_size: Results per page
+                - has_next/has_previous: Pagination indicators
+                - applied_filters: Dictionary of filters that were applied
+                - suggestion: Suggestions for interpreting or modifying results
 
-        ListIncidentsError: Pydantic model with error message if the operation fails
+            ListIncidentsError: Pydantic model with error message if the operation fails
+
     """
+    params = ListIncidentsParams(
+        page=page,
+        page_size=page_size,
+        get_all=get_all,
+        ordering=ordering,
+        search=search,
+        status=status,
+        mine=mine,
+        assignee_id=assignee_id,
+        severity=severity,
+        score_min=score_min,
+        score_max=score_max,
+        validity=validity,
+        detector_group_name=detector_group_name,
+        detector_type=detector_type,
+        detector_category=detector_category,
+        issue_name=issue_name,
+        secret_category=secret_category,
+        secret_family=secret_family,
+        secret_provider=secret_provider,
+        source_ids=source_ids,
+        source_type=source_type,
+        source_criticality=source_criticality,
+        occurrence_count_min=occurrence_count_min,
+        presence=presence,
+        opened_for_days=opened_for_days,
+        tags=tags,
+        exclude_tags=exclude_tags,
+        public_exposure=public_exposure,
+        integration=integration,
+        issue_tracker=issue_tracker,
+        has_related_issues=has_related_issues,
+        location=location,
+        feedback=feedback,
+        publicly_shared=publicly_shared,
+        secret_manager_type=secret_manager_type,
+        secret_manager_instance=secret_manager_instance,
+        nhi_env=nhi_env,
+        nhi_policy=nhi_policy,
+        teams=teams,
+        similar_to=similar_to,
+        date_before=date_before,
+        date_after=date_after,
+        secret_scope=secret_scope,
+        analyzer_status=analyzer_status,
+        custom_tags=custom_tags,
+    )
+
     client = await get_client()
 
     try:

--- a/packages/gg_api_core/src/gg_api_core/tools/list_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_incidents.py
@@ -5,6 +5,15 @@ from typing import Annotated, Any
 from pydantic import BaseModel, Field
 
 from gg_api_core.client import DEFAULT_PAGINATION_MAX_BYTES, MAX_PAGINATION_PAGES
+from gg_api_core.generated_filter_vocabulary import (
+    IncidentSeverityFilter,
+    IncidentSourceTypeFilter,
+    IncidentStatusFilter,
+    IncidentValidityFilter,
+)
+from gg_api_core.incident_filter_adapters import (
+    IncidentIntegrationFilter,
+)
 from gg_api_core.incident_filters import (
     DEFAULT_EXCLUDED_TAGS,
     DEFAULT_SEVERITIES,
@@ -108,77 +117,253 @@ class ListIncidentsError(BaseModel):
 
 
 async def list_incidents(
-    page: Annotated[int, Field(default=1, ge=1, description='Page number (1-indexed)')] = 1,
-    page_size: Annotated[int, Field(default=20, ge=1, le=100, description='Number of results per page (default: 20, max: 100)')] = 20,
-    get_all: Annotated[bool, Field(default=False, description="If True, fetch all pages (capped at ~20.0KB; check 'has_more' to see if results were truncated)")] = False,
-    ordering: Annotated[str | None, Field(default='-date', description="Sort field with optional '-' prefix for descending. Options: score, -score, date, -date, severity, -severity, status, -status")] = '-date',
-    search: Annotated[str | None, Field(default=None, description='Search term to filter incidents by name or content')] = None,
-    status: Annotated[list[str] | str | None, Field(default=['TRIGGERED', 'ASSIGNED', 'RESOLVED'], description="Filter by status. Values: TRIGGERED (unassigned active), ASSIGNED (assigned active), RESOLVED, IGNORED. Default excludes IGNORED. Note that OPENED is not a valid status but means 'TRIGGERED OR ASSIGNED'.")] = ['TRIGGERED', 'ASSIGNED', 'RESOLVED'],
-    mine: Annotated[bool, Field(default=False, description='If True, fetch only incidents assigned to the current user. Overrides assignee_id.')] = False,
-    assignee_id: Annotated[int | None, Field(default=None, description="Filter by assignee member ID. Use 0 for unassigned incidents. Cannot be used with 'mine'.")] = None,
-    severity: Annotated[list[str | int] | str | int | None, Field(default=[10, 20, 30, 100], description='Filter by severity levels. Values: critical (10), high (20), medium (30), low (40), info (50), unknown (100). Default excludes LOW and INFO.')] = [10, 20, 30, 100],
-    score_min: Annotated[int | None, Field(default=None, ge=0, le=100, description='Filter incidents with a score greater than or equal to this value (0-100). Higher scores indicate higher priority incidents.')] = None,
-    score_max: Annotated[int | None, Field(default=None, ge=0, le=100, description='Filter incidents with a score less than or equal to this value (0-100).')] = None,
-    validity: Annotated[list[str] | str | None, Field(default=['valid', 'failed_to_check', 'no_checker', 'not_checked'], description='Filter by validity status. Values: valid, invalid, failed_to_check, no_checker, not_checked. Default excludes INVALID.')] = ['valid', 'failed_to_check', 'no_checker', 'not_checked'],
-    detector_group_name: Annotated[list[str] | str | None, Field(default=None, description="Filter by detector group name (e.g., 'AWS Keys', 'GitHub Tokens')")] = None,
-    detector_type: Annotated[list[str] | str | None, Field(default=None, description='Filter by detector type/nature')] = None,
-    detector_category: Annotated[list[str] | str | None, Field(default=None, description='Filter by detector category')] = None,
-    issue_name: Annotated[list[str] | str | None, Field(default=None, description='Filter by issue/incident name')] = None,
-    secret_category: Annotated[list[str] | str | None, Field(default=None, description='Filter by secret category')] = None,
-    secret_family: Annotated[list[str] | str | None, Field(default=None, description='Filter by secret family')] = None,
-    secret_provider: Annotated[list[str] | str | None, Field(default=None, description="Filter by secret provider (e.g., 'aws', 'github', 'google')")] = None,
-    source_ids: Annotated[list[int] | int | None, Field(default=None, description='Filter by source ID(s). Can be obtained using list_source or find_current_source_id tools.')] = None,
-    source_type: Annotated[list[str] | str | None, Field(default=None, description="Filter by source type (e.g., 'github', 'gitlab', 'bitbucket')")] = None,
-    source_criticality: Annotated[list[str] | str | None, Field(default=None, description='Filter by source criticality. Values: critical, high, medium, low, unknown')] = None,
-    occurrence_count_min: Annotated[int | None, Field(default=None, description='Filter incidents with at least this many occurrences')] = None,
-    presence: Annotated[list[str] | str | None, Field(default=None, description='Filter by occurrence presence status. Values: present, removed')] = None,
-    opened_for_days: Annotated[int | None, Field(default=None, description='Filter incidents that have been open for at least this many days')] = None,
-    tags: Annotated[list[str] | str | None, Field(default=None, description="Filter by tag names (e.g., 'REGRESSION', 'PUBLICLY_EXPOSED', 'TEST_FILE')")] = None,
-    exclude_tags: Annotated[list[str] | str | None, Field(default=['TEST_FILE', 'FALSE_POSITIVE', 'CHECK_RUN_SKIP_FALSE_POSITIVE', 'CHECK_RUN_SKIP_LOW_RISK', 'CHECK_RUN_SKIP_TEST_CRED'], description='Exclude incidents with these tag names. Default excludes TEST_FILE, FALSE_POSITIVE, and CHECK_RUN_SKIP_* tags.')] = ['TEST_FILE', 'FALSE_POSITIVE', 'CHECK_RUN_SKIP_FALSE_POSITIVE', 'CHECK_RUN_SKIP_LOW_RISK', 'CHECK_RUN_SKIP_TEST_CRED'],
-    public_exposure: Annotated[list[str] | str | None, Field(default=None, description='Filter by public exposure. Values: source_publicly_visible, public_incident_linked, leaked_outside_perimeter')] = None,
-    integration: Annotated[list[str] | str | None, Field(default=None, description="Filter by integration type (e.g., 'github', 'gitlab', 'slack')")] = None,
-    issue_tracker: Annotated[list[str] | str | None, Field(default=None, description='Filter by issue tracker type. Values: jira_cloud_notifier, jira_data_center_notifier, servicenow')] = None,
-    has_related_issues: Annotated[bool | None, Field(default=None, description='Filter to incidents with (True) or without (False) related issues')] = None,
-    location: Annotated[bool | None, Field(default=None, description='Filter to incidents with (True) or without (False) location information')] = None,
-    feedback: Annotated[bool | None, Field(default=None, description='Filter to incidents with (True) or without (False) feedback')] = None,
-    publicly_shared: Annotated[bool | None, Field(default=None, description="Filter to incidents that are (True) or aren't (False) publicly shared")] = None,
-    secret_manager_type: Annotated[list[str] | str | None, Field(default=None, description='Filter by vault type. Values: hashicorpvault, awssecretsmanager, azurekeyvault, gcpsecretmanager, cyberarksaas, cyberarkselfhosted, akeyless, delineasecretserver')] = None,
-    secret_manager_instance: Annotated[list[int] | int | None, Field(default=None, description='Filter by vault instance ID(s)')] = None,
-    nhi_env: Annotated[list[str] | str | None, Field(default=None, description='Filter by NHI environment name(s)')] = None,
-    nhi_policy: Annotated[list[str] | str | None, Field(default=None, description='Filter by NHI policy breach name(s)')] = None,
-    teams: Annotated[list[int] | int | None, Field(default=None, description='Filter by team ID(s)')] = None,
-    similar_to: Annotated[int | None, Field(default=None, description='Filter incidents similar to the given incident ID')] = None,
-    date_before: Annotated[str | None, Field(default=None, description='Filter incidents detected before this date (YYYY-MM-DD format)')] = None,
-    date_after: Annotated[str | None, Field(default=None, description='Filter incidents detected after this date (YYYY-MM-DD format)')] = None,
-    secret_scope: Annotated[list[str] | str | None, Field(default=None, description='Filter by secret scope name(s)')] = None,
-    analyzer_status: Annotated[list[str] | str | None, Field(default=None, description='Filter by analyzer status. Values: no_checker, not_checked, checked, invalid, failed_to_check')] = None,
-    custom_tags: Annotated[list[int] | int | None, Field(default=None, description='Filter by custom tag ID(s)')] = None,
+    page: Annotated[int, Field(default=1, ge=1, description="Page number (1-indexed)")] = 1,
+    page_size: Annotated[
+        int, Field(default=20, ge=1, le=100, description="Number of results per page (default: 20, max: 100)")
+    ] = 20,
+    get_all: Annotated[
+        bool,
+        Field(
+            default=False,
+            description="If True, fetch all pages (capped at ~20.0KB; check 'has_more' to see if results were truncated)",
+        ),
+    ] = False,
+    ordering: Annotated[
+        str | None,
+        Field(
+            default="-date",
+            description="Sort field with optional '-' prefix for descending. Options: score, -score, date, -date, severity, -severity, status, -status",
+        ),
+    ] = "-date",
+    search: Annotated[
+        str | None, Field(default=None, description="Search term to filter incidents by name or content")
+    ] = None,
+    status: Annotated[
+        list[IncidentStatusFilter] | IncidentStatusFilter | None,
+        Field(
+            default=DEFAULT_STATUSES,
+            description="Filter by status. Values: TRIGGERED, ASSIGNED, RESOLVED, IGNORED. Default excludes IGNORED.",
+        ),
+    ] = DEFAULT_STATUSES,
+    mine: Annotated[
+        bool,
+        Field(
+            default=False,
+            description="If True, fetch only incidents assigned to the current user. Overrides assignee_id.",
+        ),
+    ] = False,
+    assignee_id: Annotated[
+        int | None,
+        Field(
+            default=None,
+            description="Filter by assignee member ID. Use 0 for unassigned incidents. Cannot be used with 'mine'.",
+        ),
+    ] = None,
+    severity: Annotated[
+        list[IncidentSeverityFilter] | IncidentSeverityFilter | None,
+        Field(
+            default=DEFAULT_SEVERITIES,
+            description="Filter by severity levels. Values: critical (10), high (20), medium (30), low (40), info (50), unknown (100). Default excludes LOW and INFO.",
+        ),
+    ] = DEFAULT_SEVERITIES,
+    score_min: Annotated[
+        int | None,
+        Field(
+            default=None,
+            ge=0,
+            le=100,
+            description="Filter incidents with a score greater than or equal to this value (0-100). Higher scores indicate higher priority incidents.",
+        ),
+    ] = None,
+    score_max: Annotated[
+        int | None,
+        Field(
+            default=None,
+            ge=0,
+            le=100,
+            description="Filter incidents with a score less than or equal to this value (0-100).",
+        ),
+    ] = None,
+    validity: Annotated[
+        list[IncidentValidityFilter] | IncidentValidityFilter | None,
+        Field(
+            default=DEFAULT_VALIDITIES,
+            description="Filter by validity status. Values: valid, invalid, failed_to_check, no_checker, unknown. Default excludes INVALID.",
+        ),
+    ] = DEFAULT_VALIDITIES,
+    detector_group_name: Annotated[
+        list[str] | str | None,
+        Field(default=None, description="Filter by detector group name (e.g., 'AWS Keys', 'GitHub Tokens')"),
+    ] = None,
+    detector_type: Annotated[
+        list[str] | str | None, Field(default=None, description="Filter by detector type/nature")
+    ] = None,
+    detector_category: Annotated[
+        list[str] | str | None, Field(default=None, description="Filter by detector category")
+    ] = None,
+    issue_name: Annotated[
+        list[str] | str | None, Field(default=None, description="Filter by issue/incident name")
+    ] = None,
+    secret_category: Annotated[
+        list[str] | str | None, Field(default=None, description="Filter by secret category")
+    ] = None,
+    secret_family: Annotated[list[str] | str | None, Field(default=None, description="Filter by secret family")] = None,
+    secret_provider: Annotated[
+        list[str] | str | None,
+        Field(default=None, description="Filter by secret provider (e.g., 'aws', 'github', 'google')"),
+    ] = None,
+    source_ids: Annotated[
+        list[int] | int | None,
+        Field(
+            default=None,
+            description="Filter by source ID(s). Can be obtained using list_source or find_current_source_id tools.",
+        ),
+    ] = None,
+    source_type: Annotated[
+        list[IncidentSourceTypeFilter] | IncidentSourceTypeFilter | None,
+        Field(
+            default=None,
+            description="Filter by public API source type (for example: github, gitlab, bitbucket, azure_devops).",
+        ),
+    ] = None,
+    source_criticality: Annotated[
+        list[str] | str | None,
+        Field(default=None, description="Filter by source criticality. Values: critical, high, medium, low, unknown"),
+    ] = None,
+    occurrence_count_min: Annotated[
+        int | None, Field(default=None, description="Filter incidents with at least this many occurrences")
+    ] = None,
+    presence: Annotated[
+        list[str] | str | None,
+        Field(default=None, description="Filter by occurrence presence status. Values: present, removed"),
+    ] = None,
+    opened_for_days: Annotated[
+        int | None, Field(default=None, description="Filter incidents that have been open for at least this many days")
+    ] = None,
+    tags: Annotated[
+        list[str] | str | None,
+        Field(default=None, description="Filter by tag names (e.g., 'REGRESSION', 'PUBLICLY_EXPOSED', 'TEST_FILE')"),
+    ] = None,
+    exclude_tags: Annotated[
+        list[str] | str | None,
+        Field(
+            default=[
+                "TEST_FILE",
+                "FALSE_POSITIVE",
+                "CHECK_RUN_SKIP_FALSE_POSITIVE",
+                "CHECK_RUN_SKIP_LOW_RISK",
+                "CHECK_RUN_SKIP_TEST_CRED",
+            ],
+            description="Exclude incidents with these tag names. Default excludes TEST_FILE, FALSE_POSITIVE, and CHECK_RUN_SKIP_* tags.",
+        ),
+    ] = [
+        "TEST_FILE",
+        "FALSE_POSITIVE",
+        "CHECK_RUN_SKIP_FALSE_POSITIVE",
+        "CHECK_RUN_SKIP_LOW_RISK",
+        "CHECK_RUN_SKIP_TEST_CRED",
+    ],
+    public_exposure: Annotated[
+        list[str] | str | None,
+        Field(
+            default=None,
+            description="Filter by public exposure. Values: source_publicly_visible, public_incident_linked, leaked_outside_perimeter",
+        ),
+    ] = None,
+    integration: Annotated[
+        list[IncidentIntegrationFilter] | IncidentIntegrationFilter | None,
+        Field(
+            default=None,
+            description="Filter by audited integration name. Values: github, github_enterprise_server, gitlab",
+        ),
+    ] = None,
+    issue_tracker: Annotated[
+        list[str] | str | None,
+        Field(
+            default=None,
+            description="Filter by issue tracker type. Values: jira_cloud_notifier, jira_data_center_notifier, servicenow",
+        ),
+    ] = None,
+    has_related_issues: Annotated[
+        bool | None,
+        Field(default=None, description="Filter to incidents with (True) or without (False) related issues"),
+    ] = None,
+    location: Annotated[
+        bool | None,
+        Field(default=None, description="Filter to incidents with (True) or without (False) location information"),
+    ] = None,
+    feedback: Annotated[
+        bool | None, Field(default=None, description="Filter to incidents with (True) or without (False) feedback")
+    ] = None,
+    publicly_shared: Annotated[
+        bool | None,
+        Field(default=None, description="Filter to incidents that are (True) or aren't (False) publicly shared"),
+    ] = None,
+    secret_manager_type: Annotated[
+        list[str] | str | None,
+        Field(
+            default=None,
+            description="Filter by vault type. Values: hashicorpvault, awssecretsmanager, azurekeyvault, gcpsecretmanager, cyberarksaas, cyberarkselfhosted, akeyless, delineasecretserver",
+        ),
+    ] = None,
+    secret_manager_instance: Annotated[
+        list[int] | int | None, Field(default=None, description="Filter by vault instance ID(s)")
+    ] = None,
+    nhi_env: Annotated[
+        list[str] | str | None, Field(default=None, description="Filter by NHI environment name(s)")
+    ] = None,
+    nhi_policy: Annotated[
+        list[str] | str | None, Field(default=None, description="Filter by NHI policy breach name(s)")
+    ] = None,
+    teams: Annotated[list[int] | int | None, Field(default=None, description="Filter by team ID(s)")] = None,
+    similar_to: Annotated[
+        int | None, Field(default=None, description="Filter incidents similar to the given incident ID")
+    ] = None,
+    date_before: Annotated[
+        str | None, Field(default=None, description="Filter incidents detected before this date (YYYY-MM-DD format)")
+    ] = None,
+    date_after: Annotated[
+        str | None, Field(default=None, description="Filter incidents detected after this date (YYYY-MM-DD format)")
+    ] = None,
+    secret_scope: Annotated[
+        list[str] | str | None, Field(default=None, description="Filter by secret scope name(s)")
+    ] = None,
+    analyzer_status: Annotated[
+        list[str] | str | None,
+        Field(
+            default=None,
+            description="Filter by analyzer status. Values: no_checker, not_checked, checked, invalid, failed_to_check",
+        ),
+    ] = None,
+    custom_tags: Annotated[
+        list[int] | int | None, Field(default=None, description="Filter by custom tag ID(s)")
+    ] = None,
 ) -> ListIncidentsResult | ListIncidentsError:
     """
-        List secret incidents with enhanced filtering using the MCP-optimized endpoint.
+    List secret incidents with enhanced filtering using the MCP-optimized endpoint.
 
-        This endpoint provides filtering options including detector type, secret category,
-        source criticality, public exposure, and more. It uses page-based pagination.
+    This endpoint provides filtering options including detector type, secret category,
+    source criticality, public exposure, and more. It uses page-based pagination.
 
-        Features:
-        - Page-based pagination
-        - Status values: TRIGGERED, ASSIGNED, RESOLVED, IGNORED
-        - Rich filtering options for detector types, secret categories, and public exposure
-        - Returns detailed incident data including custom tags, vault metadata, and similar issue counts
+    Features:
+    - Page-based pagination
+    - Status values: TRIGGERED, ASSIGNED, RESOLVED, IGNORED
+    - Rich filtering options for detector types, secret categories, and public exposure
+    - Returns detailed incident data including custom tags, vault metadata, and similar issue counts
 
-        Args:
-            params: ListIncidentsParams model containing all filtering options.
+    Args:
+        params: ListIncidentsParams model containing all filtering options.
 
-        Returns:
-            ListIncidentsResult: Pydantic model containing:
-                - incidents: List of incident objects with detailed information
-                - page: Current page number
-                - page_size: Results per page
-                - has_next/has_previous: Pagination indicators
-                - applied_filters: Dictionary of filters that were applied
-                - suggestion: Suggestions for interpreting or modifying results
+    Returns:
+        ListIncidentsResult: Pydantic model containing:
+            - incidents: List of incident objects with detailed information
+            - page: Current page number
+            - page_size: Results per page
+            - has_next/has_previous: Pagination indicators
+            - applied_filters: Dictionary of filters that were applied
+            - suggestion: Suggestions for interpreting or modifying results
 
-            ListIncidentsError: Pydantic model with error message if the operation fails
+        ListIncidentsError: Pydantic model with error message if the operation fails
 
     """
     params = ListIncidentsParams(

--- a/packages/gg_api_core/src/gg_api_core/tools/list_public_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_public_incidents.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Annotated, Any
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -266,23 +266,79 @@ def _build_filter_info(params: ListPublicIncidentsParams) -> dict[str, Any]:
 
 
 async def list_public_incidents(
-    params: ListPublicIncidentsParams = ListPublicIncidentsParams(),
+    per_page: Annotated[int, Field(default=20, ge=1, le=100, description='Number of results per page (default: 20, max: 100)')] = 20,
+    cursor: Annotated[str | None, Field(default=None, description='Pagination cursor for fetching the next page of results')] = None,
+    get_all: Annotated[bool, Field(default=False, description="If True, fetch all pages (capped at ~20.0KB; check 'has_more' and use cursor to continue)")] = False,
+    date_before: Annotated[str | None, Field(default=None, description='Entries found before this date (ISO datetime, e.g. 2025-01-31T00:00:00Z)')] = None,
+    date_after: Annotated[str | None, Field(default=None, description='Entries found after this date (ISO datetime)')] = None,
+    triggered_at_before: Annotated[str | None, Field(default=None, description='Incidents triggered before this date (ISO datetime)')] = None,
+    triggered_at_after: Annotated[str | None, Field(default=None, description='Incidents triggered after this date (ISO datetime)')] = None,
+    assignee_email: Annotated[str | None, Field(default=None, description='Filter by assignee email')] = None,
+    assignee_id: Annotated[int | None, Field(default=None, description='Filter by assignee user id')] = None,
+    status: Annotated[list[IncidentStatus] | IncidentStatus | None, Field(default=['TRIGGERED', 'ASSIGNED', 'RESOLVED'], description='Filter by incident status. Values: TRIGGERED, ASSIGNED, RESOLVED, IGNORED. Accepts a single value or a list. Default excludes IGNORED.')] = ['TRIGGERED', 'ASSIGNED', 'RESOLVED'],
+    severity: Annotated[list[IncidentSeverity] | IncidentSeverity | None, Field(default=['critical', 'high', 'medium', 'unknown'], description='Filter by severity. Values: critical, high, medium, low, info, unknown. Accepts a single value or a list. Default excludes LOW and INFO.')] = ['critical', 'high', 'medium', 'unknown'],
+    validity: Annotated[list[IncidentValidity] | IncidentValidity | None, Field(default=['valid', 'failed_to_check', 'no_checker', 'unknown'], description='Filter by validity. Values: valid, invalid, failed_to_check, no_checker, unknown. Accepts a single value or a list. Default excludes INVALID.')] = ['valid', 'failed_to_check', 'no_checker', 'unknown'],
+    tags: Annotated[str | None, Field(default=None, description="Filter by tags. Comma-separated list of tag names (e.g. 'FROM_HISTORICAL_SCAN,INTERNALLY_LEAKED'). Use 'NONE' to filter incidents with no tags.")] = None,
+    custom_tags: Annotated[str | None, Field(default=None, description='Comma-separated list of custom tag UUIDs to filter by')] = None,
+    custom_tag_key: Annotated[str | None, Field(default=None, description='Filter incidents that have a custom tag with this key')] = None,
+    custom_tag_value: Annotated[str | None, Field(default=None, description='Filter incidents that have a custom tag with this value')] = None,
+    ordering: Annotated[str | None, Field(default='-date', description="Sort field with optional '-' prefix for descending. Options: date, -date, resolved_at, -resolved_at, ignored_at, -ignored_at, risk_score, -risk_score")] = '-date',
+    detector_group_name: Annotated[str | None, Field(default=None, description="Filter by detector group name (e.g. 'slackbot_token')")] = None,
+    ignorer_id: Annotated[int | None, Field(default=None, description='Filter incidents ignored by this user id')] = None,
+    ignorer_api_token_id: Annotated[str | None, Field(default=None, description='Filter incidents ignored by this API token id')] = None,
+    resolver_id: Annotated[int | None, Field(default=None, description='Filter incidents resolved by this user id')] = None,
+    resolver_api_token_id: Annotated[str | None, Field(default=None, description='Filter incidents resolved by this API token id')] = None,
+    feedback: Annotated[bool | None, Field(default=None, description='Filter to incidents with (True) or without (False) feedback')] = None,
+    declarative_secret_status: Annotated[str | None, Field(default=None, description='Filter by declarative secret status (revoked, active, test_credential, false_positive, low_risk)')] = None,
+    risk_score_min: Annotated[int | None, Field(default=None, ge=0, le=100, description='Filter incidents with risk score >= this value (0-100)')] = None,
+    risk_score_max: Annotated[int | None, Field(default=None, ge=0, le=100, description='Filter incidents with risk score <= this value (0-100)')] = None,
 ) -> ListPublicIncidentsResult | ListPublicIncidentsError:
-    """List public secret incidents detected by GitGuardian on public sources (e.g. public GitHub).
-
-    Public incidents differ from internal incidents: they correspond to secrets leaked outside the
-    organization perimeter and surfaced via GitGuardian Public Monitoring (Explore). Use this tool
-    instead of `list_incidents` when investigating leaks on public sources.
-
-    Wraps GET /v1/public-incidents/secrets and uses cursor-based pagination.
-
-    Args:
-        params: ListPublicIncidentsParams model containing all filtering options.
-
-    Returns:
-        ListPublicIncidentsResult with the public incidents page, or
-        ListPublicIncidentsError on failure.
     """
+    List public secret incidents detected by GitGuardian on public sources (e.g. public GitHub).
+
+        Public incidents differ from internal incidents: they correspond to secrets leaked outside the
+        organization perimeter and surfaced via GitGuardian Public Monitoring (Explore). Use this tool
+        instead of `list_incidents` when investigating leaks on public sources.
+
+        Wraps GET /v1/public-incidents/secrets and uses cursor-based pagination.
+
+        Args:
+            params: ListPublicIncidentsParams model containing all filtering options.
+
+        Returns:
+            ListPublicIncidentsResult with the public incidents page, or
+            ListPublicIncidentsError on failure.
+
+    """
+    params = ListPublicIncidentsParams(
+        per_page=per_page,
+        cursor=cursor,
+        get_all=get_all,
+        date_before=date_before,
+        date_after=date_after,
+        triggered_at_before=triggered_at_before,
+        triggered_at_after=triggered_at_after,
+        assignee_email=assignee_email,
+        assignee_id=assignee_id,
+        status=status,
+        severity=severity,
+        validity=validity,
+        tags=tags,
+        custom_tags=custom_tags,
+        custom_tag_key=custom_tag_key,
+        custom_tag_value=custom_tag_value,
+        ordering=ordering,
+        detector_group_name=detector_group_name,
+        ignorer_id=ignorer_id,
+        ignorer_api_token_id=ignorer_api_token_id,
+        resolver_id=resolver_id,
+        resolver_api_token_id=resolver_api_token_id,
+        feedback=feedback,
+        declarative_secret_status=declarative_secret_status,
+        risk_score_min=risk_score_min,
+        risk_score_max=risk_score_max,
+    )
+
     client = await get_client()
 
     try:

--- a/packages/gg_api_core/src/gg_api_core/tools/list_public_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_public_incidents.py
@@ -266,32 +266,114 @@ def _build_filter_info(params: ListPublicIncidentsParams) -> dict[str, Any]:
 
 
 async def list_public_incidents(
-    per_page: Annotated[int, Field(default=20, ge=1, le=100, description='Number of results per page (default: 20, max: 100)')] = 20,
-    cursor: Annotated[str | None, Field(default=None, description='Pagination cursor for fetching the next page of results')] = None,
-    get_all: Annotated[bool, Field(default=False, description="If True, fetch all pages (capped at ~20.0KB; check 'has_more' and use cursor to continue)")] = False,
-    date_before: Annotated[str | None, Field(default=None, description='Entries found before this date (ISO datetime, e.g. 2025-01-31T00:00:00Z)')] = None,
-    date_after: Annotated[str | None, Field(default=None, description='Entries found after this date (ISO datetime)')] = None,
-    triggered_at_before: Annotated[str | None, Field(default=None, description='Incidents triggered before this date (ISO datetime)')] = None,
-    triggered_at_after: Annotated[str | None, Field(default=None, description='Incidents triggered after this date (ISO datetime)')] = None,
-    assignee_email: Annotated[str | None, Field(default=None, description='Filter by assignee email')] = None,
-    assignee_id: Annotated[int | None, Field(default=None, description='Filter by assignee user id')] = None,
-    status: Annotated[list[IncidentStatus] | IncidentStatus | None, Field(default=['TRIGGERED', 'ASSIGNED', 'RESOLVED'], description='Filter by incident status. Values: TRIGGERED, ASSIGNED, RESOLVED, IGNORED. Accepts a single value or a list. Default excludes IGNORED.')] = ['TRIGGERED', 'ASSIGNED', 'RESOLVED'],
-    severity: Annotated[list[IncidentSeverity] | IncidentSeverity | None, Field(default=['critical', 'high', 'medium', 'unknown'], description='Filter by severity. Values: critical, high, medium, low, info, unknown. Accepts a single value or a list. Default excludes LOW and INFO.')] = ['critical', 'high', 'medium', 'unknown'],
-    validity: Annotated[list[IncidentValidity] | IncidentValidity | None, Field(default=['valid', 'failed_to_check', 'no_checker', 'unknown'], description='Filter by validity. Values: valid, invalid, failed_to_check, no_checker, unknown. Accepts a single value or a list. Default excludes INVALID.')] = ['valid', 'failed_to_check', 'no_checker', 'unknown'],
-    tags: Annotated[str | None, Field(default=None, description="Filter by tags. Comma-separated list of tag names (e.g. 'FROM_HISTORICAL_SCAN,INTERNALLY_LEAKED'). Use 'NONE' to filter incidents with no tags.")] = None,
-    custom_tags: Annotated[str | None, Field(default=None, description='Comma-separated list of custom tag UUIDs to filter by')] = None,
-    custom_tag_key: Annotated[str | None, Field(default=None, description='Filter incidents that have a custom tag with this key')] = None,
-    custom_tag_value: Annotated[str | None, Field(default=None, description='Filter incidents that have a custom tag with this value')] = None,
-    ordering: Annotated[str | None, Field(default='-date', description="Sort field with optional '-' prefix for descending. Options: date, -date, resolved_at, -resolved_at, ignored_at, -ignored_at, risk_score, -risk_score")] = '-date',
-    detector_group_name: Annotated[str | None, Field(default=None, description="Filter by detector group name (e.g. 'slackbot_token')")] = None,
-    ignorer_id: Annotated[int | None, Field(default=None, description='Filter incidents ignored by this user id')] = None,
-    ignorer_api_token_id: Annotated[str | None, Field(default=None, description='Filter incidents ignored by this API token id')] = None,
-    resolver_id: Annotated[int | None, Field(default=None, description='Filter incidents resolved by this user id')] = None,
-    resolver_api_token_id: Annotated[str | None, Field(default=None, description='Filter incidents resolved by this API token id')] = None,
-    feedback: Annotated[bool | None, Field(default=None, description='Filter to incidents with (True) or without (False) feedback')] = None,
-    declarative_secret_status: Annotated[str | None, Field(default=None, description='Filter by declarative secret status (revoked, active, test_credential, false_positive, low_risk)')] = None,
-    risk_score_min: Annotated[int | None, Field(default=None, ge=0, le=100, description='Filter incidents with risk score >= this value (0-100)')] = None,
-    risk_score_max: Annotated[int | None, Field(default=None, ge=0, le=100, description='Filter incidents with risk score <= this value (0-100)')] = None,
+    per_page: Annotated[
+        int, Field(default=20, ge=1, le=100, description="Number of results per page (default: 20, max: 100)")
+    ] = 20,
+    cursor: Annotated[
+        str | None, Field(default=None, description="Pagination cursor for fetching the next page of results")
+    ] = None,
+    get_all: Annotated[
+        bool,
+        Field(
+            default=False,
+            description="If True, fetch all pages (capped at ~20.0KB; check 'has_more' and use cursor to continue)",
+        ),
+    ] = False,
+    date_before: Annotated[
+        str | None,
+        Field(default=None, description="Entries found before this date (ISO datetime, e.g. 2025-01-31T00:00:00Z)"),
+    ] = None,
+    date_after: Annotated[
+        str | None, Field(default=None, description="Entries found after this date (ISO datetime)")
+    ] = None,
+    triggered_at_before: Annotated[
+        str | None, Field(default=None, description="Incidents triggered before this date (ISO datetime)")
+    ] = None,
+    triggered_at_after: Annotated[
+        str | None, Field(default=None, description="Incidents triggered after this date (ISO datetime)")
+    ] = None,
+    assignee_email: Annotated[str | None, Field(default=None, description="Filter by assignee email")] = None,
+    assignee_id: Annotated[int | None, Field(default=None, description="Filter by assignee user id")] = None,
+    status: Annotated[
+        list[IncidentStatusFilter] | IncidentStatusFilter | None,
+        Field(
+            default=DEFAULT_STATUSES,
+            description="Filter by incident status. Values: TRIGGERED, ASSIGNED, RESOLVED, IGNORED. "
+            "Accepts a single value or a list. Default excludes IGNORED.",
+        ),
+    ] = DEFAULT_STATUSES,
+    severity: Annotated[
+        list[IncidentSeverityFilter] | IncidentSeverityFilter | None,
+        Field(
+            default=DEFAULT_SEVERITIES,
+            description="Filter by severity. Values: critical, high, medium, low, info, unknown. "
+            "Accepts a single value or a list. Default excludes LOW and INFO.",
+        ),
+    ] = DEFAULT_SEVERITIES,
+    validity: Annotated[
+        list[IncidentValidityFilter] | IncidentValidityFilter | None,
+        Field(
+            default=DEFAULT_VALIDITIES,
+            description="Filter by validity. Values: valid, invalid, failed_to_check, no_checker, unknown. "
+            "Accepts a single value or a list. Default excludes INVALID.",
+        ),
+    ] = DEFAULT_VALIDITIES,
+    tags: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Filter by tags. Comma-separated list of tag names (e.g. 'FROM_HISTORICAL_SCAN,INTERNALLY_LEAKED'). Use 'NONE' to filter incidents with no tags.",
+        ),
+    ] = None,
+    custom_tags: Annotated[
+        str | None, Field(default=None, description="Comma-separated list of custom tag UUIDs to filter by")
+    ] = None,
+    custom_tag_key: Annotated[
+        str | None, Field(default=None, description="Filter incidents that have a custom tag with this key")
+    ] = None,
+    custom_tag_value: Annotated[
+        str | None, Field(default=None, description="Filter incidents that have a custom tag with this value")
+    ] = None,
+    ordering: Annotated[
+        str | None,
+        Field(
+            default="-date",
+            description="Sort field with optional '-' prefix for descending. Options: date, -date, resolved_at, -resolved_at, ignored_at, -ignored_at, risk_score, -risk_score",
+        ),
+    ] = "-date",
+    detector_group_name: Annotated[
+        str | None, Field(default=None, description="Filter by detector group name (e.g. 'slackbot_token')")
+    ] = None,
+    ignorer_id: Annotated[
+        int | None, Field(default=None, description="Filter incidents ignored by this user id")
+    ] = None,
+    ignorer_api_token_id: Annotated[
+        str | None, Field(default=None, description="Filter incidents ignored by this API token id")
+    ] = None,
+    resolver_id: Annotated[
+        int | None, Field(default=None, description="Filter incidents resolved by this user id")
+    ] = None,
+    resolver_api_token_id: Annotated[
+        str | None, Field(default=None, description="Filter incidents resolved by this API token id")
+    ] = None,
+    feedback: Annotated[
+        bool | None, Field(default=None, description="Filter to incidents with (True) or without (False) feedback")
+    ] = None,
+    declarative_secret_status: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Filter by declarative secret status (revoked, active, test_credential, false_positive, low_risk)",
+        ),
+    ] = None,
+    risk_score_min: Annotated[
+        int | None,
+        Field(default=None, ge=0, le=100, description="Filter incidents with risk score >= this value (0-100)"),
+    ] = None,
+    risk_score_max: Annotated[
+        int | None,
+        Field(default=None, ge=0, le=100, description="Filter incidents with risk score <= this value (0-100)"),
+    ] = None,
 ) -> ListPublicIncidentsResult | ListPublicIncidentsError:
     """
     List public secret incidents detected by GitGuardian on public sources (e.g. public GitHub).

--- a/packages/gg_api_core/src/gg_api_core/tools/list_public_occurrences.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_public_occurrences.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Annotated, Any
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -155,7 +155,94 @@ def _build_filter_info(params: ListPublicOccurrencesParams) -> dict[str, Any]:
 
 
 async def list_public_occurrences(
-    params: ListPublicOccurrencesParams,
+    incident_id: Annotated[
+        int,
+        Field(description="The id of the public secret incident to list occurrences for"),
+    ],
+    per_page: Annotated[
+        int,
+        Field(default=20, ge=1, le=100, description="Number of results per page (default: 20, max: 100)"),
+    ] = 20,
+    cursor: Annotated[str | None, Field(default=None, description="Pagination cursor for fetching the next page of results")] = None,
+    get_all: Annotated[
+        bool,
+        Field(
+            default=False,
+            description=(
+                f"If True, fetch all pages (capped at ~{DEFAULT_PAGINATION_MAX_BYTES / 1000}KB; "
+                "check 'has_more' and use cursor to continue)"
+            ),
+        ),
+    ] = False,
+    date_before: Annotated[
+        str | None, Field(default=None, description="Entries found before this date (ISO datetime, e.g. 2025-01-31T00:00:00Z)")
+    ] = None,
+    date_after: Annotated[str | None, Field(default=None, description="Entries found after this date (ISO datetime)")] = None,
+    source_id: Annotated[int | None, Field(default=None, description="Filter occurrences belonging to this source ID")] = None,
+    presence: Annotated[str | None, Field(default=None, description="Filter by presence status (present, removed)")] = None,
+    sha: Annotated[str | None, Field(default=None, min_length=3, description="Filter by commit sha (>=3 characters)")] = None,
+    filepath: Annotated[
+        str | None, Field(default=None, min_length=3, description="Filter by filepath (>=3 characters)")
+    ] = None,
+    attachment_reason: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                "Filter by attachment reason. Comma-separated values allowed. "
+                "Options: by_dev_from_perimeter, on_github_org_in_perimeter, from_secret_grasper"
+            ),
+        ),
+    ] = None,
+    severity: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                "Filter occurrences by the severity of their related incident. "
+                "Comma-separated values allowed (e.g. 'critical,high'). "
+                "Options: critical, high, medium, low, info, unknown"
+            ),
+        ),
+    ] = None,
+    status: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                "Filter occurrences by the status of their related incident. "
+                "Comma-separated values allowed (e.g. 'TRIGGERED,ASSIGNED'). "
+                "Options: IGNORED, TRIGGERED, ASSIGNED, RESOLVED"
+            ),
+        ),
+    ] = None,
+    validity: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                "Filter occurrences by the validity of their related secret. "
+                "Comma-separated values allowed. "
+                "Options: valid, invalid, failed_to_check, no_checker, unknown"
+            ),
+        ),
+    ] = None,
+    tags: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                "Filter by tags. Comma-separated list of tag names. Use 'NONE' to filter occurrences with no tags."
+            ),
+        ),
+    ] = None,
+    ordering: Annotated[
+        str | None,
+        Field(
+            default="-date",
+            description="Sort field with optional '-' prefix for descending. Options: id, -id, date, -date",
+        ),
+    ] = "-date",
 ) -> ListPublicOccurrencesResult | ListPublicOccurrencesError:
     """List occurrences of a public secret incident detected by GitGuardian Public Monitoring.
 
@@ -166,12 +253,45 @@ async def list_public_occurrences(
     Wraps GET /v1/public-incidents/secrets/{incident_id}/occurrences and uses cursor-based pagination.
 
     Args:
-        params: ListPublicOccurrencesParams model containing the incident_id and all filters.
+        incident_id: The id of the public secret incident to list occurrences for
+        per_page: Number of results per page (default: 20, max: 100)
+        cursor: Pagination cursor
+        get_all: If True, fetch all pages
+        date_before: Entries found before this date
+        date_after: Entries found after this date
+        source_id: Filter occurrences belonging to this source ID
+        presence: Filter by presence status
+        sha: Filter by commit sha (>=3 characters)
+        filepath: Filter by filepath (>=3 characters)
+        attachment_reason: Filter by attachment reason
+        severity: Filter by severity of related incident
+        status: Filter by status of related incident
+        validity: Filter by validity of related secret
+        tags: Filter by tags
+        ordering: Sort field
 
     Returns:
         ListPublicOccurrencesResult with the occurrences page, or
         ListPublicOccurrencesError on failure.
     """
+    params = ListPublicOccurrencesParams(
+        incident_id=incident_id,
+        per_page=per_page,
+        cursor=cursor,
+        get_all=get_all,
+        date_before=date_before,
+        date_after=date_after,
+        source_id=source_id,
+        presence=presence,
+        sha=sha,
+        filepath=filepath,
+        attachment_reason=attachment_reason,
+        severity=severity,
+        status=status,
+        validity=validity,
+        tags=tags,
+        ordering=ordering,
+    )
     client = await get_client()
 
     try:

--- a/packages/gg_api_core/src/gg_api_core/tools/list_public_occurrences.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_public_occurrences.py
@@ -163,7 +163,9 @@ async def list_public_occurrences(
         int,
         Field(default=20, ge=1, le=100, description="Number of results per page (default: 20, max: 100)"),
     ] = 20,
-    cursor: Annotated[str | None, Field(default=None, description="Pagination cursor for fetching the next page of results")] = None,
+    cursor: Annotated[
+        str | None, Field(default=None, description="Pagination cursor for fetching the next page of results")
+    ] = None,
     get_all: Annotated[
         bool,
         Field(
@@ -175,12 +177,21 @@ async def list_public_occurrences(
         ),
     ] = False,
     date_before: Annotated[
-        str | None, Field(default=None, description="Entries found before this date (ISO datetime, e.g. 2025-01-31T00:00:00Z)")
+        str | None,
+        Field(default=None, description="Entries found before this date (ISO datetime, e.g. 2025-01-31T00:00:00Z)"),
     ] = None,
-    date_after: Annotated[str | None, Field(default=None, description="Entries found after this date (ISO datetime)")] = None,
-    source_id: Annotated[int | None, Field(default=None, description="Filter occurrences belonging to this source ID")] = None,
-    presence: Annotated[str | None, Field(default=None, description="Filter by presence status (present, removed)")] = None,
-    sha: Annotated[str | None, Field(default=None, min_length=3, description="Filter by commit sha (>=3 characters)")] = None,
+    date_after: Annotated[
+        str | None, Field(default=None, description="Entries found after this date (ISO datetime)")
+    ] = None,
+    source_id: Annotated[
+        int | None, Field(default=None, description="Filter occurrences belonging to this source ID")
+    ] = None,
+    presence: Annotated[
+        str | None, Field(default=None, description="Filter by presence status (present, removed)")
+    ] = None,
+    sha: Annotated[
+        str | None, Field(default=None, min_length=3, description="Filter by commit sha (>=3 characters)")
+    ] = None,
     filepath: Annotated[
         str | None, Field(default=None, min_length=3, description="Filter by filepath (>=3 characters)")
     ] = None,
@@ -195,37 +206,16 @@ async def list_public_occurrences(
         ),
     ] = None,
     severity: Annotated[
-        str | None,
-        Field(
-            default=None,
-            description=(
-                "Filter occurrences by the severity of their related incident. "
-                "Comma-separated values allowed (e.g. 'critical,high'). "
-                "Options: critical, high, medium, low, info, unknown"
-            ),
-        ),
+        list[IncidentSeverityFilter] | IncidentSeverityFilter | None,
+        Field(default=None, description="Filter occurrences by related incident severity."),
     ] = None,
     status: Annotated[
-        str | None,
-        Field(
-            default=None,
-            description=(
-                "Filter occurrences by the status of their related incident. "
-                "Comma-separated values allowed (e.g. 'TRIGGERED,ASSIGNED'). "
-                "Options: IGNORED, TRIGGERED, ASSIGNED, RESOLVED"
-            ),
-        ),
+        list[IncidentStatusFilter] | IncidentStatusFilter | None,
+        Field(default=None, description="Filter occurrences by related incident status."),
     ] = None,
     validity: Annotated[
-        str | None,
-        Field(
-            default=None,
-            description=(
-                "Filter occurrences by the validity of their related secret. "
-                "Comma-separated values allowed. "
-                "Options: valid, invalid, failed_to_check, no_checker, unknown"
-            ),
-        ),
+        list[IncidentValidityFilter] | IncidentValidityFilter | None,
+        Field(default=None, description="Filter occurrences by related secret validity."),
     ] = None,
     tags: Annotated[
         str | None,

--- a/packages/gg_api_core/src/gg_api_core/tools/list_repo_occurrences.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_repo_occurrences.py
@@ -206,16 +206,25 @@ async def list_repo_occurrences(
         ),
     ] = DEFAULT_EXCLUDED_TAGS,
     status: Annotated[
-        list[IncidentStatus] | None,
-        Field(default=DEFAULT_STATUSES, description="Filter by status (list of status names)"),
+        list[IncidentStatusFilter] | IncidentStatusFilter | None,
+        Field(
+            default=DEFAULT_STATUSES,
+            description="Filter by status. Values: TRIGGERED, ASSIGNED, RESOLVED, IGNORED. Default excludes IGNORED.",
+        ),
     ] = DEFAULT_STATUSES,
     severity: Annotated[
-        list[IncidentSeverity] | None,
-        Field(default=DEFAULT_SEVERITIES, description="Filter by severity (list of severity names)"),
+        list[IncidentSeverityFilter] | IncidentSeverityFilter | None,
+        Field(
+            default=DEFAULT_SEVERITIES,
+            description="Filter by severity levels. Values: critical (10), high (20), medium (30), low (40), info (50), unknown (100). Default excludes LOW and INFO.",
+        ),
     ] = DEFAULT_SEVERITIES,
     validity: Annotated[
-        list[IncidentValidity] | None,
-        Field(default=DEFAULT_VALIDITIES, description="Filter by validity (list of validity names)"),
+        list[IncidentValidityFilter] | IncidentValidityFilter | None,
+        Field(
+            default=DEFAULT_VALIDITIES,
+            description="Filter by validity status. Values: valid, invalid, failed_to_check, no_checker, unknown. Default excludes INVALID.",
+        ),
     ] = DEFAULT_VALIDITIES,
     mine: Annotated[
         bool,
@@ -235,12 +244,16 @@ async def list_repo_occurrences(
             description="The GitGuardian source ID to filter by. Can be obtained using list_source or find_current_source_id tools.",
         ),
     ] = None,
-    ordering: Annotated[str | None, Field(default=None, description="Sort field (e.g., 'date', '-date' for descending)")] = None,
+    ordering: Annotated[
+        str | None, Field(default=None, description="Sort field (e.g., 'date', '-date' for descending)")
+    ] = None,
     per_page: Annotated[
         int,
         Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)"),
     ] = 20,
-    cursor: Annotated[str | None, Field(default=None, description="Pagination cursor for fetching next page of results")] = None,
+    cursor: Annotated[
+        str | None, Field(default=None, description="Pagination cursor for fetching next page of results")
+    ] = None,
     get_all: Annotated[
         bool,
         Field(

--- a/packages/gg_api_core/src/gg_api_core/tools/list_repo_occurrences.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_repo_occurrences.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Annotated, Any
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -188,7 +188,66 @@ def _build_suggestion(params: ListRepoOccurrencesParams, occurrences_count: int)
 
 
 async def list_repo_occurrences(
-    params: ListRepoOccurrencesParams = ListRepoOccurrencesParams(),
+    from_date: Annotated[
+        str | None,
+        Field(default=None, description="Filter occurrences created after this date (ISO format: YYYY-MM-DD)"),
+    ] = None,
+    to_date: Annotated[
+        str | None,
+        Field(default=None, description="Filter occurrences created before this date (ISO format: YYYY-MM-DD)"),
+    ] = None,
+    presence: Annotated[str | None, Field(default=None, description="Filter by presence status")] = None,
+    tags: Annotated[list[str] | None, Field(default=None, description="Filter by tags (list of tag names)")] = None,
+    exclude_tags: Annotated[
+        list[TagNames] | None,
+        Field(
+            default=DEFAULT_EXCLUDED_TAGS,
+            description="Exclude occurrences with these tag names. Pass empty list to disable filtering.",
+        ),
+    ] = DEFAULT_EXCLUDED_TAGS,
+    status: Annotated[
+        list[IncidentStatus] | None,
+        Field(default=DEFAULT_STATUSES, description="Filter by status (list of status names)"),
+    ] = DEFAULT_STATUSES,
+    severity: Annotated[
+        list[IncidentSeverity] | None,
+        Field(default=DEFAULT_SEVERITIES, description="Filter by severity (list of severity names)"),
+    ] = DEFAULT_SEVERITIES,
+    validity: Annotated[
+        list[IncidentValidity] | None,
+        Field(default=DEFAULT_VALIDITIES, description="Filter by validity (list of validity names)"),
+    ] = DEFAULT_VALIDITIES,
+    mine: Annotated[
+        bool,
+        Field(
+            default=False,
+            description="If True, fetch occurrences related to issues assigned to the current user",
+        ),
+    ] = False,
+    member_assignee_id: Annotated[
+        int | None,
+        Field(default=None, description="Filter by the member the incident is assigned to"),
+    ] = None,
+    source_id: Annotated[
+        str | int | None,
+        Field(
+            default=None,
+            description="The GitGuardian source ID to filter by. Can be obtained using list_source or find_current_source_id tools.",
+        ),
+    ] = None,
+    ordering: Annotated[str | None, Field(default=None, description="Sort field (e.g., 'date', '-date' for descending)")] = None,
+    per_page: Annotated[
+        int,
+        Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)"),
+    ] = 20,
+    cursor: Annotated[str | None, Field(default=None, description="Pagination cursor for fetching next page of results")] = None,
+    get_all: Annotated[
+        bool,
+        Field(
+            default=False,
+            description=f"If True, fetch all pages (capped at ~{DEFAULT_PAGINATION_MAX_BYTES / 1000}KB; check 'has_more' and use cursor to continue)",
+        ),
+    ] = False,
 ) -> ListRepoOccurrencesResult | ListRepoOccurrencesError:
     """
     List secret occurrences for a specific repository using the GitGuardian v1/occurrences/secrets API.
@@ -211,8 +270,21 @@ async def list_repo_occurrences(
     By default, occurrences tagged with TEST_FILE or FALSE_POSITIVE are excluded. Pass exclude_tags=[] to disable this filtering.
 
     Args:
-        params: ListRepoOccurrencesParams model containing all filtering options.
-               Optionally filter by source_id.
+        from_date: Filter occurrences created after this date
+        to_date: Filter occurrences created before this date
+        presence: Filter by presence status
+        tags: Filter by tags (list of tag names)
+        exclude_tags: Exclude occurrences with these tag names
+        status: Filter by status (list of status names)
+        severity: Filter by severity (list of severity names)
+        validity: Filter by validity (list of validity names)
+        mine: If True, fetch occurrences related to issues assigned to the current user
+        member_assignee_id: Filter by the member the incident is assigned to
+        source_id: The GitGuardian source ID to filter by
+        ordering: Sort field
+        per_page: Number of results per page (default: 20)
+        cursor: Pagination cursor
+        get_all: If True, fetch all pages
 
     Returns:
         ListRepoOccurrencesResult: Pydantic model containing:
@@ -226,6 +298,23 @@ async def list_repo_occurrences(
 
         ListRepoOccurrencesError: Pydantic model with error message if the operation fails
     """
+    params = ListRepoOccurrencesParams(
+        from_date=from_date,
+        to_date=to_date,
+        presence=presence,
+        tags=tags,
+        exclude_tags=exclude_tags,
+        status=status,
+        severity=severity,
+        validity=validity,
+        mine=mine,
+        member_assignee_id=member_assignee_id,
+        source_id=source_id,
+        ordering=ordering,
+        per_page=per_page,
+        cursor=cursor,
+        get_all=get_all,
+    )
     client = await get_client()
     logger.debug(f"Listing occurrences with source_id={params.source_id}")
 

--- a/packages/gg_api_core/src/gg_api_core/tools/list_sources.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_sources.py
@@ -109,31 +109,7 @@ async def list_sources(
         Field(default=None, description="Filter sources based on their health status"),
     ] = None,
     type: Annotated[
-        Literal[
-            "bitbucket",
-            "bitbucket_cloud",
-            "github",
-            "gitlab",
-            "azure_devops",
-            "slack",
-            "jira_cloud",
-            "confluence_cloud",
-            "microsoft_teams",
-            "confluence_data_center",
-            "jira_data_center",
-            "aws_ecr",
-            "azure_cr",
-            "google_artifact",
-            "jfrog_artifact",
-            "docker_hub",
-            "servicenow",
-            "sharepoint_online",
-            "sharepoint_online_drive",
-            "sharepoint_online_pages",
-            "microsoft_onedrive",
-            "custom_source",
-        ]
-        | None,
+        IncidentSourceTypeFilter | None,
         Field(default=None, description="Filter by source type (e.g., 'github', 'gitlab', 'bitbucket')"),
     ] = None,
     ordering: Annotated[
@@ -149,7 +125,9 @@ async def list_sources(
         Literal["critical", "high", "medium", "low", "unknown"] | None,
         Field(default=None, description="Filter by source criticality level"),
     ] = None,
-    monitored: Annotated[bool | None, Field(default=None, description="Filter by monitored status (true/false)")] = None,
+    monitored: Annotated[
+        bool | None, Field(default=None, description="Filter by monitored status (true/false)")
+    ] = None,
     team_id: Annotated[
         int | None,
         Field(

--- a/packages/gg_api_core/src/gg_api_core/tools/list_sources.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_sources.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
@@ -94,7 +94,82 @@ class ListSourcesResult(BaseModel):
     )
 
 
-async def list_sources(params: ListSourcesParams = ListSourcesParams()) -> ListSourcesResult:
+async def list_sources(
+    search: Annotated[str | None, Field(default=None, description="Search string to filter sources by name")] = None,
+    last_scan_status: Annotated[
+        Literal["pending", "running", "canceled", "failed", "too_large", "timeout", "pending_timeout", "finished"]
+        | None,
+        Field(
+            default=None,
+            description="Filter sources based on the status of their latest historical scan",
+        ),
+    ] = None,
+    health: Annotated[
+        Literal["safe", "unknown", "at_risk"] | None,
+        Field(default=None, description="Filter sources based on their health status"),
+    ] = None,
+    type: Annotated[
+        Literal[
+            "bitbucket",
+            "bitbucket_cloud",
+            "github",
+            "gitlab",
+            "azure_devops",
+            "slack",
+            "jira_cloud",
+            "confluence_cloud",
+            "microsoft_teams",
+            "confluence_data_center",
+            "jira_data_center",
+            "aws_ecr",
+            "azure_cr",
+            "google_artifact",
+            "jfrog_artifact",
+            "docker_hub",
+            "servicenow",
+            "sharepoint_online",
+            "sharepoint_online_drive",
+            "sharepoint_online_pages",
+            "microsoft_onedrive",
+            "custom_source",
+        ]
+        | None,
+        Field(default=None, description="Filter by source type (e.g., 'github', 'gitlab', 'bitbucket')"),
+    ] = None,
+    ordering: Annotated[
+        Literal["last_scan_date", "-last_scan_date"] | None,
+        Field(default=None, description="Sort by last scan date. Prefix with '-' for descending order."),
+    ] = None,
+    visibility: Annotated[
+        Literal["public", "private", "internal"] | None,
+        Field(default=None, description="Filter by visibility status"),
+    ] = None,
+    external_id: Annotated[str | None, Field(default=None, description="Filter by specific external id")] = None,
+    source_criticality: Annotated[
+        Literal["critical", "high", "medium", "low", "unknown"] | None,
+        Field(default=None, description="Filter by source criticality level"),
+    ] = None,
+    monitored: Annotated[bool | None, Field(default=None, description="Filter by monitored status (true/false)")] = None,
+    team_id: Annotated[
+        int | None,
+        Field(
+            default=None,
+            description="Filter sources by team id. Only sources belonging to the given team's perimeter are returned.",
+        ),
+    ] = None,
+    per_page: Annotated[
+        int,
+        Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)"),
+    ] = 20,
+    cursor: Annotated[str | None, Field(default=None, description="Pagination cursor from a previous response")] = None,
+    get_all: Annotated[
+        bool,
+        Field(
+            default=False,
+            description=f"If True, fetch all pages (capped at ~{DEFAULT_PAGINATION_MAX_BYTES / 1000}KB; check 'has_more' and use cursor to continue)",
+        ),
+    ] = False,
+) -> ListSourcesResult:
     """
     List sources known by GitGuardian.
 
@@ -102,7 +177,19 @@ async def list_sources(params: ListSourcesParams = ListSourcesParams()) -> ListS
     GitGuardian is monitoring for secrets.
 
     Args:
-        params: ListSourcesParams model containing all filtering options
+        search: Search string to filter sources by name
+        last_scan_status: Filter by latest historical scan status
+        health: Filter by health status
+        type: Filter by source type
+        ordering: Sort by last scan date
+        visibility: Filter by visibility status
+        external_id: Filter by external id
+        source_criticality: Filter by source criticality level
+        monitored: Filter by monitored status
+        team_id: Filter sources by team id
+        per_page: Number of results per page (default: 20)
+        cursor: Pagination cursor
+        get_all: If True, fetch all pages
 
     Returns:
         ListSourcesResult: Pydantic model containing:
@@ -113,6 +200,21 @@ async def list_sources(params: ListSourcesParams = ListSourcesParams()) -> ListS
     Raises:
         ToolError: If the listing operation fails
     """
+    params = ListSourcesParams(
+        search=search,
+        last_scan_status=last_scan_status,
+        health=health,
+        type=type,
+        ordering=ordering,
+        visibility=visibility,
+        external_id=external_id,
+        source_criticality=source_criticality,
+        monitored=monitored,
+        team_id=team_id,
+        per_page=per_page,
+        cursor=cursor,
+        get_all=get_all,
+    )
     client = await get_client()
     logger.debug("Listing sources")
 

--- a/packages/gg_api_core/src/gg_api_core/tools/list_users.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_users.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any
+from typing import Annotated, Any
 
 from pydantic import BaseModel, Field
 
@@ -50,7 +50,43 @@ class ListUsersResult(BaseModel):
     )
 
 
-async def list_users(params: ListUsersParams = ListUsersParams()) -> ListUsersResult:
+async def list_users(
+    cursor: Annotated[str | None, Field(default=None, description="Pagination cursor for fetching next page of results")] = None,
+    per_page: Annotated[
+        int,
+        Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)"),
+    ] = 20,
+    role: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Filter members based on their role (owner, manager, member, restricted). Deprecated - use access_level instead",
+        ),
+    ] = None,
+    access_level: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Filter members based on their access level (owner, manager, member, restricted)",
+        ),
+    ] = None,
+    active: Annotated[bool | None, Field(default=None, description="Filter members based on their active status")] = None,
+    search: Annotated[str | None, Field(default=None, description="Search members based on their name or email")] = None,
+    ordering: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Sort results by field (created_at, -created_at, last_login, -last_login). Use '-' prefix for descending order",
+        ),
+    ] = None,
+    get_all: Annotated[
+        bool,
+        Field(
+            default=False,
+            description=f"If True, fetch all pages (capped at ~{DEFAULT_PAGINATION_MAX_BYTES / 1000}KB; check 'has_more' and use cursor to continue)",
+        ),
+    ] = False,
+) -> ListUsersResult:
     """
     List members/users in the GitGuardian workspace.
 
@@ -58,7 +94,14 @@ async def list_users(params: ListUsersParams = ListUsersParams()) -> ListUsersRe
     access level, active status, creation date, and last login.
 
     Args:
-        params: ListUsersParams model containing all filtering and pagination options
+        cursor: Pagination cursor for fetching next page of results
+        per_page: Number of results per page (default: 20, min: 1, max: 100)
+        role: Optional role filter (deprecated, use access_level)
+        access_level: Optional access level filter
+        active: Optional active status filter
+        search: Optional search term
+        ordering: Optional sort field
+        get_all: If True, fetch all pages
 
     Returns:
         ListUsersResult: Pydantic model containing:
@@ -69,6 +112,16 @@ async def list_users(params: ListUsersParams = ListUsersParams()) -> ListUsersRe
     Raises:
         ToolError: If the listing operation fails
     """
+    params = ListUsersParams(
+        cursor=cursor,
+        per_page=per_page,
+        role=role,
+        access_level=access_level,
+        active=active,
+        search=search,
+        ordering=ordering,
+        get_all=get_all,
+    )
     client = await get_client()
     logger.debug("Listing workspace members")
 

--- a/packages/gg_api_core/src/gg_api_core/tools/list_users.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/list_users.py
@@ -51,7 +51,9 @@ class ListUsersResult(BaseModel):
 
 
 async def list_users(
-    cursor: Annotated[str | None, Field(default=None, description="Pagination cursor for fetching next page of results")] = None,
+    cursor: Annotated[
+        str | None, Field(default=None, description="Pagination cursor for fetching next page of results")
+    ] = None,
     per_page: Annotated[
         int,
         Field(default=20, description="Number of results per page (default: 20, min: 1, max: 100)"),
@@ -70,8 +72,12 @@ async def list_users(
             description="Filter members based on their access level (owner, manager, member, restricted)",
         ),
     ] = None,
-    active: Annotated[bool | None, Field(default=None, description="Filter members based on their active status")] = None,
-    search: Annotated[str | None, Field(default=None, description="Search members based on their name or email")] = None,
+    active: Annotated[
+        bool | None, Field(default=None, description="Filter members based on their active status")
+    ] = None,
+    search: Annotated[
+        str | None, Field(default=None, description="Search members based on their name or email")
+    ] = None,
     ordering: Annotated[
         str | None,
         Field(

--- a/packages/gg_api_core/src/gg_api_core/tools/manage_incident.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/manage_incident.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
@@ -26,7 +26,29 @@ class ManageIncidentParams(BaseModel):
     )
 
 
-async def manage_private_incident(params: ManageIncidentParams) -> dict[str, Any]:
+async def manage_private_incident(
+    incident_id: Annotated[str | int, Field(description="ID of the secret incident to manage")],
+    action: Annotated[
+        Literal["unassign", "resolve", "ignore", "reopen"],
+        Field(
+            description="Action to perform on the incident: 'unassign' removes any assigned member, 'resolve' marks the incident as resolved, 'ignore' marks as ignored (use with ignore_reason), 'reopen' reopens a resolved or ignored incident"
+        ),
+    ],
+    ignore_reason: Annotated[
+        Literal["test_credential", "false_positive", "low_risk", "invalid"] | None,
+        Field(
+            default=None,
+            description="Reason for ignoring the incident. Required when action is 'ignore'. Must be explicitly provided by the user. Options: 'test_credential' (secret is for testing), 'false_positive' (not a real secret), 'low_risk' (secret poses minimal risk), 'invalid' (secret is invalid/inactive)",
+        ),
+    ] = None,
+    secret_revoked: Annotated[
+        bool | None,
+        Field(
+            default=None,
+            description="Whether the secret has been revoked/rotated. Required when action is 'resolve'. Must be explicitly provided by the user.",
+        ),
+    ] = None,
+) -> dict[str, Any]:
     """
     Perform lifecycle management actions on a secret incident.
 
@@ -39,11 +61,10 @@ async def manage_private_incident(params: ManageIncidentParams) -> dict[str, Any
     Note: To assign an incident to a member, use the dedicated 'assign_incident' tool instead.
 
     Args:
-        params: ManageIncidentParams containing:
-            - incident_id: The ID of the incident to manage
-            - action: The lifecycle action to perform (unassign, resolve, ignore, or reopen)
-            - ignore_reason: Required when action is 'ignore'. One of: test_credential, false_positive, low_risk, invalid
-            - secret_revoked: Required when action is 'resolve'. Whether the secret was revoked/rotated
+        incident_id: The ID of the incident to manage
+        action: The lifecycle action to perform (unassign, resolve, ignore, or reopen)
+        ignore_reason: Required when action is 'ignore'. One of: test_credential, false_positive, low_risk, invalid
+        secret_revoked: Required when action is 'resolve'. Whether the secret was revoked/rotated
 
     Returns:
         Dictionary containing the updated incident data from the API
@@ -51,6 +72,12 @@ async def manage_private_incident(params: ManageIncidentParams) -> dict[str, Any
     Raises:
         ToolError: If the action fails or if an invalid action is provided
     """
+    params = ManageIncidentParams(
+        incident_id=incident_id,
+        action=action,
+        ignore_reason=ignore_reason,
+        secret_revoked=secret_revoked,
+    )
     client = await get_client()
     logger.debug(f"Managing incident {params.incident_id} with action: {params.action}")
 
@@ -108,16 +135,24 @@ class UpdateIncidentSeverityParams(BaseModel):
     )
 
 
-async def update_incident_severity(params: UpdateIncidentSeverityParams) -> dict[str, Any]:
+async def update_incident_severity(
+    incident_id: Annotated[str | int, Field(description="ID of the secret incident")],
+    severity: Annotated[
+        Literal["critical", "high", "medium", "low", "info", "unknown"],
+        Field(description="New severity for the incident"),
+    ],
+) -> dict[str, Any]:
     """
     Set the severity of a secret incident.
 
     Args:
-        params: UpdateIncidentSeverityParams model containing the severity update configuration
+        incident_id: ID of the secret incident
+        severity: New severity for the incident (critical, high, medium, low, info, unknown)
 
     Returns:
         Updated incident data
     """
+    params = UpdateIncidentSeverityParams(incident_id=incident_id, severity=severity)
     client = await get_client()
     logger.debug(f"Updating incident {params.incident_id} severity to {params.severity}")
 

--- a/packages/gg_api_core/src/gg_api_core/tools/read_custom_tags.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/read_custom_tags.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Literal
+from typing import Annotated, Literal
 
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
@@ -18,7 +18,17 @@ class ReadCustomTagsParams(BaseModel):
     tag_id: str | int = Field(description="The ID of the custom tag to retrieve. Required when action is 'get_tag'.")
 
 
-async def read_custom_tags(params: ReadCustomTagsParams):
+async def read_custom_tags(
+    action: Annotated[
+        Literal["list_tags", "get_tag"],
+        Field(
+            description="Choose 'list_tags' to retrieve all custom tags, or 'get_tag' to retrieve a specific tag by ID. Required."
+        ),
+    ],
+    tag_id: Annotated[
+        str | int, Field(description="The ID of the custom tag to retrieve. Required when action is 'get_tag'.")
+    ],
+):
     """
     Read custom tags from the GitGuardian dashboard.
 
@@ -26,13 +36,13 @@ async def read_custom_tags(params: ReadCustomTagsParams):
     Use action='get_tag' with a tag_id to retrieve a specific tag.
 
     Args:
-        params: ReadCustomTagsParams model containing custom tags query configuration
-            action: The action to perform ('list_tags' or 'get_tag'). Defaults to 'list_tags'
-            tag_id: The ID of a specific tag to retrieve (required when action='get_tag')
+        action: The action to perform ('list_tags' or 'get_tag')
+        tag_id: The ID of a specific tag to retrieve (required when action='get_tag')
 
     Returns:
         Custom tag data based on the action performed
     """
+    params = ReadCustomTagsParams(action=action, tag_id=tag_id)
     try:
         client = await get_client()
 

--- a/packages/gg_api_core/src/gg_api_core/tools/remediate_secret_incidents.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/remediate_secret_incidents.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
 from jinja2 import Template
 from pydantic import BaseModel, Field, model_validator
@@ -92,7 +92,49 @@ class RemediateSecretIncidentsError(BaseModel):
 
 
 async def remediate_secret_incidents(
-    params: RemediateSecretIncidentsParams = RemediateSecretIncidentsParams(),
+    source_id: Annotated[
+        str | int | None,
+        Field(
+            default=None,
+            description="The source ID of the repository. Pass the current repository source ID if not provided.",
+        ),
+    ] = None,
+    get_all: Annotated[
+        bool,
+        Field(default=True, description="Whether to get all occurrences or just the first page"),
+    ] = True,
+    mine: Annotated[
+        bool,
+        Field(
+            default=False,
+            description="If True, fetch only incidents assigned to the current user. Set to False to get all incidents.",
+        ),
+    ] = False,
+    git_commands: Annotated[
+        bool,
+        Field(default=True, description="Whether to include git commands to fix incidents in git history"),
+    ] = True,
+    create_env_example: Annotated[
+        bool,
+        Field(
+            default=True,
+            description="Whether to suggest creating a .env.example file with placeholders for detected secrets",
+        ),
+    ] = True,
+    add_to_env: Annotated[
+        bool,
+        Field(default=True, description="Whether to suggest adding secrets to .env file"),
+    ] = True,
+    list_repo_occurrences_params: Annotated[
+        ListRepoOccurrencesParamsForRemediate | None,
+        Field(
+            default=None,
+            description=(
+                "Parameters for listing repository occurrences. If omitted, defaults to the current "
+                "repository's source_id with DEFAULT_BRANCH tag filtering."
+            ),
+        ),
+    ] = None,
 ) -> RemediateSecretIncidentsResult | RemediateSecretIncidentsError:
     """
     Find and remediate secret incidents in the current repository.
@@ -100,11 +142,26 @@ async def remediate_secret_incidents(
     This tool uses the occurrences API to find secrets and provides simple remediation suggestions.
 
     Args:
-        params: RemediateSecretIncidentsParams model containing remediation configuration
+        source_id: The source ID of the repository
+        get_all: Whether to get all occurrences or just the first page
+        mine: If True, fetch only incidents assigned to the current user
+        git_commands: Whether to include git commands to fix incidents in git history
+        create_env_example: Whether to suggest creating a .env.example file
+        add_to_env: Whether to suggest adding secrets to .env file
+        list_repo_occurrences_params: Parameters for listing repository occurrences (optional)
 
     Returns:
         RemediateSecretIncidentsResult or RemediateSecretIncidentsError
     """
+    params = RemediateSecretIncidentsParams(
+        source_id=source_id,
+        get_all=get_all,
+        mine=mine,
+        git_commands=git_commands,
+        create_env_example=create_env_example,
+        add_to_env=add_to_env,
+        list_repo_occurrences_params=list_repo_occurrences_params,
+    )
     logger.debug(f"Using remediate_secret_incidents for source_id: {params.source_id}")
 
     try:
@@ -119,7 +176,7 @@ async def remediate_secret_incidents(
             }
         )
 
-        occurrences_result = await list_repo_occurrences(occurrences_params)
+        occurrences_result = await list_repo_occurrences(**occurrences_params.model_dump())
         if isinstance(occurrences_result, ListRepoOccurrencesError):
             return RemediateSecretIncidentsError(
                 error=occurrences_result.error,

--- a/packages/gg_api_core/src/gg_api_core/tools/revoke_secret.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/revoke_secret.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Annotated
 
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
@@ -24,7 +25,9 @@ class RevokeSecretResult(BaseModel):
     is_async: bool | None = Field(default=None, description="Whether the revocation is being processed asynchronously")
 
 
-async def revoke_secret(params: RevokeSecretParams) -> RevokeSecretResult:
+async def revoke_secret(
+    secret_id: Annotated[str | int, Field(description="ID of the secret to revoke")],
+) -> RevokeSecretResult:
     """
     Revoke a secret by its ID.
 
@@ -33,7 +36,7 @@ async def revoke_secret(params: RevokeSecretParams) -> RevokeSecretResult:
     the secret type and provider.
 
     Args:
-        params: RevokeSecretParams model containing the secret ID to revoke
+        secret_id: The ID of the secret to revoke
 
     Returns:
         RevokeSecretResult: Pydantic model containing:
@@ -44,6 +47,7 @@ async def revoke_secret(params: RevokeSecretParams) -> RevokeSecretResult:
     Raises:
         ToolError: If the revocation operation fails
     """
+    params = RevokeSecretParams(secret_id=secret_id)
     client = await get_client()
     logger.debug(f"Revoking secret with ID: {params.secret_id}")
 

--- a/packages/gg_api_core/src/gg_api_core/tools/scan_secret.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/scan_secret.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Annotated, Any
 
 from pydantic import BaseModel, Field
 
@@ -31,7 +31,21 @@ class ScanSecretsResult(BaseModel):
     scan_results: list[dict[str, Any]] = Field(default_factory=list, description="Scan results for each document")
 
 
-async def scan_secrets(params: ScanSecretsParams) -> ScanSecretsResult:
+async def scan_secrets(
+    documents: Annotated[
+        list[dict[str, str]],
+        Field(
+            description="""
+            List of documents to scan, each with 'document' and optional 'filename'.
+            Format: [{'document': 'file content', 'filename': 'optional_filename.txt'}, ...]
+            IMPORTANT:
+            - document is the content of the file, not the filename, is a string and is mandatory.
+            - Do not send documents that are not related to the codebase, only send files that are part of the codebase.
+            - Do not send documents that are in the .gitignore file.
+            """
+        ),
+    ],
+) -> ScanSecretsResult:
     """
     Scan multiple content items for secrets and policy breaks.
 
@@ -44,7 +58,7 @@ async def scan_secrets(params: ScanSecretsParams) -> ScanSecretsResult:
     - The 'document' field is the file content (string), not the filename
 
     Args:
-        params: ScanSecretsParams model containing documents to scan
+        documents: List of documents to scan
 
     Returns:
         ScanSecretsResult: Pydantic model containing:
@@ -57,6 +71,7 @@ async def scan_secrets(params: ScanSecretsParams) -> ScanSecretsResult:
     Raises:
         Exception: If the scan operation fails or documents are invalid
     """
+    params = ScanSecretsParams(documents=documents)
     try:
         client = await get_client()
 

--- a/packages/gg_api_core/src/gg_api_core/tools/update_public_incident_status.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/update_public_incident_status.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
@@ -46,7 +46,38 @@ class UpdatePublicIncidentStatusParams(BaseModel):
     )
 
 
-async def update_public_incident_status(params: UpdatePublicIncidentStatusParams) -> dict[str, Any]:
+async def update_public_incident_status(
+    incident_id: Annotated[int, Field(description="ID of the public secret incident to update")],
+    action: Annotated[
+        Literal["resolve", "ignore", "reopen"],
+        Field(
+            description="Action to perform on the public incident: 'resolve' marks the incident "
+            "as resolved (use with resolve_reason), 'ignore' marks as ignored (use with "
+            "ignore_reason), 'reopen' reopens a previously resolved or ignored incident"
+        ),
+    ],
+    resolve_reason: Annotated[
+        PublicResolveReason | None,
+        Field(
+            default=None,
+            description="Reason for resolving the public incident. Required when action is "
+            "'resolve'. Must be explicitly provided by the user. Options: 'revoked' (the secret "
+            "has been revoked/rotated), 'dmca_request' (resolved via DMCA takedown), "
+            "'source_deleted' (the public source hosting the secret has been deleted)",
+        ),
+    ] = None,
+    ignore_reason: Annotated[
+        PublicIgnoreReason | None,
+        Field(
+            default=None,
+            description="Reason for ignoring the public incident. Required when action is "
+            "'ignore'. Must be explicitly provided by the user. Options: 'test_credential' "
+            "(secret is for testing), 'false_positive' (not a real secret), 'low_risk' (secret "
+            "poses minimal risk), 'invalid' (secret is invalid/inactive), 'ignore_actor' "
+            "(ignore based on the leaking actor), 'ignore_secret' (ignore this specific secret)",
+        ),
+    ] = None,
+) -> dict[str, Any]:
     """
     Update the status of a public secret incident detected by GitGuardian Public Monitoring.
 
@@ -66,11 +97,10 @@ async def update_public_incident_status(params: UpdatePublicIncidentStatusParams
     Note: To assign a public incident to a member, use `assign_public_incident` instead.
 
     Args:
-        params: UpdatePublicIncidentStatusParams containing:
-            - incident_id: ID of the public incident to update
-            - action: The action to perform (resolve, ignore, or reopen)
-            - resolve_reason: Required when action is 'resolve'
-            - ignore_reason: Required when action is 'ignore'
+        incident_id: ID of the public incident to update
+        action: The action to perform (resolve, ignore, or reopen)
+        resolve_reason: Required when action is 'resolve'
+        ignore_reason: Required when action is 'ignore'
 
     Returns:
         Dictionary containing the updated public incident data from the API
@@ -78,6 +108,12 @@ async def update_public_incident_status(params: UpdatePublicIncidentStatusParams
     Raises:
         ToolError: If the action fails or required parameters are missing
     """
+    params = UpdatePublicIncidentStatusParams(
+        incident_id=incident_id,
+        action=action,
+        resolve_reason=resolve_reason,
+        ignore_reason=ignore_reason,
+    )
     client = await get_client()
     logger.debug(f"Updating public incident {params.incident_id} status with action: {params.action}")
 

--- a/packages/gg_api_core/src/gg_api_core/tools/write_custom_tags.py
+++ b/packages/gg_api_core/src/gg_api_core/tools/write_custom_tags.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
@@ -25,7 +25,28 @@ class WriteCustomTagsParams(BaseModel):
     )
 
 
-async def write_custom_tags(params: WriteCustomTagsParams):
+async def write_custom_tags(
+    action: Annotated[
+        Literal["create_tag", "delete_tag"],
+        Field(
+            description="Choose 'create_tag' to create a new custom tag, or 'delete_tag' to delete an existing tag by ID. For delete_tag, you must first call read_custom_tags to get the tag ID. Required."
+        ),
+    ],
+    tag: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description='Tag to create in "key" or "key:value" format. Required when action is "create_tag".',
+        ),
+    ] = None,
+    tag_id: Annotated[
+        str | int | None,
+        Field(
+            default=None,
+            description="The ID of the custom tag to delete. Required when action is 'delete_tag'. Use read_custom_tags to list available tags and get their IDs.",
+        ),
+    ] = None,
+):
     """
     Create or delete custom tags in the GitGuardian dashboard.
 
@@ -38,14 +59,14 @@ async def write_custom_tags(params: WriteCustomTagsParams):
     2. Then call this function with action="delete_tag" and the specific tag_id
 
     Args:
-        params: WriteCustomTagsParams model containing custom tags write configuration
-            action: The action to perform ('create_tag' or 'delete_tag'). Required.
-            tag: Tag to create in "key" or "key:value" format (required for create_tag)
-            tag_id: ID of the tag to delete (required for delete_tag, obtain from read_custom_tags)
+        action: The action to perform ('create_tag' or 'delete_tag'). Required.
+        tag: Tag to create in "key" or "key:value" format (required for create_tag)
+        tag_id: ID of the tag to delete (required for delete_tag, obtain from read_custom_tags)
 
     Returns:
         Result based on the action performed
     """
+    params = WriteCustomTagsParams(action=action, tag=tag, tag_id=tag_id)
     try:
         client = await get_client()
 
@@ -86,7 +107,13 @@ class UpdateOrCreateIncidentCustomTagsParams(BaseModel):
     )
 
 
-async def update_or_create_incident_custom_tags(params: UpdateOrCreateIncidentCustomTagsParams) -> dict[str, Any]:
+async def update_or_create_incident_custom_tags(
+    incident_id: Annotated[str | int, Field(description="ID of the secret incident")],
+    custom_tags: Annotated[
+        list[str],
+        Field(description='List of custom tags to apply to the incident. Format: "key" or "key:value"'),
+    ],
+) -> dict[str, Any]:
     """
     Update a secret incident with custom tags, creating tags if they don't exist.
 
@@ -95,11 +122,13 @@ async def update_or_create_incident_custom_tags(params: UpdateOrCreateIncidentCu
     - "key:value" (creates a label with a value)
 
     Args:
-        params: UpdateOrCreateIncidentCustomTagsParams model containing custom tags configuration
+        incident_id: ID of the secret incident
+        custom_tags: List of custom tags to apply, in "key" or "key:value" format
 
     Returns:
         Updated incident data
     """
+    params = UpdateOrCreateIncidentCustomTagsParams(incident_id=incident_id, custom_tags=custom_tags)
     client = await get_client()
     logger.debug(f"Updating custom tags for incident {params.incident_id}")
 

--- a/tests/cassettes/README.md
+++ b/tests/cassettes/README.md
@@ -112,7 +112,7 @@ from gg_mcp.tools import some_tool
 @pytest.mark.asyncio
 async def test_some_tool(real_client, use_cassette):
     with use_cassette("test_some_tool"):
-        result = await some_tool(params)
+        result = await some_tool(**params.model_dump())
         assert result is not None
 ```
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -389,7 +389,7 @@ def use_cassette(request):
         @pytest.mark.asyncio
         async def test_something(real_client, use_cassette):
             with use_cassette("test_something"):
-                result = await some_tool(params)
+                result = await some_tool(**params.model_dump())
     """
     test_file = request.fspath
     cassette_dir = _get_cassette_dir_for_test(str(test_file))

--- a/tests/e2e/test_api_failure_modes.py
+++ b/tests/e2e/test_api_failure_modes.py
@@ -25,7 +25,7 @@ class TestServerErrorRetries:
             side_effect=[httpx.Response(500, text="boom"), httpx.Response(200, json=INCIDENT)]
         )
 
-        result = await call_tool(mcp_client, "get_incident", {"params": {"incident_id": 77}})
+        result = await call_tool(mcp_client, "get_incident", {"incident_id": 77})
 
         assert route.call_count == 2
         assert tool_output(result) == {"incident": INCIDENT}
@@ -40,7 +40,7 @@ class TestServerErrorRetries:
         """
         route = gg_api.get("/incidents/secrets/77").respond(500, text="boom")
 
-        result = await call_tool(mcp_client, "get_incident", {"params": {"incident_id": 77}})
+        result = await call_tool(mcp_client, "get_incident", {"incident_id": 77})
 
         assert route.call_count == 4
         assert "500" in tool_error_text(result)
@@ -55,7 +55,7 @@ class TestNetworkFailures:
         """
         gg_api.get("/incidents/secrets/77").mock(side_effect=httpx.ConnectError("connection refused"))
 
-        result = await call_tool(mcp_client, "get_incident", {"params": {"incident_id": 77}})
+        result = await call_tool(mcp_client, "get_incident", {"incident_id": 77})
 
         assert "connection refused" in tool_error_text(result)
 
@@ -67,7 +67,7 @@ class TestNetworkFailures:
         """
         gg_api.get("/incidents/secrets/77").mock(side_effect=httpx.ReadTimeout("timed out"))
 
-        result = await call_tool(mcp_client, "get_incident", {"params": {"incident_id": 77}})
+        result = await call_tool(mcp_client, "get_incident", {"incident_id": 77})
 
         assert "timed out" in tool_error_text(result)
 
@@ -95,7 +95,7 @@ class TestDownstreamUnauthorizedBridge:
             "tools/call",
             {
                 "name": "scan_secrets",
-                "arguments": {"params": {"documents": [{"document": "x", "filename": "x.py"}]}},
+                "arguments": {"documents": [{"document": "x", "filename": "x.py"}]},
             },
         )
 

--- a/tests/e2e/test_auth_and_tool_visibility.py
+++ b/tests/e2e/test_auth_and_tool_visibility.py
@@ -236,14 +236,14 @@ class TestScopeBasedToolVisibility:
                 call_tool(
                     mcp_client,
                     "get_incident",
-                    {"params": {"incident_id": 77}},
+                    {"incident_id": 77},
                     headers=mcp_headers("full-scope-token"),
                     request_id=201,
                 ),
                 call_tool(
                     mcp_client,
                     "scan_secrets",
-                    {"params": {"documents": [{"document": "x = 1", "filename": "x.py"}]}},
+                    {"documents": [{"document": "x = 1", "filename": "x.py"}]},
                     headers=mcp_headers("scan-only-token"),
                     request_id=202,
                 ),
@@ -265,7 +265,7 @@ class TestScopeBasedToolVisibility:
         mock_token_scopes(scopes=["scan"])
         route = gg_api.get("/incidents-for-mcp").respond(200, json={"results": [], "next": None, "previous": None})
 
-        result = await call_tool(mcp_client, "list_incidents", {"params": {}})
+        result = await call_tool(mcp_client, "list_incidents", {})
 
         # Scope filtering only controls visibility; enforcement happens at the
         # GitGuardian API, which rejects tokens lacking the scope.
@@ -285,8 +285,8 @@ class TestPerRequestScopeCost:
         """
         gg_api.get("/incidents/secrets/77").respond(200, json={"id": 77})
 
-        await call_tool(mcp_client, "get_incident", {"params": {"incident_id": 77}})
-        await call_tool(mcp_client, "get_incident", {"params": {"incident_id": 77}})
+        await call_tool(mcp_client, "get_incident", {"incident_id": 77})
+        await call_tool(mcp_client, "get_incident", {"incident_id": 77})
 
         # Only the dispatch path caches (per server instance, meaning
         # process-wide in production). The scope-filtered tool list cached here

--- a/tests/e2e/test_incident_read_tools.py
+++ b/tests/e2e/test_incident_read_tools.py
@@ -49,7 +49,7 @@ class TestListIncidents:
             200, json={"results": [INCIDENT], "count": 1, "next": None, "previous": None}
         )
 
-        result = await call_tool(mcp_client, "list_incidents", {"params": {}})
+        result = await call_tool(mcp_client, "list_incidents", {})
 
         assert sent_params(route) == DEFAULT_LIST_QUERY
         output = unwrap_result(result)
@@ -73,16 +73,14 @@ class TestListIncidents:
             mcp_client,
             "list_incidents",
             {
-                "params": {
-                    "severity": ["critical", "high"],
-                    "source_ids": [11, 22],
-                    "publicly_shared": True,
-                    "occurrence_count_min": 3,
-                    "date_after": "2026-07-01T15:30:00Z",
-                    "status": None,
-                    "validity": None,
-                    "exclude_tags": None,
-                }
+                "severity": ["critical", "high"],
+                "source_ids": [11, 22],
+                "publicly_shared": True,
+                "occurrence_count_min": 3,
+                "date_after": "2026-07-01T15:30:00Z",
+                "status": None,
+                "validity": None,
+                "exclude_tags": None,
             },
         )
 
@@ -110,7 +108,7 @@ class TestListIncidents:
         )
         incidents = gg_api.get("/incidents-for-mcp").respond(200, json={"results": [], "next": None, "previous": None})
 
-        await call_tool(mcp_client, "list_incidents", {"params": {"mine": True}})
+        await call_tool(mcp_client, "list_incidents", {"mine": True})
 
         assert member.called
         assert sent_params(incidents)["assignee_member_id"] == str(TEST_MEMBER_ID)
@@ -128,7 +126,7 @@ class TestListIncidents:
         gg_api.get("/api_tokens/self").respond(200, json=token_info(member_id=None))
         incidents = gg_api.get("/incidents-for-mcp").respond(200, json={"results": []})
 
-        result = await call_tool(mcp_client, "list_incidents", {"params": {"mine": True}})
+        result = await call_tool(mcp_client, "list_incidents", {"mine": True})
 
         assert "mine" in tool_error_text(result).lower()
         assert not incidents.called
@@ -142,7 +140,7 @@ class TestListIncidents:
         gg_api.get(f"/members/{TEST_MEMBER_ID}").respond(200, json={"id": TEST_MEMBER_ID})
         incidents = gg_api.get("/incidents-for-mcp").respond(200, json={"results": []})
 
-        result = await call_tool(mcp_client, "list_incidents", {"params": {"mine": True, "assignee_id": 1}})
+        result = await call_tool(mcp_client, "list_incidents", {"mine": True, "assignee_id": 1})
 
         output = unwrap_result(result)
         assert output["error"].startswith(f"Conflict: 'mine=True' implies assignee_id={TEST_MEMBER_ID}")
@@ -164,7 +162,7 @@ class TestListIncidents:
             side_effect=lambda request: httpx.Response(200, json=pages[request.url.params["page"]])
         )
 
-        result = await call_tool(mcp_client, "list_incidents", {"params": {"get_all": True}})
+        result = await call_tool(mcp_client, "list_incidents", {"get_all": True})
 
         assert route.call_count == 2
         output = unwrap_result(result)
@@ -186,7 +184,7 @@ class TestListIncidents:
             json={"detail": "Invalid API key."},
         )
 
-        result = await call_tool(mcp_client, "list_incidents", {"params": {}})
+        result = await call_tool(mcp_client, "list_incidents", {})
 
         assert str(HTTPStatus.UNAUTHORIZED.value) in tool_error_text(result)
 
@@ -201,7 +199,7 @@ class TestCountIncidents:
         """
         route = gg_api.get("/incidents-for-mcp/count").respond(200, json={"count": 1337})
 
-        result = await call_tool(mcp_client, "count_incidents", {"params": {}})
+        result = await call_tool(mcp_client, "count_incidents", {})
 
         params = sent_params(route)
         assert params == {
@@ -220,7 +218,7 @@ class TestCountIncidents:
         gg_api.get(f"/members/{TEST_MEMBER_ID}").respond(200, json={"id": TEST_MEMBER_ID})
         route = gg_api.get("/incidents-for-mcp/count").respond(200, json={"count": 2})
 
-        result = await call_tool(mcp_client, "count_incidents", {"params": {"mine": True}})
+        result = await call_tool(mcp_client, "count_incidents", {"mine": True})
 
         assert sent_params(route)["assignee_member_id"] == str(TEST_MEMBER_ID)
         assert unwrap_result(result)["count"] == 2
@@ -236,7 +234,7 @@ class TestGetIncident:
         """
         route = gg_api.get("/incidents/secrets/77").respond(200, json=INCIDENT)
 
-        result = await call_tool(mcp_client, "get_incident", {"params": {"incident_id": 77}})
+        result = await call_tool(mcp_client, "get_incident", {"incident_id": 77})
 
         assert str(route.calls.last.request.url) == "https://api.gitguardian.com/v1/incidents/secrets/77"
         assert tool_output(result) == {"incident": INCIDENT}
@@ -252,7 +250,7 @@ class TestGetIncident:
         """
         gg_api.get("/incidents/secrets/77").respond(200, json=INCIDENT)
 
-        result = await call_tool(mcp_client, "get_incident", {"params": {"incident_id": 77}})
+        result = await call_tool(mcp_client, "get_incident", {"incident_id": 77})
 
         assert result["isError"] is False
         assert result["structuredContent"] == {"incident": INCIDENT}
@@ -267,7 +265,7 @@ class TestGetIncident:
         """
         route = gg_api.get("/incidents/secrets/77").respond(200, json=INCIDENT)
 
-        await call_tool(mcp_client, "get_incident", {"params": {"incident_id": 77, "with_occurrences": 50}})
+        await call_tool(mcp_client, "get_incident", {"incident_id": 77, "with_occurrences": 50})
 
         assert sent_params(route)["with_occurrences"] == "50"
 
@@ -283,7 +281,7 @@ class TestGetIncident:
             json={"detail": "Not found."},
         )
 
-        result = await call_tool(mcp_client, "get_incident", {"params": {"incident_id": incident_id}})
+        result = await call_tool(mcp_client, "get_incident", {"incident_id": incident_id})
 
         assert str(HTTPStatus.NOT_FOUND.value) in tool_error_text(result)
 
@@ -303,7 +301,7 @@ class TestListRepoOccurrences:
             headers={"Link": '<https://api.gitguardian.com/v1/occurrences/secrets?cursor=cD0yMDI2%3D%3D>; rel="next"'},
         )
 
-        result = await call_tool(mcp_client, "list_repo_occurrences", {"params": {"source_id": 55}})
+        result = await call_tool(mcp_client, "list_repo_occurrences", {"source_id": 55})
 
         params = sent_params(route)
         assert params["source_id"] == "55"
@@ -329,7 +327,7 @@ class TestListRepoOccurrences:
         """
         route = gg_api.get("/occurrences/secrets").respond(200, json={"results": []})
 
-        await call_tool(mcp_client, "list_repo_occurrences", {"params": {"mine": True}})
+        await call_tool(mcp_client, "list_repo_occurrences", {"mine": True})
 
         assert sent_params(route)["member_assignee_id"] == str(TEST_MEMBER_ID)
 
@@ -346,7 +344,7 @@ class TestListRepoOccurrences:
         gg_api.get("/api_tokens/self").respond(200, json=token_info(member_id=None))
         occurrences = gg_api.get("/occurrences/secrets").respond(200, json={"results": []})
 
-        result = await call_tool(mcp_client, "list_repo_occurrences", {"params": {"mine": True}})
+        result = await call_tool(mcp_client, "list_repo_occurrences", {"mine": True})
 
         assert "mine" in tool_error_text(result).lower()
         assert not occurrences.called

--- a/tests/e2e/test_incident_write_tools.py
+++ b/tests/e2e/test_incident_write_tools.py
@@ -51,7 +51,7 @@ class TestManagePrivateIncident:
         """
         route = gg_api.post(expected_path).respond(200, json={"id": 42, "status": "UPDATED"})
 
-        result = await call_tool(mcp_client, "manage_private_incident", {"params": arguments})
+        result = await call_tool(mcp_client, "manage_private_incident", arguments)
 
         assert route.called
         assert sent_body(route) == expected_body
@@ -67,9 +67,7 @@ class TestManagePrivateIncident:
         """
         route = gg_api.post("/incidents/secrets/42/resolve").respond(200, json={})
 
-        result = await call_tool(
-            mcp_client, "manage_private_incident", {"params": {"incident_id": 42, "action": "resolve"}}
-        )
+        result = await call_tool(mcp_client, "manage_private_incident", {"incident_id": 42, "action": "resolve"})
 
         assert "'secret_revoked' parameter is required" in tool_error_text(result)
         assert not route.called
@@ -82,9 +80,7 @@ class TestManagePrivateIncident:
         """
         route = gg_api.post("/incidents/secrets/42/ignore").respond(200, json={})
 
-        result = await call_tool(
-            mcp_client, "manage_private_incident", {"params": {"incident_id": 42, "action": "ignore"}}
-        )
+        result = await call_tool(mcp_client, "manage_private_incident", {"incident_id": 42, "action": "ignore"})
 
         assert "'ignore_reason' parameter is required" in tool_error_text(result)
         assert not route.called
@@ -99,9 +95,7 @@ class TestUpdateIncidentSeverity:
         """
         route = gg_api.patch("/incidents/secrets/42").respond(200, json={"id": 42, "severity": "high"})
 
-        result = await call_tool(
-            mcp_client, "update_incident_severity", {"params": {"incident_id": 42, "severity": "high"}}
-        )
+        result = await call_tool(mcp_client, "update_incident_severity", {"incident_id": 42, "severity": "high"})
 
         assert sent_body(route) == {"severity": "high"}
         assert tool_output(result) == {"id": 42, "severity": "high"}
@@ -117,7 +111,7 @@ class TestAssignIncident:
         """
         route = gg_api.post("/incidents/secrets/42/assign").respond(200, json={"id": 42, "assignee_id": 4242})
 
-        result = await call_tool(mcp_client, "assign_incident", {"params": {"incident_id": 42, "mine": True}})
+        result = await call_tool(mcp_client, "assign_incident", {"incident_id": 42, "mine": True})
 
         assert sent_body(route) == {"member_id": "4242", "email": None}
         output = tool_output(result)
@@ -132,7 +126,7 @@ class TestAssignIncident:
         """
         route = gg_api.post("/incidents/secrets/42/assign").respond(200, json={"id": 42})
 
-        await call_tool(mcp_client, "assign_incident", {"params": {"incident_id": 42, "email": "dev@corp.test"}})
+        await call_tool(mcp_client, "assign_incident", {"incident_id": 42, "email": "dev@corp.test"})
 
         assert sent_body(route) == {"member_id": None, "email": "dev@corp.test"}
 
@@ -151,7 +145,7 @@ class TestUpdatePublicIncidentStatus:
         result = await call_tool(
             mcp_client,
             "update_public_incident_status",
-            {"params": {"incident_id": 7, "action": "resolve", "resolve_reason": "revoked"}},
+            {"incident_id": 7, "action": "resolve", "resolve_reason": "revoked"},
         )
 
         assert sent_body(route) == {"resolve_reason": "revoked"}
@@ -165,9 +159,7 @@ class TestUpdatePublicIncidentStatus:
         """
         route = gg_api.post("/public-incidents/secrets/7/resolve").respond(200, json={})
 
-        result = await call_tool(
-            mcp_client, "update_public_incident_status", {"params": {"incident_id": 7, "action": "resolve"}}
-        )
+        result = await call_tool(mcp_client, "update_public_incident_status", {"incident_id": 7, "action": "resolve"})
 
         assert "'resolve_reason' parameter is required" in tool_error_text(result)
         assert not route.called

--- a/tests/e2e/test_scan_secrets.py
+++ b/tests/e2e/test_scan_secrets.py
@@ -37,7 +37,7 @@ class TestScanSecrets:
         ]
         route = gg_api.post("/multiscan").respond(200, json=[SCAN_RESULT, {"policy_break_count": 0}])
 
-        result = await call_tool(mcp_client, "scan_secrets", {"params": {"documents": documents}})
+        result = await call_tool(mcp_client, "scan_secrets", {"documents": documents})
 
         assert_authenticated_request(route)
         assert sent_body(route) == documents
@@ -56,7 +56,7 @@ class TestScanSecrets:
         route = gg_api.post("/multiscan").respond(200, json=[SCAN_RESULT])
         documents = [{"document": "x = 1\n"}]
 
-        result = await call_tool(mcp_client, "scan_secrets", {"params": {"documents": documents}})
+        result = await call_tool(mcp_client, "scan_secrets", {"documents": documents})
 
         assert route.called
         assert sent_body(route) == documents
@@ -70,7 +70,7 @@ class TestScanSecrets:
         """
         route = gg_api.post("/multiscan").respond(200, json=[])
 
-        result = await call_tool(mcp_client, "scan_secrets", {"params": {"documents": []}})
+        result = await call_tool(mcp_client, "scan_secrets", {"documents": []})
 
         assert "non-empty list" in tool_error_text(result)
         assert not route.called
@@ -86,7 +86,7 @@ class TestScanSecrets:
         result = await call_tool(
             mcp_client,
             "scan_secrets",
-            {"params": {"documents": [{"document": "x", "filename": "x.py"}]}},
+            {"documents": [{"document": "x", "filename": "x.py"}]},
         )
 
         assert "400" in tool_error_text(result)

--- a/tests/e2e/test_stdio_server.py
+++ b/tests/e2e/test_stdio_server.py
@@ -95,7 +95,7 @@ class TestPatEnvAuthentication:
         server = build_server()
         assert server.authentication_mode.value == "PERSONAL_ACCESS_TOKEN_ENV_VAR"
         async with Client(server) as client:
-            result = await client.call_tool("get_incident", {"params": {"incident_id": 77}})
+            result = await client.call_tool("get_incident", {"incident_id": 77})
 
         assert result.structured_content == {"incident": INCIDENT}
         assert_authenticated_request(scope_route, STDIO_PAT)
@@ -126,7 +126,7 @@ class TestPatEnvAuthentication:
         server = build_server()
         assert server.authentication_mode.value == "LOCAL_OAUTH_FLOW"
         async with Client(server) as client:
-            result = await client.call_tool("get_incident", {"params": {"incident_id": 77}})
+            result = await client.call_tool("get_incident", {"incident_id": 77})
 
         assert result.structured_content == {"incident": INCIDENT}
         assert route.calls.last.request.headers["Authorization"] == f"Token {STDIO_PAT}"
@@ -182,7 +182,7 @@ class TestPatEnvAuthentication:
         server = build_server()
         assert server.authentication_mode.value == "LOCAL_OAUTH_FLOW"
         async with Client(server) as client:
-            result = await client.call_tool("get_incident", {"params": {"incident_id": 77}})
+            result = await client.call_tool("get_incident", {"incident_id": 77})
 
         assert result.structured_content == {"incident": INCIDENT}
         assert_authenticated_request(scope_route, stored_pat)
@@ -300,7 +300,7 @@ class TestSingleTenantSelfHealing:
         route = gg_api.get("/incidents/secrets/77").mock(side_effect=invalid_then_success)
 
         async with Client(build_server()) as client:
-            result = await client.call_tool("get_incident", {"params": {"incident_id": 77}})
+            result = await client.call_tool("get_incident", {"incident_id": 77})
 
         assert route.call_count == 2
         assert seen_authorization == [f"Token {STDIO_PAT}", f"Token {STDIO_PAT}"]
@@ -322,7 +322,7 @@ class TestSingleTenantSelfHealing:
         async with Client(build_server()) as client:
             result = await client.call_tool(
                 "get_incident",
-                {"params": {"incident_id": 77}},
+                {"incident_id": 77},
                 raise_on_error=False,
             )
 
@@ -348,7 +348,7 @@ class TestSingleTenantSelfHealing:
         async with Client(build_server()) as client:
             result = await client.call_tool(
                 "get_incident",
-                {"params": {"incident_id": 77}},
+                {"incident_id": 77},
                 raise_on_error=False,
             )
 

--- a/tests/e2e/test_stdio_transport.py
+++ b/tests/e2e/test_stdio_transport.py
@@ -116,7 +116,7 @@ async def test_installed_stdio_entrypoint_serves_gitguardian_tools(
     async with Client(transport) as client:
         result = await client.call_tool(
             "get_incident",
-            {"params": {"incident_id": 77}},
+            {"incident_id": 77},
         )
 
     assert result.structured_content == {"incident": INCIDENT}

--- a/tests/e2e/test_workspace_tools.py
+++ b/tests/e2e/test_workspace_tools.py
@@ -37,7 +37,7 @@ class TestListSources:
         result = await call_tool(
             mcp_client,
             "list_sources",
-            {"params": {"type": "github", "monitored": True, "search": "gg"}},
+            {"type": "github", "monitored": True, "search": "gg"},
         )
 
         params = sent_params(route)
@@ -63,7 +63,7 @@ class TestReadCustomTags:
         tags = [{"id": "1", "key": "team", "value": "payments"}]
         route = gg_api.get("/custom_tags").respond(200, json=tags)
 
-        result = await call_tool(mcp_client, "read_custom_tags", {"params": {"action": "list_tags"}})
+        result = await call_tool(mcp_client, "read_custom_tags", {"action": "list_tags"})
 
         assert route.called
         assert sent_params(route) == {}
@@ -78,7 +78,7 @@ class TestReadCustomTags:
         tag = {"id": "9", "key": "env", "value": "prod"}
         route = gg_api.get("/custom_tags/9").respond(200, json=tag)
 
-        result = await call_tool(mcp_client, "read_custom_tags", {"params": {"action": "get_tag", "tag_id": 9}})
+        result = await call_tool(mcp_client, "read_custom_tags", {"action": "get_tag", "tag_id": 9})
 
         assert route.called
         assert tool_output(result) == tag
@@ -158,7 +158,7 @@ class TestRemediateSecretIncidents:
         """
         route = gg_api.get("/occurrences/secrets").respond(200, json={"results": self.OCCURRENCES})
 
-        result = await call_tool(mcp_client, "remediate_secret_incidents", {"params": {"source_id": 55}})
+        result = await call_tool(mcp_client, "remediate_secret_incidents", {"source_id": 55})
 
         params = sent_params(route)
         assert params["source_id"] == "55"
@@ -178,7 +178,7 @@ class TestRemediateSecretIncidents:
         """
         gg_api.get("/occurrences/secrets").respond(200, json={"results": self.OCCURRENCES})
 
-        result = await call_tool(mcp_client, "remediate_secret_incidents", {"params": {"source_id": 55, "mine": True}})
+        result = await call_tool(mcp_client, "remediate_secret_incidents", {"source_id": 55, "mine": True})
 
         output = unwrap_result(result)
         occurrences = output["sub_tools_results"]["list_repo_occurrences"]["occurrences"]
@@ -204,6 +204,6 @@ class TestRemediateSecretIncidents:
             side_effect=[httpx.Response(200, json=token_info())] + [httpx.Response(500, text="boom")] * 4
         )
 
-        result = await call_tool(mcp_client, "remediate_secret_incidents", {"params": {"source_id": 55, "mine": True}})
+        result = await call_tool(mcp_client, "remediate_secret_incidents", {"source_id": 55, "mine": True})
 
         assert "500" in tool_error_text(result)

--- a/tests/helpers/sentry_mcp_transaction_probe.py
+++ b/tests/helpers/sentry_mcp_transaction_probe.py
@@ -32,14 +32,12 @@ async def _call_scan_tool(server: FastMCP) -> None:
         await session.call_tool(
             "scan_secrets",
             {
-                "params": {
-                    "documents": [
-                        {
-                            "document": RAW_DOCUMENT,
-                            "filename": "settings.py",
-                        }
-                    ]
-                }
+                "documents": [
+                    {
+                        "document": RAW_DOCUMENT,
+                        "filename": "settings.py",
+                    }
+                ]
             },
         )
 

--- a/tests/tools/test_activity_logs.py
+++ b/tests/tools/test_activity_logs.py
@@ -54,7 +54,7 @@ class TestListIncidentActivityLogs:
             return_value={"data": [_note_entry(), _action_entry()], "cursor": None, "has_more": False}
         )
 
-        result = await list_incident_activity_logs(ListActivityLogsParams(incident_id=21460))
+        result = await list_incident_activity_logs(incident_id=21460)
 
         mock_gitguardian_client.list_incident_activity_logs.assert_called_once_with(
             incident_id=21460, params={"per_page": 20}, get_all=False
@@ -76,10 +76,8 @@ class TestListIncidentActivityLogs:
         )
 
         result = await list_incident_activity_logs(
-            ListActivityLogsParams(
                 incident_id=21460, content_key="RESOLVE", member_id=480870, cursor="abc", per_page=50
             )
-        )
 
         mock_gitguardian_client.list_incident_activity_logs.assert_called_once_with(
             incident_id=21460,
@@ -99,7 +97,7 @@ class TestListIncidentActivityLogs:
         mock_gitguardian_client.list_incident_activity_logs = AsyncMock(side_effect=Exception("boom"))
 
         with pytest.raises(ToolError) as exc_info:
-            await list_incident_activity_logs(ListActivityLogsParams(incident_id=21460))
+            await list_incident_activity_logs(incident_id=21460)
 
         assert "boom" in str(exc_info.value)
 
@@ -122,7 +120,7 @@ class TestListPublicIncidentActivityLogs:
             }
         )
 
-        result = await list_public_incident_activity_logs(ListActivityLogsParams(incident_id=3759))
+        result = await list_public_incident_activity_logs(incident_id=3759)
 
         mock_gitguardian_client.list_public_incident_activity_logs.assert_called_once_with(
             incident_id=3759, params={"per_page": 20}, get_all=False

--- a/tests/tools/test_activity_logs.py
+++ b/tests/tools/test_activity_logs.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock
 import pytest
 from fastmcp.exceptions import ToolError
 from gg_api_core.tools.activity_logs import (
-    ListActivityLogsParams,
     ListActivityLogsResult,
     list_incident_activity_logs,
     list_public_incident_activity_logs,
@@ -76,8 +75,8 @@ class TestListIncidentActivityLogs:
         )
 
         result = await list_incident_activity_logs(
-                incident_id=21460, content_key="RESOLVE", member_id=480870, cursor="abc", per_page=50
-            )
+            incident_id=21460, content_key="RESOLVE", member_id=480870, cursor="abc", per_page=50
+        )
 
         mock_gitguardian_client.list_incident_activity_logs.assert_called_once_with(
             incident_id=21460,

--- a/tests/tools/test_assign_incident.py
+++ b/tests/tools/test_assign_incident.py
@@ -107,7 +107,7 @@ class TestAssignIncident:
             return_value={"id": 123, "assignee_id": 456, "status": "ASSIGNED"}
         )
 
-        result = await assign_incident(AssignIncidentParams(incident_id=123, assignee_member_id=456))
+        result = await assign_incident(incident_id=123, assignee_member_id=456)
 
         # Verify the client was called with the correct parameters
         mock_gitguardian_client.assign_incident.assert_called_once_with(
@@ -136,7 +136,7 @@ class TestAssignIncident:
             return_value={"id": 123, "assignee_id": 789, "status": "ASSIGNED"}
         )
 
-        result = await assign_incident(AssignIncidentParams(incident_id=123, email="user@example.com"))
+        result = await assign_incident(incident_id=123, email="user@example.com")
 
         # Verify the client was called with email parameter directly
         mock_gitguardian_client.assign_incident.assert_called_once_with(
@@ -169,7 +169,7 @@ class TestAssignIncident:
             return_value={"id": 123, "assignee_id": 480870, "status": "ASSIGNED"}
         )
 
-        result = await assign_incident(AssignIncidentParams(incident_id=123, mine=True))
+        result = await assign_incident(incident_id=123, mine=True)
 
         # Verify get_current_token_info was called (not get_current_member)
         mock_gitguardian_client.get_current_token_info.assert_called_once()
@@ -199,7 +199,7 @@ class TestAssignIncident:
         mock_gitguardian_client.assign_incident = AsyncMock(side_effect=Exception("API error: Incident not found"))
 
         with pytest.raises(ToolError) as exc_info:
-            await assign_incident(AssignIncidentParams(incident_id=999, assignee_member_id=456))
+            await assign_incident(incident_id=999, assignee_member_id=456)
 
         assert "API error: Incident not found" in str(exc_info.value)
 
@@ -218,6 +218,6 @@ class TestAssignIncident:
         )
 
         with pytest.raises(ToolError) as exc_info:
-            await assign_incident(AssignIncidentParams(incident_id=123, mine=True))
+            await assign_incident(incident_id=123, mine=True)
 
         assert "Could not determine current user ID from token info" in str(exc_info.value)

--- a/tests/tools/test_assign_public_incident.py
+++ b/tests/tools/test_assign_public_incident.py
@@ -131,7 +131,7 @@ class TestAssignPublicIncident:
             return_value=_full_public_incident_payload(incident_id=3759, assignee_id=456)
         )
 
-        result = await assign_public_incident(AssignPublicIncidentParams(incident_id=3759, assignee_member_id=456))
+        result = await assign_public_incident(incident_id=3759, assignee_member_id=456)
 
         mock_gitguardian_client.assign_public_incident.assert_called_once_with(
             incident_id=3759,
@@ -159,7 +159,7 @@ class TestAssignPublicIncident:
             return_value=_full_public_incident_payload(incident_id=3759, assignee_id=789)
         )
 
-        result = await assign_public_incident(AssignPublicIncidentParams(incident_id=3759, email="user@example.com"))
+        result = await assign_public_incident(incident_id=3759, email="user@example.com")
 
         mock_gitguardian_client.assign_public_incident.assert_called_once_with(
             incident_id=3759,
@@ -186,7 +186,7 @@ class TestAssignPublicIncident:
             return_value=_full_public_incident_payload(incident_id=3759, assignee_id=480870)
         )
 
-        result = await assign_public_incident(AssignPublicIncidentParams(incident_id=3759, mine=True))
+        result = await assign_public_incident(incident_id=3759, mine=True)
 
         mock_gitguardian_client.get_current_token_info.assert_called_once()
         mock_gitguardian_client.assign_public_incident.assert_called_once_with(
@@ -211,7 +211,7 @@ class TestAssignPublicIncident:
             return_value=_full_public_incident_payload(incident_id=42, assignee_id=480870)
         )
 
-        await assign_public_incident(AssignPublicIncidentParams(incident_id=42, mine=True, send_email=False))
+        await assign_public_incident(incident_id=42, mine=True, send_email=False)
 
         mock_gitguardian_client.assign_public_incident.assert_called_once_with(
             incident_id=42,
@@ -234,7 +234,7 @@ class TestAssignPublicIncident:
         )
 
         with pytest.raises(ToolError) as exc_info:
-            await assign_public_incident(AssignPublicIncidentParams(incident_id=999, assignee_member_id=456))
+            await assign_public_incident(incident_id=999, assignee_member_id=456)
 
         assert "API error: Public incident not found" in str(exc_info.value)
 
@@ -252,6 +252,6 @@ class TestAssignPublicIncident:
         )
 
         with pytest.raises(ToolError) as exc_info:
-            await assign_public_incident(AssignPublicIncidentParams(incident_id=123, mine=True))
+            await assign_public_incident(incident_id=123, mine=True)
 
         assert "Could not determine current user ID from token info" in str(exc_info.value)

--- a/tests/tools/test_count_incidents.py
+++ b/tests/tools/test_count_incidents.py
@@ -94,7 +94,7 @@ class TestCountIncidentsTool:
         mock_client.count_incidents_for_mcp.return_value = {"count": 42}
 
         with patch("gg_api_core.tools.count_incidents.get_client", return_value=mock_client):
-            result = await count_incidents(CountIncidentsParams())
+            result = await count_incidents()
 
         assert isinstance(result, CountIncidentsResult)
         assert result.count == 42
@@ -105,7 +105,7 @@ class TestCountIncidentsTool:
         mock_client.count_incidents_for_mcp.return_value = {"count": 0}
 
         with patch("gg_api_core.tools.count_incidents.get_client", return_value=mock_client):
-            result = await count_incidents(CountIncidentsParams())
+            result = await count_incidents()
 
         assert isinstance(result, CountIncidentsResult)
         assert result.count == 0
@@ -122,7 +122,7 @@ class TestCountIncidentsTool:
         )
 
         with patch("gg_api_core.tools.count_incidents.get_client", return_value=mock_client):
-            result = await count_incidents(params)
+            result = await count_incidents(**params.model_dump())
 
         assert isinstance(result, CountIncidentsResult)
         assert result.count == 5
@@ -144,7 +144,7 @@ class TestCountIncidentsTool:
         params = CountIncidentsParams(mine=True)
 
         with patch("gg_api_core.tools.count_incidents.get_client", return_value=mock_client):
-            result = await count_incidents(params)
+            result = await count_incidents(**params.model_dump())
 
         assert isinstance(result, CountIncidentsResult)
         assert result.count == 3
@@ -159,7 +159,7 @@ class TestCountIncidentsTool:
         params = CountIncidentsParams(mine=True, assignee_id=50)
 
         with patch("gg_api_core.tools.count_incidents.get_client", return_value=mock_client):
-            result = await count_incidents(params)
+            result = await count_incidents(**params.model_dump())
 
         assert isinstance(result, CountIncidentsError)
         assert "Conflict" in result.error
@@ -215,7 +215,7 @@ class TestCountIncidentsTool:
         mock_client.count_incidents_for_mcp.side_effect = Exception("API error")
 
         with patch("gg_api_core.tools.count_incidents.get_client", return_value=mock_client):
-            result = await count_incidents(CountIncidentsParams())
+            result = await count_incidents()
 
         assert isinstance(result, CountIncidentsError)
         assert "API error" in result.error

--- a/tests/tools/test_count_incidents.py
+++ b/tests/tools/test_count_incidents.py
@@ -175,7 +175,7 @@ class TestCountIncidentsTool:
         client._request_get = AsyncMock(return_value={"count": 7})
 
         with patch("gg_api_core.tools.count_incidents.get_client", return_value=client):
-            result = await count_incidents(CountIncidentsParams(validity=["unknown"]))
+            result = await count_incidents(**CountIncidentsParams(validity=["unknown"]).model_dump())
 
         assert isinstance(result, CountIncidentsResult)
         query = client._request_get.call_args.kwargs["params"]
@@ -192,7 +192,7 @@ class TestCountIncidentsTool:
         mock_client.count_incidents_for_mcp.return_value = {"count": 1}
 
         with patch("gg_api_core.tools.count_incidents.get_client", return_value=mock_client):
-            await count_incidents(CountIncidentsParams(severity=["critical", "unknown"]))
+            await count_incidents(**CountIncidentsParams(severity=["critical", "unknown"]).model_dump())
 
         call_kwargs = mock_client.count_incidents_for_mcp.call_args.kwargs
         assert call_kwargs["severity"] == ["critical", "unknown"]

--- a/tests/tools/test_create_code_fix_request.py
+++ b/tests/tools/test_create_code_fix_request.py
@@ -24,7 +24,9 @@ class TestCreateCodeFixRequest:
         mock_gitguardian_client.create_code_fix_request = AsyncMock(return_value=mock_response)
 
         # Call the function with single issue
-        result = await create_code_fix_request(locations=[LocationToFix(issue_id=12345, location_ids=[67890, 67891, 67892])])
+        result = await create_code_fix_request(
+            locations=[LocationToFix(issue_id=12345, location_ids=[67890, 67891, 67892])]
+        )
 
         # Verify client was called with correct parameters
         mock_gitguardian_client.create_code_fix_request.assert_called_once_with(
@@ -53,11 +55,11 @@ class TestCreateCodeFixRequest:
 
         # Call the function with multiple issues
         result = await create_code_fix_request(
-                locations=[
-                    LocationToFix(issue_id=12345, location_ids=[67890]),
-                    LocationToFix(issue_id=12346, location_ids=[67893, 67894]),
-                ]
-            )
+            locations=[
+                LocationToFix(issue_id=12345, location_ids=[67890]),
+                LocationToFix(issue_id=12346, location_ids=[67893, 67894]),
+            ]
+        )
 
         # Verify client was called with correct parameters
         mock_gitguardian_client.create_code_fix_request.assert_called_once_with(

--- a/tests/tools/test_create_code_fix_request.py
+++ b/tests/tools/test_create_code_fix_request.py
@@ -24,9 +24,7 @@ class TestCreateCodeFixRequest:
         mock_gitguardian_client.create_code_fix_request = AsyncMock(return_value=mock_response)
 
         # Call the function with single issue
-        result = await create_code_fix_request(
-            CreateCodeFixRequestParams(locations=[LocationToFix(issue_id=12345, location_ids=[67890, 67891, 67892])])
-        )
+        result = await create_code_fix_request(locations=[LocationToFix(issue_id=12345, location_ids=[67890, 67891, 67892])])
 
         # Verify client was called with correct parameters
         mock_gitguardian_client.create_code_fix_request.assert_called_once_with(
@@ -55,13 +53,11 @@ class TestCreateCodeFixRequest:
 
         # Call the function with multiple issues
         result = await create_code_fix_request(
-            CreateCodeFixRequestParams(
                 locations=[
                     LocationToFix(issue_id=12345, location_ids=[67890]),
                     LocationToFix(issue_id=12346, location_ids=[67893, 67894]),
                 ]
             )
-        )
 
         # Verify client was called with correct parameters
         mock_gitguardian_client.create_code_fix_request.assert_called_once_with(
@@ -89,9 +85,7 @@ class TestCreateCodeFixRequest:
 
         # Call the function and expect a ToolError
         with pytest.raises(ToolError) as excinfo:
-            await create_code_fix_request(
-                CreateCodeFixRequestParams(locations=[LocationToFix(issue_id=12345, location_ids=[67890])])
-            )
+            await create_code_fix_request(locations=[LocationToFix(issue_id=12345, location_ids=[67890])])
 
         # Verify error message
         assert "not enabled" in str(excinfo.value)
@@ -110,9 +104,7 @@ class TestCreateCodeFixRequest:
 
         # Call the function and expect a ToolError
         with pytest.raises(ToolError) as excinfo:
-            await create_code_fix_request(
-                CreateCodeFixRequestParams(locations=[LocationToFix(issue_id=12345, location_ids=[67890])])
-            )
+            await create_code_fix_request(locations=[LocationToFix(issue_id=12345, location_ids=[67890])])
 
         # Verify error message
         assert "Too many locations" in str(excinfo.value)
@@ -131,9 +123,7 @@ class TestCreateCodeFixRequest:
 
         # Call the function and expect a ToolError
         with pytest.raises(ToolError) as excinfo:
-            await create_code_fix_request(
-                CreateCodeFixRequestParams(locations=[LocationToFix(issue_id=12345, location_ids=[67890])])
-            )
+            await create_code_fix_request(locations=[LocationToFix(issue_id=12345, location_ids=[67890])])
 
         # Verify error message
         assert "No valid locations" in str(excinfo.value)
@@ -152,9 +142,7 @@ class TestCreateCodeFixRequest:
 
         # Call the function and expect a ToolError
         with pytest.raises(ToolError) as excinfo:
-            await create_code_fix_request(
-                CreateCodeFixRequestParams(locations=[LocationToFix(issue_id=12345, location_ids=[67890])])
-            )
+            await create_code_fix_request(locations=[LocationToFix(issue_id=12345, location_ids=[67890])])
 
         # Verify error message
         assert "already have open pull requests" in str(excinfo.value)
@@ -173,9 +161,7 @@ class TestCreateCodeFixRequest:
 
         # Call the function and expect a ToolError
         with pytest.raises(ToolError) as excinfo:
-            await create_code_fix_request(
-                CreateCodeFixRequestParams(locations=[LocationToFix(issue_id=12345, location_ids=[67890])])
-            )
+            await create_code_fix_request(locations=[LocationToFix(issue_id=12345, location_ids=[67890])])
 
         # Verify error message mentions permissions
         assert "permission" in str(excinfo.value).lower()
@@ -194,9 +180,7 @@ class TestCreateCodeFixRequest:
 
         # Call the function and expect a ToolError
         with pytest.raises(ToolError) as excinfo:
-            await create_code_fix_request(
-                CreateCodeFixRequestParams(locations=[LocationToFix(issue_id=12345, location_ids=[67890])])
-            )
+            await create_code_fix_request(locations=[LocationToFix(issue_id=12345, location_ids=[67890])])
 
         # Verify error message mentions API key
         assert "API key" in str(excinfo.value) or "404" in str(excinfo.value)
@@ -214,9 +198,7 @@ class TestCreateCodeFixRequest:
 
         # Call the function and expect a ToolError
         with pytest.raises(ToolError) as excinfo:
-            await create_code_fix_request(
-                CreateCodeFixRequestParams(locations=[LocationToFix(issue_id=12345, location_ids=[67890])])
-            )
+            await create_code_fix_request(locations=[LocationToFix(issue_id=12345, location_ids=[67890])])
 
         # Verify error message contains the original error
         assert error_message in str(excinfo.value)
@@ -255,9 +237,7 @@ class TestCreateCodeFixRequest:
         mock_gitguardian_client.create_code_fix_request = AsyncMock(return_value=mock_response)
 
         # Call the function
-        result = await create_code_fix_request(
-            CreateCodeFixRequestParams(locations=[LocationToFix(issue_id=12345, location_ids=[67890])])
-        )
+        result = await create_code_fix_request(locations=[LocationToFix(issue_id=12345, location_ids=[67890])])
 
         # Verify response has default message
         assert result.success is True
@@ -278,7 +258,7 @@ class TestCreateCodeFixRequest:
         locations = [LocationToFix(issue_id=100 + i, location_ids=[1000 + i, 2000 + i, 3000 + i]) for i in range(5)]
 
         # Call the function
-        result = await create_code_fix_request(CreateCodeFixRequestParams(locations=locations))
+        result = await create_code_fix_request(locations=locations)
 
         # Verify client was called
         assert mock_gitguardian_client.create_code_fix_request.called

--- a/tests/tools/test_flat_signature_conformance.py
+++ b/tests/tools/test_flat_signature_conformance.py
@@ -1,0 +1,129 @@
+"""Conformance guard: a flattened tool signature must match its params model.
+
+Flattening restates each params model field as a top-level ``Annotated``
+parameter, so the field definition now lives in two places. The model is the
+source of truth: it is what the tool body constructs, what carries the
+cross-field validators, and what the generated filter vocabularies feed. When
+the signature drifts from it the tool still imports and still passes its own
+tests, but it advertises a contract the body will reject.
+
+Every failure seen while stacking this branch on the generated vocabularies was
+one of the three checks below: a parameter naming a type the module no longer
+imported, a default the model rejects (``severity=[10, 20, 30, 100]`` against a
+names-only Literal), and a parameter typed ``list[str]`` while the model
+accepted a Literal.
+"""
+
+import importlib
+import inspect
+import pkgutil
+import typing
+
+import gg_api_core.tools as tools_package
+import pytest
+from pydantic import BaseModel
+
+
+def _tool_and_model_pairs():
+    """Yield ``(tool_name, function, params_model)`` for every flattened tool.
+
+    A tool is paired with the ``*Params`` model in its own module whose name is
+    the PascalCase form of the function name. Tools without such a model (they
+    take no model, or compose several) are skipped rather than guessed at.
+    """
+    for module_info in pkgutil.iter_modules(tools_package.__path__):
+        module = importlib.import_module(f"gg_api_core.tools.{module_info.name}")
+        for name, obj in vars(module).items():
+            if name.startswith("_") or not inspect.iscoroutinefunction(obj):
+                continue
+            if obj.__module__ != module.__name__:
+                continue
+            expected = "".join(part.title() for part in name.split("_")) + "Params"
+            model = getattr(module, expected, None)
+            if isinstance(model, type) and issubclass(model, BaseModel):
+                yield pytest.param(name, obj, model, id=name)
+
+
+PAIRS = list(_tool_and_model_pairs())
+
+
+def test_pairs_were_discovered():
+    """A silent zero-pair discovery would make every check below vacuous."""
+    assert len(PAIRS) >= 20
+
+
+@pytest.mark.parametrize(("name", "function", "model"), PAIRS)
+def test_signature_exposes_exactly_the_model_fields(name, function, model):
+    """
+    GIVEN a flattened tool and its params model
+    WHEN their field names are compared
+    THEN the signature exposes exactly the model's fields
+    """
+    signature_params = set(inspect.signature(function).parameters)
+
+    assert signature_params == set(model.model_fields)
+
+
+@pytest.mark.parametrize(("name", "function", "model"), PAIRS)
+def test_signature_defaults_match_the_model_defaults(name, function, model):
+    """
+    GIVEN a flattened tool parameter carrying a default
+    WHEN it is compared with the matching model field default
+    THEN they are equal
+
+    A signature default the model rejects breaks every call that relies on it,
+    which is how `severity=[10, 20, 30, 100]` reached a names-only Literal.
+    """
+    for field, parameter in inspect.signature(function).parameters.items():
+        if parameter.default is inspect.Parameter.empty:
+            continue
+        expected = model.model_fields[field].get_default(call_default_factory=True)
+        assert parameter.default == expected, f"{name}.{field} default drifted from the model"
+
+
+@pytest.mark.parametrize(("name", "function", "model"), PAIRS)
+def test_required_fields_agree(name, function, model):
+    """
+    GIVEN a model field with no default
+    WHEN the signature is inspected
+    THEN that parameter is required there too, so the schema marks it required
+    """
+    signature = inspect.signature(function)
+
+    for field, info in model.model_fields.items():
+        if info.is_required():
+            assert signature.parameters[field].default is inspect.Parameter.empty, (
+                f"{name}.{field} is required on the model but optional in the signature"
+            )
+
+
+def _literal_members(annotation):
+    """Every Literal member reachable in an annotation, flattened."""
+    members = set()
+    stack = [annotation]
+    while stack:
+        current = stack.pop()
+        if typing.get_origin(current) is typing.Literal:
+            members.update(typing.get_args(current))
+            continue
+        stack.extend(typing.get_args(current))
+    return members
+
+
+@pytest.mark.parametrize(("name", "function", "model"), PAIRS)
+def test_signature_vocabulary_matches_the_model(name, function, model):
+    """
+    GIVEN a model field constrained to a Literal vocabulary
+    WHEN the matching signature parameter is inspected
+    THEN it offers the same members
+
+    The signature is allowed to be wider in shape, accepting a bare value where
+    the model wants a list, but it must not advertise a different vocabulary.
+    """
+    hints = typing.get_type_hints(function, include_extras=True)
+
+    for field, info in model.model_fields.items():
+        expected = _literal_members(info.annotation)
+        if not expected:
+            continue
+        assert _literal_members(hints[field]) == expected, f"{name}.{field} vocabulary drifted"

--- a/tests/tools/test_generate_honey_tokens.py
+++ b/tests/tools/test_generate_honey_tokens.py
@@ -99,7 +99,7 @@ async def test_generate_honeytoken_surfaces_api_detail_on_400(caplog):
         with caplog.at_level(logging.WARNING, logger="gg_api_core.tools.generate_honey_token"):
             with pytest.raises(ToolError) as excinfo:
                 # new_token=True skips the reuse lookup and goes straight to creation.
-                await generate_honeytoken(GenerateHoneytokenParams(name="dup", new_token=True))
+                await generate_honeytoken(name="dup", new_token=True)
 
     assert detail in str(excinfo.value)
     errors = [r for r in caplog.records if r.levelno >= logging.ERROR]

--- a/tests/tools/test_generate_honey_tokens.py
+++ b/tests/tools/test_generate_honey_tokens.py
@@ -84,7 +84,7 @@ async def test_generate_honeytoken_surfaces_api_detail_on_400(caplog):
     from unittest.mock import MagicMock, patch
 
     import httpx
-    from gg_api_core.tools.generate_honey_token import GenerateHoneytokenParams, generate_honeytoken
+    from gg_api_core.tools.generate_honey_token import generate_honeytoken
 
     detail = "Another active honeytoken already exists with this name"
     mock_response = MagicMock()

--- a/tests/tools/test_get_incident.py
+++ b/tests/tools/test_get_incident.py
@@ -38,7 +38,7 @@ class TestGetIncident:
         }
         mock_gitguardian_client.get_incident = AsyncMock(return_value=mock_response)
 
-        result = await get_incident(GetIncidentParams(incident_id=3759))
+        result = await get_incident(incident_id=3759)
 
         mock_gitguardian_client.get_incident.assert_called_once_with(
             incident_id=3759,
@@ -64,7 +64,7 @@ class TestGetIncident:
         }
         mock_gitguardian_client.get_incident = AsyncMock(return_value=mock_response)
 
-        await get_incident(GetIncidentParams(incident_id=1234, with_occurrences=50))
+        await get_incident(incident_id=1234, with_occurrences=50)
 
         call_kwargs = mock_gitguardian_client.get_incident.call_args.kwargs
         assert call_kwargs["incident_id"] == 1234
@@ -84,7 +84,7 @@ class TestGetIncident:
         }
         mock_gitguardian_client.get_incident = AsyncMock(return_value=mock_response)
 
-        await get_incident(GetIncidentParams(incident_id=5678, with_occurrences=0))
+        await get_incident(incident_id=5678, with_occurrences=0)
 
         call_kwargs = mock_gitguardian_client.get_incident.call_args.kwargs
         assert call_kwargs["with_occurrences"] == 0
@@ -103,7 +103,7 @@ class TestGetIncident:
         }
         mock_gitguardian_client.get_incident = AsyncMock(return_value=mock_response)
 
-        result = await get_incident(GetIncidentParams(incident_id=9999, with_occurrences=100))
+        result = await get_incident(incident_id=9999, with_occurrences=100)
 
         call_kwargs = mock_gitguardian_client.get_incident.call_args.kwargs
         assert call_kwargs["with_occurrences"] == 100
@@ -162,7 +162,7 @@ class TestGetIncident:
         }
         mock_gitguardian_client.get_incident = AsyncMock(return_value=mock_response)
 
-        result = await get_incident(GetIncidentParams(incident_id=3759))
+        result = await get_incident(incident_id=3759)
 
         assert result.incident["id"] == 3759
         assert result.incident["detector"]["name"] == "slack_bot_token"
@@ -183,7 +183,7 @@ class TestGetIncident:
         mock_gitguardian_client.get_incident = AsyncMock(side_effect=Exception(error_message))
 
         with pytest.raises(ToolError) as excinfo:
-            await get_incident(GetIncidentParams(incident_id=99999))
+            await get_incident(incident_id=99999)
 
         assert error_message in str(excinfo.value)
 
@@ -198,7 +198,7 @@ class TestGetIncident:
         mock_gitguardian_client.get_incident = AsyncMock(side_effect=Exception(error_message))
 
         with pytest.raises(ToolError) as excinfo:
-            await get_incident(GetIncidentParams(incident_id=1234))
+            await get_incident(incident_id=1234)
 
         assert error_message in str(excinfo.value)
 

--- a/tests/tools/test_get_member.py
+++ b/tests/tools/test_get_member.py
@@ -27,7 +27,7 @@ class TestGetMember:
         }
         mock_gitguardian_client.get_member = AsyncMock(return_value=mock_response)
 
-        result = await get_member(GetMemberParams(member_id=3252))
+        result = await get_member(member_id=3252)
 
         mock_gitguardian_client.get_member.assert_called_once_with(member_id=3252)
         assert result.member is not None
@@ -56,7 +56,7 @@ class TestGetMember:
         }
         mock_gitguardian_client.get_member = AsyncMock(return_value=mock_response)
 
-        result = await get_member(GetMemberParams(member_id=1234))
+        result = await get_member(member_id=1234)
 
         assert result.member["role"] == "manager"
         assert result.member["access_level"] == "manager"
@@ -80,7 +80,7 @@ class TestGetMember:
         }
         mock_gitguardian_client.get_member = AsyncMock(return_value=mock_response)
 
-        result = await get_member(GetMemberParams(member_id=5678))
+        result = await get_member(member_id=5678)
 
         assert result.member["active"] is False
         assert result.member["last_login"] is None
@@ -96,7 +96,7 @@ class TestGetMember:
         mock_gitguardian_client.get_member = AsyncMock(side_effect=Exception(error_message))
 
         with pytest.raises(ToolError) as excinfo:
-            await get_member(GetMemberParams(member_id=99999))
+            await get_member(member_id=99999)
 
         assert error_message in str(excinfo.value)
 
@@ -111,7 +111,7 @@ class TestGetMember:
         mock_gitguardian_client.get_member = AsyncMock(side_effect=Exception(error_message))
 
         with pytest.raises(ToolError) as excinfo:
-            await get_member(GetMemberParams(member_id=1234))
+            await get_member(member_id=1234)
 
         assert error_message in str(excinfo.value)
 

--- a/tests/tools/test_get_public_incident.py
+++ b/tests/tools/test_get_public_incident.py
@@ -40,7 +40,7 @@ class TestGetPublicIncident:
         }
         mock_gitguardian_client.get_public_incident = AsyncMock(return_value=mock_response)
 
-        result = await get_public_incident(GetPublicIncidentParams(incident_id=3759))
+        result = await get_public_incident(incident_id=3759)
 
         mock_gitguardian_client.get_public_incident.assert_called_once_with(incident_id=3759)
         assert result.incident["id"] == 3759
@@ -100,7 +100,7 @@ class TestGetPublicIncident:
         }
         mock_gitguardian_client.get_public_incident = AsyncMock(return_value=mock_response)
 
-        result = await get_public_incident(GetPublicIncidentParams(incident_id=3759))
+        result = await get_public_incident(incident_id=3759)
 
         assert result.incident == mock_response
 
@@ -114,7 +114,7 @@ class TestGetPublicIncident:
         mock_gitguardian_client.get_public_incident = AsyncMock(side_effect=Exception("Public incident not found"))
 
         with pytest.raises(ToolError) as excinfo:
-            await get_public_incident(GetPublicIncidentParams(incident_id=99999))
+            await get_public_incident(incident_id=99999)
 
         assert "Public incident not found" in str(excinfo.value)
 
@@ -128,7 +128,7 @@ class TestGetPublicIncident:
         mock_gitguardian_client.get_public_incident = AsyncMock(side_effect=Exception("API connection failed"))
 
         with pytest.raises(ToolError) as excinfo:
-            await get_public_incident(GetPublicIncidentParams(incident_id=1234))
+            await get_public_incident(incident_id=1234)
 
         assert "API connection failed" in str(excinfo.value)
 

--- a/tests/tools/test_incident_notes.py
+++ b/tests/tools/test_incident_notes.py
@@ -8,7 +8,6 @@ import pytest
 from fastmcp.exceptions import ToolError
 from gg_api_core.tools.incident_notes import (
     ListCommentsResult,
-    ListIncidentCommentsParams,
     ManageIncidentCommentParams,
     list_incident_comments,
     list_public_incident_comments,

--- a/tests/tools/test_incident_notes.py
+++ b/tests/tools/test_incident_notes.py
@@ -116,9 +116,7 @@ class TestManageIncidentComment:
         """
         mock_gitguardian_client.create_incident_note = AsyncMock(return_value=_note_payload())
 
-        result = await manage_incident_comment(
-            ManageIncidentCommentParams(incident_id=123, action="add", comment="Looks like a test credential")
-        )
+        result = await manage_incident_comment(incident_id=123, action="add", comment="Looks like a test credential")
 
         mock_gitguardian_client.create_incident_note.assert_called_once_with(
             incident_id=123, comment="Looks like a test credential"
@@ -135,9 +133,7 @@ class TestManageIncidentComment:
         """
         mock_gitguardian_client.update_incident_note = AsyncMock(return_value=_note_payload(comment="Updated comment"))
 
-        result = await manage_incident_comment(
-            ManageIncidentCommentParams(incident_id=123, action="edit", comment="Updated comment", comment_id=42)
-        )
+        result = await manage_incident_comment(incident_id=123, action="edit", comment="Updated comment", comment_id=42)
 
         mock_gitguardian_client.update_incident_note.assert_called_once_with(
             incident_id=123, note_id=42, comment="Updated comment"
@@ -154,7 +150,7 @@ class TestManageIncidentComment:
         mock_gitguardian_client.create_incident_note = AsyncMock(side_effect=Exception("API error: forbidden"))
 
         with pytest.raises(ToolError) as exc_info:
-            await manage_incident_comment(ManageIncidentCommentParams(incident_id=123, action="add", comment="hi"))
+            await manage_incident_comment(incident_id=123, action="add", comment="hi")
 
         assert "API error: forbidden" in str(exc_info.value)
 
@@ -171,9 +167,7 @@ class TestManagePublicIncidentComment:
         """
         mock_gitguardian_client.create_public_incident_note = AsyncMock(return_value=_note_payload())
 
-        result = await manage_public_incident_comment(
-            ManageIncidentCommentParams(incident_id=3759, action="add", comment="Reported to the actor")
-        )
+        result = await manage_public_incident_comment(incident_id=3759, action="add", comment="Reported to the actor")
 
         mock_gitguardian_client.create_public_incident_note.assert_called_once_with(
             incident_id=3759, comment="Reported to the actor"
@@ -189,9 +183,7 @@ class TestManagePublicIncidentComment:
         """
         mock_gitguardian_client.update_public_incident_note = AsyncMock(return_value=_note_payload())
 
-        await manage_public_incident_comment(
-            ManageIncidentCommentParams(incident_id=3759, action="edit", comment="Edited", comment_id=42)
-        )
+        await manage_public_incident_comment(incident_id=3759, action="edit", comment="Edited", comment_id=42)
 
         mock_gitguardian_client.update_public_incident_note.assert_called_once_with(
             incident_id=3759, note_id=42, comment="Edited"
@@ -212,7 +204,7 @@ class TestListIncidentComments:
             return_value={"data": [_note_payload(), _note_payload(note_id=43)], "cursor": None, "has_more": False}
         )
 
-        result = await list_incident_comments(ListIncidentCommentsParams(incident_id=123))
+        result = await list_incident_comments(incident_id=123)
 
         mock_gitguardian_client.list_incident_notes.assert_called_once_with(
             incident_id=123, params={"per_page": 20}, get_all=False
@@ -232,9 +224,7 @@ class TestListIncidentComments:
             return_value={"data": [_note_payload()], "cursor": "next-cursor", "has_more": True}
         )
 
-        result = await list_public_incident_comments(
-            ListIncidentCommentsParams(incident_id=3759, cursor="abc", per_page=50)
-        )
+        result = await list_public_incident_comments(incident_id=3759, cursor="abc", per_page=50)
 
         mock_gitguardian_client.list_public_incident_notes.assert_called_once_with(
             incident_id=3759, params={"per_page": 50, "cursor": "abc"}, get_all=False
@@ -252,6 +242,6 @@ class TestListIncidentComments:
         mock_gitguardian_client.list_incident_notes = AsyncMock(side_effect=Exception("boom"))
 
         with pytest.raises(ToolError) as exc_info:
-            await list_incident_comments(ListIncidentCommentsParams(incident_id=123))
+            await list_incident_comments(incident_id=123)
 
         assert "boom" in str(exc_info.value)

--- a/tests/tools/test_list_detectors.py
+++ b/tests/tools/test_list_detectors.py
@@ -37,7 +37,7 @@ class TestListDetectors:
         }
         mock_gitguardian_client.list_detectors = AsyncMock(return_value=mock_response)
 
-        result = await list_detectors(ListDetectorsParams())
+        result = await list_detectors()
 
         mock_gitguardian_client.list_detectors.assert_called_once()
         assert len(result.detectors) == 2
@@ -65,7 +65,7 @@ class TestListDetectors:
         }
         mock_gitguardian_client.list_detectors = AsyncMock(return_value=mock_response)
 
-        result = await list_detectors(ListDetectorsParams())
+        result = await list_detectors()
 
         assert len(result.detectors) == 1
         assert result.next_cursor == "next_page_cursor"
@@ -92,7 +92,7 @@ class TestListDetectors:
         }
         mock_gitguardian_client.list_detectors = AsyncMock(return_value=mock_response)
 
-        result = await list_detectors(ListDetectorsParams(search="github"))
+        result = await list_detectors(search="github")
 
         call_kwargs = mock_gitguardian_client.list_detectors.call_args.kwargs
         assert call_kwargs["search"] == "github"
@@ -119,7 +119,7 @@ class TestListDetectors:
         }
         mock_gitguardian_client.list_detectors = AsyncMock(return_value=mock_response)
 
-        result = await list_detectors(ListDetectorsParams(type="generic"))
+        result = await list_detectors(type="generic")
 
         call_kwargs = mock_gitguardian_client.list_detectors.call_args.kwargs
         assert call_kwargs["type"] == "generic"
@@ -144,7 +144,7 @@ class TestListDetectors:
         }
         mock_gitguardian_client.list_detectors = AsyncMock(return_value=mock_response)
 
-        result = await list_detectors(ListDetectorsParams(get_all=True))
+        result = await list_detectors(get_all=True)
 
         call_kwargs = mock_gitguardian_client.list_detectors.call_args.kwargs
         assert call_kwargs["get_all"] is True
@@ -160,7 +160,7 @@ class TestListDetectors:
         mock_response = {"data": [], "cursor": None, "has_more": False}
         mock_gitguardian_client.list_detectors = AsyncMock(return_value=mock_response)
 
-        result = await list_detectors(ListDetectorsParams(search="nonexistent"))
+        result = await list_detectors(search="nonexistent")
 
         assert len(result.detectors) == 0
         assert result.next_cursor is None
@@ -177,7 +177,7 @@ class TestListDetectors:
         mock_gitguardian_client.list_detectors = AsyncMock(side_effect=Exception(error_message))
 
         with pytest.raises(ToolError) as excinfo:
-            await list_detectors(ListDetectorsParams())
+            await list_detectors()
 
         assert error_message in str(excinfo.value)
 
@@ -195,7 +195,7 @@ class TestListDetectors:
         }
         mock_gitguardian_client.list_detectors = AsyncMock(return_value=mock_response)
 
-        await list_detectors(ListDetectorsParams(per_page=50))
+        await list_detectors(per_page=50)
 
         call_kwargs = mock_gitguardian_client.list_detectors.call_args.kwargs
         assert call_kwargs["per_page"] == 50
@@ -214,7 +214,7 @@ class TestListDetectors:
         }
         mock_gitguardian_client.list_detectors = AsyncMock(return_value=mock_response)
 
-        result = await list_detectors(ListDetectorsParams(cursor="second_page_cursor"))
+        result = await list_detectors(cursor="second_page_cursor")
 
         call_kwargs = mock_gitguardian_client.list_detectors.call_args.kwargs
         assert call_kwargs["cursor"] == "second_page_cursor"

--- a/tests/tools/test_list_detectors.py
+++ b/tests/tools/test_list_detectors.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from fastmcp.exceptions import ToolError
-from gg_api_core.tools.list_detectors import ListDetectorsParams, list_detectors
+from gg_api_core.tools.list_detectors import list_detectors
 
 
 class TestListDetectors:

--- a/tests/tools/test_list_honey_tokens.py
+++ b/tests/tools/test_list_honey_tokens.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from fastmcp.exceptions import ToolError
-from gg_api_core.tools.list_honeytokens import ListHoneytokensParams, list_honeytokens
+from gg_api_core.tools.list_honeytokens import list_honeytokens
 
 
 class TestListHoneytokens:
@@ -38,17 +38,17 @@ class TestListHoneytokens:
 
         # Call the function
         result = await list_honeytokens(
-                status=None,
-                search=None,
-                ordering=None,
-                show_token=False,
-                creator_id=None,
-                creator_api_token_id=None,
-                per_page=20,
-                cursor=None,
-                get_all=False,
-                mine=False,
-            )
+            status=None,
+            search=None,
+            ordering=None,
+            show_token=False,
+            creator_id=None,
+            creator_api_token_id=None,
+            per_page=20,
+            cursor=None,
+            get_all=False,
+            mine=False,
+        )
 
         # Verify client was called with correct parameters
         mock_gitguardian_client.list_honeytokens.assert_called_once()
@@ -81,17 +81,17 @@ class TestListHoneytokens:
 
         # Call the function
         result = await list_honeytokens(
-                status=None,
-                search=None,
-                ordering=None,
-                show_token=False,
-                creator_id=None,
-                creator_api_token_id=None,
-                per_page=20,
-                cursor=None,
-                get_all=False,
-                mine=False,
-            )
+            status=None,
+            search=None,
+            ordering=None,
+            show_token=False,
+            creator_id=None,
+            creator_api_token_id=None,
+            per_page=20,
+            cursor=None,
+            get_all=False,
+            mine=False,
+        )
 
         # Verify response includes cursor
         assert len(result.honeytokens) == 1
@@ -121,16 +121,16 @@ class TestListHoneytokens:
 
         # Call the function with filters
         result = await list_honeytokens(
-                status="ACTIVE",
-                search="filtered",
-                ordering="-created_at",
-                show_token=True,
-                creator_id=None,
-                creator_api_token_id=None,
-                per_page=50,
-                get_all=False,
-                mine=False,
-            )
+            status="ACTIVE",
+            search="filtered",
+            ordering="-created_at",
+            show_token=True,
+            creator_id=None,
+            creator_api_token_id=None,
+            per_page=50,
+            get_all=False,
+            mine=False,
+        )
 
         # Verify client was called with correct parameters
         call_kwargs = mock_gitguardian_client.list_honeytokens.call_args.kwargs
@@ -171,16 +171,16 @@ class TestListHoneytokens:
 
         # Call the function with mine=True
         result = await list_honeytokens(
-                status=None,
-                search=None,
-                ordering=None,
-                show_token=False,
-                creator_id=None,
-                creator_api_token_id=None,
-                per_page=20,
-                get_all=False,
-                mine=True,
-            )
+            status=None,
+            search=None,
+            ordering=None,
+            show_token=False,
+            creator_id=None,
+            creator_api_token_id=None,
+            per_page=20,
+            get_all=False,
+            mine=True,
+        )
 
         # Verify get_current_token_info was called
         mock_gitguardian_client.get_current_token_info.assert_called_once()
@@ -209,16 +209,16 @@ class TestListHoneytokens:
 
         # Call the function with mine=True
         await list_honeytokens(
-                status=None,
-                search=None,
-                ordering=None,
-                show_token=False,
-                creator_id=None,
-                creator_api_token_id=None,
-                per_page=20,
-                get_all=False,
-                mine=True,
-            )
+            status=None,
+            search=None,
+            ordering=None,
+            show_token=False,
+            creator_id=None,
+            creator_api_token_id=None,
+            per_page=20,
+            get_all=False,
+            mine=True,
+        )
 
         # Verify that creator_id was not set (should be None)
         call_kwargs = mock_gitguardian_client.list_honeytokens.call_args.kwargs
@@ -245,16 +245,16 @@ class TestListHoneytokens:
 
         # Call the function with get_all=True
         result = await list_honeytokens(
-                status=None,
-                search=None,
-                ordering=None,
-                show_token=False,
-                creator_id=None,
-                creator_api_token_id=None,
-                per_page=20,
-                get_all=True,
-                mine=False,
-            )
+            status=None,
+            search=None,
+            ordering=None,
+            show_token=False,
+            creator_id=None,
+            creator_api_token_id=None,
+            per_page=20,
+            get_all=True,
+            mine=False,
+        )
 
         # Verify client was called with get_all=True
         call_kwargs = mock_gitguardian_client.list_honeytokens.call_args.kwargs
@@ -276,17 +276,17 @@ class TestListHoneytokens:
 
         # Call the function
         result = await list_honeytokens(
-                status=None,
-                search=None,
-                ordering=None,
-                show_token=False,
-                creator_id=None,
-                creator_api_token_id=None,
-                per_page=20,
-                cursor=None,
-                get_all=False,
-                mine=False,
-            )
+            status=None,
+            search=None,
+            ordering=None,
+            show_token=False,
+            creator_id=None,
+            creator_api_token_id=None,
+            per_page=20,
+            cursor=None,
+            get_all=False,
+            mine=False,
+        )
 
         # Verify response is empty
         assert len(result.honeytokens) == 0
@@ -301,16 +301,16 @@ class TestListHoneytokens:
         # Call the function and expect a ToolError
         with pytest.raises(ToolError) as excinfo:
             await list_honeytokens(
-                    status=None,
-                    search=None,
-                    ordering=None,
-                    show_token=False,
-                    creator_id=None,
-                    creator_api_token_id=None,
-                    per_page=20,
-                    get_all=False,
-                    mine=False,
-                )
+                status=None,
+                search=None,
+                ordering=None,
+                show_token=False,
+                creator_id=None,
+                creator_api_token_id=None,
+                per_page=20,
+                get_all=False,
+                mine=False,
+            )
 
         # Verify error message
         assert error_message in str(excinfo.value)
@@ -328,16 +328,16 @@ class TestListHoneytokens:
 
         # Call the function with explicit creator_id
         await list_honeytokens(
-                status=None,
-                search=None,
-                ordering=None,
-                show_token=False,
-                creator_id="specific_user_123",
-                creator_api_token_id=None,
-                per_page=20,
-                get_all=False,
-                mine=False,
-            )
+            status=None,
+            search=None,
+            ordering=None,
+            show_token=False,
+            creator_id="specific_user_123",
+            creator_api_token_id=None,
+            per_page=20,
+            get_all=False,
+            mine=False,
+        )
 
         # Verify client was called with correct creator_id
         call_kwargs = mock_gitguardian_client.list_honeytokens.call_args.kwargs
@@ -356,16 +356,16 @@ class TestListHoneytokens:
 
         # Call the function with creator_api_token_id
         await list_honeytokens(
-                status=None,
-                search=None,
-                ordering=None,
-                show_token=False,
-                creator_id=None,
-                creator_api_token_id="token_123",
-                per_page=20,
-                get_all=False,
-                mine=False,
-            )
+            status=None,
+            search=None,
+            ordering=None,
+            show_token=False,
+            creator_id=None,
+            creator_api_token_id="token_123",
+            per_page=20,
+            get_all=False,
+            mine=False,
+        )
 
         # Verify client was called with correct creator_api_token_id
         call_kwargs = mock_gitguardian_client.list_honeytokens.call_args.kwargs
@@ -395,16 +395,16 @@ class TestListHoneytokens:
 
         # Call the function with show_token=True
         result = await list_honeytokens(
-                status=None,
-                search=None,
-                ordering=None,
-                show_token=True,
-                creator_id=None,
-                creator_api_token_id=None,
-                per_page=20,
-                get_all=False,
-                mine=False,
-            )
+            status=None,
+            search=None,
+            ordering=None,
+            show_token=True,
+            creator_id=None,
+            creator_api_token_id=None,
+            per_page=20,
+            get_all=False,
+            mine=False,
+        )
 
         # Verify client was called with show_token=True
         call_kwargs = mock_gitguardian_client.list_honeytokens.call_args.kwargs
@@ -430,16 +430,16 @@ class TestListHoneytokens:
         # Call the function with mine=True - should raise the exception
         with pytest.raises(Exception, match="Token info failed"):
             await list_honeytokens(
-                    status=None,
-                    search=None,
-                    ordering=None,
-                    show_token=False,
-                    creator_id=None,
-                    creator_api_token_id=None,
-                    per_page=20,
-                    get_all=False,
-                    mine=True,
-                )
+                status=None,
+                search=None,
+                ordering=None,
+                show_token=False,
+                creator_id=None,
+                creator_api_token_id=None,
+                per_page=20,
+                get_all=False,
+                mine=True,
+            )
 
     @pytest.mark.asyncio
     async def test_list_honeytokens_cursor_pagination(self, mock_gitguardian_client):
@@ -461,17 +461,17 @@ class TestListHoneytokens:
 
         # Call the function with a cursor from "previous page"
         result = await list_honeytokens(
-                status=None,
-                search=None,
-                ordering=None,
-                show_token=False,
-                creator_id=None,
-                creator_api_token_id=None,
-                per_page=20,
-                cursor="second_page_cursor",  # Cursor from previous request
-                get_all=False,
-                mine=False,
-            )
+            status=None,
+            search=None,
+            ordering=None,
+            show_token=False,
+            creator_id=None,
+            creator_api_token_id=None,
+            per_page=20,
+            cursor="second_page_cursor",  # Cursor from previous request
+            get_all=False,
+            mine=False,
+        )
 
         # Verify cursor was passed to the client
         call_kwargs = mock_gitguardian_client.list_honeytokens.call_args.kwargs
@@ -500,17 +500,17 @@ class TestListHoneytokens:
 
         # Call the function
         result = await list_honeytokens(
-                status=None,
-                search=None,
-                ordering=None,
-                show_token=False,
-                creator_id=None,
-                creator_api_token_id=None,
-                per_page=20,
-                cursor=None,
-                get_all=False,
-                mine=False,
-            )
+            status=None,
+            search=None,
+            ordering=None,
+            show_token=False,
+            creator_id=None,
+            creator_api_token_id=None,
+            per_page=20,
+            cursor=None,
+            get_all=False,
+            mine=False,
+        )
 
         # Verify next_cursor is None (last page)
         assert len(result.honeytokens) == 1

--- a/tests/tools/test_list_honey_tokens.py
+++ b/tests/tools/test_list_honey_tokens.py
@@ -38,7 +38,6 @@ class TestListHoneytokens:
 
         # Call the function
         result = await list_honeytokens(
-            ListHoneytokensParams(
                 status=None,
                 search=None,
                 ordering=None,
@@ -50,7 +49,6 @@ class TestListHoneytokens:
                 get_all=False,
                 mine=False,
             )
-        )
 
         # Verify client was called with correct parameters
         mock_gitguardian_client.list_honeytokens.assert_called_once()
@@ -83,7 +81,6 @@ class TestListHoneytokens:
 
         # Call the function
         result = await list_honeytokens(
-            ListHoneytokensParams(
                 status=None,
                 search=None,
                 ordering=None,
@@ -95,7 +92,6 @@ class TestListHoneytokens:
                 get_all=False,
                 mine=False,
             )
-        )
 
         # Verify response includes cursor
         assert len(result.honeytokens) == 1
@@ -125,7 +121,6 @@ class TestListHoneytokens:
 
         # Call the function with filters
         result = await list_honeytokens(
-            ListHoneytokensParams(
                 status="ACTIVE",
                 search="filtered",
                 ordering="-created_at",
@@ -136,7 +131,6 @@ class TestListHoneytokens:
                 get_all=False,
                 mine=False,
             )
-        )
 
         # Verify client was called with correct parameters
         call_kwargs = mock_gitguardian_client.list_honeytokens.call_args.kwargs
@@ -177,7 +171,6 @@ class TestListHoneytokens:
 
         # Call the function with mine=True
         result = await list_honeytokens(
-            ListHoneytokensParams(
                 status=None,
                 search=None,
                 ordering=None,
@@ -188,7 +181,6 @@ class TestListHoneytokens:
                 get_all=False,
                 mine=True,
             )
-        )
 
         # Verify get_current_token_info was called
         mock_gitguardian_client.get_current_token_info.assert_called_once()
@@ -217,7 +209,6 @@ class TestListHoneytokens:
 
         # Call the function with mine=True
         await list_honeytokens(
-            ListHoneytokensParams(
                 status=None,
                 search=None,
                 ordering=None,
@@ -228,7 +219,6 @@ class TestListHoneytokens:
                 get_all=False,
                 mine=True,
             )
-        )
 
         # Verify that creator_id was not set (should be None)
         call_kwargs = mock_gitguardian_client.list_honeytokens.call_args.kwargs
@@ -255,7 +245,6 @@ class TestListHoneytokens:
 
         # Call the function with get_all=True
         result = await list_honeytokens(
-            ListHoneytokensParams(
                 status=None,
                 search=None,
                 ordering=None,
@@ -266,7 +255,6 @@ class TestListHoneytokens:
                 get_all=True,
                 mine=False,
             )
-        )
 
         # Verify client was called with get_all=True
         call_kwargs = mock_gitguardian_client.list_honeytokens.call_args.kwargs
@@ -288,7 +276,6 @@ class TestListHoneytokens:
 
         # Call the function
         result = await list_honeytokens(
-            ListHoneytokensParams(
                 status=None,
                 search=None,
                 ordering=None,
@@ -300,7 +287,6 @@ class TestListHoneytokens:
                 get_all=False,
                 mine=False,
             )
-        )
 
         # Verify response is empty
         assert len(result.honeytokens) == 0
@@ -315,7 +301,6 @@ class TestListHoneytokens:
         # Call the function and expect a ToolError
         with pytest.raises(ToolError) as excinfo:
             await list_honeytokens(
-                ListHoneytokensParams(
                     status=None,
                     search=None,
                     ordering=None,
@@ -326,7 +311,6 @@ class TestListHoneytokens:
                     get_all=False,
                     mine=False,
                 )
-            )
 
         # Verify error message
         assert error_message in str(excinfo.value)
@@ -344,7 +328,6 @@ class TestListHoneytokens:
 
         # Call the function with explicit creator_id
         await list_honeytokens(
-            ListHoneytokensParams(
                 status=None,
                 search=None,
                 ordering=None,
@@ -355,7 +338,6 @@ class TestListHoneytokens:
                 get_all=False,
                 mine=False,
             )
-        )
 
         # Verify client was called with correct creator_id
         call_kwargs = mock_gitguardian_client.list_honeytokens.call_args.kwargs
@@ -374,7 +356,6 @@ class TestListHoneytokens:
 
         # Call the function with creator_api_token_id
         await list_honeytokens(
-            ListHoneytokensParams(
                 status=None,
                 search=None,
                 ordering=None,
@@ -385,7 +366,6 @@ class TestListHoneytokens:
                 get_all=False,
                 mine=False,
             )
-        )
 
         # Verify client was called with correct creator_api_token_id
         call_kwargs = mock_gitguardian_client.list_honeytokens.call_args.kwargs
@@ -415,7 +395,6 @@ class TestListHoneytokens:
 
         # Call the function with show_token=True
         result = await list_honeytokens(
-            ListHoneytokensParams(
                 status=None,
                 search=None,
                 ordering=None,
@@ -426,7 +405,6 @@ class TestListHoneytokens:
                 get_all=False,
                 mine=False,
             )
-        )
 
         # Verify client was called with show_token=True
         call_kwargs = mock_gitguardian_client.list_honeytokens.call_args.kwargs
@@ -452,7 +430,6 @@ class TestListHoneytokens:
         # Call the function with mine=True - should raise the exception
         with pytest.raises(Exception, match="Token info failed"):
             await list_honeytokens(
-                ListHoneytokensParams(
                     status=None,
                     search=None,
                     ordering=None,
@@ -463,7 +440,6 @@ class TestListHoneytokens:
                     get_all=False,
                     mine=True,
                 )
-            )
 
     @pytest.mark.asyncio
     async def test_list_honeytokens_cursor_pagination(self, mock_gitguardian_client):
@@ -485,7 +461,6 @@ class TestListHoneytokens:
 
         # Call the function with a cursor from "previous page"
         result = await list_honeytokens(
-            ListHoneytokensParams(
                 status=None,
                 search=None,
                 ordering=None,
@@ -497,7 +472,6 @@ class TestListHoneytokens:
                 get_all=False,
                 mine=False,
             )
-        )
 
         # Verify cursor was passed to the client
         call_kwargs = mock_gitguardian_client.list_honeytokens.call_args.kwargs
@@ -526,7 +500,6 @@ class TestListHoneytokens:
 
         # Call the function
         result = await list_honeytokens(
-            ListHoneytokensParams(
                 status=None,
                 search=None,
                 ordering=None,
@@ -538,7 +511,6 @@ class TestListHoneytokens:
                 get_all=False,
                 mine=False,
             )
-        )
 
         # Verify next_cursor is None (last page)
         assert len(result.honeytokens) == 1

--- a/tests/tools/test_list_incident_members.py
+++ b/tests/tools/test_list_incident_members.py
@@ -41,7 +41,7 @@ class TestListIncidentMembers:
             return_value=mock_client,
         ):
             params = ListIncidentMembersParams(incident_id=42)
-            result = await list_incident_members(params)
+            result = await list_incident_members(**params.model_dump())
 
             assert isinstance(result, ListIncidentMembersResult)
             assert result.total_count == 1
@@ -81,7 +81,7 @@ class TestListIncidentMembers:
                 direct_access=True,
                 per_page=50,
             )
-            result = await list_incident_members(params)
+            result = await list_incident_members(**params.model_dump())
 
             assert isinstance(result, ListIncidentMembersResult)
             assert result.total_count == 0
@@ -120,7 +120,7 @@ class TestListIncidentMembers:
                 incident_id=42,
                 cursor="some_cursor",
             )
-            result = await list_incident_members(params)
+            result = await list_incident_members(**params.model_dump())
 
             assert result.has_more is True
             assert result.next_cursor == "next_page_cursor"
@@ -144,7 +144,7 @@ class TestListIncidentMembers:
             return_value=mock_client,
         ):
             params = ListIncidentMembersParams(incident_id=42, get_all=True)
-            result = await list_incident_members(params)
+            result = await list_incident_members(**params.model_dump())
 
             assert result.total_count == 2
             mock_client.list_incident_members.assert_called_once_with(
@@ -172,7 +172,7 @@ class TestListIncidentMembers:
             return_value=mock_client,
         ):
             params = ListIncidentMembersParams(incident_id=42, direct_access=False)
-            result = await list_incident_members(params)
+            result = await list_incident_members(**params.model_dump())
 
             assert isinstance(result, ListIncidentMembersResult)
             mock_client.list_incident_members.assert_called_once_with(

--- a/tests/tools/test_list_incident_teams.py
+++ b/tests/tools/test_list_incident_teams.py
@@ -40,7 +40,7 @@ class TestListIncidentTeams:
             return_value=mock_client,
         ):
             params = ListIncidentTeamsParams(incident_id=42)
-            result = await list_incident_teams(params)
+            result = await list_incident_teams(**params.model_dump())
 
             assert isinstance(result, ListIncidentTeamsResult)
             assert result.total_count == 1
@@ -78,7 +78,7 @@ class TestListIncidentTeams:
                 direct_access=True,
                 per_page=50,
             )
-            result = await list_incident_teams(params)
+            result = await list_incident_teams(**params.model_dump())
 
             assert isinstance(result, ListIncidentTeamsResult)
             assert result.total_count == 0
@@ -115,7 +115,7 @@ class TestListIncidentTeams:
                 incident_id=42,
                 cursor="some_cursor",
             )
-            result = await list_incident_teams(params)
+            result = await list_incident_teams(**params.model_dump())
 
             assert result.has_more is True
             assert result.next_cursor == "next_page_cursor"
@@ -139,7 +139,7 @@ class TestListIncidentTeams:
             return_value=mock_client,
         ):
             params = ListIncidentTeamsParams(incident_id=42, get_all=True)
-            result = await list_incident_teams(params)
+            result = await list_incident_teams(**params.model_dump())
 
             assert result.total_count == 2
             mock_client.list_incident_teams.assert_called_once_with(
@@ -167,7 +167,7 @@ class TestListIncidentTeams:
             return_value=mock_client,
         ):
             params = ListIncidentTeamsParams(incident_id=42, direct_access=False)
-            result = await list_incident_teams(params)
+            result = await list_incident_teams(**params.model_dump())
 
             assert isinstance(result, ListIncidentTeamsResult)
             mock_client.list_incident_teams.assert_called_once_with(

--- a/tests/tools/test_list_incidents.py
+++ b/tests/tools/test_list_incidents.py
@@ -441,7 +441,7 @@ class TestListIncidentsValidityTranslation:
         client = self._client_with_mocked_transport()
 
         with patch("gg_api_core.tools.list_incidents.get_client", return_value=client):
-            await list_incidents(ListIncidentsParams(validity=["unknown"]))
+            await list_incidents(**ListIncidentsParams(validity=["unknown"]).model_dump())
 
         query = client._request_get.call_args.kwargs["params"]
         assert query["validity__in"] == "not_checked"
@@ -456,7 +456,7 @@ class TestListIncidentsValidityTranslation:
         client = self._client_with_mocked_transport()
 
         with patch("gg_api_core.tools.list_incidents.get_client", return_value=client):
-            await list_incidents(ListIncidentsParams())
+            await list_incidents(**ListIncidentsParams().model_dump())
 
         query = client._request_get.call_args.kwargs["params"]
         assert query["validity__in"] == "valid,failed_to_check,no_checker,not_checked"
@@ -471,7 +471,7 @@ class TestListIncidentsValidityTranslation:
         client = self._client_with_mocked_transport()
 
         with patch("gg_api_core.tools.list_incidents.get_client", return_value=client):
-            await list_incidents(ListIncidentsParams(validity=["valid", "invalid"]))
+            await list_incidents(**ListIncidentsParams(validity=["valid", "invalid"]).model_dump())
 
         query = client._request_get.call_args.kwargs["params"]
         assert query["validity__in"] == "valid,invalid"
@@ -491,7 +491,7 @@ class TestListIncidentsSeverityMapping:
         mock_client.list_incidents_for_mcp.return_value = {"results": [], "next": None, "previous": None}
 
         with patch("gg_api_core.tools.list_incidents.get_client", return_value=mock_client):
-            await list_incidents(ListIncidentsParams(severity=["critical", "unknown"]))
+            await list_incidents(**ListIncidentsParams(severity=["critical", "unknown"]).model_dump())
 
         call_kwargs = mock_client.list_incidents_for_mcp.call_args.kwargs
         assert call_kwargs["severity"] == ["critical", "unknown"]

--- a/tests/tools/test_list_incidents.py
+++ b/tests/tools/test_list_incidents.py
@@ -538,7 +538,7 @@ class TestListIncidentsMine:
         params = ListIncidentsParams(mine=True)
 
         with patch("gg_api_core.tools.list_incidents.get_client", return_value=mock_client):
-            await list_incidents(params)
+            await list_incidents(**params.model_dump())
 
         call_kwargs = mock_client.list_incidents_for_mcp.call_args.kwargs
         assert call_kwargs["assignee_id"] == 938094
@@ -556,7 +556,7 @@ class TestListIncidentsMine:
         params = ListIncidentsParams(mine=True, assignee_id=50)
 
         with patch("gg_api_core.tools.list_incidents.get_client", return_value=mock_client):
-            result = await list_incidents(params)
+            result = await list_incidents(**params.model_dump())
 
         assert hasattr(result, "error")
         mock_client.list_incidents_for_mcp.assert_not_called()

--- a/tests/tools/test_list_public_incidents.py
+++ b/tests/tools/test_list_public_incidents.py
@@ -25,7 +25,7 @@ class TestListPublicIncidents:
         }
         mock_gitguardian_client.list_public_incidents = AsyncMock(return_value=mock_response)
 
-        result = await list_public_incidents(ListPublicIncidentsParams())
+        result = await list_public_incidents()
 
         mock_gitguardian_client.list_public_incidents.assert_called_once()
         call_kwargs = mock_gitguardian_client.list_public_incidents.call_args.kwargs
@@ -76,7 +76,7 @@ class TestListPublicIncidents:
             ordering="-risk_score",
             per_page=50,
         )
-        result = await list_public_incidents(params)
+        result = await list_public_incidents(**params.model_dump())
 
         call_kwargs = mock_gitguardian_client.list_public_incidents.call_args.kwargs
         assert call_kwargs["status"] == [IncidentStatus.TRIGGERED]
@@ -109,7 +109,7 @@ class TestListPublicIncidents:
         )
 
         params = ListPublicIncidentsParams(status=None, severity=None, validity=None)
-        await list_public_incidents(params)
+        await list_public_incidents(**params.model_dump())
 
         call_kwargs = mock_gitguardian_client.list_public_incidents.call_args.kwargs
         assert call_kwargs["status"] is None
@@ -127,7 +127,7 @@ class TestListPublicIncidents:
             return_value={"data": [{"id": 1}], "cursor": "next_cursor_xyz", "has_more": True}
         )
 
-        result = await list_public_incidents(ListPublicIncidentsParams(cursor="prev_cursor"))
+        result = await list_public_incidents(cursor="prev_cursor")
 
         call_kwargs = mock_gitguardian_client.list_public_incidents.call_args.kwargs
         assert call_kwargs["cursor"] == "prev_cursor"
@@ -145,7 +145,7 @@ class TestListPublicIncidents:
             return_value={"data": [{"id": 1}, {"id": 2}], "cursor": None, "has_more": False}
         )
 
-        result = await list_public_incidents(ListPublicIncidentsParams(get_all=True))
+        result = await list_public_incidents(get_all=True)
 
         call_kwargs = mock_gitguardian_client.list_public_incidents.call_args.kwargs
         assert call_kwargs["get_all"] is True
@@ -160,7 +160,7 @@ class TestListPublicIncidents:
         """
         mock_gitguardian_client.list_public_incidents = AsyncMock(side_effect=Exception("Boom"))
 
-        result = await list_public_incidents(ListPublicIncidentsParams())
+        result = await list_public_incidents()
 
         assert hasattr(result, "error")
         assert "Failed to list public incidents" in result.error

--- a/tests/tools/test_list_public_occurrences.py
+++ b/tests/tools/test_list_public_occurrences.py
@@ -21,7 +21,7 @@ class TestListPublicOccurrences:
             return_value={"data": [{"id": 12345, "incident_id": 3759}], "cursor": None, "has_more": False}
         )
 
-        result = await list_public_occurrences(ListPublicOccurrencesParams(incident_id=3759))
+        result = await list_public_occurrences(incident_id=3759)
 
         mock_gitguardian_client.list_public_occurrences.assert_called_once()
         call_kwargs = mock_gitguardian_client.list_public_occurrences.call_args.kwargs
@@ -58,7 +58,7 @@ class TestListPublicOccurrences:
             ordering="-id",
             per_page=100,
         )
-        result = await list_public_occurrences(params)
+        result = await list_public_occurrences(**params.model_dump())
 
         call_kwargs = mock_gitguardian_client.list_public_occurrences.call_args.kwargs
         assert call_kwargs["incident_id"] == 42
@@ -121,7 +121,7 @@ class TestListPublicOccurrences:
             return_value={"data": [{"id": 1}], "cursor": "next_cursor", "has_more": True}
         )
 
-        result = await list_public_occurrences(ListPublicOccurrencesParams(incident_id=1, cursor="prev_cursor"))
+        result = await list_public_occurrences(incident_id=1, cursor="prev_cursor")
 
         call_kwargs = mock_gitguardian_client.list_public_occurrences.call_args.kwargs
         assert call_kwargs["cursor"] == "prev_cursor"
@@ -143,7 +143,7 @@ class TestListPublicOccurrences:
             }
         )
 
-        result = await list_public_occurrences(ListPublicOccurrencesParams(incident_id=1, get_all=True))
+        result = await list_public_occurrences(incident_id=1, get_all=True)
 
         call_kwargs = mock_gitguardian_client.list_public_occurrences.call_args.kwargs
         assert call_kwargs["get_all"] is True
@@ -158,7 +158,7 @@ class TestListPublicOccurrences:
         """
         mock_gitguardian_client.list_public_occurrences = AsyncMock(side_effect=Exception("Boom"))
 
-        result = await list_public_occurrences(ListPublicOccurrencesParams(incident_id=1))
+        result = await list_public_occurrences(incident_id=1)
 
         assert hasattr(result, "error")
         assert "Failed to list public occurrences" in result.error

--- a/tests/tools/test_list_repo_occurrences.py
+++ b/tests/tools/test_list_repo_occurrences.py
@@ -34,7 +34,7 @@ class TestListRepoOccurrences:
         mock_gitguardian_client.list_occurrences = AsyncMock(return_value=mock_response)
 
         # Call the function
-        result = await list_repo_occurrences(ListRepoOccurrencesParams(source_id="source_123"))
+        result = await list_repo_occurrences(source_id="source_123")
 
         # Verify client was called with source_id and with_sources=False
         mock_gitguardian_client.list_occurrences.assert_called_once()
@@ -64,7 +64,6 @@ class TestListRepoOccurrences:
 
         # Call the function with filters
         await list_repo_occurrences(
-            ListRepoOccurrencesParams(
                 source_id="source_123",
                 from_date="2023-01-01",
                 to_date="2023-12-31",
@@ -75,7 +74,6 @@ class TestListRepoOccurrences:
                 cursor=None,
                 get_all=False,
             )
-        )
 
         # Verify client was called with correct parameters
         mock_gitguardian_client.list_occurrences.assert_called_once()
@@ -108,11 +106,9 @@ class TestListRepoOccurrences:
 
         # Call the function with get_all=True
         result = await list_repo_occurrences(
-            ListRepoOccurrencesParams(
                 source_id="source_123",
                 get_all=True,
             )
-        )
 
         # Verify response
         assert result.occurrences_count == 2
@@ -135,10 +131,8 @@ class TestListRepoOccurrences:
         mock_gitguardian_client.list_occurrences = AsyncMock(return_value=mock_response)
 
         result = await list_repo_occurrences(
-            ListRepoOccurrencesParams(
                 source_id=None,
             )
-        )
 
         # Verify client was called without source filters
         mock_gitguardian_client.list_occurrences.assert_called_once()
@@ -160,7 +154,7 @@ class TestListRepoOccurrences:
         mock_gitguardian_client.list_occurrences = AsyncMock(side_effect=Exception(error_message))
 
         # Call the function
-        result = await list_repo_occurrences(ListRepoOccurrencesParams(source_id="source_123"))
+        result = await list_repo_occurrences(source_id="source_123")
 
         # Verify error response
         assert hasattr(result, "error")
@@ -183,11 +177,9 @@ class TestListRepoOccurrences:
 
         # Call the function with cursor
         result = await list_repo_occurrences(
-            ListRepoOccurrencesParams(
                 source_id="source_123",
                 cursor="cursor_abc",
             )
-        )
 
         # Verify client was called with cursor
         mock_gitguardian_client.list_occurrences.assert_called_once()
@@ -215,7 +207,7 @@ class TestListRepoOccurrences:
         mock_gitguardian_client.list_occurrences = AsyncMock(return_value=mock_response)
 
         # Call the function
-        result = await list_repo_occurrences(ListRepoOccurrencesParams(source_id="source_123"))
+        result = await list_repo_occurrences(source_id="source_123")
 
         # Verify response
         assert result.occurrences_count == 0
@@ -234,7 +226,7 @@ class TestListRepoOccurrences:
         mock_gitguardian_client.list_occurrences = AsyncMock(side_effect=Exception("Unexpected response format"))
 
         # Call the function
-        result = await list_repo_occurrences(ListRepoOccurrencesParams(source_id="source_123"))
+        result = await list_repo_occurrences(source_id="source_123")
 
         # Verify error response is returned
         assert hasattr(result, "error")
@@ -256,11 +248,9 @@ class TestListRepoOccurrences:
 
         # Call the function with member_assignee_id
         result = await list_repo_occurrences(
-            ListRepoOccurrencesParams(
                 source_id="source_123",
                 member_assignee_id=12345,
             )
-        )
 
         # Verify client was called with member_assignee_id
         mock_gitguardian_client.list_occurrences.assert_called_once()
@@ -292,11 +282,9 @@ class TestListRepoOccurrences:
 
         # Call the function with mine=True
         result = await list_repo_occurrences(
-            ListRepoOccurrencesParams(
                 source_id="source_123",
                 mine=True,
             )
-        )
 
         # Verify get_current_token_info was called (not get_current_member)
         mock_gitguardian_client.get_current_token_info.assert_called_once()

--- a/tests/tools/test_list_repo_occurrences.py
+++ b/tests/tools/test_list_repo_occurrences.py
@@ -64,16 +64,16 @@ class TestListRepoOccurrences:
 
         # Call the function with filters
         await list_repo_occurrences(
-                source_id="source_123",
-                from_date="2023-01-01",
-                to_date="2023-12-31",
-                presence="present",
-                tags=["tag1", "tag2"],
-                ordering="-date",
-                per_page=50,
-                cursor=None,
-                get_all=False,
-            )
+            source_id="source_123",
+            from_date="2023-01-01",
+            to_date="2023-12-31",
+            presence="present",
+            tags=["tag1", "tag2"],
+            ordering="-date",
+            per_page=50,
+            cursor=None,
+            get_all=False,
+        )
 
         # Verify client was called with correct parameters
         mock_gitguardian_client.list_occurrences.assert_called_once()
@@ -106,9 +106,9 @@ class TestListRepoOccurrences:
 
         # Call the function with get_all=True
         result = await list_repo_occurrences(
-                source_id="source_123",
-                get_all=True,
-            )
+            source_id="source_123",
+            get_all=True,
+        )
 
         # Verify response
         assert result.occurrences_count == 2
@@ -131,8 +131,8 @@ class TestListRepoOccurrences:
         mock_gitguardian_client.list_occurrences = AsyncMock(return_value=mock_response)
 
         result = await list_repo_occurrences(
-                source_id=None,
-            )
+            source_id=None,
+        )
 
         # Verify client was called without source filters
         mock_gitguardian_client.list_occurrences.assert_called_once()
@@ -177,9 +177,9 @@ class TestListRepoOccurrences:
 
         # Call the function with cursor
         result = await list_repo_occurrences(
-                source_id="source_123",
-                cursor="cursor_abc",
-            )
+            source_id="source_123",
+            cursor="cursor_abc",
+        )
 
         # Verify client was called with cursor
         mock_gitguardian_client.list_occurrences.assert_called_once()
@@ -248,9 +248,9 @@ class TestListRepoOccurrences:
 
         # Call the function with member_assignee_id
         result = await list_repo_occurrences(
-                source_id="source_123",
-                member_assignee_id=12345,
-            )
+            source_id="source_123",
+            member_assignee_id=12345,
+        )
 
         # Verify client was called with member_assignee_id
         mock_gitguardian_client.list_occurrences.assert_called_once()
@@ -282,9 +282,9 @@ class TestListRepoOccurrences:
 
         # Call the function with mine=True
         result = await list_repo_occurrences(
-                source_id="source_123",
-                mine=True,
-            )
+            source_id="source_123",
+            mine=True,
+        )
 
         # Verify get_current_token_info was called (not get_current_member)
         mock_gitguardian_client.get_current_token_info.assert_called_once()
@@ -309,7 +309,7 @@ class TestListRepoOccurrences:
         mock_response = {"data": [], "cursor": None, "has_more": False}
         mock_gitguardian_client.list_occurrences = AsyncMock(return_value=mock_response)
 
-        await list_repo_occurrences(ListRepoOccurrencesParams(validity=["unknown"]))
+        await list_repo_occurrences(**ListRepoOccurrencesParams(validity=["unknown"]).model_dump())
 
         call_kwargs = mock_gitguardian_client.list_occurrences.call_args.kwargs
         assert call_kwargs["validity"] == ["unknown"]

--- a/tests/tools/test_list_sources.py
+++ b/tests/tools/test_list_sources.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from fastmcp.exceptions import ToolError
-from gg_api_core.tools.list_sources import ListSourcesParams, list_sources
+from gg_api_core.tools.list_sources import list_sources
 
 
 class TestListSources:

--- a/tests/tools/test_list_sources.py
+++ b/tests/tools/test_list_sources.py
@@ -37,7 +37,7 @@ class TestListSources:
         }
         mock_gitguardian_client.list_sources = AsyncMock(return_value=mock_response)
 
-        result = await list_sources(ListSourcesParams())
+        result = await list_sources()
 
         mock_gitguardian_client.list_sources.assert_called_once()
         assert len(result.sources) == 2
@@ -64,7 +64,7 @@ class TestListSources:
         }
         mock_gitguardian_client.list_sources = AsyncMock(return_value=mock_response)
 
-        result = await list_sources(ListSourcesParams())
+        result = await list_sources()
 
         assert len(result.sources) == 1
         assert result.next_cursor == "next_page_cursor"
@@ -90,7 +90,7 @@ class TestListSources:
         }
         mock_gitguardian_client.list_sources = AsyncMock(return_value=mock_response)
 
-        result = await list_sources(ListSourcesParams(search="myrepo"))
+        result = await list_sources(search="myrepo")
 
         call_kwargs = mock_gitguardian_client.list_sources.call_args.kwargs
         assert call_kwargs["search"] == "myrepo"
@@ -117,7 +117,7 @@ class TestListSources:
         }
         mock_gitguardian_client.list_sources = AsyncMock(return_value=mock_response)
 
-        result = await list_sources(ListSourcesParams(type="gitlab"))
+        result = await list_sources(type="gitlab")
 
         call_kwargs = mock_gitguardian_client.list_sources.call_args.kwargs
         assert call_kwargs["type"] == "gitlab"
@@ -144,7 +144,7 @@ class TestListSources:
         }
         mock_gitguardian_client.list_sources = AsyncMock(return_value=mock_response)
 
-        result = await list_sources(ListSourcesParams(health="at_risk"))
+        result = await list_sources(health="at_risk")
 
         call_kwargs = mock_gitguardian_client.list_sources.call_args.kwargs
         assert call_kwargs["health"] == "at_risk"
@@ -171,7 +171,7 @@ class TestListSources:
         }
         mock_gitguardian_client.list_sources = AsyncMock(return_value=mock_response)
 
-        result = await list_sources(ListSourcesParams(visibility="public"))
+        result = await list_sources(visibility="public")
 
         call_kwargs = mock_gitguardian_client.list_sources.call_args.kwargs
         assert call_kwargs["visibility"] == "public"
@@ -198,7 +198,7 @@ class TestListSources:
         }
         mock_gitguardian_client.list_sources = AsyncMock(return_value=mock_response)
 
-        result = await list_sources(ListSourcesParams(last_scan_status="finished"))
+        result = await list_sources(last_scan_status="finished")
 
         call_kwargs = mock_gitguardian_client.list_sources.call_args.kwargs
         assert call_kwargs["last_scan_status"] == "finished"
@@ -224,7 +224,7 @@ class TestListSources:
         }
         mock_gitguardian_client.list_sources = AsyncMock(return_value=mock_response)
 
-        result = await list_sources(ListSourcesParams(source_criticality="critical"))
+        result = await list_sources(source_criticality="critical")
 
         call_kwargs = mock_gitguardian_client.list_sources.call_args.kwargs
         assert call_kwargs["source_criticality"] == "critical"
@@ -250,7 +250,7 @@ class TestListSources:
         }
         mock_gitguardian_client.list_sources = AsyncMock(return_value=mock_response)
 
-        result = await list_sources(ListSourcesParams(monitored=True))
+        result = await list_sources(monitored=True)
 
         call_kwargs = mock_gitguardian_client.list_sources.call_args.kwargs
         assert call_kwargs["monitored"] is True
@@ -275,7 +275,7 @@ class TestListSources:
         }
         mock_gitguardian_client.list_sources = AsyncMock(return_value=mock_response)
 
-        result = await list_sources(ListSourcesParams(team_id=42))
+        result = await list_sources(team_id=42)
 
         call_kwargs = mock_gitguardian_client.list_sources.call_args.kwargs
         assert call_kwargs["team_id"] == 42
@@ -298,7 +298,7 @@ class TestListSources:
         }
         mock_gitguardian_client.list_sources = AsyncMock(return_value=mock_response)
 
-        await list_sources(ListSourcesParams(ordering="-last_scan_date"))
+        await list_sources(ordering="-last_scan_date")
 
         call_kwargs = mock_gitguardian_client.list_sources.call_args.kwargs
         assert call_kwargs["ordering"] == "-last_scan_date"
@@ -321,7 +321,7 @@ class TestListSources:
         }
         mock_gitguardian_client.list_sources = AsyncMock(return_value=mock_response)
 
-        result = await list_sources(ListSourcesParams(get_all=True))
+        result = await list_sources(get_all=True)
 
         call_kwargs = mock_gitguardian_client.list_sources.call_args.kwargs
         assert call_kwargs["get_all"] is True
@@ -337,7 +337,7 @@ class TestListSources:
         mock_response = {"data": [], "cursor": None, "has_more": False}
         mock_gitguardian_client.list_sources = AsyncMock(return_value=mock_response)
 
-        result = await list_sources(ListSourcesParams(search="nonexistent"))
+        result = await list_sources(search="nonexistent")
 
         assert len(result.sources) == 0
         assert result.next_cursor is None
@@ -354,7 +354,7 @@ class TestListSources:
         mock_gitguardian_client.list_sources = AsyncMock(side_effect=Exception(error_message))
 
         with pytest.raises(ToolError) as excinfo:
-            await list_sources(ListSourcesParams())
+            await list_sources()
 
         assert error_message in str(excinfo.value)
 
@@ -372,7 +372,7 @@ class TestListSources:
         }
         mock_gitguardian_client.list_sources = AsyncMock(return_value=mock_response)
 
-        await list_sources(ListSourcesParams(per_page=50))
+        await list_sources(per_page=50)
 
         call_kwargs = mock_gitguardian_client.list_sources.call_args.kwargs
         assert call_kwargs["per_page"] == 50
@@ -391,7 +391,7 @@ class TestListSources:
         }
         mock_gitguardian_client.list_sources = AsyncMock(return_value=mock_response)
 
-        result = await list_sources(ListSourcesParams(cursor="second_page_cursor"))
+        result = await list_sources(cursor="second_page_cursor")
 
         call_kwargs = mock_gitguardian_client.list_sources.call_args.kwargs
         assert call_kwargs["cursor"] == "second_page_cursor"
@@ -417,7 +417,7 @@ class TestListSources:
         }
         mock_gitguardian_client.list_sources = AsyncMock(return_value=mock_response)
 
-        result = await list_sources(ListSourcesParams(external_id="12345"))
+        result = await list_sources(external_id="12345")
 
         call_kwargs = mock_gitguardian_client.list_sources.call_args.kwargs
         assert call_kwargs["external_id"] == "12345"

--- a/tests/tools/test_manage_incident.py
+++ b/tests/tools/test_manage_incident.py
@@ -95,7 +95,7 @@ class TestManagePrivateIncidentResolve:
         THEN: A ToolError is raised asking to get the information from the user
         """
         with pytest.raises(ToolError) as exc_info:
-            await manage_private_incident(ManageIncidentParams(incident_id=123, action="resolve"))
+            await manage_private_incident(incident_id=123, action="resolve")
 
         error_message = str(exc_info.value)
         assert "secret_revoked" in error_message
@@ -111,9 +111,7 @@ class TestManagePrivateIncidentResolve:
         """
         mock_gitguardian_client.resolve_incident = AsyncMock(return_value={"id": 123, "status": "RESOLVED"})
 
-        result = await manage_private_incident(
-            ManageIncidentParams(incident_id=123, action="resolve", secret_revoked=True)
-        )
+        result = await manage_private_incident(incident_id=123, action="resolve", secret_revoked=True)
 
         mock_gitguardian_client.resolve_incident.assert_called_once_with(
             incident_id="123",
@@ -130,9 +128,7 @@ class TestManagePrivateIncidentResolve:
         """
         mock_gitguardian_client.resolve_incident = AsyncMock(return_value={"id": 123, "status": "RESOLVED"})
 
-        result = await manage_private_incident(
-            ManageIncidentParams(incident_id=123, action="resolve", secret_revoked=False)
-        )
+        result = await manage_private_incident(incident_id=123, action="resolve", secret_revoked=False)
 
         mock_gitguardian_client.resolve_incident.assert_called_once_with(
             incident_id="123",
@@ -152,7 +148,7 @@ class TestManagePrivateIncidentIgnore:
         THEN: A ToolError is raised asking to get the information from the user
         """
         with pytest.raises(ToolError) as exc_info:
-            await manage_private_incident(ManageIncidentParams(incident_id=123, action="ignore"))
+            await manage_private_incident(incident_id=123, action="ignore")
 
         error_message = str(exc_info.value)
         assert "ignore_reason" in error_message
@@ -168,9 +164,7 @@ class TestManagePrivateIncidentIgnore:
         """
         mock_gitguardian_client.ignore_incident = AsyncMock(return_value={"id": 123, "status": "IGNORED"})
 
-        result = await manage_private_incident(
-            ManageIncidentParams(incident_id=123, action="ignore", ignore_reason="test_credential")
-        )
+        result = await manage_private_incident(incident_id=123, action="ignore", ignore_reason="test_credential")
 
         mock_gitguardian_client.ignore_incident.assert_called_once_with(
             incident_id="123",
@@ -187,9 +181,7 @@ class TestManagePrivateIncidentIgnore:
         """
         mock_gitguardian_client.ignore_incident = AsyncMock(return_value={"id": 123, "status": "IGNORED"})
 
-        result = await manage_private_incident(
-            ManageIncidentParams(incident_id=123, action="ignore", ignore_reason="false_positive")
-        )
+        result = await manage_private_incident(incident_id=123, action="ignore", ignore_reason="false_positive")
 
         mock_gitguardian_client.ignore_incident.assert_called_once_with(
             incident_id="123",
@@ -206,9 +198,7 @@ class TestManagePrivateIncidentIgnore:
         """
         mock_gitguardian_client.ignore_incident = AsyncMock(return_value={"id": 123, "status": "IGNORED"})
 
-        result = await manage_private_incident(
-            ManageIncidentParams(incident_id=123, action="ignore", ignore_reason="low_risk")
-        )
+        result = await manage_private_incident(incident_id=123, action="ignore", ignore_reason="low_risk")
 
         mock_gitguardian_client.ignore_incident.assert_called_once_with(
             incident_id="123",
@@ -225,9 +215,7 @@ class TestManagePrivateIncidentIgnore:
         """
         mock_gitguardian_client.ignore_incident = AsyncMock(return_value={"id": 123, "status": "IGNORED"})
 
-        result = await manage_private_incident(
-            ManageIncidentParams(incident_id=123, action="ignore", ignore_reason="invalid")
-        )
+        result = await manage_private_incident(incident_id=123, action="ignore", ignore_reason="invalid")
 
         mock_gitguardian_client.ignore_incident.assert_called_once_with(
             incident_id="123",
@@ -250,7 +238,7 @@ class TestManagePrivateIncidentOtherActions:
             return_value={"id": 123, "status": "TRIGGERED", "assignee_id": None}
         )
 
-        result = await manage_private_incident(ManageIncidentParams(incident_id=123, action="unassign"))
+        result = await manage_private_incident(incident_id=123, action="unassign")
 
         mock_gitguardian_client.unassign_incident.assert_called_once_with(incident_id="123")
         assert result["assignee_id"] is None
@@ -264,7 +252,7 @@ class TestManagePrivateIncidentOtherActions:
         """
         mock_gitguardian_client.reopen_incident = AsyncMock(return_value={"id": 123, "status": "TRIGGERED"})
 
-        result = await manage_private_incident(ManageIncidentParams(incident_id=123, action="reopen"))
+        result = await manage_private_incident(incident_id=123, action="reopen")
 
         mock_gitguardian_client.reopen_incident.assert_called_once_with(incident_id="123")
         assert result["status"] == "TRIGGERED"
@@ -283,7 +271,7 @@ class TestManagePrivateIncidentErrors:
         mock_gitguardian_client.reopen_incident = AsyncMock(side_effect=Exception("API error: Incident not found"))
 
         with pytest.raises(ToolError) as exc_info:
-            await manage_private_incident(ManageIncidentParams(incident_id=999, action="reopen"))
+            await manage_private_incident(incident_id=999, action="reopen")
 
         assert "API error: Incident not found" in str(exc_info.value)
 
@@ -299,7 +287,7 @@ class TestManagePrivateIncidentErrors:
         )
 
         with pytest.raises(ToolError) as exc_info:
-            await manage_private_incident(ManageIncidentParams(incident_id=123, action="resolve", secret_revoked=True))
+            await manage_private_incident(incident_id=123, action="resolve", secret_revoked=True)
 
         assert "Cannot resolve incident in current state" in str(exc_info.value)
 
@@ -315,8 +303,6 @@ class TestManagePrivateIncidentErrors:
         )
 
         with pytest.raises(ToolError) as exc_info:
-            await manage_private_incident(
-                ManageIncidentParams(incident_id=123, action="ignore", ignore_reason="low_risk")
-            )
+            await manage_private_incident(incident_id=123, action="ignore", ignore_reason="low_risk")
 
         assert "Cannot ignore incident in current state" in str(exc_info.value)

--- a/tests/tools/test_remediate_secret_incidents.py
+++ b/tests/tools/test_remediate_secret_incidents.py
@@ -97,7 +97,7 @@ class TestRemediateSecretIncidents:
             AsyncMock(return_value=mock_occurrences),
         ):
             # Call the function
-            result = await remediate_secret_incidents(RemediateSecretIncidentsParams(source_id="source_123"))
+            result = await remediate_secret_incidents(source_id="source_123")
 
             # Verify response structure
             assert result.remediation_instructions is not None
@@ -132,7 +132,7 @@ class TestRemediateSecretIncidents:
             AsyncMock(return_value=mock_occurrences),
         ):
             # Call the function
-            result = await remediate_secret_incidents(RemediateSecretIncidentsParams(source_id="source_123"))
+            result = await remediate_secret_incidents(source_id="source_123")
 
             # Verify response
             assert result.remediation_instructions is not None
@@ -157,7 +157,7 @@ class TestRemediateSecretIncidents:
             AsyncMock(return_value=mock_occurrences),
         ):
             # Call the function
-            result = await remediate_secret_incidents(RemediateSecretIncidentsParams(source_id="source_123"))
+            result = await remediate_secret_incidents(source_id="source_123")
 
             # Verify error response
             assert hasattr(result, "error")
@@ -206,9 +206,7 @@ class TestRemediateSecretIncidents:
             AsyncMock(return_value=mock_occurrences),
         ):
             # Call the function with mine=False
-            result = await remediate_secret_incidents(
-                RemediateSecretIncidentsParams(source_id="source_123", mine=False)
-            )
+            result = await remediate_secret_incidents(source_id="source_123", mine=False)
 
             # Verify all occurrences are included (not filtered by assignee)
             assert result.occurrences_count == 1
@@ -259,12 +257,10 @@ class TestRemediateSecretIncidents:
         ):
             # Call the function with git_commands=False
             result = await remediate_secret_incidents(
-                RemediateSecretIncidentsParams(
                     source_id="source_123",
                     git_commands=False,
                     mine=False,
                 )
-            )
 
             # Verify remediation instructions are present but without git commands
             assert result.remediation_instructions is not None
@@ -315,12 +311,10 @@ class TestRemediateSecretIncidents:
         ):
             # Call the function with create_env_example=False
             result = await remediate_secret_incidents(
-                RemediateSecretIncidentsParams(
                     source_id="source_123",
                     create_env_example=False,
                     mine=False,
                 )
-            )
 
             # Verify remediation instructions are present
             assert result.remediation_instructions is not None
@@ -389,9 +383,7 @@ class TestRemediateSecretIncidents:
             AsyncMock(return_value=mock_occurrences),
         ):
             # Call the function
-            result = await remediate_secret_incidents(
-                RemediateSecretIncidentsParams(source_id="source_123", mine=False)
-            )
+            result = await remediate_secret_incidents(source_id="source_123", mine=False)
 
             # Verify response
             assert result.occurrences_count == 2

--- a/tests/tools/test_remediate_secret_incidents.py
+++ b/tests/tools/test_remediate_secret_incidents.py
@@ -257,10 +257,10 @@ class TestRemediateSecretIncidents:
         ):
             # Call the function with git_commands=False
             result = await remediate_secret_incidents(
-                    source_id="source_123",
-                    git_commands=False,
-                    mine=False,
-                )
+                source_id="source_123",
+                git_commands=False,
+                mine=False,
+            )
 
             # Verify remediation instructions are present but without git commands
             assert result.remediation_instructions is not None
@@ -311,10 +311,10 @@ class TestRemediateSecretIncidents:
         ):
             # Call the function with create_env_example=False
             result = await remediate_secret_incidents(
-                    source_id="source_123",
-                    create_env_example=False,
-                    mine=False,
-                )
+                source_id="source_123",
+                create_env_example=False,
+                mine=False,
+            )
 
             # Verify remediation instructions are present
             assert result.remediation_instructions is not None

--- a/tests/tools/test_scan_secrets.py
+++ b/tests/tools/test_scan_secrets.py
@@ -40,7 +40,7 @@ class TestScanSecrets:
 
         # Call the function
         documents = [{"document": "API_KEY=AKIAIOSFODNN7EXAMPLE", "filename": "test.env"}]
-        result = await scan_secrets(ScanSecretsParams(documents=documents))
+        result = await scan_secrets(documents=documents)
 
         # Verify client was called with correct parameters
         mock_gitguardian_client.multiple_scan.assert_called_once_with(documents)
@@ -68,7 +68,7 @@ class TestScanSecrets:
 
         # Call the function
         documents = [{"document": "print('Hello, World!')", "filename": "test.py"}]
-        result = await scan_secrets(ScanSecretsParams(documents=documents))
+        result = await scan_secrets(documents=documents)
 
         # Verify response
         assert result.scan_results[0]["policy_break_count"] == 0
@@ -93,7 +93,7 @@ class TestScanSecrets:
             {"document": "secret_key = 'abc123'", "filename": "config1.py"},
             {"document": "print('test')", "filename": "test.py"},
         ]
-        result = await scan_secrets(ScanSecretsParams(documents=documents))
+        result = await scan_secrets(documents=documents)
 
         # Verify response
         assert len(result.scan_results) == 2
@@ -111,7 +111,7 @@ class TestScanSecrets:
 
         # Call the function without filename
         documents = [{"document": "print('test')"}]
-        await scan_secrets(ScanSecretsParams(documents=documents))
+        await scan_secrets(documents=documents)
 
         # Verify client was called
         mock_gitguardian_client.multiple_scan.assert_called_once()
@@ -125,7 +125,7 @@ class TestScanSecrets:
         """
         # Call the function with empty list and expect an error
         with pytest.raises(ValueError) as excinfo:
-            await scan_secrets(ScanSecretsParams(documents=[]))
+            await scan_secrets(documents=[])
 
         # Verify error message
         assert "must be a non-empty list" in str(excinfo.value)
@@ -139,7 +139,7 @@ class TestScanSecrets:
         """
         # Call the function with invalid document format
         with pytest.raises(ValueError) as excinfo:
-            await scan_secrets(ScanSecretsParams(documents=[{"invalid_key": "value"}]))
+            await scan_secrets(documents=[{"invalid_key": "value"}])
 
         # Verify error message
         assert "must be a dictionary with a 'document' field" in str(excinfo.value)
@@ -171,7 +171,7 @@ class TestScanSecrets:
 
         # Call the function and expect an error
         with pytest.raises(Exception) as excinfo:
-            await scan_secrets(ScanSecretsParams(documents=[{"document": "test", "filename": "test.txt"}]))
+            await scan_secrets(documents=[{"document": "test", "filename": "test.txt"}])
 
         # Verify error message
         assert error_message in str(excinfo.value)

--- a/tests/tools/test_tool_schemas.py
+++ b/tests/tools/test_tool_schemas.py
@@ -1,0 +1,211 @@
+"""
+Schema invariant guard for the flattened MCP tool signatures (SI-3963).
+
+Every API tool in ``gg_api_core.tools`` exposes its params model fields as
+top-level Annotated keyword parameters instead of a single ``params: XParams``
+wrapper. This makes the ``tools/list`` input schema flat, so clients can call
+tools with ``{}`` or a flat ``{"arguments": {...}}`` shape rather than having to
+nest everything under a ``params`` key.
+
+The assertions here mirror exactly how FastMCP derives each tool's input schema
+and validates arguments at call time, so a future tool that reintroduces a
+``params`` wrapper (or forgets to flatten a required field) fails these tests
+regardless of which server wires it up.
+"""
+
+import importlib
+import inspect
+import pkgutil
+
+import pytest
+from fastmcp.server.dependencies import without_injected_parameters
+from fastmcp.tools import Tool
+from fastmcp.utilities.types import get_cached_typeadapter
+
+import gg_api_core.tools as tools_package
+
+
+def _registered_tool_functions():
+    """Yield every async function defined in a ``gg_api_core.tools`` module.
+
+    This is the same set of callables FastMCP turns into MCP tools: public,
+    module-level ``async def`` functions declared inside the tools subpackage.
+    It intentionally includes both the full registrations (e.g.
+    ``generate_honeytoken``) and smaller inline helpers, so the invariant
+    guards the whole subpackage rather than only the wired server.
+    """
+    seen = {}
+    for module_info in pkgutil.iter_modules(tools_package.__path__):
+        if module_info.name.startswith("_"):
+            continue
+        module = importlib.import_module(f"gg_api_core.tools.{module_info.name}")
+        for name, obj in vars(module).items():
+            if name.startswith("_"):
+                continue
+            if not inspect.iscoroutinefunction(obj):
+                continue
+            if not (getattr(obj, "__module__", "") or "").startswith("gg_api_core.tools"):
+                continue
+            seen[name] = obj
+    return seen
+
+
+TOOL_FUNCTIONS = _registered_tool_functions()
+
+
+def _input_schema(tool_function) -> dict:
+    """Return the JSON schema FastMCP derives for the tool's parameters."""
+    return Tool.from_function(tool_function).parameters
+
+
+def _validate_arguments(tool_function, arguments: dict):
+    """Validate a raw arguments dict exactly like FastMCP does at call time.
+
+    ``Tool.run`` wraps the (de-injected) function in a pydantic TypeAdapter and
+    calls ``validate_python(arguments)`` before executing the body. We reuse
+    that same adapter (without awaiting the returned coroutine) so bad argument
+    shapes are caught without actually invoking any network-bound tool body.
+    """
+    wrapper = without_injected_parameters(tool_function, run_in_thread=False)
+    type_adapter = get_cached_typeadapter(wrapper)
+    result = type_adapter.validate_python(arguments)
+    # validate_python returns the (async) call structure; close it without
+    # awaiting so the tool body never executes and no RuntimeWarning leaks.
+    if inspect.iscoroutine(result):
+        result.close()
+
+
+def test_every_tool_exposes_a_flat_input_schema():
+    """
+    GIVEN every async tool function defined under ``gg_api_core.tools``
+    WHEN its input schema is derived the way FastMCP derives it at registration
+    THEN the schema has no top-level ``params`` wrapper key
+    """
+    assert TOOL_FUNCTIONS, "expected to discover at least one tool function"
+
+    for name, tool_function in TOOL_FUNCTIONS.items():
+        properties = _input_schema(tool_function).get("properties", {})
+        assert "params" not in properties, (
+            f"tool '{name}' still exposes a 'params' wrapper property; "
+            "flatten its params model into top-level Annotated parameters (SI-3963)"
+        )
+
+
+def test_required_parameters_are_top_level_properties():
+    """
+    GIVEN a tool whose input schema lists required parameters
+    WHEN its FastMCP-derived schema is inspected
+    THEN every required parameter is present as a top-level property (no
+        required field hidden behind the old ``params`` wrapper)
+    """
+    for name, tool_function in TOOL_FUNCTIONS.items():
+        schema = _input_schema(tool_function)
+        properties = schema.get("properties", {})
+        for required in schema.get("required", []):
+            assert required in properties, (
+                f"tool '{name}' marks '{required}' as required but it is not a "
+                "top-level property"
+            )
+
+
+def test_all_optional_tools_accept_empty_arguments():
+    """
+    GIVEN a tool whose input schema has no required parameters
+    WHEN an empty ``{}`` argument shape is validated through FastMCP's runtime
+    THEN the empty shape is accepted (so clients can call the tool with no args)
+    """
+    for name, tool_function in TOOL_FUNCTIONS.items():
+        schema = _input_schema(tool_function)
+        if schema.get("required"):
+            continue
+        try:
+            _validate_arguments(tool_function, {})
+        except Exception as exc:  # pragma: no cover - failure path
+            pytest.fail(f"tool '{name}' rejects empty args '{{}}': {exc}")
+
+
+def _placeholder(prop: dict):
+    """Build a JSON-schema-valid placeholder value for a parameter property."""
+    typ = prop.get("type")
+    if isinstance(typ, list):
+        # anyOf/oneOf: pick the first concrete (non-null) branch
+        for t in typ:
+            if t != "null":
+                return _placeholder({**prop, "type": t})
+        return None
+    if "anyOf" in prop:
+        for b in prop["anyOf"]:
+            if b.get("type") != "null":
+                return _placeholder(b)
+        return None
+    if "enum" in prop:
+        return prop["enum"][0]
+    if "const" in prop:
+        return prop["const"]
+    if "default" in prop and prop["type"] != "null":
+        return prop["default"]
+    if typ == "integer":
+        return 3
+    if typ == "number":
+        return 3.0
+    if typ == "boolean":
+        return False
+    if typ == "string":
+        return "x"
+    if typ == "array":
+        items = prop.get("items", {})
+        return [_placeholder(items)] if items else []
+    if typ == "object":
+        props = prop.get("properties", {})
+        return {k: _placeholder(v) for k, v in props.items()}
+    return None
+
+
+def test_flat_calls_coerce_str_to_int():
+    """
+    GIVEN a tool exposing an integer-typed top-level parameter
+    WHEN it is called with a flat ``{"<param>": "7"}`` string value
+    THEN FastMCP's runtime validation coerces the string to the int (this is
+        the exact failure mode from SI-3963's ``list_incidents`` example)
+    """
+    for name, tool_function in TOOL_FUNCTIONS.items():
+        schema = _input_schema(tool_function)
+        properties = schema.get("properties", {})
+        required = schema.get("required", [])
+        int_param = next(
+            (
+                param
+                for param, prop in properties.items()
+                if prop.get("type") == "integer"
+                or (
+                    isinstance(prop.get("type"), list)
+                    and "integer" in prop.get("type")
+                )
+            ),
+            None,
+        )
+        if int_param is None:
+            continue
+        # Fill every required sibling so only the coerced int param is tested.
+        call: dict = {int_param: "7"}
+        for param in required:
+            if param != int_param:
+                call[param] = _placeholder(properties.get(param, {}))
+        try:
+            _validate_arguments(tool_function, call)
+        except Exception as exc:  # pragma: no cover - failure path
+            pytest.fail(
+                f"tool '{name}' rejected flat call '{call}': {exc}"
+            )
+
+
+def test_required_params_schema_is_a_flat_object_shape():
+    """
+    GIVEN the input schema of any API tool
+    WHEN it is inspected
+    THEN the schema type is 'object' and its properties are the flat fields
+        (not a nested single 'params' property)
+    """
+    for name, tool_function in TOOL_FUNCTIONS.items():
+        schema = _input_schema(tool_function)
+        assert schema.get("type") == "object", f"tool '{name}' schema is not an object"

--- a/tests/tools/test_tool_schemas.py
+++ b/tests/tools/test_tool_schemas.py
@@ -17,12 +17,11 @@ import importlib
 import inspect
 import pkgutil
 
+import gg_api_core.tools as tools_package
 import pytest
 from fastmcp.server.dependencies import without_injected_parameters
 from fastmcp.tools import Tool
 from fastmcp.utilities.types import get_cached_typeadapter
-
-import gg_api_core.tools as tools_package
 
 
 def _registered_tool_functions():
@@ -103,8 +102,7 @@ def test_required_parameters_are_top_level_properties():
         properties = schema.get("properties", {})
         for required in schema.get("required", []):
             assert required in properties, (
-                f"tool '{name}' marks '{required}' as required but it is not a "
-                "top-level property"
+                f"tool '{name}' marks '{required}' as required but it is not a top-level property"
             )
 
 
@@ -177,10 +175,7 @@ def test_flat_calls_coerce_str_to_int():
                 param
                 for param, prop in properties.items()
                 if prop.get("type") == "integer"
-                or (
-                    isinstance(prop.get("type"), list)
-                    and "integer" in prop.get("type")
-                )
+                or (isinstance(prop.get("type"), list) and "integer" in prop.get("type"))
             ),
             None,
         )
@@ -194,9 +189,7 @@ def test_flat_calls_coerce_str_to_int():
         try:
             _validate_arguments(tool_function, call)
         except Exception as exc:  # pragma: no cover - failure path
-            pytest.fail(
-                f"tool '{name}' rejected flat call '{call}': {exc}"
-            )
+            pytest.fail(f"tool '{name}' rejected flat call '{call}': {exc}")
 
 
 def test_required_params_schema_is_a_flat_object_shape():

--- a/tests/tools/test_update_public_incident_status.py
+++ b/tests/tools/test_update_public_incident_status.py
@@ -99,7 +99,7 @@ class TestUpdatePublicIncidentStatusResolve:
         THEN: A ToolError is raised asking for the reason
         """
         with pytest.raises(ToolError) as exc_info:
-            await update_public_incident_status(UpdatePublicIncidentStatusParams(incident_id=123, action="resolve"))
+            await update_public_incident_status(incident_id=123, action="resolve")
 
         error_message = str(exc_info.value)
         assert "resolve_reason" in error_message
@@ -118,9 +118,7 @@ class TestUpdatePublicIncidentStatusResolve:
             return_value=_full_public_incident_payload(incident_id=123, status="RESOLVED")
         )
 
-        result = await update_public_incident_status(
-            UpdatePublicIncidentStatusParams(incident_id=123, action="resolve", resolve_reason=reason)
-        )
+        result = await update_public_incident_status(incident_id=123, action="resolve", resolve_reason=reason)
 
         mock_gitguardian_client.resolve_public_incident.assert_called_once_with(
             incident_id=123,
@@ -140,7 +138,7 @@ class TestUpdatePublicIncidentStatusIgnore:
         THEN: A ToolError is raised asking for the reason
         """
         with pytest.raises(ToolError) as exc_info:
-            await update_public_incident_status(UpdatePublicIncidentStatusParams(incident_id=123, action="ignore"))
+            await update_public_incident_status(incident_id=123, action="ignore")
 
         error_message = str(exc_info.value)
         assert "ignore_reason" in error_message
@@ -169,9 +167,7 @@ class TestUpdatePublicIncidentStatusIgnore:
             return_value=_full_public_incident_payload(incident_id=123, status="IGNORED")
         )
 
-        result = await update_public_incident_status(
-            UpdatePublicIncidentStatusParams(incident_id=123, action="ignore", ignore_reason=reason)
-        )
+        result = await update_public_incident_status(incident_id=123, action="ignore", ignore_reason=reason)
 
         mock_gitguardian_client.ignore_public_incident.assert_called_once_with(
             incident_id=123,
@@ -194,7 +190,7 @@ class TestUpdatePublicIncidentStatusReopen:
             return_value=_full_public_incident_payload(incident_id=123, status="TRIGGERED")
         )
 
-        result = await update_public_incident_status(UpdatePublicIncidentStatusParams(incident_id=123, action="reopen"))
+        result = await update_public_incident_status(incident_id=123, action="reopen")
 
         mock_gitguardian_client.reopen_public_incident.assert_called_once_with(incident_id=123)
         assert result["status"] == "TRIGGERED"
@@ -215,9 +211,7 @@ class TestUpdatePublicIncidentStatusErrors:
         )
 
         with pytest.raises(ToolError) as exc_info:
-            await update_public_incident_status(
-                UpdatePublicIncidentStatusParams(incident_id=999, action="resolve", resolve_reason="revoked")
-            )
+            await update_public_incident_status(incident_id=999, action="resolve", resolve_reason="revoked")
 
         assert "API error: Public incident not found" in str(exc_info.value)
 
@@ -233,9 +227,7 @@ class TestUpdatePublicIncidentStatusErrors:
         )
 
         with pytest.raises(ToolError) as exc_info:
-            await update_public_incident_status(
-                UpdatePublicIncidentStatusParams(incident_id=123, action="ignore", ignore_reason="low_risk")
-            )
+            await update_public_incident_status(incident_id=123, action="ignore", ignore_reason="low_risk")
 
         assert "Cannot ignore public incident in current state" in str(exc_info.value)
 
@@ -251,6 +243,6 @@ class TestUpdatePublicIncidentStatusErrors:
         )
 
         with pytest.raises(ToolError) as exc_info:
-            await update_public_incident_status(UpdatePublicIncidentStatusParams(incident_id=999, action="reopen"))
+            await update_public_incident_status(incident_id=999, action="reopen")
 
         assert "API error: Public incident not found" in str(exc_info.value)

--- a/tests/tools/test_write_custom_tags.py
+++ b/tests/tools/test_write_custom_tags.py
@@ -153,7 +153,7 @@ class TestUpdateOrCreateIncidentCustomTags:
             incident_id=123, custom_tags=["env:prod", "reviewed", "url:http://example.com"]
         )
         with patch("gg_api_core.tools.write_custom_tags.get_client", return_value=mock_client):
-            await update_or_create_incident_custom_tags(params)
+            await update_or_create_incident_custom_tags(**params.model_dump())
 
         mock_client.update_incident.assert_awaited_once_with(
             incident_id="123",

--- a/tests/tools/vcr/test_count_incidents.py
+++ b/tests/tools/vcr/test_count_incidents.py
@@ -35,7 +35,7 @@ class TestCountIncidentsVCR:
                 return_value=real_client,
             ):
                 params = CountIncidentsParams()
-                result = await count_incidents(params)
+                result = await count_incidents(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, CountIncidentsResult)
@@ -55,7 +55,7 @@ class TestCountIncidentsVCR:
                 return_value=real_client,
             ):
                 params = CountIncidentsParams(status=["TRIGGERED"])
-                result = await count_incidents(params)
+                result = await count_incidents(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, CountIncidentsResult)
@@ -76,7 +76,7 @@ class TestCountIncidentsVCR:
                 return_value=real_client,
             ):
                 params = CountIncidentsParams(severity=["critical"])
-                result = await count_incidents(params)
+                result = await count_incidents(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, CountIncidentsResult)
@@ -101,7 +101,7 @@ class TestCountIncidentsVCR:
                     validity=["valid"],
                     exclude_tags=[],
                 )
-                result = await count_incidents(params)
+                result = await count_incidents(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, CountIncidentsResult)
@@ -133,7 +133,7 @@ class TestCountIncidentsVCR:
                 assert params.severity == ["critical"]
                 assert params.validity == ["valid"]
 
-                result = await count_incidents(params)
+                result = await count_incidents(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, CountIncidentsResult)

--- a/tests/tools/vcr/test_get_incident.py
+++ b/tests/tools/vcr/test_get_incident.py
@@ -43,7 +43,7 @@ class TestGetIncidentVCR:
                     incident_id=self.TEST_INCIDENT_ID,
                 )
 
-                result = await get_incident(params)
+                result = await get_incident(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, GetIncidentResult)
@@ -72,7 +72,7 @@ class TestGetIncidentVCR:
                     with_occurrences=5,
                 )
 
-                result = await get_incident(params)
+                result = await get_incident(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, GetIncidentResult)
@@ -98,7 +98,7 @@ class TestGetIncidentVCR:
                     with_occurrences=0,
                 )
 
-                result = await get_incident(params)
+                result = await get_incident(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, GetIncidentResult)
@@ -124,7 +124,7 @@ class TestGetIncidentVCR:
                     incident_id=self.TEST_INCIDENT_ID,
                 )
 
-                result = await get_incident(params)
+                result = await get_incident(**params.model_dump())
 
                 assert result is not None
                 assert result.incident is not None

--- a/tests/tools/vcr/test_get_member.py
+++ b/tests/tools/vcr/test_get_member.py
@@ -42,7 +42,7 @@ class TestGetMemberVCR:
                     member_id=self.TEST_MEMBER_ID,
                 )
 
-                result = await get_member(params)
+                result = await get_member(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, GetMemberResult)
@@ -73,7 +73,7 @@ class TestGetMemberVCR:
                     member_id=self.TEST_MEMBER_ID,
                 )
 
-                result = await get_member(params)
+                result = await get_member(**params.model_dump())
 
                 assert result is not None
                 assert result.member is not None
@@ -98,7 +98,7 @@ class TestGetMemberVCR:
                     member_id=self.TEST_MEMBER_ID,
                 )
 
-                result = await get_member(params)
+                result = await get_member(**params.model_dump())
 
                 assert result is not None
                 assert result.member is not None

--- a/tests/tools/vcr/test_get_public_incident.py
+++ b/tests/tools/vcr/test_get_public_incident.py
@@ -11,7 +11,6 @@ from unittest.mock import patch
 import pytest
 from fastmcp.exceptions import ToolError
 from gg_api_core.tools.get_public_incident import (
-    GetPublicIncidentParams,
     GetPublicIncidentResult,
     get_public_incident,
 )

--- a/tests/tools/vcr/test_get_public_incident.py
+++ b/tests/tools/vcr/test_get_public_incident.py
@@ -39,7 +39,7 @@ class TestGetPublicIncidentVCR:
                     pytest.skip("No public incidents available on the recording workspace")
                 incident_id = page["data"][0]["id"]
 
-                result = await get_public_incident(GetPublicIncidentParams(incident_id=incident_id))
+                result = await get_public_incident(incident_id=incident_id)
 
                 assert isinstance(result, GetPublicIncidentResult)
                 assert result.incident["id"] == incident_id
@@ -61,4 +61,4 @@ class TestGetPublicIncidentVCR:
                 return_value=real_client,
             ):
                 with pytest.raises(ToolError):
-                    await get_public_incident(GetPublicIncidentParams(incident_id=999999999))
+                    await get_public_incident(incident_id=999999999)

--- a/tests/tools/vcr/test_list_detectors.py
+++ b/tests/tools/vcr/test_list_detectors.py
@@ -40,7 +40,7 @@ class TestListDetectorsVCR:
                     get_all=False,
                 )
 
-                result = await list_detectors(params)
+                result = await list_detectors(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListDetectorsResult)
@@ -71,7 +71,7 @@ class TestListDetectorsVCR:
                     get_all=False,
                 )
 
-                result = await list_detectors(params)
+                result = await list_detectors(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListDetectorsResult)
@@ -96,7 +96,7 @@ class TestListDetectorsVCR:
                     get_all=False,
                 )
 
-                result = await list_detectors(params)
+                result = await list_detectors(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListDetectorsResult)
@@ -123,7 +123,7 @@ class TestListDetectorsVCR:
                     get_all=False,
                 )
 
-                result = await list_detectors(params)
+                result = await list_detectors(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListDetectorsResult)
@@ -149,7 +149,7 @@ class TestListDetectorsVCR:
                     get_all=False,
                 )
 
-                result = await list_detectors(params)
+                result = await list_detectors(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListDetectorsResult)
@@ -175,7 +175,7 @@ class TestListDetectorsVCR:
                     get_all=True,
                 )
 
-                result = await list_detectors(params)
+                result = await list_detectors(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListDetectorsResult)

--- a/tests/tools/vcr/test_list_honeytokens.py
+++ b/tests/tools/vcr/test_list_honeytokens.py
@@ -44,7 +44,7 @@ class TestListHoneytokensVCR:
                     get_all=False,
                 )
 
-                result = await list_honeytokens(params)
+                result = await list_honeytokens(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListHoneytokensResult)
@@ -72,7 +72,7 @@ class TestListHoneytokensVCR:
                     get_all=False,
                 )
 
-                result = await list_honeytokens(params)
+                result = await list_honeytokens(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListHoneytokensResult)
@@ -104,7 +104,7 @@ class TestListHoneytokensVCR:
                     get_all=False,
                 )
 
-                result = await list_honeytokens(params)
+                result = await list_honeytokens(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListHoneytokensResult)
@@ -133,7 +133,7 @@ class TestListHoneytokensVCR:
                     get_all=False,
                 )
 
-                result = await list_honeytokens(params)
+                result = await list_honeytokens(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListHoneytokensResult)
@@ -161,7 +161,7 @@ class TestListHoneytokensVCR:
                     get_all=False,
                 )
 
-                result = await list_honeytokens(params)
+                result = await list_honeytokens(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListHoneytokensResult)
@@ -191,7 +191,7 @@ class TestListHoneytokensVCR:
                     per_page=5,
                 )
 
-                result = await list_honeytokens(params)
+                result = await list_honeytokens(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListHoneytokensResult)

--- a/tests/tools/vcr/test_list_incident_members.py
+++ b/tests/tools/vcr/test_list_incident_members.py
@@ -47,7 +47,7 @@ class TestListIncidentMembersVCR:
                     per_page=5,
                 )
 
-                result = await list_incident_members(params)
+                result = await list_incident_members(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListIncidentMembersResult)
@@ -83,7 +83,7 @@ class TestListIncidentMembersVCR:
                     per_page=10,
                 )
 
-                result = await list_incident_members(params)
+                result = await list_incident_members(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListIncidentMembersResult)
@@ -110,7 +110,7 @@ class TestListIncidentMembersVCR:
                     per_page=10,
                 )
 
-                result = await list_incident_members(params)
+                result = await list_incident_members(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListIncidentMembersResult)
@@ -140,7 +140,7 @@ class TestListIncidentMembersVCR:
                     per_page=10,
                 )
 
-                result = await list_incident_members(params)
+                result = await list_incident_members(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListIncidentMembersResult)
@@ -167,7 +167,7 @@ class TestListIncidentMembersVCR:
                     per_page=10,
                 )
 
-                result = await list_incident_members(params)
+                result = await list_incident_members(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListIncidentMembersResult)

--- a/tests/tools/vcr/test_list_incident_teams.py
+++ b/tests/tools/vcr/test_list_incident_teams.py
@@ -47,7 +47,7 @@ class TestListIncidentTeamsVCR:
                     per_page=5,
                 )
 
-                result = await list_incident_teams(params)
+                result = await list_incident_teams(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListIncidentTeamsResult)
@@ -82,7 +82,7 @@ class TestListIncidentTeamsVCR:
                     per_page=10,
                 )
 
-                result = await list_incident_teams(params)
+                result = await list_incident_teams(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListIncidentTeamsResult)
@@ -109,7 +109,7 @@ class TestListIncidentTeamsVCR:
                     per_page=10,
                 )
 
-                result = await list_incident_teams(params)
+                result = await list_incident_teams(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListIncidentTeamsResult)

--- a/tests/tools/vcr/test_list_incidents.py
+++ b/tests/tools/vcr/test_list_incidents.py
@@ -54,7 +54,7 @@ class TestListIncidentsCoercionVCR:
                 # Verify coercion happened
                 assert params.status == ["TRIGGERED"]
 
-                result = await list_incidents(params)
+                result = await list_incidents(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListIncidentsResult)
@@ -86,7 +86,7 @@ class TestListIncidentsCoercionVCR:
                 # Verify coercion happened
                 assert params.severity == ["critical"]
 
-                result = await list_incidents(params)
+                result = await list_incidents(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListIncidentsResult)
@@ -115,7 +115,7 @@ class TestListIncidentsCoercionVCR:
                 # Verify coercion happened
                 assert params.validity == ["valid"]
 
-                result = await list_incidents(params)
+                result = await list_incidents(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListIncidentsResult)
@@ -153,7 +153,7 @@ class TestListIncidentsCoercionVCR:
                 assert params.validity == ["valid"]
                 assert params.exclude_tags == ["TEST_FILE"]
 
-                result = await list_incidents(params)
+                result = await list_incidents(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListIncidentsResult)

--- a/tests/tools/vcr/test_list_public_incidents.py
+++ b/tests/tools/vcr/test_list_public_incidents.py
@@ -41,7 +41,7 @@ class TestListPublicIncidentsVCR:
                     severity=None,
                     validity=None,
                 )
-                result = await list_public_incidents(params)
+                result = await list_public_incidents(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListPublicIncidentsResult)
@@ -84,7 +84,7 @@ class TestListPublicIncidentsVCR:
                     severity=severities,
                     validity=validities,
                 )
-                result = await list_public_incidents(params)
+                result = await list_public_incidents(**params.model_dump())
 
                 assert isinstance(result, ListPublicIncidentsResult)
                 assert result.incidents_count > 0, "expected non-empty result with permissive filters"
@@ -125,7 +125,7 @@ class TestListPublicIncidentsVCR:
                     risk_score_max=100,
                     ordering="-risk_score",
                 )
-                result = await list_public_incidents(params)
+                result = await list_public_incidents(**params.model_dump())
 
                 assert isinstance(result, ListPublicIncidentsResult)
                 assert result.incidents_count > 0

--- a/tests/tools/vcr/test_list_public_occurrences.py
+++ b/tests/tools/vcr/test_list_public_occurrences.py
@@ -37,7 +37,7 @@ class TestListPublicOccurrencesVCR:
                 incident_id = incidents["data"][0]["id"]
 
                 params = ListPublicOccurrencesParams(incident_id=incident_id, per_page=5)
-                result = await list_public_occurrences(params)
+                result = await list_public_occurrences(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListPublicOccurrencesResult)
@@ -72,7 +72,7 @@ class TestListPublicOccurrencesVCR:
                     validity="valid,invalid,failed_to_check,no_checker,unknown",
                     ordering="-date",
                 )
-                result = await list_public_occurrences(params)
+                result = await list_public_occurrences(**params.model_dump())
 
                 assert isinstance(result, ListPublicOccurrencesResult)
                 assert result.occurrences_count > 0, "expected non-empty result with permissive filters"
@@ -109,7 +109,7 @@ class TestListPublicOccurrencesVCR:
                     per_page=10,
                     date_after="2020-01-01T00:00:00Z",
                 )
-                result = await list_public_occurrences(params)
+                result = await list_public_occurrences(**params.model_dump())
 
                 assert isinstance(result, ListPublicOccurrencesResult)
                 assert result.occurrences_count > 0

--- a/tests/tools/vcr/test_list_repo_occurrences.py
+++ b/tests/tools/vcr/test_list_repo_occurrences.py
@@ -50,7 +50,7 @@ class TestListRepoOccurrencesVCR:
                 assert params.mine is True
 
                 # Call the tool
-                result = await list_repo_occurrences(params)
+                result = await list_repo_occurrences(**params.model_dump())
 
                 # Verify the result
                 assert result is not None

--- a/tests/tools/vcr/test_list_sources.py
+++ b/tests/tools/vcr/test_list_sources.py
@@ -40,7 +40,7 @@ class TestListSourcesVCR:
                     get_all=False,
                 )
 
-                result = await list_sources(params)
+                result = await list_sources(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListSourcesResult)
@@ -71,7 +71,7 @@ class TestListSourcesVCR:
                     get_all=False,
                 )
 
-                result = await list_sources(params)
+                result = await list_sources(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListSourcesResult)
@@ -96,7 +96,7 @@ class TestListSourcesVCR:
                     get_all=False,
                 )
 
-                result = await list_sources(params)
+                result = await list_sources(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListSourcesResult)
@@ -124,7 +124,7 @@ class TestListSourcesVCR:
                     get_all=False,
                 )
 
-                result = await list_sources(params)
+                result = await list_sources(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListSourcesResult)
@@ -152,7 +152,7 @@ class TestListSourcesVCR:
                     get_all=False,
                 )
 
-                result = await list_sources(params)
+                result = await list_sources(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListSourcesResult)
@@ -180,7 +180,7 @@ class TestListSourcesVCR:
                     get_all=False,
                 )
 
-                result = await list_sources(params)
+                result = await list_sources(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListSourcesResult)
@@ -208,7 +208,7 @@ class TestListSourcesVCR:
                     get_all=False,
                 )
 
-                result = await list_sources(params)
+                result = await list_sources(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListSourcesResult)
@@ -232,7 +232,7 @@ class TestListSourcesVCR:
                     get_all=False,
                 )
 
-                result = await list_sources(params)
+                result = await list_sources(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListSourcesResult)
@@ -258,7 +258,7 @@ class TestListSourcesVCR:
                     get_all=False,
                 )
 
-                result = await list_sources(params)
+                result = await list_sources(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListSourcesResult)
@@ -284,7 +284,7 @@ class TestListSourcesVCR:
                     get_all=True,
                 )
 
-                result = await list_sources(params)
+                result = await list_sources(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListSourcesResult)
@@ -312,7 +312,7 @@ class TestListSourcesVCR:
                     get_all=False,
                 )
 
-                result = await list_sources(params)
+                result = await list_sources(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListSourcesResult)
@@ -338,7 +338,7 @@ class TestListSourcesVCR:
                     get_all=False,
                 )
 
-                result = await list_sources(params)
+                result = await list_sources(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListSourcesResult)

--- a/tests/tools/vcr/test_list_users.py
+++ b/tests/tools/vcr/test_list_users.py
@@ -47,7 +47,7 @@ class TestListUsersVCR:
                     get_all=False,
                 )
 
-                result = await list_users(params)
+                result = await list_users(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListUsersResult)
@@ -85,7 +85,7 @@ class TestListUsersVCR:
                     get_all=False,
                 )
 
-                result = await list_users(params)
+                result = await list_users(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListUsersResult)
@@ -112,7 +112,7 @@ class TestListUsersVCR:
                     get_all=False,
                 )
 
-                result = await list_users(params)
+                result = await list_users(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListUsersResult)
@@ -142,7 +142,7 @@ class TestListUsersVCR:
                     get_all=False,
                 )
 
-                result = await list_users(params)
+                result = await list_users(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListUsersResult)
@@ -169,7 +169,7 @@ class TestListUsersVCR:
                     get_all=False,
                 )
 
-                result = await list_users(params)
+                result = await list_users(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, ListUsersResult)

--- a/tests/tools/vcr/test_read_custom_tags.py
+++ b/tests/tools/vcr/test_read_custom_tags.py
@@ -46,7 +46,7 @@ class TestReadCustomTagsVCR:
                     tag_id="unused",  # Required by model but ignored for list_tags
                 )
 
-                result = await read_custom_tags(params)
+                result = await read_custom_tags(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, list)
@@ -81,7 +81,7 @@ class TestReadCustomTagsVCR:
                     tag_id=tag_id,
                 )
 
-                result = await read_custom_tags(params)
+                result = await read_custom_tags(**params.model_dump())
 
                 assert result is not None
                 assert isinstance(result, dict)
@@ -115,7 +115,7 @@ class TestReadCustomTagsVCR:
                     tag_id=tag_id,
                 )
 
-                result = await read_custom_tags(params)
+                result = await read_custom_tags(**params.model_dump())
 
                 # Verify full structure
                 assert result is not None


### PR DESCRIPTION
## Merge order

Three open PRs touch the same tools. Land them in this order:

1. #227 `SI-4068`. Sentry still ships tool arguments inside pydantic validation messages. Independent of the other two, and it gates the prod bump.
2. #207 `si-3940-...`. Generated filter vocabularies. Needs one small rebase once #227 lands: three import blocks where both sides are wanted.
3. #229 (this PR) `SI-3963`. Flattens tool signatures to top-level parameters. Based on #207 and cannot land before it.

Only step 2 to step 3 is a hard dependency. Git merges #229's hand-copied signatures over #207's canonical types without a single conflict, and the result has three modules that fail to import plus a `list_incidents` that rejects its own default severity. #229 is based on #207 to force that order.

#227 collides with the other two on import lines only (21 of 27 shared files merge clean), so it stays on `main` rather than sitting at the bottom of a three-way stack, where every review comment on it would force a rebase of the other two.


### Known fixes needed at rebase time

Merging all three together and running the suite surfaces exactly two problems. Both are rebase work, not defects in any single PR, and #227's discovery test catches the first one rather than letting it through:

1. `IncidentFilterParams` in `gg_api_core/incident_filters.py` must inherit `ToolParamsBase` instead of `BaseModel`. #207 introduces that shared base and #227 introduces `ToolParamsBase`, so neither branch can do it alone. Without it `ListIncidentsParams` and `CountIncidentsParams` lose `hide_input_in_errors`, and git produces that state with a conflict only on the class line, where taking the refactor's side looks like the obvious resolution. Belongs in #207's rebase.
2. `test_validation_error_reaching_sentry_carries_no_tool_arguments` in `tests/test_sentry_integration.py` calls the nested `{"params": {...}}` shape. #229 flattens it away. Belongs in #229's rebase, alongside the 52 payloads it already unwrapped.

Verified union after both: 1384 passed, ruff and pyrefly clean, `generate_filter_vocabulary.py --check` exits 0, all 34 `*Params` models carry the config, and the scan_secrets canary stays out of the Sentry event on the flat call shape.

## Rebase onto #207

The naive rebase produced only 3 conflict hunks but a broken branch, because the flattened signatures are a second copy of the vocabulary that git merges cleanly and silently:

- `list_public_incidents`, `list_repo_occurrences` and `remediate_secret_incidents` failed to import (`NameError: IncidentStatus`), because the signature referenced a name #207 removed.
- `list_incidents` rejected its own default on every call: the signature passed `severity=[10, 20, 30, 100]` to a model that now accepts names only.
- 6 tools advertised `list[str]` while validating Literals, so bad values failed inside the body instead of at schema validation, which is the opaque-failure mode #207 exists to remove.

Fixed in `fix(tools): derive flattened filter params from the canonical vocabulary`: the 19 filter parameters across the five incident tools are now generated from their model fields, so alias, default and description all come from one place and the schema cannot advertise a vocabulary the model rejects. `list_sources.type` drops its inlined 23-value `Literal` for `IncidentSourceTypeFilter` (verified member-for-member identical). Tests moved to the flat convention: 52 nested `{"params": {...}}` payloads unwrapped, 9 positional `Params` calls expanded.

Remaining duplication worth a follow-up: the other 21 flattened tools still hand-copy their field definitions. They have no vocabulary overlap with #207 so nothing is wrong today, but the same drift is possible whenever a model changes.

## Summary

Closes [SI-3963](https://linear.app/gitguardian/issue/SI-3963) - *"The params wrapper rejects the flat argument shape clients send"*.

Every GG API tool previously exposed a single required `params: XParams` pydantic model, which forced the wire contract to `{"arguments": {"params": {...}}}`.

That shape rejects both `{}` (on all-optional tools) and idiomatic flat calls. Just like the ticket describes, a client calling `list_incidents` with a flat `{"page_size": "5"}` failed on both `params` missing and the flat key being unexpected.

This PR flattens every tool signature to top-level parameters:

```python
async def list_incidents(
    page: Annotated[int, Field(default=1, ge=1, ...)] = 1,
    page_size: Annotated[int, Field(default=20, ge=1, le=100, ...)] = 20,
    ...
)
```

and **composes the shared `.Params` models back inside the body** (first statement), so existing `params.xxx` references, cross-field `model_validator`s (e.g. `manage_incident_comment`'s `comment_id`-on-edit check), and single-scalar-to-list coercion all keep working.

## What changed

- **27 tool files flattened** across get/list/manage/scan/revoke/honeytokens/notes/tags/sources/remediation and more.
- List-typed params widened to `list[X] | X | None` so a single scalar coerces to a one-element list.
- **Corresponding tests converted** to flat-argument calls; unit tests that construct `.Params` models directly are retained.
- **New schema invariant test** (`tests/tools/test_tool_schemas.py`): asserts no `params` wrapper property, every required param is a top-level property, `{}` is accepted for all-optional tools, and flat `str -> int` coercion works - checked via FastMCP's own `Tool.from_function` plus runtime `TypeAdapter` validation (offline, no network).
- This **subsumes PR #206** (`c71732f`, the `params: X = X()` default workaround for `{}`), which this change removes.

## Verify

- `uv run pytest` gives **1374 passed, 3 skipped, 9 xfailed** on the stacked branch (the earlier 700 predates the rebase onto #207).
- `tests/tools/test_tool_schemas.py` gives **5 passed**.
- `ruff` and `pyrefly` clean; #207's `generate_filter_vocabulary.py --check` still passes.

## Breaking change

The MCP `tools/list` input schemas drop the `params` wrapper in favor of flat top-level parameters. Clients currently sending `{"arguments": {"params": {...}}}` must switch to the flat shape, e.g. `{"arguments": {"page_size": 5}}`. A `BREAKING CHANGE` footer is included so the next commitizen bump surfaces it in the changelog.

## Review follow-up

Flattening restates every params model field as a top-level parameter, so each field lives in two places with nothing tying them together. Every failure hit while stacking on #207 was that drift, and none of them broke a test: a parameter naming a type its module no longer imported, a default the model rejects, and a parameter typed `list[str]` against a Literal.

`tests/tools/test_flat_signature_conformance.py` closes it with three checks over the 28 tools that pair with a model: the signature exposes exactly the model's fields, every default equals the model's, and any Literal vocabulary matches. Required-ness has to agree too, so an optional parameter cannot quietly drop out of the schema's required list. The signature may still be wider in shape, taking a bare value where the model wants a list, which is the point of the flattening. Verified by reintroducing each of the three original failures and confirming the matching check fails.

**Worth considering before this merges.** A 40-line registration-time adapter that derives the flat signature from the model reproduces these schemas exactly: I compared property sets across every tool and got 33/33 identical. That would delete the ~540 lines this PR adds and make the drift structurally impossible rather than merely tested. It needs a docstring pass, since the reused docstrings still describe a `params` argument, and it trades hand-written signatures for one dynamic-signature helper. Left as a decision for the author rather than a rewrite of this branch.

Also: #206 (`c71732f`) is no longer in this branch's history after the rebase, so the "subsumes #206" note above no longer describes the diff. #206 is still open and now redundant.
