### PR TITLE
ci: add zizmor security scanning

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+name: GitHub Actions Security Analysis
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3


### PR DESCRIPTION
## Summary

- run zizmor on pushes and pull requests targeting `main`
- upload SARIF findings to GitHub code scanning
- use least-privilege workflow permissions
- pin both third-party actions to full commit SHAs and disable checkout credential persistence

The recommended Advanced Security integration reports findings without failing the workflow; merge protection can be configured separately through GitHub rulesets.

## Validation

- `actionlint .github/workflows/zizmor.yml`
- `GH_TOKEN="$(gh auth token)" uvx zizmor --format=json .github/workflows/zizmor.yml` (0 findings)
- full repository scan still reports the same 48 pre-existing findings; the new workflow introduces none
